### PR TITLE
Add export checks for material and textures

### DIFF
--- a/albam/blender_ui/error_handling.py
+++ b/albam/blender_ui/error_handling.py
@@ -101,6 +101,4 @@ class ALBAM_OT_ErrorHandler(bpy.types.Operator):
         )
         needed = max(len(label) for label in using_space)
         width = max(needed * self.PIXELS_PER_CHAR, self.MIN_POPUP_WIDTH)
-        print("needed:", needed, "width", width)
-
         return width

--- a/albam/blender_ui/error_handling.py
+++ b/albam/blender_ui/error_handling.py
@@ -4,6 +4,7 @@ import sys
 
 import bpy
 
+from albam.exceptions import AlbamCheckFailure
 from albam.registry import blender_registry
 from albam.__version__ import __version__ as albam_version
 
@@ -28,20 +29,43 @@ class ALBAM_OT_ErrorHandler(bpy.types.Operator):
     bl_idname = "albam.error_handler_popup"
     ISSUES_URL = "https://github.com/Brachi/albam/issues"
     DISCORD_INVITE_URL = "https://discord.gg/QC2FhGhxCh"
+    ERROR_UNEXPECTED_HEADER = "An unexpected error happened"
+    ERROR_UNEXPECTED_SOLUTION_MSG = "Please provide the error shown in the console for help"
+    ERROR_CHECK_FAILURE_HEADER = "A check failed"
+    MIN_POPUP_WIDTH = 300
+    PIXELS_PER_CHAR = 7  # should be dynamic based on resolution/dpi
+
+    error_header = bpy.props.StringProperty(default="")
+    error_message = bpy.props.StringProperty(default="")
+    error_details = bpy.props.StringProperty(default="")
+    error_solution = bpy.props.StringProperty(default="")
 
     def invoke(self, context, event):
-        error = self._generate_error_report()
-        print(error)
-        return context.window_manager.invoke_props_dialog(self)
+        type_err, err, tb = sys.exc_info()
+        if issubclass(type(err), AlbamCheckFailure):
+            self.error_header = self.ERROR_CHECK_FAILURE_HEADER
+            self.error_message = err.message
+            self.error_details = err.details
+            self.error_solution = err.solution
+        else:
+            self.error_header = self.ERROR_UNEXPECTED_HEADER
+            self.error_message = ""
+            self.error_details = ""
+            self.error_solution = self.ERROR_UNEXPECTED_SOLUTION_MSG
+            error = self._generate_error_report(type_err, err, tb)
+            print(error)
+        return context.window_manager.invoke_props_dialog(self, width=self._calculate_popup_width())
 
     def execute(self, context):
         return {"FINISHED"}
 
     def draw(self, context):
         layout = self.layout
-        layout.label(text="An unexpected error happened", icon="ERROR")
+        layout.label(text=self.error_header, icon="ERROR")
         layout.separator()
-        layout.label(text="Please provide the error shown in the console for help")
+        layout.label(text=self.error_message)
+        layout.label(text=self.error_details)
+        layout.label(text=self.error_solution)
 
         layout.separator()
         layout.separator()
@@ -54,7 +78,7 @@ class ALBAM_OT_ErrorHandler(bpy.types.Operator):
         layout.separator()
 
     @staticmethod
-    def _generate_error_report():
+    def _generate_error_report(type_err, err, tb):
         type_err, err, tb = sys.exc_info()
         stack_summary = traceback.extract_tb(tb)
         traceback_str = "".join(stack_summary.format())
@@ -67,3 +91,16 @@ class ALBAM_OT_ErrorHandler(bpy.types.Operator):
         )
 
         return error
+
+    def _calculate_popup_width(self):
+        using_space = (
+            self.error_header,
+            self.error_message,
+            self.error_details,
+            self.error_solution,
+        )
+        needed = max(len(label) for label in using_space)
+        width = max(needed * self.PIXELS_PER_CHAR, self.MIN_POPUP_WIDTH)
+        print("needed:", needed, "width", width)
+
+        return width

--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -32,6 +32,7 @@ from .material import (
     serialize_materials_data,
     check_mtfw_shader_group,
 )
+from .texture import check_dds_textures
 from .structs.mod_156 import Mod156
 from .structs.mod_21 import Mod21
 
@@ -744,6 +745,7 @@ def _get_material_hash(mod, mesh):
 @blender_registry.register_export_function(app_id="re5", extension="mod")
 @blender_registry.register_export_function(app_id="rev1", extension="mod")
 @blender_registry.register_export_function(app_id="rev2", extension="mod")
+@check_dds_textures
 @check_mtfw_shader_group
 def export_mod(bl_obj):
     asset = bl_obj.albam_asset

--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -27,7 +27,11 @@ from albam.lib.blender import (
 from albam.lib.misc import chunks
 from albam.registry import blender_registry
 from albam.vfs import VirtualFile
-from .material import build_blender_materials, serialize_materials_data
+from .material import (
+    build_blender_materials,
+    serialize_materials_data,
+    check_mtfw_shader_group,
+)
 from .structs.mod_156 import Mod156
 from .structs.mod_21 import Mod21
 
@@ -740,6 +744,7 @@ def _get_material_hash(mod, mesh):
 @blender_registry.register_export_function(app_id="re5", extension="mod")
 @blender_registry.register_export_function(app_id="rev1", extension="mod")
 @blender_registry.register_export_function(app_id="rev2", extension="mod")
+@check_mtfw_shader_group
 def export_mod(bl_obj):
     asset = bl_obj.albam_asset
     app_id = asset.app_id

--- a/albam/exceptions.py
+++ b/albam/exceptions.py
@@ -1,0 +1,9 @@
+
+
+class AlbamCheckFailure(Exception):
+
+    def __init__(self, message, details, solution):
+        super().__init__(message)
+        self.message = message
+        self.details = details
+        self.solution = solution

--- a/albam/lib/blender.py
+++ b/albam/lib/blender.py
@@ -2,6 +2,8 @@ from collections import namedtuple, deque
 from copy import deepcopy
 import math
 
+import bpy
+
 
 BoundingBox = namedtuple('bounding_box', (
     'min_x', 'min_y', 'min_z',
@@ -268,6 +270,20 @@ def get_bl_materials(blender_objects):
             materials.append(mat)
             cache.add(mat.name)
     return materials
+
+
+def is_blimage_dds(bl_im):
+    is_dds = False
+    if bl_im.packed_file:
+        data = bl_im.packed_file.data
+    else:
+        fp = bpy.path.abspath(bl_im.filepath)
+        with open(fp, 'rb') as f:
+            data = f.read(4)
+    id_magic = data[:4]
+    if id_magic == b"DDS ":
+        is_dds = True
+    return is_dds
 
 
 def get_dist(point_a, point_b):

--- a/albam/lib/dds.py
+++ b/albam/lib/dds.py
@@ -208,6 +208,9 @@ class DDSHeader(Structure):
         else:
             with open(abspath(bl_im.filepath), "rb") as f:
                 data = f.read()
+        id_magic = data[:4]
+        if not id_magic == b"DDS ":
+            raise TypeError(f"Image {bl_im.name} is not a dds image. Id: {id_magic}")
         header_data = io.BytesIO(data[:header_size])  # FIXME unnecessary copy
         header_data.readinto(dds_header)
         dds_header._dds_data = data[header_size:]


### PR DESCRIPTION
Fixes #29.

## Initial implementation of checks before export

When an exception of type `AlbamCheckFailure` is raised in operators
covered by `albam_error_handler`, extra details and solutions are
provided. The header changes as well, since the error is not unexpected.

**Note**: The checks are executed sequentially and the first to fail is reported. It might be nice to
capture all checks and report them at the end. Maybe in future iterations

**TODO**: the `detail` section of the exception contains all the offending materials/textures.
That list can become quite long. The popup grows in width with that list, since there are no
easy multi-line support in these popups. Should be nice to cover that case better, and either
implement a `UIList` or wrap the text and provide a tooltip for full details, for example.

### Initial export check for mtfw shader group
A check is performed before export that all materials use the `mtfw shader group`
on mtfw apps. If not,  the affected materials are shown with instructions to fix it:

![image](https://github.com/Brachi/albam/assets/6393834/7d9c7b5b-d1fa-4d30-88e4-de3b3bb8b0d6)


### Initial export check for dds textures

A check is performed before export that all textures present in the
materials assigned to the meshes to export are DDS only.
The wrong textures are reported in a popup with the materials where they
are used.

![image](https://github.com/Brachi/albam/assets/6393834/9f9faf42-a160-4d38-b12f-256f28df0769)


