### PR TITLE
Bugfix/issue 5 textures not exported

### DIFF
--- a/albam/__init__.py
+++ b/albam/__init__.py
@@ -43,7 +43,6 @@ def register():
 
     # Not using PointerProperty/PropertyGroup since they are not editable from the UI
     # TODO: look if that can be added into blender
-    bpy.types.Texture.albam_imported_texture_type = bpy.props.IntProperty(options={'HIDDEN'})
     bpy.types.Texture.albam_imported_texture_folder = bpy.props.StringProperty()
     bpy.types.Texture.albam_imported_texture_value_1 = bpy.props.FloatProperty()
     bpy.types.Texture.albam_imported_texture_value_2 = bpy.props.FloatProperty()

--- a/albam/__init__.py
+++ b/albam/__init__.py
@@ -43,7 +43,6 @@ def register():
 
     # Not using PointerProperty/PropertyGroup since they are not editable from the UI
     # TODO: look if that can be added into blender
-    bpy.types.Texture.albam_imported_texture_folder = bpy.props.StringProperty()
     bpy.types.Texture.albam_imported_texture_value_1 = bpy.props.FloatProperty()
     bpy.types.Texture.albam_imported_texture_value_2 = bpy.props.FloatProperty()
     bpy.types.Texture.albam_imported_texture_value_3 = bpy.props.FloatProperty()

--- a/albam/mtframework/blender_export.py
+++ b/albam/mtframework/blender_export.py
@@ -157,7 +157,7 @@ def export_mod156(parent_blender_object):
                  version_rev=1,
                  bone_count=saved_mod.bone_count,
                  mesh_count=get_mesh_count_from_blender_objects(meshes_children),
-                 material_count=len(exported_materials.materials_array),
+                 material_count=len(exported_materials.materials_data_array),
                  vertex_count=get_vertex_count_from_blender_objects(meshes_children),
                  face_count=(ctypes.sizeof(exported_meshes.index_buffer) // 2) + 1,
                  edge_count=0,  # TODO: add edge_count
@@ -197,7 +197,7 @@ def export_mod156(parent_blender_object):
                  unk_13=saved_mod.unk_13,
                  bone_palette_array=bone_palette_array,
                  textures_array=exported_materials.textures_array,
-                 materials_data_array=exported_materials.materials_array,
+                 materials_data_array=exported_materials.materials_data_array,
                  meshes_array=exported_meshes.meshes_array,
                  meshes_array_2=meshes_array_2,
                  vertex_buffer=exported_meshes.vertex_buffer,

--- a/albam/mtframework/blender_export.py
+++ b/albam/mtframework/blender_export.py
@@ -22,7 +22,10 @@ from albam.mtframework.mod import (
     VERTEX_FORMATS_TO_CLASSES,
     )
 from albam.mtframework import Arc, Mod156, Tex112
-from albam.mtframework.utils import vertices_export_locations
+from albam.mtframework.utils import (
+    vertices_export_locations,
+    blender_texture_to_texture_code,
+    )
 from albam.utils import (
     pack_half_float,
     get_offset,
@@ -469,7 +472,8 @@ def _export_textures_and_materials(blender_objects):
             texture = texture_slot.texture
             # texture_indices expects index-1 based
             texture_index = textures.index(texture) + 1
-            material_data.texture_indices[texture.albam_imported_texture_type] = texture_index
+            texture_code = blender_texture_to_texture_code(texture_slot)
+            material_data.texture_indices[texture_code] = texture_index
         materials_data_array[mat_index] = material_data
         materials_mapping[mat.name] = mat_index
 

--- a/albam/mtframework/blender_import.py
+++ b/albam/mtframework/blender_import.py
@@ -197,6 +197,7 @@ def _create_blender_textures_from_mod(mod, base_dir):
         path = '.'.join((path, 'tex'))
         if not os.path.isfile(path):
             # TODO: log warnings, figure out 'rtex' format
+            print('path {} does not exist'.format(path))
             continue
         tex = Tex112(path)
         try:
@@ -233,8 +234,13 @@ def _create_blender_materials_from_mod(mod, model_name, textures):
         for texture_code, tex_index in enumerate(material.texture_indices):
             if not tex_index:
                 continue
+            try:
+                texture_target = textures[tex_index]
+            except IndexError:
+                # TODO
+                print('tex_index {} not found. Texture len(): {}'.format(tex_index, len(textures)))
+                continue
             slot = blender_material.texture_slots.add()
-            texture_target = textures[tex_index]
             if not texture_target:
                 # This means the conversion failed before
                 # TODO: logging

--- a/albam/mtframework/blender_import.py
+++ b/albam/mtframework/blender_import.py
@@ -193,7 +193,6 @@ def _create_blender_textures_from_mod(mod, base_dir):
 
     for i, texture_path in enumerate(mod.textures_array):
         path = texture_path[:].decode('ascii').partition('\x00')[0]
-        folder = ntpath.dirname(path)
         path = os.path.join(base_dir, *path.split(ntpath.sep))
         path = '.'.join((path, 'tex'))
         if not os.path.isfile(path):
@@ -211,11 +210,11 @@ def _create_blender_textures_from_mod(mod, base_dir):
         with open(dds_path, 'wb') as w:
             w.write(dds)
         image = bpy.data.images.load(dds_path)
-        texture = bpy.data.textures.new(os.path.basename(path), type='IMAGE')
+        texture_name_no_extension = os.path.splitext(os.path.basename(path))[0]
+        texture = bpy.data.textures.new(texture_name_no_extension, type='IMAGE')
         texture.image = image
         textures.append(texture)
         # saving meta data for export
-        texture.albam_imported_texture_folder = folder
         texture.albam_imported_texture_value_1 = tex.unk_float_1
         texture.albam_imported_texture_value_2 = tex.unk_float_2
         texture.albam_imported_texture_value_3 = tex.unk_float_3

--- a/albam/mtframework/blender_import.py
+++ b/albam/mtframework/blender_import.py
@@ -15,6 +15,8 @@ from albam.mtframework.utils import (
     get_indices_array,
     get_bone_parents_from_mod,
     transform_vertices_from_bbox,
+    texture_code_to_blender_texture,
+
     )
 from albam.utils import (
     chunks,
@@ -229,45 +231,18 @@ def _create_blender_materials_from_mod(mod, model_name, textures):
         blender_material.alpha = 0.0
         blender_material.specular_intensity = 0.2  # would be nice to get this info from the mod
         materials.append(blender_material)
-        for i, tex_index in enumerate(material.texture_indices):
-            if tex_index == 0:
+        for texture_code, tex_index in enumerate(material.texture_indices):
+            if not tex_index:
                 continue
             slot = blender_material.texture_slots.add()
-            try:
-                texture_target = textures[tex_index]
-            except IndexError:
-                # TODO: should never happen, but log it
-                continue
+            texture_target = textures[tex_index]
             if not texture_target:
                 # This means the conversion failed before
+                # TODO: logging
                 continue
+            texture_code_to_blender_texture(texture_code, slot, blender_material)
             slot.texture = texture_target
-            slot.use_map_alpha = True
-            # Inserting meta data for export
-            texture_target.albam_imported_texture_type = i
-            if i == 0:
-                # Diffuse
-                slot.use_map_color_diffuse = True
-            elif i == 1:
-                # Normal
-                slot.use_map_color_diffuse = False
-                slot.use_map_normal = True
-                slot.normal_factor = 0.05
-            elif i == 2:
-                # Specular
-                slot.use_map_color_diffuse = False
-                slot.use_map_specular = True
-                blender_material.specular_intensity = 0.0
-            elif i == 7:
-                # cube map normal
-                slot.use_map_color_diffuse = False
-                slot.use_map_normal = True
-                slot.normal_factor = 0.05
-                slot.texture_coords = 'GLOBAL'
-                slot.mapping = 'CUBE'
-            else:
-                slot.use_map_color_diffuse = False
-                # TODO: 3, 4, 5, 6,
+
     return materials
 
 

--- a/albam/mtframework/utils.py
+++ b/albam/mtframework/utils.py
@@ -1,4 +1,5 @@
 import ctypes
+from collections import Counter
 import ntpath
 
 from albam.exceptions import BuildMeshError
@@ -163,8 +164,19 @@ def get_texture_dirs(mod):
     """Returns a dict of <texture_name>: <texture_dir>"""
     texture_dirs = {}
     for texture_path in mod.textures_array:
-        texture_dir, texture_name_no_ext = (ntpath.split(texture_path[:]
-                                            .decode('ascii')
-                                            .partition('\x00')[0]))
+        texture_path = texture_path[:].decode('ascii').partition('\x00')[0]
+        texture_dir, texture_name_no_ext = ntpath.split(texture_path)
         texture_dirs[texture_name_no_ext] = texture_dir
     return texture_dirs
+
+
+def get_default_texture_dir(mod):
+    if not mod.textures_array:
+        return None
+    texture_dirs = []
+    for texture_path in mod.textures_array:
+        texture_path = texture_path[:].decode('ascii').partition('\x00')[0]
+        texture_dir = ntpath.split(texture_path)[0]
+        texture_dirs.append(texture_dir)
+
+    return Counter(texture_dirs).most_common(1)[0][0]

--- a/albam/mtframework/utils.py
+++ b/albam/mtframework/utils.py
@@ -1,4 +1,5 @@
 import ctypes
+import ntpath
 
 from albam.exceptions import BuildMeshError
 from albam.mtframework.mod import (
@@ -156,3 +157,14 @@ def blender_texture_to_texture_code(blender_texture_slot):
         texture_code = 7
 
     return texture_code
+
+
+def get_texture_dirs(mod):
+    """Returns a dict of <texture_name>: <texture_dir>"""
+    texture_dirs = {}
+    for texture_path in mod.textures_array:
+        texture_dir, texture_name_no_ext = (ntpath.split(texture_path[:]
+                                            .decode('ascii')
+                                            .partition('\x00')[0]))
+        texture_dirs[texture_name_no_ext] = texture_dir
+    return texture_dirs

--- a/albam/mtframework/utils.py
+++ b/albam/mtframework/utils.py
@@ -104,3 +104,55 @@ def get_bone_parents_from_mod(bone, bones_array):
         if parent_index != 255:
             parents.append(parent_index)
     return parents
+
+
+def texture_code_to_blender_texture(texture_code, blender_texture_slot, blender_material):
+    blender_texture_slot.use_map_alpha = True
+    if texture_code == 0:
+        # Diffuse
+        blender_texture_slot.use_map_color_diffuse = True
+    elif texture_code == 1:
+        # Normal
+        blender_texture_slot.use_map_color_diffuse = False
+        blender_texture_slot.use_map_normal = True
+        blender_texture_slot.normal_factor = 0.05
+    elif texture_code == 2:
+        # Specular
+        blender_texture_slot.use_map_color_diffuse = False
+        blender_texture_slot.use_map_specular = True
+        blender_material.specular_intensity = 0.0
+    elif texture_code == 7:
+        # cube map normal
+        blender_texture_slot.use_map_color_diffuse = False
+        blender_texture_slot.use_map_normal = True
+        blender_texture_slot.normal_factor = 0.05
+        blender_texture_slot.texture_coords = 'GLOBAL'
+        blender_texture_slot.mapping = 'CUBE'
+    else:
+        print('texture_code not supported', texture_code)
+        blender_texture_slot.use_map_color_diffuse = False
+        # TODO: 3, 4, 5, 6,
+
+
+def blender_texture_to_texture_code(blender_texture_slot):
+    texture_code = 0
+
+    # Diffuse
+    if blender_texture_slot.use_map_color_diffuse:
+        texture_code = 0
+
+    # Normal
+    elif blender_texture_slot.use_map_normal and blender_texture_slot.texture_coords == 'UV':
+        texture_code = 1
+
+    # Specular
+    elif blender_texture_slot.use_map_specular:
+        texture_code = 2
+
+    # Cube normal
+    elif (blender_texture_slot.use_map_normal and
+          blender_texture_slot.texture_coords == 'GLOBAL' and
+          blender_texture_slot.mapping == 'CUBE'):
+        texture_code = 7
+
+    return texture_code

--- a/albam/utils.py
+++ b/albam/utils.py
@@ -389,6 +389,13 @@ def ensure_ntpath(path):
     return ntpath.join(*splitted)
 
 
+def ntpath_to_os_path(path):
+    splitted = path.split(ntpath.sep)
+    if len(splitted) == 1:
+        return path
+    return os.path.join(*splitted)
+
+
 def triangles_list_to_triangles_strip(blender_mesh):
     """
     Export triangle strips from a blender mesh.


### PR DESCRIPTION
Refactors to avoid using metadata about the location of the textures at export time. Now the texture names are used as IDs.
When the texture to export it's found in the original imported model, the original dir location is used.
When not found, a default_dir is inferred based on the original textures location: the location with the most textures is used.