### PR TITLE
Ignore empty vertex groups

### DIFF
--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from albam.lib.blender import (
     get_bone_indices_and_weights_per_vertex,
+    get_mesh_vertex_groups,
     get_model_bounding_box,
     get_model_bounding_sphere,
     get_normals_per_vertex,
@@ -1057,21 +1058,16 @@ def _create_bone_palettes(src_mod, bl_armature, bl_meshes):
 
     bone_palette = {'mesh_indices': set(), 'bone_indices': set()}
     for i, mesh in enumerate(bl_meshes):
-        vertex_group_mapping = {vg.index: bl_armature.pose.bones.find(
-            vg.name) for vg in mesh.vertex_groups}
-        vertex_group_mapping = {k: v for k,
-                                v in vertex_group_mapping.items() if v != -1}
-        try:
-            bone_indices = (
-                {vertex_group_mapping[vgroup.group]
-                 for vertex in mesh.data.vertices
-                 for vgroup in vertex.groups}
-            )
-        except Exception:
-            print("Can't find vertex group in the armature")
 
-        msg = "Mesh {} is influenced by more than 32 bones, which is not supported".format(
-            mesh.name)
+        mesh_vertex_groups = get_mesh_vertex_groups(mesh)
+        bone_indices = {
+            bl_armature.pose.bones.find(mesh.vertex_groups[vgi].name)
+            for vgi, vertices in mesh_vertex_groups.items() if vertices
+        }
+        bone_indices = {bi for bi in bone_indices if bi != -1}
+
+        # TODO: check at export time for all meshes
+        msg = f"Mesh {mesh.name} is influenced by more than 32 bones, which is not supported"
         assert len(bone_indices) <= MAX_BONE_PALETTE_SIZE, msg
 
         current = bone_palette['bone_indices']
@@ -1529,11 +1525,13 @@ def _calculate_weight_bounds(bl_obj, bl_mesh, dst_mod, meshes_data):
             dst_mod, bl_mesh, meshes_data)
         unsorted_weight_bounds.append(weight_bound)
     else:
+        mesh_vertex_groups = get_mesh_vertex_groups(bl_mesh)
         for vg in bl_mesh.vertex_groups:
             weight_bound = _calculate_vertex_group_weight_bound(
-                bl_mesh.data, bl_obj, vg, dst_mod, meshes_data
+                mesh_vertex_groups, bl_obj, vg, dst_mod, meshes_data
             )
-            unsorted_weight_bounds.append(weight_bound)
+            if weight_bound:
+                unsorted_weight_bounds.append(weight_bound)
     return sorted(unsorted_weight_bounds, key=lambda x: x.bone_id)
 
 
@@ -1630,18 +1628,14 @@ def _set_static_mesh_weight_bounds(dst_mod, bl_mesh_ob, meshes_data):
     return wb
 
 
-def _calculate_vertex_group_weight_bound(blender_mesh, armature, vertex_group, dst_mod, meshes_data):
-    vertices_in_group = []
+def _calculate_vertex_group_weight_bound(mesh_vertex_groups, armature, vertex_group, dst_mod, meshes_data):
+    vertices_in_group = mesh_vertex_groups.get(vertex_group.index)
+    if not vertices_in_group:
+        return
 
     bone_index = armature.pose.bones.find(vertex_group.name)
     pose_bone = armature.pose.bones[bone_index]
     pose_bone_matrix = Matrix.Translation(pose_bone.head).inverted()
-
-    for v in blender_mesh.vertices:
-        v_groups = {g.group for g in v.groups}
-        if vertex_group.index not in v_groups:
-            continue
-        vertices_in_group.append(v)
 
     vertices_in_group_bone_space = [
         pose_bone_matrix @ v.co for v in vertices_in_group]

--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -1189,8 +1189,8 @@ def _serialize_meshes_data(bl_obj, bl_meshes, src_mod, dst_mod, materials_map, b
         mesh.face_offset = face_offset
         mesh.vertex_position = current_vertex_position
         mesh.idx_bone_palette = mesh_bone_palette_index
-        mesh.num_unique_bone_ids = len(
-            bl_mesh.vertex_groups) if is_skeletal else 1
+        # TODO: rename to num_weight_bounds
+        mesh.num_unique_bone_ids = 1
 
         if dst_mod.header.version in (156,):
             mesh.unk_03 = 0
@@ -1200,6 +1200,8 @@ def _serialize_meshes_data(bl_obj, bl_meshes, src_mod, dst_mod, materials_map, b
         mesh_weight_bounds = _calculate_weight_bounds(
             bl_obj, bl_mesh, dst_mod, meshes_data)
         meshes_data.weight_bounds.extend(mesh_weight_bounds)
+        # TODO: rename to num_weight_bounds
+        mesh.num_unique_bone_ids = len(mesh_weight_bounds)
 
         current_vertex_position += num_vertices
         vertex_offset_accumulated += (num_vertices * vertex_stride)

--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -1117,7 +1117,6 @@ def _serialize_meshes_data(bl_obj, bl_meshes, src_mod, dst_mod, materials_map, b
     index_buffer = bytearray()
     bbox_data = _create_bbox_data(dst_mod)
     use_strips = dst_mod.header.version == 156
-    is_skeletal = dst_mod.header.num_bones > 0
 
     current_vertex_position = 0
     current_vertex_offset = 0

--- a/albam/lib/blender.py
+++ b/albam/lib/blender.py
@@ -167,6 +167,8 @@ def get_uvs_per_vertex(blender_mesh_object, layer_index):
     except IndexError:
         return vertices
     uvs_per_loop = uv_layer.data
+    if not uvs_per_loop:
+        return vertices
     for i, loop in enumerate(blender_mesh_object.data.loops):
         vertex_index = loop.vertex_index
         if vertex_index in vertices:

--- a/albam/lib/blender.py
+++ b/albam/lib/blender.py
@@ -177,6 +177,21 @@ def get_uvs_per_vertex(blender_mesh_object, layer_index):
     return vertices
 
 
+def get_mesh_vertex_groups(bl_mesh):
+    """
+    Given a mesh object, return a dict
+    with `vertex_group_index : [vertices...]
+    """
+    vertex_groups = {}  # index: vertices
+
+    for v in bl_mesh.data.vertices:
+        v_groups = {g.group for g in v.groups}
+        for v_group in v_groups:
+            vertex_groups.setdefault(v_group, []).append(v)
+
+    return vertex_groups
+
+
 def get_bone_indices_and_weights_per_vertex(blender_object):
     """
     Return {vertex_index: [(bone_index, weight_value), ...]}


### PR DESCRIPTION
Fixes #82 

Untested yet on any game, appreciate some help there.

Ignore empty vertex groups at export time both for bone-palettes and weight bounds