### PR TITLE
Initial copy/paste operators for props

### DIFF
--- a/albam/blender_ui/custom_properties.py
+++ b/albam/blender_ui/custom_properties.py
@@ -8,7 +8,6 @@ def AlbamCustomPropertiesFactory(kind: str):
     """
     Generate subclasses of bpy.props.PropertyGroup
     based on kind, which can be "mesh", "image", or "material".
-
     These subclassess will use the blender registry to include
     custom properties for each app_id.
 

--- a/albam/blender_ui/custom_properties.py
+++ b/albam/blender_ui/custom_properties.py
@@ -180,13 +180,17 @@ class ALBAM_PT_CustomPropertiesBase(bpy.types.Panel):
         app_name = [app[1] for app in APPS if app[0] == app_id][0]
         custom_props = context_item.albam_custom_properties.get_custom_properties_for_appid(app_id)
         props_name = context_item.albam_custom_properties.APPID_MAP[app_id]
-        self.layout.label(text=f"App: {app_name}")
-        # TODO: layout, place next to app_name, not to the very right
-        row = self.layout.row()
-        row.label(text=f"Props: {props_name}")
+
+        layout = self.layout
+        layout.use_property_split = True
+
+        row = layout.row(align=True)
+        row.label(text=f"{props_name} ({app_name})", icon="PROPERTIES")
         row.operator("albam.custom_props_copy", icon="COPYDOWN", text="")
         row.operator("albam.custom_props_paste", icon="PASTEDOWN", text="")
-        self.layout.separator()
+
+        self.layout.separator(factor=3.0)
+
         for k in custom_props.__annotations__:
             self.layout.prop(custom_props, k)
 
@@ -225,7 +229,7 @@ class ClipboardData(bpy.types.PropertyGroup):
 @blender_registry.register_blender_type
 class ALBAM_OT_CustomPropertiesCopy(bpy.types.Operator):
     """
-    Copy Operator for mesh and material context only
+    Store properties in context.scene.albam.clipboard
     """
     bl_idname = "albam.custom_props_copy"
     bl_label = "Copy Albam Custom Properties"
@@ -239,6 +243,9 @@ class ALBAM_OT_CustomPropertiesCopy(bpy.types.Operator):
 
 @blender_registry.register_blender_type
 class ALBAM_OT_CustomPropertiesPaste(bpy.types.Operator):
+    """
+    Paste properties stored in context.scene.albam.clipboard
+    """
     bl_idname = "albam.custom_props_paste"
     bl_label = "Paste Albam Custom Properties"
 

--- a/albam/blender_ui/data.py
+++ b/albam/blender_ui/data.py
@@ -2,7 +2,6 @@ import bpy
 
 from albam.registry import blender_registry
 
-
 def AlbamDataFactory():
 
     def create_data():

--- a/albam/blender_ui/data.py
+++ b/albam/blender_ui/data.py
@@ -2,6 +2,7 @@ import bpy
 
 from albam.registry import blender_registry
 
+
 def AlbamDataFactory():
 
     def create_data():


### PR DESCRIPTION
Closes #83 .
A minimal version of copy/paster, trying to improve what was done in #89, removing code duplication.
Custom properties layout was slightly modified, and 4 new buttons were added: copy, pate, export and import.

![image](https://github.com/Brachi/albam/assets/6393834/bfc80796-b0a0-494f-8bcf-1a61181a5620)


The clipboard, stored in `bpy.context.scene.albam.clipboard` stores a json dumped as a string. It can be obtained as a dict with `clipboard.get_buffer`. The structure is a dictionary with the name of the custom_props as keys. This way, multiple apps can use it at the same time, without interfering with each other.
The copy button updates that buffer, and the paste button obtains it and updates the custom props bases on it.

Export saves the properties as a json format for later reuse of the Import operator.
Importing simply loads and validates a provided json, and reports information, warnings or errors.

Example:
```
{'mod_156_material': {
                      'cubemap_roughness': 0.20000000298023224,
                      'detail_normal_multiplier': 30.0,
                      'detail_normal_power': 0.6000000238418579,
                      'normal_scale': 1.0,
                      'skin_weights_type': 3,
                      'surface_opaque': False,
                      'surface_unk': False
                      },
 'mrl_params': {
                'blend_state_type': 'BSAddAlpha',
                'f_albedo_blend2_color': [1.0, 1.0, 1.0, 1.0],
                'f_albedo_blend_color': [1.0, 1.0, 1.0, 1.0],
                'f_albedo_color': [1.0, 1.0, 1.0],
                'f_albedo_color2': [1.0, 1.0, 1.0, 0.0],
                'f_alpha_clip_threshold': 0.0,
                'f_anisotoropic_direction': [0.0, 1.0, 0.0],
                'f_anistropic_uv': [0.33329999446868896, 1.0]
                },
}
```