### PR TITLE
Feature/use coverage inside blender

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+branch = True
+source = .

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,4 @@
 [run]
 branch = True
 source = .
+omit = */python/lib/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,11 @@ python:
 
 
 before_install:
-  - sudo add-apt-repository -y ppa:thomas-schiex/blender
-  - sudo apt-get update
-  - sudo apt-get install -y blender
+  #- sudo add-apt-repository -y ppa:thomas-schiex/blender
+  #- sudo apt-get update
+  #- sudo apt-get install -y blender
+  - wget http://download.blender.org/release/Blender2.77/blender-2.77a-linux-glibc211-x86_64.tar.bz2
+  - tar -xjf blender-2.77a-linux-glibc211-x86_64.tar.bz2
   - sudo ln /dev/null /dev/raw1394
 
 install:
@@ -19,7 +21,7 @@ install:
 
 script:
   - python3 scripts/download_sample_files.py
-  - python3 -m coverage run --source="." --branch -m pytest --blender=$(which blender)
+  - python3 -m coverage run --source="." --branch -m pytest --blender=$TRAVIS_BUILD_DIR/blender-2.77a-linux-glibc211-x86_64/blender
   - python3 -m coverage combine
 
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
 script:
   - python3 scripts/download_sample_files.py
   - python3 -m coverage run --source="." --branch -m pytest --blender=$(which blender)
+  - python3 -m coverage combine
 
 after_success: coveralls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
 
 script:
   - python3 scripts/download_sample_files.py
-  - python3 -m coverage run -m pytest -sv --blender=$TRAVIS_BUILD_DIR/blender-2.77a-linux-glibc211-x86_64/blender
+  - python3 -m coverage run -m pytest --blender=$TRAVIS_BUILD_DIR/blender-2.77a-linux-glibc211-x86_64/blender
   - python3 -m coverage combine
 
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
 
 script:
   - python3 scripts/download_sample_files.py
-  - python3 -m coverage run --source="." --branch -m pytest --blender=$TRAVIS_BUILD_DIR/blender-2.77a-linux-glibc211-x86_64/blender
+  - python3 -m coverage run -m pytest -sv --blender=$TRAVIS_BUILD_DIR/blender-2.77a-linux-glibc211-x86_64/blender
   - python3 -m coverage combine
 
 after_success: coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 coverage==4.0.3
 coveralls==1.1
-pytest==2.9.0
+pytest>=3.0.2
 requests==2.9.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,17 @@
+import configparser
 import os
 from pathlib import Path
+import re
 import subprocess
 import shutil
 
+import coverage
 import pytest
 
 SAMPLES_DIR = os.path.join(os.path.dirname(__file__), 'sample-files')
 ALBAM_ROOT_DIR = Path(__file__).parent.parent
 ALBAM_MODULE_DIR = ALBAM_ROOT_DIR / 'albam'
+COVERAGERC_FILE = ALBAM_ROOT_DIR / '.coveragerc'
 
 
 def pytest_addoption(parser):
@@ -29,8 +33,32 @@ def setup_blender(tmpdir_factory):
         pytest.skip('No blender bin path supplied')
     assert os.path.isfile(blender)
 
-    # install albam
-    zip_path = str(tmpdir_factory.getbasetemp().join('albam'))  # '.zip' is already appended
+    blender_site_packages = _get_blender_site_packages(blender)
+    albam_addon_source_path = _get_albam_addon_source_path(blender)
+    _install_albam_as_addon(tmpdir_factory.getbasetemp(), blender)
+    _install_coverage(blender_site_packages)
+    _setup_coverage_on_startup(blender_site_packages)
+    blender_coveragerc = _create_coveragerc_for_blender(tmpdir_factory.getbasetemp(), albam_addon_source_path)
+
+    os.environ['COVERAGE_PROCESS_START'] = blender_coveragerc
+
+    _set_paths_in_coveragerc(albam_addon_source_path)
+    # TODO: leave coveragerc like it was, after the session finishes
+    yield blender
+
+
+def _get_blender_site_packages(blender_path):
+    expr = "import sys;print('path=', [f for f in sys.path if 'site-packages' in f][0])"
+    cmd = '{} --background --python-expr "{}"'.format(blender_path, expr)
+    output = subprocess.check_output(cmd, shell=True)
+    blender_site_packages = re.match('path= (.*)', output.decode('utf-8')).group(1)
+    assert os.path.isdir(blender_site_packages)
+
+    return blender_site_packages
+
+
+def _install_albam_as_addon(base_temp, blender_path):
+    zip_path = str(base_temp.join('albam'))  # '.zip' is already appended
     shutil.make_archive(zip_path, 'zip', str(ALBAM_ROOT_DIR), str(ALBAM_MODULE_DIR.parts[-1]))
 
     script = """
@@ -42,12 +70,70 @@ except:
     sys.exit(1)
 sys.exit()
 """.format(zip_path + '.zip')
-    script_file = tmpdir_factory.getbasetemp().join('script_install_albam.py')
+    script_file = base_temp.join('script_install_albam.py')
     script_file.write(script)
-    cmd = '{} --background --python {}'.format(blender, script_file)
+    cmd = '{} --background --python {}'.format(blender_path, script_file)
 
-    subprocess.check_output(cmd, shell=True)
+    subprocess.check_call(cmd, shell=True)
 
-    # check if coverage is being run
 
-    return blender
+def _install_coverage(blender_site_packages_path):
+
+    coverage_dir = os.path.dirname(coverage.__file__)
+    dst = os.path.join(blender_site_packages_path, 'coverage')
+    try:
+        shutil.copytree(coverage_dir, dst)
+    except FileExistsError:
+        # coverage already installed
+        pass
+
+
+def _setup_coverage_on_startup(blender_site_packages_path):
+    # for now, overwriting
+    dst = os.path.join(blender_site_packages_path, 'sitecustomize.py')
+    with open(dst, 'w') as w:
+        w.write('import coverage\n')
+        w.write('coverage.process_startup()\n')
+
+
+def _get_albam_addon_source_path(blender_path):
+    expr = "import albam,os;print('path=', os.path.dirname(albam.__file__))"
+    cmd = '{} --background --python-expr "{}"'.format(blender_path, expr)
+    output = subprocess.check_output(cmd, shell=True)
+    albam_source_path = re.match('path= (.*)', output.decode('utf-8')).group(1)
+    assert os.path.isdir(albam_source_path)
+
+    return albam_source_path
+
+
+def _create_coveragerc_for_blender(base_temp, albam_source_path):
+    dst = base_temp.join('coveragercblender')
+    content = """[run]
+branch = True
+data_file = .coverage.blender
+source = {}
+""".format(albam_source_path)
+    dst.write(content)
+
+    return str(dst)
+
+
+def _set_paths_in_coveragerc(albam_addon_source_path):
+    """adds [paths] to the current .coveragerc adding the source installed as addond,
+    for combining both coverage files"""
+
+    # XXX this is temporary until it's decided how albam is shipped
+    # if multiple addons are installed, coverage will take all addons as missing
+    # files
+    albam_addon_source_path = os.path.dirname(albam_addon_source_path)
+
+    config = configparser.ConfigParser()
+    config.read([str(COVERAGERC_FILE)])
+    try:
+        config.add_section('paths')
+    except configparser.DuplicateSectionError:
+        pass
+    config.set('paths', 'source', '.\n{}'.format(albam_addon_source_path))
+
+    with open(str(COVERAGERC_FILE), 'w') as w:
+        config.write(w)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,8 +55,9 @@ def _get_blender_site_packages(blender_path):
     try:
         blender_site_packages = dirs[0]
     except IndexError:
-        print('dirs', dirs)
         print('blender_path', blender_path)
+        print('dirs', [os.path.join(root, d) for root, dirs, _ in os.walk(blender_dir)
+                       for d in dirs])
         raise
 
     # another way, doesn't work on travis for now because of stderr messages

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,14 +43,15 @@ def setup_blender(tmpdir_factory):
     os.environ['COVERAGE_PROCESS_START'] = blender_coveragerc
 
     _set_paths_in_coveragerc(albam_addon_source_path)
-    # TODO: leave coveragerc like it was, after the session finishes
     yield blender
+    # TODO: leave coveragerc like it was, after the session finishes
 
 
 def _get_blender_site_packages(blender_path):
     expr = "import sys;print('path=', [f for f in sys.path if 'site-packages' in f][0])"
     cmd = '{} --background --python-expr "{}"'.format(blender_path, expr)
     output = subprocess.check_output(cmd, shell=True)
+    print('DEBUG, output', output)
     blender_site_packages = re.match('path= (.*)', output.decode('utf-8')).group(1)
     assert os.path.isdir(blender_site_packages)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,10 @@ def setup_blender(tmpdir_factory):
     _setup_coverage_on_startup(blender_site_packages)
     blender_coveragerc = _create_coveragerc_for_blender(tmpdir_factory.getbasetemp(), albam_addon_source_path)
 
+    print('blender_coveragerc', blender_coveragerc)
+    with open(blender_coveragerc) as f:
+        print('blendercoveragerc content:',  f.read())
+
     os.environ['COVERAGE_PROCESS_START'] = blender_coveragerc
 
     _set_paths_in_coveragerc(albam_addon_source_path)
@@ -124,7 +128,7 @@ def _get_albam_addon_source_path(blender_path):
 
 def _create_coveragerc_for_blender(base_temp, albam_source_path):
     # TODO: check why coverals includes python/lib sources
-    dst = base_temp.join('coveragercblender')
+    dst = base_temp.join('.coveragercblender')
     content = """[run]
 branch = True
 data_file = .coverage.blender

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,7 @@ import bpy
 import sys
 try:
     bpy.ops.wm.addon_install(overwrite=True, filepath='{}')
+    bpy.ops.wm.addon_enable(module='albam')
 except:
     sys.exit(1)
 sys.exit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,11 +123,13 @@ def _get_albam_addon_source_path(blender_path):
 
 
 def _create_coveragerc_for_blender(base_temp, albam_source_path):
+    # TODO: check why coverals includes python/lib sources
     dst = base_temp.join('coveragercblender')
     content = """[run]
 branch = True
 data_file = .coverage.blender
 source = {}
+omit = */python/lib/*
 """.format(albam_source_path)
     dst.write(content)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,12 +48,20 @@ def setup_blender(tmpdir_factory):
 
 
 def _get_blender_site_packages(blender_path):
+
+    blender_dir = os.path.dirname(blender_path)
+    dirs = [os.path.join(root, d) for root, dirs, _ in os.walk(blender_dir)
+            for d in dirs if d == 'site-packages']
+    blender_site_packages = dirs[0]
+
+    # another way, doesn't work on travis for now because of stderr messages
+    '''
     expr = "import sys;print('path=', [f for f in sys.path if 'site-packages' in f][0])"
     cmd = '{} --background --python-expr "{}"'.format(blender_path, expr)
     output = subprocess.check_output(cmd, shell=True)
-    print('DEBUG, output', output)
     blender_site_packages = re.match('path= (.*)', output.decode('utf-8')).group(1)
     assert os.path.isdir(blender_site_packages)
+    '''
 
     return blender_site_packages
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,12 @@ def _get_blender_site_packages(blender_path):
     blender_dir = os.path.dirname(blender_path)
     dirs = [os.path.join(root, d) for root, dirs, _ in os.walk(blender_dir)
             for d in dirs if d == 'site-packages']
-    blender_site_packages = dirs[0]
+    try:
+        blender_site_packages = dirs[0]
+    except IndexError:
+        print('dirs', dirs)
+        print('blender_path', blender_path)
+        raise
 
     # another way, doesn't work on travis for now because of stderr messages
     '''

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,9 +33,9 @@ def setup_blender(tmpdir_factory):
         pytest.skip('No blender bin path supplied')
     assert os.path.isfile(blender)
 
+    _install_albam_as_addon(tmpdir_factory.getbasetemp(), blender)
     blender_site_packages = _get_blender_site_packages(blender)
     albam_addon_source_path = _get_albam_addon_source_path(blender)
-    _install_albam_as_addon(tmpdir_factory.getbasetemp(), blender)
     _install_coverage(blender_site_packages)
     _setup_coverage_on_startup(blender_site_packages)
     blender_coveragerc = _create_coveragerc_for_blender(tmpdir_factory.getbasetemp(), albam_addon_source_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,13 @@
 import os
+from pathlib import Path
+import subprocess
+import shutil
+
+import pytest
 
 SAMPLES_DIR = os.path.join(os.path.dirname(__file__), 'sample-files')
+ALBAM_ROOT_DIR = Path(__file__).parent.parent
+ALBAM_MODULE_DIR = ALBAM_ROOT_DIR / 'albam'
 
 
 def pytest_addoption(parser):
@@ -8,3 +15,39 @@ def pytest_addoption(parser):
     parser.addoption('--dirarc', help='Specified a custom folder for arc files (Re5)')
     parser.addoption('--arcregex', help='Regex that will be applied while searching for arc files')
     parser.addoption('--blender', help='Path to Blender executable for performing functional tests')
+
+
+@pytest.fixture(scope='session')
+def setup_blender(tmpdir_factory):
+    """Setups blender to be able to run tests inside of it:
+    * Installs albam as an addon, with the current code, overwriting existing installs
+    * Adds a sitecustomize.py file to be used by coverage if it's being used outside
+    * cleanups everythings after done
+    """
+    blender = pytest.config.getoption('blender')
+    if not blender:
+        pytest.skip('No blender bin path supplied')
+    assert os.path.isfile(blender)
+
+    # install albam
+    zip_path = str(tmpdir_factory.getbasetemp().join('albam'))  # '.zip' is already appended
+    shutil.make_archive(zip_path, 'zip', str(ALBAM_ROOT_DIR), str(ALBAM_MODULE_DIR.parts[-1]))
+
+    script = """
+import bpy
+import sys
+try:
+    bpy.ops.wm.addon_install(overwrite=True, filepath='{}')
+except:
+    sys.exit(1)
+sys.exit()
+""".format(zip_path + '.zip')
+    script_file = tmpdir_factory.getbasetemp().join('script_install_albam.py')
+    script_file.write(script)
+    cmd = '{} --background --python {}'.format(blender, script_file)
+
+    subprocess.check_output(cmd, shell=True)
+
+    # check if coverage is being run
+
+    return blender

--- a/tests/test_mtframework_blender.py
+++ b/tests/test_mtframework_blender.py
@@ -68,11 +68,7 @@ UnpackedData = namedtuple('UnpackedData', ('mods_original', 'textures_original',
 
 
 @pytest.fixture(scope='module', params=arc_re5_samples())
-def unpacked_data(request, tmpdir_factory):
-    blender = pytest.config.getoption('blender')
-    if not blender:
-        pytest.skip('No blender bin path supplied')
-
+def unpacked_data(request, tmpdir_factory, setup_blender):
     import_arc_filepath = request.param
     if import_arc_filepath.endswith(tuple(KNOWN_ARC_BLENDER_CRASH)):
         pytest.xfail('Known arc crashes blender')
@@ -87,7 +83,7 @@ def unpacked_data(request, tmpdir_factory):
                                        export_arc_filepath=export_arc_filepath,
                                        import_unpack_dir=import_unpack_dir.name,
                                        log_filepath=log_filepath))
-    args = '{} -noaudio --background --python {}'.format(blender, script_filepath)
+    args = '{} -noaudio --background --python {}'.format(setup_blender, script_filepath)
     try:
         subprocess.check_output((args,), shell=True)
     except subprocess.CalledProcessError:
@@ -448,7 +444,6 @@ def test_mod156_import_export_materials_data_array_texture_paths(unpacked_data):
 
 
 def test_mod156_import_export_materials_data_array_values(unpacked_data):
-    print()
     for mod_original, mod_exported in zip(unpacked_data.mods_original, unpacked_data.mods_exported):
         for i, material_original in enumerate(mod_original.materials_data_array):
             material_exported = mod_exported.materials_data_array[i]


### PR DESCRIPTION
Added coverage measuring inside of blender's subprocess. To see the results ```coverage combine``` must be run before ```coverage report```. Unfortunately I couldn't make the combine step work inside of the test session, so a TODO was created.