### PR TITLE
Fix version parsing when enabling the addon

### DIFF
--- a/albam/__init__.py
+++ b/albam/__init__.py
@@ -12,13 +12,15 @@ from albam.blender_ui.data import (
     AlbamCustomPropertiesImageFactory,
 )
 from albam.registry import blender_registry
-from albam.__version__ import __version__
+from albam.__version__ import __version__ as version
+
+__version__ = version
 
 
 bl_info = {
     "name": "Albam",
     "author": "Sebastian A. Brachi",
-    "version": tuple(__version__.split(".")),
+    "version": (0, 3, 6),  # needs to be kept in sync with __version__ manually
     "blender": (2, 80, 0),
     "location": "Properties Panel",
     "description": "Import-Export multiple video-game formats",


### PR DESCRIPTION
Apparently Blender doesn't support a dynamic generation of the version tuple, so it needs to be left duplicated with the version we use in a separate module.