### PR TITLE
ISSUE-24: fix normalization of weight values in Mod156 export.

### DIFF
--- a/albam/lib/blender.py
+++ b/albam/lib/blender.py
@@ -173,7 +173,9 @@ def get_vertex_count_from_blender_objects(blender_objects):
 
 
 def get_bone_indices_and_weights_per_vertex(blender_object):
-    '''Returns {vertex_index: [(bone_index, weight_value), ...]}'''
+    """
+    Return {vertex_index: [(bone_index, weight_value), ...]}
+    """
     vertex_groups = blender_object.vertex_groups
     modifiers = {m.type: m for m in blender_object.modifiers}
     weights_per_vertex = {}
@@ -195,9 +197,7 @@ def get_bone_indices_and_weights_per_vertex(blender_object):
             vgroup_name = vertex_groups[group.group].name
             bone_index = bone_names_to_index[vgroup_name]
             pair = (bone_index, group.weight)
-            # XXX RE5 hack
-            if len(weights_per_vertex[vertex.index]) < 4:
-                weights_per_vertex[vertex.index].append(pair)
+            weights_per_vertex[vertex.index].append(pair)
     return weights_per_vertex
 
 

--- a/tests/mtframework/test_mod156.py
+++ b/tests/mtframework/test_mod156.py
@@ -1,3 +1,4 @@
+from albam.engines.mtframework.utils import get_vertices_array
 from albam.lib.structure import get_offset, get_size
 
 
@@ -49,6 +50,13 @@ def test_size_fields(mod156):
     assert mod156.bone_palette_count == len(mod156.bone_palette_array)
     assert mod156.vertex_count == len(mod156.vertex_buffer) // 32
     assert mod156.face_count == len(mod156.index_buffer) + 1
+
+
+def test_mesh_vertices_bone_weights_sum(mod156_mesh):
+    mod = mod156_mesh._parent_structure
+    mesh_vertices = get_vertices_array(mod, mod156_mesh)
+    for vertex in mesh_vertices:
+        assert not mod.bone_count or sum(vertex.weight_values) == 255
 
 
 def test_mesh_constant_fields(mod156_mesh):

--- a/tests/mtframework/test_mod156_export.py
+++ b/tests/mtframework/test_mod156_export.py
@@ -1,5 +1,6 @@
 from itertools import chain
 
+from albam.engines.mtframework.utils import get_vertices_array
 from tests.conftest import assert_same_attributes, assert_approximate_fields
 
 EXPECTED_MAX_INDICES_COUNT_RATIO = 0.17
@@ -78,3 +79,11 @@ def test_meshes_array_immutable_fields(mod156_original, mod156_exported):
         assert_same_attributes(mesh_original, mesh_exported, 'level_of_detail')
         assert_same_attributes(mesh_original, mesh_exported, 'material_index')
         assert_same_attributes(mesh_original, mesh_exported, 'vertex_stride')
+
+
+def test_mesh_vertices_bone_weights_sum(mod156_original, mod156_exported):
+    # almost duplicate from test_mod156.py
+    for mesh_index, mesh in enumerate(mod156_exported.meshes_array):
+        mesh_vertices = get_vertices_array(mod156_exported, mesh)
+        for vertex_index, vertex in enumerate(mesh_vertices):
+            assert not mod156_exported.bone_count or sum(vertex.weight_values) == 255


### PR DESCRIPTION
Fixes #24
Remove 'hack' for vertices with more than 4 bone influences (this would probably needs more more work and might break some meshes, but will be done in another issue
Add test that the sum of all weights is always 255