### PR TITLE
Fix Rev2 heads importing

### DIFF
--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -470,16 +470,10 @@ def _process_vertex_colors(mod_version, vertex, rgba_out, use_156rgba):
 def _process_weights(mod, mesh, vertex, vertex_index, weights_per_bone):
     if not hasattr(vertex, "bone_indices"):
         return
-
     bone_indices = _get_bone_indices(mod, mesh, vertex.bone_indices)
     weights = _get_weights(mod, mesh, vertex)
 
-    # TODO: verify in parsing tests that bone_index = 0 is never taken into account
     for bi, bone_index in enumerate(bone_indices):
-        if bone_index == 0 and (
-            (mesh.vertex_format not in (0xC31F201C,) and mod.header.num_bones != 1)
-        ):  # no root bone, 0 is acceptable
-            continue
         weight = weights[bi]
         if not weight:
             continue


### PR DESCRIPTION
Fixes #73 

* Remove restriction for root bone weights Allow to import weights for the root bone (index = 0) always. This restriction was added when some static meshes were displaying incorrectly when having only one bone IIRC. I haven't taken note of those files, so now they'll probably be buggy again. Given that character meshes are modded pretty much exclusively and static meshes barely get any attention for export, I think it's better to leave this as is until the need arises.