### PR TITLE
Custom properties secondary

### DIFF
--- a/albam/blender_ui/custom_properties.py
+++ b/albam/blender_ui/custom_properties.py
@@ -94,7 +94,6 @@ def AlbamCustomPropertiesFactory(kind: str):
         # Adding to the registry now anyways so auto-unregistering works
         blender_registry.types.append(SubPanel)
 
-
     def get_custom_properties(self):
         """
         Shortcut to get the custom properties based on the app_id

--- a/albam/blender_ui/export_panel.py
+++ b/albam/blender_ui/export_panel.py
@@ -148,7 +148,7 @@ class ALBAM_OT_Export(bpy.types.Operator):
         root_id = f"{app_id}-{bl_obj.name}-{round(time.time())}"
         vfile_root = VirtualFileData(app_id, root_id)
         vfs = context.scene.albam.exported
-        vfs.add_vfiles_as_tree(vfile_root, vfiles)
+        vfs.add_vfiles_as_tree(app_id, vfile_root, vfiles)
 
     @classmethod
     def poll(cls, context):

--- a/albam/blender_ui/import_panel.py
+++ b/albam/blender_ui/import_panel.py
@@ -50,7 +50,7 @@ class AlbamApps(bpy.types.PropertyGroup):
 
 @blender_registry.register_blender_type
 class ALBAM_OT_Import(bpy.types.Operator):
-    bl_idname = "albam.import"
+    bl_idname = "albam.import_vfile"
     bl_label = "import item"
 
     def execute(self, context):  # pragma: no cover
@@ -338,5 +338,5 @@ class ALBAM_PT_ImportButton(bpy.types.Panel):
     def draw(self, context):
         self.layout.separator()
         row = self.layout.row()
-        row.operator("albam.import", text="Import")
+        row.operator("albam.import_vfile", text="Import")
         self.layout.row()

--- a/albam/blender_ui/import_panel.py
+++ b/albam/blender_ui/import_panel.py
@@ -48,6 +48,11 @@ class AlbamApps(bpy.types.PropertyGroup):
         return APP_CONFIG_FILE_CACHE.get(app_id)
 
 
+@blender_registry.register_blender_prop_albam(name="import_settings")
+class AlbamImportSettings(bpy.types.PropertyGroup):
+    import_only_main_lods : bpy.props.BoolProperty(default=True)
+
+
 @blender_registry.register_blender_type
 class ALBAM_OT_Import(bpy.types.Operator):
     bl_idname = "albam.import_vfile"

--- a/albam/blender_ui/tools.py
+++ b/albam/blender_ui/tools.py
@@ -1,6 +1,6 @@
 import bmesh
 import bpy
-import os
+import ntpath
 
 from albam.registry import blender_registry
 from albam.lib.bone_names import BONES_BODY, BONES_HEAD
@@ -281,25 +281,28 @@ def set_image_albam_attr(blender_material, app_id, local_path):
         "rev1": (23, 19, 25, 31),
         "rev2": (24, 20, 25, 31),
     }
-    if blender_material:
-        if blender_material.node_tree:
-            for tn in blender_material.node_tree.nodes:
-                if tn.type == 'TEX_IMAGE':
-                    type = blender_texture_to_texture_code(tn)
-                    name = os.path.splitext(tn.image.name)[0]
-                    if not tn.image.albam_asset.relative_path:
-                        tn.image.albam_asset.relative_path = local_path + name + '.tex'
-                    tn.image.albam_asset.app_id = app_id
-                    if app_id in ["re0", "re1", "rev1", "rev2"]:
-                        tex_compr_preset = TEX_COMPRESSION.get(app_id)
-                        if type == 0:
-                            tn.image.albam_custom_properties.tex_157.compression_format = tex_compr_preset[1]
-                        if type == 1:
-                            tn.image.albam_custom_properties.tex_157.compression_format = tex_compr_preset[3]
-                        if type == 2:
-                            tn.image.albam_custom_properties.tex_157.compression_format = tex_compr_preset[2]
-                        if type == 7:
-                            tn.image.albam_custom_properties.tex_157.compression_format = tex_compr_preset[3]
+    if not blender_material or not blender_material.node_tree:
+        return
+
+    for tn in blender_material.node_tree.nodes:
+        if not tn.type == "TEX_IMAGE":
+            continue
+        type = blender_texture_to_texture_code(tn)
+        name = ntpath.splitext(tn.image.name)[0]
+        if not tn.image.albam_asset.relative_path:
+            tn.image.albam_asset.relative_path = local_path + name + '.tex'
+        tn.image.albam_asset.app_id = app_id
+        tex_157_props = tn.image.albam_custom_properties.get_custom_properties_for_appid(app_id)
+        if app_id in ["re0", "re1", "rev1", "rev2"]:
+            tex_compr_preset = TEX_COMPRESSION.get(app_id)
+            if type == 0:
+                tex_157_props.compression_format = tex_compr_preset[1]
+            if type == 1:
+                tex_157_props.compression_format = tex_compr_preset[3]
+            if type == 2:
+                tex_157_props.compression_format = tex_compr_preset[2]
+            if type == 7:
+                tex_157_props.compression_format = tex_compr_preset[3]
 
 
 def rename_bones(armature_ob, names_preset):

--- a/albam/engines/mtfw/archive.py
+++ b/albam/engines/mtfw/archive.py
@@ -47,9 +47,8 @@ class ArcWrapper:
 
     def __init__(self, file_path):
         self.file_path = file_path
-        with open(file_path, 'rb') as f:
-            self.parsed = Arc.from_bytes(f.read())
-            self.parsed._read()
+        self.parsed = Arc.from_file(file_path)
+        self.parsed._read()
 
     def get_file_entries_by_type(self, file_type):
         filtered = []

--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -314,7 +314,9 @@ def build_blender_model(file_list_item, context):
             material_hash = _get_material_hash(mod, mesh)
             use_156rgba = False
             if mod_version == 156 and (not skeleton and materials.get(material_hash)):
-                use_156rgba = materials[material_hash].albam_custom_properties.mod_156_material.use_8_bones
+                albam_custom_props = materials[material_hash].albam_custom_properties
+                mod_156_material_props = albam_custom_props.get_custom_properties_for_appid(app_id)
+                use_156rgba = mod_156_material_props.use_8_bones
 
             bl_mesh_ob = build_blender_mesh(
                 app_id, mod, mesh, name, bbox_data, mod_version in VERSIONS_USE_TRISTRIPS, use_156rgba
@@ -1213,6 +1215,9 @@ def _export_vertices(app_id, bl_mesh, mesh, mesh_bone_palette, dst_mod, bbox_dat
     has_bones = bool(dst_mod.header.num_bones)
     use_special_vf = False
 
+    albam_custom_props = bl_mesh.material_slots[0].material.albam_custom_properties
+    mod_156_material_props = albam_custom_props.get_custom_properties_for_appid(app_id)
+
     vertex_count = len(bl_mesh.data.vertices)
     if dst_mod.header.version == 156:
         if max_bones_per_vertex > 4:
@@ -1220,11 +1225,8 @@ def _export_vertices(app_id, bl_mesh, mesh, mesh_bone_palette, dst_mod, bbox_dat
         VertexCls = VERTEX_FORMATS_MAPPER[max_bones_per_vertex]
         vertex_size = 32
         vertex_format = max_bones_per_vertex
-        use_special_vf = (
-            bl_mesh.material_slots[0]
-            .material.albam_custom_properties
-            .mod_156_material.use_8_bones
-        )
+        use_special_vf = mod_156_material_props.use_8_bones
+
     elif dst_mod.header.version == 210:
         custom_properties = bl_mesh.data.albam_custom_properties.get_custom_properties_for_appid(app_id)
         try:

--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -279,6 +279,7 @@ BBOX_AFFECTED = [
 VERSIONS_USE_BONE_PALETTES = {156}
 VERSIONS_BONES_BBOX_AFFECTED = {210, 211}
 VERSIONS_USE_TRISTRIPS = {156}
+MAIN_LODS = {1, 255}
 
 
 @blender_registry.register_import_function(app_id="re0", extension="mod", file_category="MESH")
@@ -287,8 +288,6 @@ VERSIONS_USE_TRISTRIPS = {156}
 @blender_registry.register_import_function(app_id="rev1", extension="mod", file_category="MESH")
 @blender_registry.register_import_function(app_id="rev2", extension="mod", file_category="MESH")
 def build_blender_model(file_list_item, context):
-    LODS_TO_IMPORT = (1, 255)
-
     app_id = file_list_item.app_id
     mod_bytes = file_list_item.get_bytes()
     mod_version = mod_bytes[4]
@@ -296,6 +295,8 @@ def build_blender_model(file_list_item, context):
     ModCls = MOD_CLASS_MAPPER[mod_version]
     mod = ModCls.from_bytes(mod_bytes)
     mod._read()
+
+    import_settings = context.scene.albam.import_settings
 
     bl_object_name = file_list_item.display_name
     bbox_data = _create_bbox_data(mod)
@@ -305,7 +306,9 @@ def build_blender_model(file_list_item, context):
     materials = build_blender_materials(
         file_list_item, context, mod, bl_object_name)
 
-    for i, mesh in enumerate(m for m in mod.meshes_data.meshes if m.level_of_detail in LODS_TO_IMPORT):
+    for i, mesh in enumerate(mod.meshes_data.meshes):
+        if import_settings.import_only_main_lods and mesh.level_of_detail not in MAIN_LODS:
+            continue
         try:
             name = f"{bl_object_name}_{str(i).zfill(4)}"
             material_hash = _get_material_hash(mod, mesh)
@@ -330,6 +333,7 @@ def build_blender_model(file_list_item, context):
 
         except Exception as err:
             print(f"[{bl_object_name}] error building mesh {i} {err}")
+            raise
             continue
 
     bl_object.albam_asset.original_bytes = mod_bytes
@@ -388,7 +392,9 @@ def build_blender_mesh(app_id, mod, mesh, name, bbox_data, use_tri_strips=False,
 
     custom_properties = me_ob.albam_custom_properties.get_custom_properties_for_appid(
         app_id)
-    custom_properties.set_from_source(mesh)
+    custom_properties.copy_custom_properties_from(mesh)
+    # XXX TMP hack, TODO convert vertex formats to enums
+    custom_properties.vertex_format = str(mesh.vertex_format)
     return ob
 
 
@@ -1146,7 +1152,7 @@ def _serialize_meshes_data(bl_obj, bl_meshes, src_mod, dst_mod, materials_map, b
         # Beware of vertex_format being a string type, overriden below
         custom_properties = bl_mesh.data.albam_custom_properties.get_custom_properties_for_appid(
             app_id)
-        custom_properties.set_to_dest(mesh)
+        custom_properties.copy_custom_properties_to(mesh)
 
         # TODO: pre-check for no materials
         mesh.idx_material = materials_map[bl_mesh.data.materials[0].name]
@@ -1748,20 +1754,15 @@ class Mod156MeshCustomProperties(bpy.types.PropertyGroup):
     unk_10: bpy.props.IntProperty(default=0)  # TODO: restrictions
     unk_11: bpy.props.IntProperty(default=0)  # TODO: restrictions
 
-    def set_from_source(self, mesh):
-        # XXX assume only properties are part of annotations
+    # FIXME: dedupe
+    def copy_custom_properties_to(self, dst_obj):
         for attr_name in self.__annotations__:
-            self.copy_attr(mesh, self, attr_name)
+            setattr(dst_obj, attr_name, getattr(self, attr_name))
 
-    def set_to_dest(self, mesh):
+    # FIXME: dedupe
+    def copy_custom_properties_from(self, src_obj):
         for attr_name in self.__annotations__:
-            self.copy_attr(self, mesh, attr_name)
-
-    @staticmethod
-    def copy_attr(src, dst, name):
-        # will raise, making sure there's consistency
-        src_value = getattr(src, name)
-        setattr(dst, name, src_value)
+            setattr(self, attr_name, getattr(src_obj, attr_name))
 
 
 @blender_registry.register_custom_properties_mesh("mod_21_mesh", ("re0", "re1", "rev1", "rev2",))
@@ -1780,24 +1781,16 @@ class Mod21MeshCustomProperties(bpy.types.PropertyGroup):
     unk_01: bpy.props.IntProperty(default=0)  # TODO u1
     vertex_format: bpy.props.StringProperty()
 
-    # XXX copy paste above and in material
-    def set_from_source(self, mesh):
-        # XXX assume only properties are part of annotations
+    # FIXME: dedupe
+    def copy_custom_properties_to(self, dst_obj):
+        for attr_name in self.__annotations__:
+            setattr(dst_obj, attr_name, getattr(self, attr_name))
+
+    # FIXME: dedupe
+    def copy_custom_properties_from(self, src_obj):
         for attr_name in self.__annotations__:
             try:
-                self.copy_attr(mesh, self, attr_name)
+                setattr(self, attr_name, getattr(src_obj, attr_name))
             except TypeError:
-                # hack for IntProperty apparently only being for signed integers
-                self.copy_attr(mesh, self, attr_name, func=str)
-
-    def set_to_dest(self, mesh):
-        for attr_name in self.__annotations__:
-            self.copy_attr(self, mesh, attr_name)
-
-    @staticmethod
-    def copy_attr(src, dst, name, func=None):
-        # will raise, making sure there's consistency
-        src_value = getattr(src, name)
-        if func:
-            src_value = func(src_value)
-        setattr(dst, name, src_value)
+                pass
+                # print(f"Type mismatch {attr_name}, {src_obj}")

--- a/albam/engines/mtfw/structs/mrl.ksy
+++ b/albam/engines/mtfw/structs/mrl.ksy
@@ -7,7 +7,7 @@ meta:
   title: MTFramework material format
 
 params:
-  - {id: cb_globals_version, type: u2}
+  - {id: app_id, type: str}  # TODO: enum
 
 seq:
   - {id: id_magic, contents: [0x4d, 0x52, 0x4c, 0x00]}
@@ -102,35 +102,7 @@ types:
           cases:
             "shader_object_hash::globals": cb_globals
             "shader_object_hash::cbdistortion" : str_cb_distortion
-            "shader_object_hash::cbmaterial" : str_cb_material
-            #0x7b2c214c: cb_s_globals # Re6
-            #0xefca3222: str_cb_distortion
-            #0xefca322b: str_cb_distortion
-            #0xefca3227: str_cb_distortion
-            #0xefca3220: str_cb_distortion
-            #0x6c8011f9: str_cb_material
-            #0x6c801200: str_cb_material
-            #0x6c8011f4: str_cb_material
-            #0x6c8011fe: str_cb_material
-            #0x6c8011ea: str_cb_material
-
-            #0xc48f7223: str_cb_vtx_distortion_refract
-            #0xc48f722c: str_cb_vtx_distortion_refract
-            #0xc48f7228: str_cb_vtx_distortion_refract
-            #0x15419236: str_cb_vtx_displacement
-            #0x1541922f: str_cb_vtx_displacement
-            #0x51814237: str_cb_vtx_displacement2
-            #0x22882238: str_cb_vtx_displacement3
-            #0x6f01631b: str_cb_color_mask
-            #0x61c6e23d: str_cb_vtx_disp_mask_uv
-            #0xaee37319: str_cb_ba_alpha_clip
-            #0xaee3730c: cb_unk_01 #2934141708 alpha clip?
-            #0x6F01630e: cb_unk_02 # color mas ?
-            #0xc48f7221: cb_unk_01 #3297735201 distortion refract ?
-            #0x84115310: cb_unk_03 #2215727888
-            #0x61E43233: str_cb_vtx_disp_ex
-            #0x51814230: str_cb_vtx_displacement2
-            #0x22882231: str_cb_vtx_displacement3 #579346993
+            "shader_object_hash::cbmaterial" : cb_material
         if: cmd_type == cmd_type::set_constant_buffer
 
   anim_data:
@@ -304,15 +276,40 @@ types:
     seq:
       - {id: ofs_const_buff, type: u4}
 
+  cb_material:
+      instances:
+        app_specific:
+          pos: _parent._parent.ofs_cmd + _parent.value_cmd.as<cmd_ofs_buffer>.ofs_float_buff
+          type:
+            switch-on: "_root.app_id"
+            cases:
+              '"re0"': cb_material_1
+              '"re1"': cb_material_1
+              '"rev1"': cb_material_1
+              '"rev2"': cb_material_1
+              _ : cb_material_1
+
   cb_globals:
+      instances:
+        app_specific:
+          pos: _parent._parent.ofs_cmd + _parent.value_cmd.as<cmd_ofs_buffer>.ofs_float_buff
+          type:
+            switch-on: "_root.app_id"
+            cases:
+              '"re0"': cb_globals_1
+              '"re1"': cb_globals_1
+              '"rev1"': cb_globals_1
+              '"rev2"': cb_globals_2
+              _ : cb_globals_1
+
+  cb_globals_1:
     instances:
       size_:
-        value: "_root.cb_globals_version == 2 ? 480 : 288"
-
+        value: 288
     seq:
       - {id: f_alpha_clip_threshold, type: f4} # 0
       - {id: f_albedo_color, type: f4, repeat: expr, repeat-expr: 3} #1
-      - {id: f_albedo_blend_color, type: f4, repeat: expr, repeat-expr: 4} #4 
+      - {id: f_albedo_blend_color, type: f4, repeat: expr, repeat-expr: 4} #4
       - {id: f_detail_normal_power, type: f4} #8
       - {id: f_detail_normal_uv_scale, type: f4} #9
       - {id: f_detail_normal2_power, type: f4} #10
@@ -347,24 +344,68 @@ types:
       - {id: f_primary_color, type: f4, repeat: expr, repeat-expr: 4} #64
       - {id: f_secondary_color, type: f4, repeat: expr, repeat-expr: 4} #68
 
-      - {id: f_albedo_color2, type: f4, repeat: expr, repeat-expr: 4, if: _root.cb_globals_version == 2} #72
-      - {id: f_specular_color2, type: f4, repeat: expr, repeat-expr: 3, if: _root.cb_globals_version == 2} #76
-      - {id: f_fresnel_schlick2, type: f4, if: _root.cb_globals_version == 2} #79
-      - {id: f_shininess2, type: f4, repeat: expr, repeat-expr: 4, if: _root.cb_globals_version == 2} #80
-      - {id: f_transparency_clip_threshold, type: f4, repeat: expr, repeat-expr: 4, if: _root.cb_globals_version == 2} #84
-      - {id: f_blend_uv, type: f4, if: _root.cb_globals_version == 2} #88
-      - {id: f_normal_power, type: f4, repeat: expr, repeat-expr: 3, if: _root.cb_globals_version == 2} #89
-      - {id: f_albedo_blend2_color, type: f4, repeat: expr, repeat-expr: 4, if: _root.cb_globals_version == 2} #92
-      - {id: f_detail_normal_u_v_scale, type: f4, repeat: expr, repeat-expr: 2, if: _root.cb_globals_version == 2} #96
-      - {id: f_fresnel_legacy, type: f4, repeat: expr, repeat-expr: 2, if: _root.cb_globals_version == 2} #98
-      - {id: f_normal_mask_pow0, type: f4, repeat: expr, repeat-expr: 4, if: _root.cb_globals_version == 2} #100
-      - {id: f_normal_mask_pow1, type: f4, repeat: expr, repeat-expr: 4, if: _root.cb_globals_version == 2} #104
-      - {id: f_normal_mask_pow2, type: f4, repeat: expr, repeat-expr: 4, if: _root.cb_globals_version == 2} #108
-      - {id: f_texture_blend_rate, type: f4, repeat: expr, repeat-expr: 4, if: _root.cb_globals_version == 2} #112
-      - {id: f_texture_blend_color, type: f4, repeat: expr, repeat-expr: 4, if: _root.cb_globals_version == 2} #116
+  cb_globals_2:
+    instances:
+      size_:
+        value: 480
+    seq:
+      - {id: f_alpha_clip_threshold, type: f4} # 0
+      - {id: f_albedo_color, type: f4, repeat: expr, repeat-expr: 3} #1
+      - {id: f_albedo_blend_color, type: f4, repeat: expr, repeat-expr: 4} #4
+      - {id: f_detail_normal_power, type: f4} #8
+      - {id: f_detail_normal_uv_scale, type: f4} #9
+      - {id: f_detail_normal2_power, type: f4} #10
+      - {id: f_detail_normal2_uv_scale, type: f4} #11
+      - {id: f_primary_shift, type: f4} #12
+      - {id: f_secondary_shift, type: f4} #13
+      - {id: f_parallax_factor, type: f4} #14
+      - {id: f_parallax_self_occlusion, type: f4} #15
+      - {id: f_parallax_min_sample, type: f4} #16
+      - {id: f_parallax_max_sample, type: f4, repeat: expr, repeat-expr: 3} #17
+      - {id: f_light_map_color, type: f4, repeat: expr, repeat-expr: 4} #20
+      - {id: f_thin_map_color, type: f4, repeat: expr, repeat-expr: 3} #24
+      - {id: f_thin_scattering, type: f4} #27
+      - {id: f_screen_uv_scale, type: f4, repeat: expr, repeat-expr: 2} #28
+      - {id: f_screen_uv_offset, type: f4, repeat: expr, repeat-expr: 2} #30
+      - {id: f_indirect_offset, type: f4, repeat: expr, repeat-expr: 2} #32
+      - {id: f_indirect_scale, type: f4, repeat: expr, repeat-expr: 2} #34
+      - {id: f_fresnel_schlick, type: f4} #36
+      - {id: f_fresnel_schlick_rgb, type: f4, repeat: expr, repeat-expr: 3} #37
+      - {id: f_specular_color, type: f4, repeat: expr, repeat-expr: 3} #40
+      - {id: f_shininess, type: f4} #43
+      - {id: f_emission_color, type: f4, repeat: expr, repeat-expr: 3} #44
+      - {id: f_emission_threshold, type: f4} #47
+      - {id: f_constant_color, type: f4, repeat: expr, repeat-expr: 4} #48
+      - {id: f_roughness, type: f4} #52
+      - {id: f_roughness_rgb, type: f4, repeat: expr, repeat-expr: 3} #53
+      - {id: f_anisotoropic_direction, type: f4, repeat: expr, repeat-expr: 3} #56
+      - {id: f_smoothness, type: f4} #59
+      - {id: f_anistropic_uv, type: f4,repeat: expr, repeat-expr: 2} #60
+      - {id: f_primary_expo, type: f4} #62
+      - {id: f_secondary_expo, type: f4} #63
+      - {id: f_primary_color, type: f4, repeat: expr, repeat-expr: 4} #64
+      - {id: f_secondary_color, type: f4, repeat: expr, repeat-expr: 4} #68
+      - {id: f_albedo_color2, type: f4, repeat: expr, repeat-expr: 4} #72
+      - {id: f_specular_color2, type: f4, repeat: expr, repeat-expr: 3} #76
+      - {id: f_fresnel_schlick2, type: f4} #79
+      - {id: f_shininess2, type: f4, repeat: expr, repeat-expr: 4} #80
+      - {id: f_transparency_clip_threshold, type: f4, repeat: expr, repeat-expr: 4} #84
+      - {id: f_blend_uv, type: f4} #88
+      - {id: f_normal_power, type: f4, repeat: expr, repeat-expr: 3} #89
+      - {id: f_albedo_blend2_color, type: f4, repeat: expr, repeat-expr: 4} #92
+      - {id: f_detail_normal_u_v_scale, type: f4, repeat: expr, repeat-expr: 2} #96
+      - {id: f_fresnel_legacy, type: f4, repeat: expr, repeat-expr: 2} #98
+      - {id: f_normal_mask_pow0, type: f4, repeat: expr, repeat-expr: 4} #100
+      - {id: f_normal_mask_pow1, type: f4, repeat: expr, repeat-expr: 4} #104
+      - {id: f_normal_mask_pow2, type: f4, repeat: expr, repeat-expr: 4} #108
+      - {id: f_texture_blend_rate, type: f4, repeat: expr, repeat-expr: 4} #112
+      - {id: f_texture_blend_color, type: f4, repeat: expr, repeat-expr: 4} #116
 
 
-  str_cb_material: #all games 32 floats
+  cb_material_1: #all games 32 floats
+    instances:
+      size_:
+        value: 128
     seq:
       - {id: f_diffuse_color, type: f4, repeat: expr, repeat-expr: 3}
       - {id: f_transparency, type: f4}
@@ -373,9 +414,6 @@ types:
       - {id: f_uv_transform, type: f4, repeat: expr, repeat-expr: 8}
       - {id: f_uv_transform2, type: f4, repeat: expr, repeat-expr: 8}
       - {id: f_uv_transform3, type: f4, repeat: expr, repeat-expr: 8}
-    instances:
-      size_:
-        value: 128
 
   str_cb_ba_alpha_clip: # 4 floats 0xaee37319
     seq:

--- a/albam/engines/mtfw/structs/mrl.py
+++ b/albam/engines/mtfw/structs/mrl.py
@@ -3,28 +3,28 @@
 
 import kaitaistruct
 from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
-from enum import Enum
+from enum import IntEnum
 
 
-if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 11):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.11 or later is required, but you have %s" % (kaitaistruct.__version__))
 
 class Mrl(ReadWriteKaitaiStruct):
 
-    class MaterialType(Enum):
+    class MaterialType(IntEnum):
         type_n_draw__material_std = 1605430244
 
-    class TextureType(Enum):
+    class TextureType(IntEnum):
         type_r_texture = 606035435
 
-    class CmdType(Enum):
+    class CmdType(IntEnum):
         set_flag = 0
         set_constant_buffer = 1
         set_sampler_state = 2
         set_texture = 3
         set_unk = 4
 
-    class ShaderObjectHash(Enum):
+    class ShaderObjectHash(IntEnum):
         flinearcolor = 144
         getbiasedviewposition = 543
         fbaselightscattering = 1145
@@ -2972,11 +2972,11 @@ class Mrl(ReadWriteKaitaiStruct):
         cbshadowreceive0 = 1048082
         fgrassbillboardposition = 1048090
         fsystemcopygamma = 1048350
-    def __init__(self, cb_globals_version, _io=None, _parent=None, _root=None):
+    def __init__(self, app_id, _io=None, _parent=None, _root=None):
         self._io = _io
         self._parent = _parent
         self._root = _root if _root else self
-        self.cb_globals_version = cb_globals_version
+        self.app_id = app_id
 
     def _read(self):
         self.id_magic = self._io.read_bytes(4)
@@ -3038,7 +3038,7 @@ class Mrl(ReadWriteKaitaiStruct):
         if (len(self.id_magic) != 4):
             raise kaitaistruct.ConsistencyError(u"id_magic", len(self.id_magic), 4)
         if not (self.id_magic == b"\x4D\x52\x4C\x00"):
-            raise kaitaistruct.ValidationNotEqualError(b"\x4D\x52\x4C\x00", self.id_magic, self._io, u"/seq/0")
+            raise kaitaistruct.ValidationNotEqualError(b"\x4D\x52\x4C\x00", self.id_magic, None, u"/seq/0")
         if (len(self.textures) != self.num_textures):
             raise kaitaistruct.ConsistencyError(u"textures", len(self.textures), self.num_textures)
         for i in range(len(self.textures)):
@@ -3117,6 +3117,497 @@ class Mrl(ReadWriteKaitaiStruct):
                     raise kaitaistruct.ConsistencyError(u"values", self.values[i]._parent, self)
 
 
+
+    class CbMaterial(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root
+            self._should_write_app_specific = False
+            self.app_specific__to_write = True
+
+        def _read(self):
+            pass
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.app_specific
+            _on = self._root.app_id
+            if _on == u"re1":
+                pass
+                self.app_specific._fetch_instances()
+            elif _on == u"rev1":
+                pass
+                self.app_specific._fetch_instances()
+            elif _on == u"re0":
+                pass
+                self.app_specific._fetch_instances()
+            elif _on == u"rev2":
+                pass
+                self.app_specific._fetch_instances()
+            else:
+                pass
+                self.app_specific._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbMaterial, self)._write__seq(io)
+            self._should_write_app_specific = self.app_specific__to_write
+
+
+        def _check(self):
+            pass
+
+        @property
+        def app_specific(self):
+            if self._should_write_app_specific:
+                self._write_app_specific()
+            if hasattr(self, '_m_app_specific'):
+                return self._m_app_specific
+
+            _pos = self._io.pos()
+            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
+            _on = self._root.app_id
+            if _on == u"re1":
+                pass
+                self._m_app_specific = Mrl.CbMaterial1(self._io, self, self._root)
+                self._m_app_specific._read()
+            elif _on == u"rev1":
+                pass
+                self._m_app_specific = Mrl.CbMaterial1(self._io, self, self._root)
+                self._m_app_specific._read()
+            elif _on == u"re0":
+                pass
+                self._m_app_specific = Mrl.CbMaterial1(self._io, self, self._root)
+                self._m_app_specific._read()
+            elif _on == u"rev2":
+                pass
+                self._m_app_specific = Mrl.CbMaterial1(self._io, self, self._root)
+                self._m_app_specific._read()
+            else:
+                pass
+                self._m_app_specific = Mrl.CbMaterial1(self._io, self, self._root)
+                self._m_app_specific._read()
+            self._io.seek(_pos)
+            return getattr(self, '_m_app_specific', None)
+
+        @app_specific.setter
+        def app_specific(self, v):
+            self._m_app_specific = v
+
+        def _write_app_specific(self):
+            self._should_write_app_specific = False
+            _pos = self._io.pos()
+            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
+            _on = self._root.app_id
+            if _on == u"re1":
+                pass
+                self.app_specific._write__seq(self._io)
+            elif _on == u"rev1":
+                pass
+                self.app_specific._write__seq(self._io)
+            elif _on == u"re0":
+                pass
+                self.app_specific._write__seq(self._io)
+            elif _on == u"rev2":
+                pass
+                self.app_specific._write__seq(self._io)
+            else:
+                pass
+                self.app_specific._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+        def _check_app_specific(self):
+            pass
+            _on = self._root.app_id
+            if _on == u"re1":
+                pass
+                if self.app_specific._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
+                if self.app_specific._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
+            elif _on == u"rev1":
+                pass
+                if self.app_specific._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
+                if self.app_specific._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
+            elif _on == u"re0":
+                pass
+                if self.app_specific._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
+                if self.app_specific._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
+            elif _on == u"rev2":
+                pass
+                if self.app_specific._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
+                if self.app_specific._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
+            else:
+                pass
+                if self.app_specific._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
+                if self.app_specific._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
+
+
+    class CbGlobals1(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.f_alpha_clip_threshold = self._io.read_f4le()
+            self.f_albedo_color = []
+            for i in range(3):
+                self.f_albedo_color.append(self._io.read_f4le())
+
+            self.f_albedo_blend_color = []
+            for i in range(4):
+                self.f_albedo_blend_color.append(self._io.read_f4le())
+
+            self.f_detail_normal_power = self._io.read_f4le()
+            self.f_detail_normal_uv_scale = self._io.read_f4le()
+            self.f_detail_normal2_power = self._io.read_f4le()
+            self.f_detail_normal2_uv_scale = self._io.read_f4le()
+            self.f_primary_shift = self._io.read_f4le()
+            self.f_secondary_shift = self._io.read_f4le()
+            self.f_parallax_factor = self._io.read_f4le()
+            self.f_parallax_self_occlusion = self._io.read_f4le()
+            self.f_parallax_min_sample = self._io.read_f4le()
+            self.f_parallax_max_sample = []
+            for i in range(3):
+                self.f_parallax_max_sample.append(self._io.read_f4le())
+
+            self.f_light_map_color = []
+            for i in range(4):
+                self.f_light_map_color.append(self._io.read_f4le())
+
+            self.f_thin_map_color = []
+            for i in range(3):
+                self.f_thin_map_color.append(self._io.read_f4le())
+
+            self.f_thin_scattering = self._io.read_f4le()
+            self.f_screen_uv_scale = []
+            for i in range(2):
+                self.f_screen_uv_scale.append(self._io.read_f4le())
+
+            self.f_screen_uv_offset = []
+            for i in range(2):
+                self.f_screen_uv_offset.append(self._io.read_f4le())
+
+            self.f_indirect_offset = []
+            for i in range(2):
+                self.f_indirect_offset.append(self._io.read_f4le())
+
+            self.f_indirect_scale = []
+            for i in range(2):
+                self.f_indirect_scale.append(self._io.read_f4le())
+
+            self.f_fresnel_schlick = self._io.read_f4le()
+            self.f_fresnel_schlick_rgb = []
+            for i in range(3):
+                self.f_fresnel_schlick_rgb.append(self._io.read_f4le())
+
+            self.f_specular_color = []
+            for i in range(3):
+                self.f_specular_color.append(self._io.read_f4le())
+
+            self.f_shininess = self._io.read_f4le()
+            self.f_emission_color = []
+            for i in range(3):
+                self.f_emission_color.append(self._io.read_f4le())
+
+            self.f_emission_threshold = self._io.read_f4le()
+            self.f_constant_color = []
+            for i in range(4):
+                self.f_constant_color.append(self._io.read_f4le())
+
+            self.f_roughness = self._io.read_f4le()
+            self.f_roughness_rgb = []
+            for i in range(3):
+                self.f_roughness_rgb.append(self._io.read_f4le())
+
+            self.f_anisotoropic_direction = []
+            for i in range(3):
+                self.f_anisotoropic_direction.append(self._io.read_f4le())
+
+            self.f_smoothness = self._io.read_f4le()
+            self.f_anistropic_uv = []
+            for i in range(2):
+                self.f_anistropic_uv.append(self._io.read_f4le())
+
+            self.f_primary_expo = self._io.read_f4le()
+            self.f_secondary_expo = self._io.read_f4le()
+            self.f_primary_color = []
+            for i in range(4):
+                self.f_primary_color.append(self._io.read_f4le())
+
+            self.f_secondary_color = []
+            for i in range(4):
+                self.f_secondary_color.append(self._io.read_f4le())
+
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.f_albedo_color)):
+                pass
+
+            for i in range(len(self.f_albedo_blend_color)):
+                pass
+
+            for i in range(len(self.f_parallax_max_sample)):
+                pass
+
+            for i in range(len(self.f_light_map_color)):
+                pass
+
+            for i in range(len(self.f_thin_map_color)):
+                pass
+
+            for i in range(len(self.f_screen_uv_scale)):
+                pass
+
+            for i in range(len(self.f_screen_uv_offset)):
+                pass
+
+            for i in range(len(self.f_indirect_offset)):
+                pass
+
+            for i in range(len(self.f_indirect_scale)):
+                pass
+
+            for i in range(len(self.f_fresnel_schlick_rgb)):
+                pass
+
+            for i in range(len(self.f_specular_color)):
+                pass
+
+            for i in range(len(self.f_emission_color)):
+                pass
+
+            for i in range(len(self.f_constant_color)):
+                pass
+
+            for i in range(len(self.f_roughness_rgb)):
+                pass
+
+            for i in range(len(self.f_anisotoropic_direction)):
+                pass
+
+            for i in range(len(self.f_anistropic_uv)):
+                pass
+
+            for i in range(len(self.f_primary_color)):
+                pass
+
+            for i in range(len(self.f_secondary_color)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbGlobals1, self)._write__seq(io)
+            self._io.write_f4le(self.f_alpha_clip_threshold)
+            for i in range(len(self.f_albedo_color)):
+                pass
+                self._io.write_f4le(self.f_albedo_color[i])
+
+            for i in range(len(self.f_albedo_blend_color)):
+                pass
+                self._io.write_f4le(self.f_albedo_blend_color[i])
+
+            self._io.write_f4le(self.f_detail_normal_power)
+            self._io.write_f4le(self.f_detail_normal_uv_scale)
+            self._io.write_f4le(self.f_detail_normal2_power)
+            self._io.write_f4le(self.f_detail_normal2_uv_scale)
+            self._io.write_f4le(self.f_primary_shift)
+            self._io.write_f4le(self.f_secondary_shift)
+            self._io.write_f4le(self.f_parallax_factor)
+            self._io.write_f4le(self.f_parallax_self_occlusion)
+            self._io.write_f4le(self.f_parallax_min_sample)
+            for i in range(len(self.f_parallax_max_sample)):
+                pass
+                self._io.write_f4le(self.f_parallax_max_sample[i])
+
+            for i in range(len(self.f_light_map_color)):
+                pass
+                self._io.write_f4le(self.f_light_map_color[i])
+
+            for i in range(len(self.f_thin_map_color)):
+                pass
+                self._io.write_f4le(self.f_thin_map_color[i])
+
+            self._io.write_f4le(self.f_thin_scattering)
+            for i in range(len(self.f_screen_uv_scale)):
+                pass
+                self._io.write_f4le(self.f_screen_uv_scale[i])
+
+            for i in range(len(self.f_screen_uv_offset)):
+                pass
+                self._io.write_f4le(self.f_screen_uv_offset[i])
+
+            for i in range(len(self.f_indirect_offset)):
+                pass
+                self._io.write_f4le(self.f_indirect_offset[i])
+
+            for i in range(len(self.f_indirect_scale)):
+                pass
+                self._io.write_f4le(self.f_indirect_scale[i])
+
+            self._io.write_f4le(self.f_fresnel_schlick)
+            for i in range(len(self.f_fresnel_schlick_rgb)):
+                pass
+                self._io.write_f4le(self.f_fresnel_schlick_rgb[i])
+
+            for i in range(len(self.f_specular_color)):
+                pass
+                self._io.write_f4le(self.f_specular_color[i])
+
+            self._io.write_f4le(self.f_shininess)
+            for i in range(len(self.f_emission_color)):
+                pass
+                self._io.write_f4le(self.f_emission_color[i])
+
+            self._io.write_f4le(self.f_emission_threshold)
+            for i in range(len(self.f_constant_color)):
+                pass
+                self._io.write_f4le(self.f_constant_color[i])
+
+            self._io.write_f4le(self.f_roughness)
+            for i in range(len(self.f_roughness_rgb)):
+                pass
+                self._io.write_f4le(self.f_roughness_rgb[i])
+
+            for i in range(len(self.f_anisotoropic_direction)):
+                pass
+                self._io.write_f4le(self.f_anisotoropic_direction[i])
+
+            self._io.write_f4le(self.f_smoothness)
+            for i in range(len(self.f_anistropic_uv)):
+                pass
+                self._io.write_f4le(self.f_anistropic_uv[i])
+
+            self._io.write_f4le(self.f_primary_expo)
+            self._io.write_f4le(self.f_secondary_expo)
+            for i in range(len(self.f_primary_color)):
+                pass
+                self._io.write_f4le(self.f_primary_color[i])
+
+            for i in range(len(self.f_secondary_color)):
+                pass
+                self._io.write_f4le(self.f_secondary_color[i])
+
+
+
+        def _check(self):
+            pass
+            if (len(self.f_albedo_color) != 3):
+                raise kaitaistruct.ConsistencyError(u"f_albedo_color", len(self.f_albedo_color), 3)
+            for i in range(len(self.f_albedo_color)):
+                pass
+
+            if (len(self.f_albedo_blend_color) != 4):
+                raise kaitaistruct.ConsistencyError(u"f_albedo_blend_color", len(self.f_albedo_blend_color), 4)
+            for i in range(len(self.f_albedo_blend_color)):
+                pass
+
+            if (len(self.f_parallax_max_sample) != 3):
+                raise kaitaistruct.ConsistencyError(u"f_parallax_max_sample", len(self.f_parallax_max_sample), 3)
+            for i in range(len(self.f_parallax_max_sample)):
+                pass
+
+            if (len(self.f_light_map_color) != 4):
+                raise kaitaistruct.ConsistencyError(u"f_light_map_color", len(self.f_light_map_color), 4)
+            for i in range(len(self.f_light_map_color)):
+                pass
+
+            if (len(self.f_thin_map_color) != 3):
+                raise kaitaistruct.ConsistencyError(u"f_thin_map_color", len(self.f_thin_map_color), 3)
+            for i in range(len(self.f_thin_map_color)):
+                pass
+
+            if (len(self.f_screen_uv_scale) != 2):
+                raise kaitaistruct.ConsistencyError(u"f_screen_uv_scale", len(self.f_screen_uv_scale), 2)
+            for i in range(len(self.f_screen_uv_scale)):
+                pass
+
+            if (len(self.f_screen_uv_offset) != 2):
+                raise kaitaistruct.ConsistencyError(u"f_screen_uv_offset", len(self.f_screen_uv_offset), 2)
+            for i in range(len(self.f_screen_uv_offset)):
+                pass
+
+            if (len(self.f_indirect_offset) != 2):
+                raise kaitaistruct.ConsistencyError(u"f_indirect_offset", len(self.f_indirect_offset), 2)
+            for i in range(len(self.f_indirect_offset)):
+                pass
+
+            if (len(self.f_indirect_scale) != 2):
+                raise kaitaistruct.ConsistencyError(u"f_indirect_scale", len(self.f_indirect_scale), 2)
+            for i in range(len(self.f_indirect_scale)):
+                pass
+
+            if (len(self.f_fresnel_schlick_rgb) != 3):
+                raise kaitaistruct.ConsistencyError(u"f_fresnel_schlick_rgb", len(self.f_fresnel_schlick_rgb), 3)
+            for i in range(len(self.f_fresnel_schlick_rgb)):
+                pass
+
+            if (len(self.f_specular_color) != 3):
+                raise kaitaistruct.ConsistencyError(u"f_specular_color", len(self.f_specular_color), 3)
+            for i in range(len(self.f_specular_color)):
+                pass
+
+            if (len(self.f_emission_color) != 3):
+                raise kaitaistruct.ConsistencyError(u"f_emission_color", len(self.f_emission_color), 3)
+            for i in range(len(self.f_emission_color)):
+                pass
+
+            if (len(self.f_constant_color) != 4):
+                raise kaitaistruct.ConsistencyError(u"f_constant_color", len(self.f_constant_color), 4)
+            for i in range(len(self.f_constant_color)):
+                pass
+
+            if (len(self.f_roughness_rgb) != 3):
+                raise kaitaistruct.ConsistencyError(u"f_roughness_rgb", len(self.f_roughness_rgb), 3)
+            for i in range(len(self.f_roughness_rgb)):
+                pass
+
+            if (len(self.f_anisotoropic_direction) != 3):
+                raise kaitaistruct.ConsistencyError(u"f_anisotoropic_direction", len(self.f_anisotoropic_direction), 3)
+            for i in range(len(self.f_anisotoropic_direction)):
+                pass
+
+            if (len(self.f_anistropic_uv) != 2):
+                raise kaitaistruct.ConsistencyError(u"f_anistropic_uv", len(self.f_anistropic_uv), 2)
+            for i in range(len(self.f_anistropic_uv)):
+                pass
+
+            if (len(self.f_primary_color) != 4):
+                raise kaitaistruct.ConsistencyError(u"f_primary_color", len(self.f_primary_color), 4)
+            for i in range(len(self.f_primary_color)):
+                pass
+
+            if (len(self.f_secondary_color) != 4):
+                raise kaitaistruct.ConsistencyError(u"f_secondary_color", len(self.f_secondary_color), 4)
+            for i in range(len(self.f_secondary_color)):
+                pass
+
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 288
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
 
     class StrCbBaAlphaClip(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
@@ -3477,7 +3968,7 @@ class Mrl(ReadWriteKaitaiStruct):
         def _write__seq(self, io=None):
             super(Mrl.ShaderObject, self)._write__seq(io)
             self._io.write_bits_int_le(12, self.index)
-            self._io.write_bits_int_le(20, self.name_hash.value)
+            self._io.write_bits_int_le(20, int(self.name_hash))
 
 
         def _check(self):
@@ -3489,735 +3980,239 @@ class Mrl(ReadWriteKaitaiStruct):
             self._io = _io
             self._parent = _parent
             self._root = _root
+            self._should_write_app_specific = False
+            self.app_specific__to_write = True
 
         def _read(self):
-            self.f_alpha_clip_threshold = self._io.read_f4le()
-            self.f_albedo_color = []
+            pass
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.app_specific
+            _on = self._root.app_id
+            if _on == u"re1":
+                pass
+                self.app_specific._fetch_instances()
+            elif _on == u"rev1":
+                pass
+                self.app_specific._fetch_instances()
+            elif _on == u"re0":
+                pass
+                self.app_specific._fetch_instances()
+            elif _on == u"rev2":
+                pass
+                self.app_specific._fetch_instances()
+            else:
+                pass
+                self.app_specific._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbGlobals, self)._write__seq(io)
+            self._should_write_app_specific = self.app_specific__to_write
+
+
+        def _check(self):
+            pass
+
+        @property
+        def app_specific(self):
+            if self._should_write_app_specific:
+                self._write_app_specific()
+            if hasattr(self, '_m_app_specific'):
+                return self._m_app_specific
+
+            _pos = self._io.pos()
+            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
+            _on = self._root.app_id
+            if _on == u"re1":
+                pass
+                self._m_app_specific = Mrl.CbGlobals1(self._io, self, self._root)
+                self._m_app_specific._read()
+            elif _on == u"rev1":
+                pass
+                self._m_app_specific = Mrl.CbGlobals1(self._io, self, self._root)
+                self._m_app_specific._read()
+            elif _on == u"re0":
+                pass
+                self._m_app_specific = Mrl.CbGlobals1(self._io, self, self._root)
+                self._m_app_specific._read()
+            elif _on == u"rev2":
+                pass
+                self._m_app_specific = Mrl.CbGlobals2(self._io, self, self._root)
+                self._m_app_specific._read()
+            else:
+                pass
+                self._m_app_specific = Mrl.CbGlobals1(self._io, self, self._root)
+                self._m_app_specific._read()
+            self._io.seek(_pos)
+            return getattr(self, '_m_app_specific', None)
+
+        @app_specific.setter
+        def app_specific(self, v):
+            self._m_app_specific = v
+
+        def _write_app_specific(self):
+            self._should_write_app_specific = False
+            _pos = self._io.pos()
+            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
+            _on = self._root.app_id
+            if _on == u"re1":
+                pass
+                self.app_specific._write__seq(self._io)
+            elif _on == u"rev1":
+                pass
+                self.app_specific._write__seq(self._io)
+            elif _on == u"re0":
+                pass
+                self.app_specific._write__seq(self._io)
+            elif _on == u"rev2":
+                pass
+                self.app_specific._write__seq(self._io)
+            else:
+                pass
+                self.app_specific._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+        def _check_app_specific(self):
+            pass
+            _on = self._root.app_id
+            if _on == u"re1":
+                pass
+                if self.app_specific._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
+                if self.app_specific._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
+            elif _on == u"rev1":
+                pass
+                if self.app_specific._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
+                if self.app_specific._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
+            elif _on == u"re0":
+                pass
+                if self.app_specific._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
+                if self.app_specific._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
+            elif _on == u"rev2":
+                pass
+                if self.app_specific._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
+                if self.app_specific._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
+            else:
+                pass
+                if self.app_specific._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
+                if self.app_specific._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
+
+
+    class CbMaterial1(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.f_diffuse_color = []
             for i in range(3):
-                self.f_albedo_color.append(self._io.read_f4le())
+                self.f_diffuse_color.append(self._io.read_f4le())
 
-            self.f_albedo_blend_color = []
-            for i in range(4):
-                self.f_albedo_blend_color.append(self._io.read_f4le())
-
-            self.f_detail_normal_power = self._io.read_f4le()
-            self.f_detail_normal_uv_scale = self._io.read_f4le()
-            self.f_detail_normal2_power = self._io.read_f4le()
-            self.f_detail_normal2_uv_scale = self._io.read_f4le()
-            self.f_primary_shift = self._io.read_f4le()
-            self.f_secondary_shift = self._io.read_f4le()
-            self.f_parallax_factor = self._io.read_f4le()
-            self.f_parallax_self_occlusion = self._io.read_f4le()
-            self.f_parallax_min_sample = self._io.read_f4le()
-            self.f_parallax_max_sample = []
+            self.f_transparency = self._io.read_f4le()
+            self.f_reflective_color = []
             for i in range(3):
-                self.f_parallax_max_sample.append(self._io.read_f4le())
+                self.f_reflective_color.append(self._io.read_f4le())
 
-            self.f_light_map_color = []
-            for i in range(4):
-                self.f_light_map_color.append(self._io.read_f4le())
+            self.f_transparency_volume = self._io.read_f4le()
+            self.f_uv_transform = []
+            for i in range(8):
+                self.f_uv_transform.append(self._io.read_f4le())
 
-            self.f_thin_map_color = []
-            for i in range(3):
-                self.f_thin_map_color.append(self._io.read_f4le())
+            self.f_uv_transform2 = []
+            for i in range(8):
+                self.f_uv_transform2.append(self._io.read_f4le())
 
-            self.f_thin_scattering = self._io.read_f4le()
-            self.f_screen_uv_scale = []
-            for i in range(2):
-                self.f_screen_uv_scale.append(self._io.read_f4le())
-
-            self.f_screen_uv_offset = []
-            for i in range(2):
-                self.f_screen_uv_offset.append(self._io.read_f4le())
-
-            self.f_indirect_offset = []
-            for i in range(2):
-                self.f_indirect_offset.append(self._io.read_f4le())
-
-            self.f_indirect_scale = []
-            for i in range(2):
-                self.f_indirect_scale.append(self._io.read_f4le())
-
-            self.f_fresnel_schlick = self._io.read_f4le()
-            self.f_fresnel_schlick_rgb = []
-            for i in range(3):
-                self.f_fresnel_schlick_rgb.append(self._io.read_f4le())
-
-            self.f_specular_color = []
-            for i in range(3):
-                self.f_specular_color.append(self._io.read_f4le())
-
-            self.f_shininess = self._io.read_f4le()
-            self.f_emission_color = []
-            for i in range(3):
-                self.f_emission_color.append(self._io.read_f4le())
-
-            self.f_emission_threshold = self._io.read_f4le()
-            self.f_constant_color = []
-            for i in range(4):
-                self.f_constant_color.append(self._io.read_f4le())
-
-            self.f_roughness = self._io.read_f4le()
-            self.f_roughness_rgb = []
-            for i in range(3):
-                self.f_roughness_rgb.append(self._io.read_f4le())
-
-            self.f_anisotoropic_direction = []
-            for i in range(3):
-                self.f_anisotoropic_direction.append(self._io.read_f4le())
-
-            self.f_smoothness = self._io.read_f4le()
-            self.f_anistropic_uv = []
-            for i in range(2):
-                self.f_anistropic_uv.append(self._io.read_f4le())
-
-            self.f_primary_expo = self._io.read_f4le()
-            self.f_secondary_expo = self._io.read_f4le()
-            self.f_primary_color = []
-            for i in range(4):
-                self.f_primary_color.append(self._io.read_f4le())
-
-            self.f_secondary_color = []
-            for i in range(4):
-                self.f_secondary_color.append(self._io.read_f4le())
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                self.f_albedo_color2 = []
-                for i in range(4):
-                    self.f_albedo_color2.append(self._io.read_f4le())
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                self.f_specular_color2 = []
-                for i in range(3):
-                    self.f_specular_color2.append(self._io.read_f4le())
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                self.f_fresnel_schlick2 = self._io.read_f4le()
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                self.f_shininess2 = []
-                for i in range(4):
-                    self.f_shininess2.append(self._io.read_f4le())
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                self.f_transparency_clip_threshold = []
-                for i in range(4):
-                    self.f_transparency_clip_threshold.append(self._io.read_f4le())
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                self.f_blend_uv = self._io.read_f4le()
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                self.f_normal_power = []
-                for i in range(3):
-                    self.f_normal_power.append(self._io.read_f4le())
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                self.f_albedo_blend2_color = []
-                for i in range(4):
-                    self.f_albedo_blend2_color.append(self._io.read_f4le())
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                self.f_detail_normal_u_v_scale = []
-                for i in range(2):
-                    self.f_detail_normal_u_v_scale.append(self._io.read_f4le())
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                self.f_fresnel_legacy = []
-                for i in range(2):
-                    self.f_fresnel_legacy.append(self._io.read_f4le())
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                self.f_normal_mask_pow0 = []
-                for i in range(4):
-                    self.f_normal_mask_pow0.append(self._io.read_f4le())
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                self.f_normal_mask_pow1 = []
-                for i in range(4):
-                    self.f_normal_mask_pow1.append(self._io.read_f4le())
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                self.f_normal_mask_pow2 = []
-                for i in range(4):
-                    self.f_normal_mask_pow2.append(self._io.read_f4le())
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                self.f_texture_blend_rate = []
-                for i in range(4):
-                    self.f_texture_blend_rate.append(self._io.read_f4le())
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                self.f_texture_blend_color = []
-                for i in range(4):
-                    self.f_texture_blend_color.append(self._io.read_f4le())
-
+            self.f_uv_transform3 = []
+            for i in range(8):
+                self.f_uv_transform3.append(self._io.read_f4le())
 
 
 
         def _fetch_instances(self):
             pass
-            for i in range(len(self.f_albedo_color)):
+            for i in range(len(self.f_diffuse_color)):
                 pass
 
-            for i in range(len(self.f_albedo_blend_color)):
+            for i in range(len(self.f_reflective_color)):
                 pass
 
-            for i in range(len(self.f_parallax_max_sample)):
+            for i in range(len(self.f_uv_transform)):
                 pass
 
-            for i in range(len(self.f_light_map_color)):
+            for i in range(len(self.f_uv_transform2)):
                 pass
 
-            for i in range(len(self.f_thin_map_color)):
+            for i in range(len(self.f_uv_transform3)):
                 pass
-
-            for i in range(len(self.f_screen_uv_scale)):
-                pass
-
-            for i in range(len(self.f_screen_uv_offset)):
-                pass
-
-            for i in range(len(self.f_indirect_offset)):
-                pass
-
-            for i in range(len(self.f_indirect_scale)):
-                pass
-
-            for i in range(len(self.f_fresnel_schlick_rgb)):
-                pass
-
-            for i in range(len(self.f_specular_color)):
-                pass
-
-            for i in range(len(self.f_emission_color)):
-                pass
-
-            for i in range(len(self.f_constant_color)):
-                pass
-
-            for i in range(len(self.f_roughness_rgb)):
-                pass
-
-            for i in range(len(self.f_anisotoropic_direction)):
-                pass
-
-            for i in range(len(self.f_anistropic_uv)):
-                pass
-
-            for i in range(len(self.f_primary_color)):
-                pass
-
-            for i in range(len(self.f_secondary_color)):
-                pass
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_albedo_color2)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_specular_color2)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_shininess2)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_transparency_clip_threshold)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_normal_power)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_albedo_blend2_color)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_detail_normal_u_v_scale)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_fresnel_legacy)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_normal_mask_pow0)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_normal_mask_pow1)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_normal_mask_pow2)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_texture_blend_rate)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_texture_blend_color)):
-                    pass
-
 
 
 
         def _write__seq(self, io=None):
-            super(Mrl.CbGlobals, self)._write__seq(io)
-            self._io.write_f4le(self.f_alpha_clip_threshold)
-            for i in range(len(self.f_albedo_color)):
+            super(Mrl.CbMaterial1, self)._write__seq(io)
+            for i in range(len(self.f_diffuse_color)):
                 pass
-                self._io.write_f4le(self.f_albedo_color[i])
+                self._io.write_f4le(self.f_diffuse_color[i])
 
-            for i in range(len(self.f_albedo_blend_color)):
+            self._io.write_f4le(self.f_transparency)
+            for i in range(len(self.f_reflective_color)):
                 pass
-                self._io.write_f4le(self.f_albedo_blend_color[i])
+                self._io.write_f4le(self.f_reflective_color[i])
 
-            self._io.write_f4le(self.f_detail_normal_power)
-            self._io.write_f4le(self.f_detail_normal_uv_scale)
-            self._io.write_f4le(self.f_detail_normal2_power)
-            self._io.write_f4le(self.f_detail_normal2_uv_scale)
-            self._io.write_f4le(self.f_primary_shift)
-            self._io.write_f4le(self.f_secondary_shift)
-            self._io.write_f4le(self.f_parallax_factor)
-            self._io.write_f4le(self.f_parallax_self_occlusion)
-            self._io.write_f4le(self.f_parallax_min_sample)
-            for i in range(len(self.f_parallax_max_sample)):
+            self._io.write_f4le(self.f_transparency_volume)
+            for i in range(len(self.f_uv_transform)):
                 pass
-                self._io.write_f4le(self.f_parallax_max_sample[i])
+                self._io.write_f4le(self.f_uv_transform[i])
 
-            for i in range(len(self.f_light_map_color)):
+            for i in range(len(self.f_uv_transform2)):
                 pass
-                self._io.write_f4le(self.f_light_map_color[i])
+                self._io.write_f4le(self.f_uv_transform2[i])
 
-            for i in range(len(self.f_thin_map_color)):
+            for i in range(len(self.f_uv_transform3)):
                 pass
-                self._io.write_f4le(self.f_thin_map_color[i])
-
-            self._io.write_f4le(self.f_thin_scattering)
-            for i in range(len(self.f_screen_uv_scale)):
-                pass
-                self._io.write_f4le(self.f_screen_uv_scale[i])
-
-            for i in range(len(self.f_screen_uv_offset)):
-                pass
-                self._io.write_f4le(self.f_screen_uv_offset[i])
-
-            for i in range(len(self.f_indirect_offset)):
-                pass
-                self._io.write_f4le(self.f_indirect_offset[i])
-
-            for i in range(len(self.f_indirect_scale)):
-                pass
-                self._io.write_f4le(self.f_indirect_scale[i])
-
-            self._io.write_f4le(self.f_fresnel_schlick)
-            for i in range(len(self.f_fresnel_schlick_rgb)):
-                pass
-                self._io.write_f4le(self.f_fresnel_schlick_rgb[i])
-
-            for i in range(len(self.f_specular_color)):
-                pass
-                self._io.write_f4le(self.f_specular_color[i])
-
-            self._io.write_f4le(self.f_shininess)
-            for i in range(len(self.f_emission_color)):
-                pass
-                self._io.write_f4le(self.f_emission_color[i])
-
-            self._io.write_f4le(self.f_emission_threshold)
-            for i in range(len(self.f_constant_color)):
-                pass
-                self._io.write_f4le(self.f_constant_color[i])
-
-            self._io.write_f4le(self.f_roughness)
-            for i in range(len(self.f_roughness_rgb)):
-                pass
-                self._io.write_f4le(self.f_roughness_rgb[i])
-
-            for i in range(len(self.f_anisotoropic_direction)):
-                pass
-                self._io.write_f4le(self.f_anisotoropic_direction[i])
-
-            self._io.write_f4le(self.f_smoothness)
-            for i in range(len(self.f_anistropic_uv)):
-                pass
-                self._io.write_f4le(self.f_anistropic_uv[i])
-
-            self._io.write_f4le(self.f_primary_expo)
-            self._io.write_f4le(self.f_secondary_expo)
-            for i in range(len(self.f_primary_color)):
-                pass
-                self._io.write_f4le(self.f_primary_color[i])
-
-            for i in range(len(self.f_secondary_color)):
-                pass
-                self._io.write_f4le(self.f_secondary_color[i])
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_albedo_color2)):
-                    pass
-                    self._io.write_f4le(self.f_albedo_color2[i])
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_specular_color2)):
-                    pass
-                    self._io.write_f4le(self.f_specular_color2[i])
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                self._io.write_f4le(self.f_fresnel_schlick2)
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_shininess2)):
-                    pass
-                    self._io.write_f4le(self.f_shininess2[i])
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_transparency_clip_threshold)):
-                    pass
-                    self._io.write_f4le(self.f_transparency_clip_threshold[i])
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                self._io.write_f4le(self.f_blend_uv)
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_normal_power)):
-                    pass
-                    self._io.write_f4le(self.f_normal_power[i])
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_albedo_blend2_color)):
-                    pass
-                    self._io.write_f4le(self.f_albedo_blend2_color[i])
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_detail_normal_u_v_scale)):
-                    pass
-                    self._io.write_f4le(self.f_detail_normal_u_v_scale[i])
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_fresnel_legacy)):
-                    pass
-                    self._io.write_f4le(self.f_fresnel_legacy[i])
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_normal_mask_pow0)):
-                    pass
-                    self._io.write_f4le(self.f_normal_mask_pow0[i])
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_normal_mask_pow1)):
-                    pass
-                    self._io.write_f4le(self.f_normal_mask_pow1[i])
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_normal_mask_pow2)):
-                    pass
-                    self._io.write_f4le(self.f_normal_mask_pow2[i])
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_texture_blend_rate)):
-                    pass
-                    self._io.write_f4le(self.f_texture_blend_rate[i])
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                for i in range(len(self.f_texture_blend_color)):
-                    pass
-                    self._io.write_f4le(self.f_texture_blend_color[i])
-
+                self._io.write_f4le(self.f_uv_transform3[i])
 
 
 
         def _check(self):
             pass
-            if (len(self.f_albedo_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_albedo_color", len(self.f_albedo_color), 3)
-            for i in range(len(self.f_albedo_color)):
+            if (len(self.f_diffuse_color) != 3):
+                raise kaitaistruct.ConsistencyError(u"f_diffuse_color", len(self.f_diffuse_color), 3)
+            for i in range(len(self.f_diffuse_color)):
                 pass
 
-            if (len(self.f_albedo_blend_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_albedo_blend_color", len(self.f_albedo_blend_color), 4)
-            for i in range(len(self.f_albedo_blend_color)):
+            if (len(self.f_reflective_color) != 3):
+                raise kaitaistruct.ConsistencyError(u"f_reflective_color", len(self.f_reflective_color), 3)
+            for i in range(len(self.f_reflective_color)):
                 pass
 
-            if (len(self.f_parallax_max_sample) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_parallax_max_sample", len(self.f_parallax_max_sample), 3)
-            for i in range(len(self.f_parallax_max_sample)):
+            if (len(self.f_uv_transform) != 8):
+                raise kaitaistruct.ConsistencyError(u"f_uv_transform", len(self.f_uv_transform), 8)
+            for i in range(len(self.f_uv_transform)):
                 pass
 
-            if (len(self.f_light_map_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_light_map_color", len(self.f_light_map_color), 4)
-            for i in range(len(self.f_light_map_color)):
+            if (len(self.f_uv_transform2) != 8):
+                raise kaitaistruct.ConsistencyError(u"f_uv_transform2", len(self.f_uv_transform2), 8)
+            for i in range(len(self.f_uv_transform2)):
                 pass
 
-            if (len(self.f_thin_map_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_thin_map_color", len(self.f_thin_map_color), 3)
-            for i in range(len(self.f_thin_map_color)):
+            if (len(self.f_uv_transform3) != 8):
+                raise kaitaistruct.ConsistencyError(u"f_uv_transform3", len(self.f_uv_transform3), 8)
+            for i in range(len(self.f_uv_transform3)):
                 pass
-
-            if (len(self.f_screen_uv_scale) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_screen_uv_scale", len(self.f_screen_uv_scale), 2)
-            for i in range(len(self.f_screen_uv_scale)):
-                pass
-
-            if (len(self.f_screen_uv_offset) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_screen_uv_offset", len(self.f_screen_uv_offset), 2)
-            for i in range(len(self.f_screen_uv_offset)):
-                pass
-
-            if (len(self.f_indirect_offset) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_indirect_offset", len(self.f_indirect_offset), 2)
-            for i in range(len(self.f_indirect_offset)):
-                pass
-
-            if (len(self.f_indirect_scale) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_indirect_scale", len(self.f_indirect_scale), 2)
-            for i in range(len(self.f_indirect_scale)):
-                pass
-
-            if (len(self.f_fresnel_schlick_rgb) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_fresnel_schlick_rgb", len(self.f_fresnel_schlick_rgb), 3)
-            for i in range(len(self.f_fresnel_schlick_rgb)):
-                pass
-
-            if (len(self.f_specular_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_specular_color", len(self.f_specular_color), 3)
-            for i in range(len(self.f_specular_color)):
-                pass
-
-            if (len(self.f_emission_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_emission_color", len(self.f_emission_color), 3)
-            for i in range(len(self.f_emission_color)):
-                pass
-
-            if (len(self.f_constant_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_constant_color", len(self.f_constant_color), 4)
-            for i in range(len(self.f_constant_color)):
-                pass
-
-            if (len(self.f_roughness_rgb) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_roughness_rgb", len(self.f_roughness_rgb), 3)
-            for i in range(len(self.f_roughness_rgb)):
-                pass
-
-            if (len(self.f_anisotoropic_direction) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_anisotoropic_direction", len(self.f_anisotoropic_direction), 3)
-            for i in range(len(self.f_anisotoropic_direction)):
-                pass
-
-            if (len(self.f_anistropic_uv) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_anistropic_uv", len(self.f_anistropic_uv), 2)
-            for i in range(len(self.f_anistropic_uv)):
-                pass
-
-            if (len(self.f_primary_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_primary_color", len(self.f_primary_color), 4)
-            for i in range(len(self.f_primary_color)):
-                pass
-
-            if (len(self.f_secondary_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_secondary_color", len(self.f_secondary_color), 4)
-            for i in range(len(self.f_secondary_color)):
-                pass
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                if (len(self.f_albedo_color2) != 4):
-                    raise kaitaistruct.ConsistencyError(u"f_albedo_color2", len(self.f_albedo_color2), 4)
-                for i in range(len(self.f_albedo_color2)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                if (len(self.f_specular_color2) != 3):
-                    raise kaitaistruct.ConsistencyError(u"f_specular_color2", len(self.f_specular_color2), 3)
-                for i in range(len(self.f_specular_color2)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                if (len(self.f_shininess2) != 4):
-                    raise kaitaistruct.ConsistencyError(u"f_shininess2", len(self.f_shininess2), 4)
-                for i in range(len(self.f_shininess2)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                if (len(self.f_transparency_clip_threshold) != 4):
-                    raise kaitaistruct.ConsistencyError(u"f_transparency_clip_threshold", len(self.f_transparency_clip_threshold), 4)
-                for i in range(len(self.f_transparency_clip_threshold)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                if (len(self.f_normal_power) != 3):
-                    raise kaitaistruct.ConsistencyError(u"f_normal_power", len(self.f_normal_power), 3)
-                for i in range(len(self.f_normal_power)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                if (len(self.f_albedo_blend2_color) != 4):
-                    raise kaitaistruct.ConsistencyError(u"f_albedo_blend2_color", len(self.f_albedo_blend2_color), 4)
-                for i in range(len(self.f_albedo_blend2_color)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                if (len(self.f_detail_normal_u_v_scale) != 2):
-                    raise kaitaistruct.ConsistencyError(u"f_detail_normal_u_v_scale", len(self.f_detail_normal_u_v_scale), 2)
-                for i in range(len(self.f_detail_normal_u_v_scale)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                if (len(self.f_fresnel_legacy) != 2):
-                    raise kaitaistruct.ConsistencyError(u"f_fresnel_legacy", len(self.f_fresnel_legacy), 2)
-                for i in range(len(self.f_fresnel_legacy)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                if (len(self.f_normal_mask_pow0) != 4):
-                    raise kaitaistruct.ConsistencyError(u"f_normal_mask_pow0", len(self.f_normal_mask_pow0), 4)
-                for i in range(len(self.f_normal_mask_pow0)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                if (len(self.f_normal_mask_pow1) != 4):
-                    raise kaitaistruct.ConsistencyError(u"f_normal_mask_pow1", len(self.f_normal_mask_pow1), 4)
-                for i in range(len(self.f_normal_mask_pow1)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                if (len(self.f_normal_mask_pow2) != 4):
-                    raise kaitaistruct.ConsistencyError(u"f_normal_mask_pow2", len(self.f_normal_mask_pow2), 4)
-                for i in range(len(self.f_normal_mask_pow2)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                if (len(self.f_texture_blend_rate) != 4):
-                    raise kaitaistruct.ConsistencyError(u"f_texture_blend_rate", len(self.f_texture_blend_rate), 4)
-                for i in range(len(self.f_texture_blend_rate)):
-                    pass
-
-
-            if (self._root.cb_globals_version == 2):
-                pass
-                if (len(self.f_texture_blend_color) != 4):
-                    raise kaitaistruct.ConsistencyError(u"f_texture_blend_color", len(self.f_texture_blend_color), 4)
-                for i in range(len(self.f_texture_blend_color)):
-                    pass
-
 
 
         @property
@@ -4225,7 +4220,7 @@ class Mrl(ReadWriteKaitaiStruct):
             if hasattr(self, '_m_size_'):
                 return self._m_size_
 
-            self._m_size_ = (480 if (self._root.cb_globals_version == 2) else 288)
+            self._m_size_ = 128
             return getattr(self, '_m_size_', None)
 
         def _invalidate_size_(self):
@@ -4527,121 +4522,6 @@ class Mrl(ReadWriteKaitaiStruct):
             pass
 
 
-    class StrCbMaterial(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.f_diffuse_color = []
-            for i in range(3):
-                self.f_diffuse_color.append(self._io.read_f4le())
-
-            self.f_transparency = self._io.read_f4le()
-            self.f_reflective_color = []
-            for i in range(3):
-                self.f_reflective_color.append(self._io.read_f4le())
-
-            self.f_transparency_volume = self._io.read_f4le()
-            self.f_uv_transform = []
-            for i in range(8):
-                self.f_uv_transform.append(self._io.read_f4le())
-
-            self.f_uv_transform2 = []
-            for i in range(8):
-                self.f_uv_transform2.append(self._io.read_f4le())
-
-            self.f_uv_transform3 = []
-            for i in range(8):
-                self.f_uv_transform3.append(self._io.read_f4le())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.f_diffuse_color)):
-                pass
-
-            for i in range(len(self.f_reflective_color)):
-                pass
-
-            for i in range(len(self.f_uv_transform)):
-                pass
-
-            for i in range(len(self.f_uv_transform2)):
-                pass
-
-            for i in range(len(self.f_uv_transform3)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.StrCbMaterial, self)._write__seq(io)
-            for i in range(len(self.f_diffuse_color)):
-                pass
-                self._io.write_f4le(self.f_diffuse_color[i])
-
-            self._io.write_f4le(self.f_transparency)
-            for i in range(len(self.f_reflective_color)):
-                pass
-                self._io.write_f4le(self.f_reflective_color[i])
-
-            self._io.write_f4le(self.f_transparency_volume)
-            for i in range(len(self.f_uv_transform)):
-                pass
-                self._io.write_f4le(self.f_uv_transform[i])
-
-            for i in range(len(self.f_uv_transform2)):
-                pass
-                self._io.write_f4le(self.f_uv_transform2[i])
-
-            for i in range(len(self.f_uv_transform3)):
-                pass
-                self._io.write_f4le(self.f_uv_transform3[i])
-
-
-
-        def _check(self):
-            pass
-            if (len(self.f_diffuse_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_diffuse_color", len(self.f_diffuse_color), 3)
-            for i in range(len(self.f_diffuse_color)):
-                pass
-
-            if (len(self.f_reflective_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_reflective_color", len(self.f_reflective_color), 3)
-            for i in range(len(self.f_reflective_color)):
-                pass
-
-            if (len(self.f_uv_transform) != 8):
-                raise kaitaistruct.ConsistencyError(u"f_uv_transform", len(self.f_uv_transform), 8)
-            for i in range(len(self.f_uv_transform)):
-                pass
-
-            if (len(self.f_uv_transform2) != 8):
-                raise kaitaistruct.ConsistencyError(u"f_uv_transform2", len(self.f_uv_transform2), 8)
-            for i in range(len(self.f_uv_transform2)):
-                pass
-
-            if (len(self.f_uv_transform3) != 8):
-                raise kaitaistruct.ConsistencyError(u"f_uv_transform3", len(self.f_uv_transform3), 8)
-            for i in range(len(self.f_uv_transform3)):
-                pass
-
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 128
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
     class TextureSlot(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
             self._io = _io
@@ -4668,7 +4548,7 @@ class Mrl(ReadWriteKaitaiStruct):
 
         def _write__seq(self, io=None):
             super(Mrl.TextureSlot, self)._write__seq(io)
-            self._io.write_u4le(self.type_hash.value)
+            self._io.write_u4le(int(self.type_hash))
             self._io.write_u4le(self.unk_02)
             self._io.write_u4le(self.unk_03)
             self._io.write_bytes((self.texture_path).encode(u"ASCII"))
@@ -5382,6 +5262,573 @@ class Mrl(ReadWriteKaitaiStruct):
 
 
 
+    class CbGlobals2(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.f_alpha_clip_threshold = self._io.read_f4le()
+            self.f_albedo_color = []
+            for i in range(3):
+                self.f_albedo_color.append(self._io.read_f4le())
+
+            self.f_albedo_blend_color = []
+            for i in range(4):
+                self.f_albedo_blend_color.append(self._io.read_f4le())
+
+            self.f_detail_normal_power = self._io.read_f4le()
+            self.f_detail_normal_uv_scale = self._io.read_f4le()
+            self.f_detail_normal2_power = self._io.read_f4le()
+            self.f_detail_normal2_uv_scale = self._io.read_f4le()
+            self.f_primary_shift = self._io.read_f4le()
+            self.f_secondary_shift = self._io.read_f4le()
+            self.f_parallax_factor = self._io.read_f4le()
+            self.f_parallax_self_occlusion = self._io.read_f4le()
+            self.f_parallax_min_sample = self._io.read_f4le()
+            self.f_parallax_max_sample = []
+            for i in range(3):
+                self.f_parallax_max_sample.append(self._io.read_f4le())
+
+            self.f_light_map_color = []
+            for i in range(4):
+                self.f_light_map_color.append(self._io.read_f4le())
+
+            self.f_thin_map_color = []
+            for i in range(3):
+                self.f_thin_map_color.append(self._io.read_f4le())
+
+            self.f_thin_scattering = self._io.read_f4le()
+            self.f_screen_uv_scale = []
+            for i in range(2):
+                self.f_screen_uv_scale.append(self._io.read_f4le())
+
+            self.f_screen_uv_offset = []
+            for i in range(2):
+                self.f_screen_uv_offset.append(self._io.read_f4le())
+
+            self.f_indirect_offset = []
+            for i in range(2):
+                self.f_indirect_offset.append(self._io.read_f4le())
+
+            self.f_indirect_scale = []
+            for i in range(2):
+                self.f_indirect_scale.append(self._io.read_f4le())
+
+            self.f_fresnel_schlick = self._io.read_f4le()
+            self.f_fresnel_schlick_rgb = []
+            for i in range(3):
+                self.f_fresnel_schlick_rgb.append(self._io.read_f4le())
+
+            self.f_specular_color = []
+            for i in range(3):
+                self.f_specular_color.append(self._io.read_f4le())
+
+            self.f_shininess = self._io.read_f4le()
+            self.f_emission_color = []
+            for i in range(3):
+                self.f_emission_color.append(self._io.read_f4le())
+
+            self.f_emission_threshold = self._io.read_f4le()
+            self.f_constant_color = []
+            for i in range(4):
+                self.f_constant_color.append(self._io.read_f4le())
+
+            self.f_roughness = self._io.read_f4le()
+            self.f_roughness_rgb = []
+            for i in range(3):
+                self.f_roughness_rgb.append(self._io.read_f4le())
+
+            self.f_anisotoropic_direction = []
+            for i in range(3):
+                self.f_anisotoropic_direction.append(self._io.read_f4le())
+
+            self.f_smoothness = self._io.read_f4le()
+            self.f_anistropic_uv = []
+            for i in range(2):
+                self.f_anistropic_uv.append(self._io.read_f4le())
+
+            self.f_primary_expo = self._io.read_f4le()
+            self.f_secondary_expo = self._io.read_f4le()
+            self.f_primary_color = []
+            for i in range(4):
+                self.f_primary_color.append(self._io.read_f4le())
+
+            self.f_secondary_color = []
+            for i in range(4):
+                self.f_secondary_color.append(self._io.read_f4le())
+
+            self.f_albedo_color2 = []
+            for i in range(4):
+                self.f_albedo_color2.append(self._io.read_f4le())
+
+            self.f_specular_color2 = []
+            for i in range(3):
+                self.f_specular_color2.append(self._io.read_f4le())
+
+            self.f_fresnel_schlick2 = self._io.read_f4le()
+            self.f_shininess2 = []
+            for i in range(4):
+                self.f_shininess2.append(self._io.read_f4le())
+
+            self.f_transparency_clip_threshold = []
+            for i in range(4):
+                self.f_transparency_clip_threshold.append(self._io.read_f4le())
+
+            self.f_blend_uv = self._io.read_f4le()
+            self.f_normal_power = []
+            for i in range(3):
+                self.f_normal_power.append(self._io.read_f4le())
+
+            self.f_albedo_blend2_color = []
+            for i in range(4):
+                self.f_albedo_blend2_color.append(self._io.read_f4le())
+
+            self.f_detail_normal_u_v_scale = []
+            for i in range(2):
+                self.f_detail_normal_u_v_scale.append(self._io.read_f4le())
+
+            self.f_fresnel_legacy = []
+            for i in range(2):
+                self.f_fresnel_legacy.append(self._io.read_f4le())
+
+            self.f_normal_mask_pow0 = []
+            for i in range(4):
+                self.f_normal_mask_pow0.append(self._io.read_f4le())
+
+            self.f_normal_mask_pow1 = []
+            for i in range(4):
+                self.f_normal_mask_pow1.append(self._io.read_f4le())
+
+            self.f_normal_mask_pow2 = []
+            for i in range(4):
+                self.f_normal_mask_pow2.append(self._io.read_f4le())
+
+            self.f_texture_blend_rate = []
+            for i in range(4):
+                self.f_texture_blend_rate.append(self._io.read_f4le())
+
+            self.f_texture_blend_color = []
+            for i in range(4):
+                self.f_texture_blend_color.append(self._io.read_f4le())
+
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.f_albedo_color)):
+                pass
+
+            for i in range(len(self.f_albedo_blend_color)):
+                pass
+
+            for i in range(len(self.f_parallax_max_sample)):
+                pass
+
+            for i in range(len(self.f_light_map_color)):
+                pass
+
+            for i in range(len(self.f_thin_map_color)):
+                pass
+
+            for i in range(len(self.f_screen_uv_scale)):
+                pass
+
+            for i in range(len(self.f_screen_uv_offset)):
+                pass
+
+            for i in range(len(self.f_indirect_offset)):
+                pass
+
+            for i in range(len(self.f_indirect_scale)):
+                pass
+
+            for i in range(len(self.f_fresnel_schlick_rgb)):
+                pass
+
+            for i in range(len(self.f_specular_color)):
+                pass
+
+            for i in range(len(self.f_emission_color)):
+                pass
+
+            for i in range(len(self.f_constant_color)):
+                pass
+
+            for i in range(len(self.f_roughness_rgb)):
+                pass
+
+            for i in range(len(self.f_anisotoropic_direction)):
+                pass
+
+            for i in range(len(self.f_anistropic_uv)):
+                pass
+
+            for i in range(len(self.f_primary_color)):
+                pass
+
+            for i in range(len(self.f_secondary_color)):
+                pass
+
+            for i in range(len(self.f_albedo_color2)):
+                pass
+
+            for i in range(len(self.f_specular_color2)):
+                pass
+
+            for i in range(len(self.f_shininess2)):
+                pass
+
+            for i in range(len(self.f_transparency_clip_threshold)):
+                pass
+
+            for i in range(len(self.f_normal_power)):
+                pass
+
+            for i in range(len(self.f_albedo_blend2_color)):
+                pass
+
+            for i in range(len(self.f_detail_normal_u_v_scale)):
+                pass
+
+            for i in range(len(self.f_fresnel_legacy)):
+                pass
+
+            for i in range(len(self.f_normal_mask_pow0)):
+                pass
+
+            for i in range(len(self.f_normal_mask_pow1)):
+                pass
+
+            for i in range(len(self.f_normal_mask_pow2)):
+                pass
+
+            for i in range(len(self.f_texture_blend_rate)):
+                pass
+
+            for i in range(len(self.f_texture_blend_color)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbGlobals2, self)._write__seq(io)
+            self._io.write_f4le(self.f_alpha_clip_threshold)
+            for i in range(len(self.f_albedo_color)):
+                pass
+                self._io.write_f4le(self.f_albedo_color[i])
+
+            for i in range(len(self.f_albedo_blend_color)):
+                pass
+                self._io.write_f4le(self.f_albedo_blend_color[i])
+
+            self._io.write_f4le(self.f_detail_normal_power)
+            self._io.write_f4le(self.f_detail_normal_uv_scale)
+            self._io.write_f4le(self.f_detail_normal2_power)
+            self._io.write_f4le(self.f_detail_normal2_uv_scale)
+            self._io.write_f4le(self.f_primary_shift)
+            self._io.write_f4le(self.f_secondary_shift)
+            self._io.write_f4le(self.f_parallax_factor)
+            self._io.write_f4le(self.f_parallax_self_occlusion)
+            self._io.write_f4le(self.f_parallax_min_sample)
+            for i in range(len(self.f_parallax_max_sample)):
+                pass
+                self._io.write_f4le(self.f_parallax_max_sample[i])
+
+            for i in range(len(self.f_light_map_color)):
+                pass
+                self._io.write_f4le(self.f_light_map_color[i])
+
+            for i in range(len(self.f_thin_map_color)):
+                pass
+                self._io.write_f4le(self.f_thin_map_color[i])
+
+            self._io.write_f4le(self.f_thin_scattering)
+            for i in range(len(self.f_screen_uv_scale)):
+                pass
+                self._io.write_f4le(self.f_screen_uv_scale[i])
+
+            for i in range(len(self.f_screen_uv_offset)):
+                pass
+                self._io.write_f4le(self.f_screen_uv_offset[i])
+
+            for i in range(len(self.f_indirect_offset)):
+                pass
+                self._io.write_f4le(self.f_indirect_offset[i])
+
+            for i in range(len(self.f_indirect_scale)):
+                pass
+                self._io.write_f4le(self.f_indirect_scale[i])
+
+            self._io.write_f4le(self.f_fresnel_schlick)
+            for i in range(len(self.f_fresnel_schlick_rgb)):
+                pass
+                self._io.write_f4le(self.f_fresnel_schlick_rgb[i])
+
+            for i in range(len(self.f_specular_color)):
+                pass
+                self._io.write_f4le(self.f_specular_color[i])
+
+            self._io.write_f4le(self.f_shininess)
+            for i in range(len(self.f_emission_color)):
+                pass
+                self._io.write_f4le(self.f_emission_color[i])
+
+            self._io.write_f4le(self.f_emission_threshold)
+            for i in range(len(self.f_constant_color)):
+                pass
+                self._io.write_f4le(self.f_constant_color[i])
+
+            self._io.write_f4le(self.f_roughness)
+            for i in range(len(self.f_roughness_rgb)):
+                pass
+                self._io.write_f4le(self.f_roughness_rgb[i])
+
+            for i in range(len(self.f_anisotoropic_direction)):
+                pass
+                self._io.write_f4le(self.f_anisotoropic_direction[i])
+
+            self._io.write_f4le(self.f_smoothness)
+            for i in range(len(self.f_anistropic_uv)):
+                pass
+                self._io.write_f4le(self.f_anistropic_uv[i])
+
+            self._io.write_f4le(self.f_primary_expo)
+            self._io.write_f4le(self.f_secondary_expo)
+            for i in range(len(self.f_primary_color)):
+                pass
+                self._io.write_f4le(self.f_primary_color[i])
+
+            for i in range(len(self.f_secondary_color)):
+                pass
+                self._io.write_f4le(self.f_secondary_color[i])
+
+            for i in range(len(self.f_albedo_color2)):
+                pass
+                self._io.write_f4le(self.f_albedo_color2[i])
+
+            for i in range(len(self.f_specular_color2)):
+                pass
+                self._io.write_f4le(self.f_specular_color2[i])
+
+            self._io.write_f4le(self.f_fresnel_schlick2)
+            for i in range(len(self.f_shininess2)):
+                pass
+                self._io.write_f4le(self.f_shininess2[i])
+
+            for i in range(len(self.f_transparency_clip_threshold)):
+                pass
+                self._io.write_f4le(self.f_transparency_clip_threshold[i])
+
+            self._io.write_f4le(self.f_blend_uv)
+            for i in range(len(self.f_normal_power)):
+                pass
+                self._io.write_f4le(self.f_normal_power[i])
+
+            for i in range(len(self.f_albedo_blend2_color)):
+                pass
+                self._io.write_f4le(self.f_albedo_blend2_color[i])
+
+            for i in range(len(self.f_detail_normal_u_v_scale)):
+                pass
+                self._io.write_f4le(self.f_detail_normal_u_v_scale[i])
+
+            for i in range(len(self.f_fresnel_legacy)):
+                pass
+                self._io.write_f4le(self.f_fresnel_legacy[i])
+
+            for i in range(len(self.f_normal_mask_pow0)):
+                pass
+                self._io.write_f4le(self.f_normal_mask_pow0[i])
+
+            for i in range(len(self.f_normal_mask_pow1)):
+                pass
+                self._io.write_f4le(self.f_normal_mask_pow1[i])
+
+            for i in range(len(self.f_normal_mask_pow2)):
+                pass
+                self._io.write_f4le(self.f_normal_mask_pow2[i])
+
+            for i in range(len(self.f_texture_blend_rate)):
+                pass
+                self._io.write_f4le(self.f_texture_blend_rate[i])
+
+            for i in range(len(self.f_texture_blend_color)):
+                pass
+                self._io.write_f4le(self.f_texture_blend_color[i])
+
+
+
+        def _check(self):
+            pass
+            if (len(self.f_albedo_color) != 3):
+                raise kaitaistruct.ConsistencyError(u"f_albedo_color", len(self.f_albedo_color), 3)
+            for i in range(len(self.f_albedo_color)):
+                pass
+
+            if (len(self.f_albedo_blend_color) != 4):
+                raise kaitaistruct.ConsistencyError(u"f_albedo_blend_color", len(self.f_albedo_blend_color), 4)
+            for i in range(len(self.f_albedo_blend_color)):
+                pass
+
+            if (len(self.f_parallax_max_sample) != 3):
+                raise kaitaistruct.ConsistencyError(u"f_parallax_max_sample", len(self.f_parallax_max_sample), 3)
+            for i in range(len(self.f_parallax_max_sample)):
+                pass
+
+            if (len(self.f_light_map_color) != 4):
+                raise kaitaistruct.ConsistencyError(u"f_light_map_color", len(self.f_light_map_color), 4)
+            for i in range(len(self.f_light_map_color)):
+                pass
+
+            if (len(self.f_thin_map_color) != 3):
+                raise kaitaistruct.ConsistencyError(u"f_thin_map_color", len(self.f_thin_map_color), 3)
+            for i in range(len(self.f_thin_map_color)):
+                pass
+
+            if (len(self.f_screen_uv_scale) != 2):
+                raise kaitaistruct.ConsistencyError(u"f_screen_uv_scale", len(self.f_screen_uv_scale), 2)
+            for i in range(len(self.f_screen_uv_scale)):
+                pass
+
+            if (len(self.f_screen_uv_offset) != 2):
+                raise kaitaistruct.ConsistencyError(u"f_screen_uv_offset", len(self.f_screen_uv_offset), 2)
+            for i in range(len(self.f_screen_uv_offset)):
+                pass
+
+            if (len(self.f_indirect_offset) != 2):
+                raise kaitaistruct.ConsistencyError(u"f_indirect_offset", len(self.f_indirect_offset), 2)
+            for i in range(len(self.f_indirect_offset)):
+                pass
+
+            if (len(self.f_indirect_scale) != 2):
+                raise kaitaistruct.ConsistencyError(u"f_indirect_scale", len(self.f_indirect_scale), 2)
+            for i in range(len(self.f_indirect_scale)):
+                pass
+
+            if (len(self.f_fresnel_schlick_rgb) != 3):
+                raise kaitaistruct.ConsistencyError(u"f_fresnel_schlick_rgb", len(self.f_fresnel_schlick_rgb), 3)
+            for i in range(len(self.f_fresnel_schlick_rgb)):
+                pass
+
+            if (len(self.f_specular_color) != 3):
+                raise kaitaistruct.ConsistencyError(u"f_specular_color", len(self.f_specular_color), 3)
+            for i in range(len(self.f_specular_color)):
+                pass
+
+            if (len(self.f_emission_color) != 3):
+                raise kaitaistruct.ConsistencyError(u"f_emission_color", len(self.f_emission_color), 3)
+            for i in range(len(self.f_emission_color)):
+                pass
+
+            if (len(self.f_constant_color) != 4):
+                raise kaitaistruct.ConsistencyError(u"f_constant_color", len(self.f_constant_color), 4)
+            for i in range(len(self.f_constant_color)):
+                pass
+
+            if (len(self.f_roughness_rgb) != 3):
+                raise kaitaistruct.ConsistencyError(u"f_roughness_rgb", len(self.f_roughness_rgb), 3)
+            for i in range(len(self.f_roughness_rgb)):
+                pass
+
+            if (len(self.f_anisotoropic_direction) != 3):
+                raise kaitaistruct.ConsistencyError(u"f_anisotoropic_direction", len(self.f_anisotoropic_direction), 3)
+            for i in range(len(self.f_anisotoropic_direction)):
+                pass
+
+            if (len(self.f_anistropic_uv) != 2):
+                raise kaitaistruct.ConsistencyError(u"f_anistropic_uv", len(self.f_anistropic_uv), 2)
+            for i in range(len(self.f_anistropic_uv)):
+                pass
+
+            if (len(self.f_primary_color) != 4):
+                raise kaitaistruct.ConsistencyError(u"f_primary_color", len(self.f_primary_color), 4)
+            for i in range(len(self.f_primary_color)):
+                pass
+
+            if (len(self.f_secondary_color) != 4):
+                raise kaitaistruct.ConsistencyError(u"f_secondary_color", len(self.f_secondary_color), 4)
+            for i in range(len(self.f_secondary_color)):
+                pass
+
+            if (len(self.f_albedo_color2) != 4):
+                raise kaitaistruct.ConsistencyError(u"f_albedo_color2", len(self.f_albedo_color2), 4)
+            for i in range(len(self.f_albedo_color2)):
+                pass
+
+            if (len(self.f_specular_color2) != 3):
+                raise kaitaistruct.ConsistencyError(u"f_specular_color2", len(self.f_specular_color2), 3)
+            for i in range(len(self.f_specular_color2)):
+                pass
+
+            if (len(self.f_shininess2) != 4):
+                raise kaitaistruct.ConsistencyError(u"f_shininess2", len(self.f_shininess2), 4)
+            for i in range(len(self.f_shininess2)):
+                pass
+
+            if (len(self.f_transparency_clip_threshold) != 4):
+                raise kaitaistruct.ConsistencyError(u"f_transparency_clip_threshold", len(self.f_transparency_clip_threshold), 4)
+            for i in range(len(self.f_transparency_clip_threshold)):
+                pass
+
+            if (len(self.f_normal_power) != 3):
+                raise kaitaistruct.ConsistencyError(u"f_normal_power", len(self.f_normal_power), 3)
+            for i in range(len(self.f_normal_power)):
+                pass
+
+            if (len(self.f_albedo_blend2_color) != 4):
+                raise kaitaistruct.ConsistencyError(u"f_albedo_blend2_color", len(self.f_albedo_blend2_color), 4)
+            for i in range(len(self.f_albedo_blend2_color)):
+                pass
+
+            if (len(self.f_detail_normal_u_v_scale) != 2):
+                raise kaitaistruct.ConsistencyError(u"f_detail_normal_u_v_scale", len(self.f_detail_normal_u_v_scale), 2)
+            for i in range(len(self.f_detail_normal_u_v_scale)):
+                pass
+
+            if (len(self.f_fresnel_legacy) != 2):
+                raise kaitaistruct.ConsistencyError(u"f_fresnel_legacy", len(self.f_fresnel_legacy), 2)
+            for i in range(len(self.f_fresnel_legacy)):
+                pass
+
+            if (len(self.f_normal_mask_pow0) != 4):
+                raise kaitaistruct.ConsistencyError(u"f_normal_mask_pow0", len(self.f_normal_mask_pow0), 4)
+            for i in range(len(self.f_normal_mask_pow0)):
+                pass
+
+            if (len(self.f_normal_mask_pow1) != 4):
+                raise kaitaistruct.ConsistencyError(u"f_normal_mask_pow1", len(self.f_normal_mask_pow1), 4)
+            for i in range(len(self.f_normal_mask_pow1)):
+                pass
+
+            if (len(self.f_normal_mask_pow2) != 4):
+                raise kaitaistruct.ConsistencyError(u"f_normal_mask_pow2", len(self.f_normal_mask_pow2), 4)
+            for i in range(len(self.f_normal_mask_pow2)):
+                pass
+
+            if (len(self.f_texture_blend_rate) != 4):
+                raise kaitaistruct.ConsistencyError(u"f_texture_blend_rate", len(self.f_texture_blend_rate), 4)
+            for i in range(len(self.f_texture_blend_rate)):
+                pass
+
+            if (len(self.f_texture_blend_color) != 4):
+                raise kaitaistruct.ConsistencyError(u"f_texture_blend_color", len(self.f_texture_blend_color), 4)
+            for i in range(len(self.f_texture_blend_color)):
+                pass
+
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 480
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
     class Material(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
             self._io = _io
@@ -5438,7 +5885,7 @@ class Mrl(ReadWriteKaitaiStruct):
             super(Mrl.Material, self)._write__seq(io)
             self._should_write_resources = self.resources__to_write
             self._should_write_anims = self.anims__to_write
-            self._io.write_u4le(self.type_hash.value)
+            self._io.write_u4le(int(self.type_hash))
             self._io.write_u4le(self.name_hash_crcjam32)
             self._io.write_u4le(self.cmd_buffer_size)
             self._io.write_u4le(self.blend_state_hash)
@@ -5984,7 +6431,7 @@ class Mrl(ReadWriteKaitaiStruct):
         def _write__seq(self, io=None):
             super(Mrl.ResourceBinding, self)._write__seq(io)
             self._should_write_float_buffer = self.float_buffer__to_write
-            self._io.write_bits_int_le(4, self.cmd_type.value)
+            self._io.write_bits_int_le(4, int(self.cmd_type))
             self._io.write_bits_int_le(16, self.unused)
             self._io.write_bits_int_le(12, self.shader_obj_idx)
             _on = self.cmd_type
@@ -6082,7 +6529,7 @@ class Mrl(ReadWriteKaitaiStruct):
                     self._m_float_buffer._read()
                 elif _on == Mrl.ShaderObjectHash.cbmaterial:
                     pass
-                    self._m_float_buffer = Mrl.StrCbMaterial(self._io, self, self._root)
+                    self._m_float_buffer = Mrl.CbMaterial(self._io, self, self._root)
                     self._m_float_buffer._read()
                 self._io.seek(_pos)
 

--- a/albam/registry.py
+++ b/albam/registry.py
@@ -1,5 +1,4 @@
 
-
 class BlenderRegistry:
     def __init__(self):
         self.import_registry = {}
@@ -12,6 +11,7 @@ class BlenderRegistry:
         self.import_options_custom_poll_funcs = {}
         self.import_operator_poll_funcs = {}
         self.custom_properties_material = {}
+        self.custom_properties_material_secondary = {}
         self.custom_properties_mesh = {}
         self.custom_properties_image = {}
         self.file_categories = {}
@@ -78,21 +78,21 @@ class BlenderRegistry:
 
         return decorator
 
-    def register_custom_properties_material(self, name, app_ids):
+    def register_custom_properties_material(self, name, app_ids, is_secondary=False):
         def decorator(cls):
-            self.custom_properties_material[name] = (cls, app_ids)
+            self.custom_properties_material[name] = (cls, app_ids, is_secondary)
             return cls
         return decorator
 
-    def register_custom_properties_mesh(self, name, app_ids):
+    def register_custom_properties_mesh(self, name, app_ids, is_secondary=False):
         def decorator(cls):
-            self.custom_properties_mesh[name] = (cls, app_ids)
+            self.custom_properties_mesh[name] = (cls, app_ids, is_secondary)
             return cls
         return decorator
 
-    def register_custom_properties_image(self, name, app_ids):
+    def register_custom_properties_image(self, name, app_ids, is_secondary=False):
         def decorator(cls):
-            self.custom_properties_image[name] = (cls, app_ids)
+            self.custom_properties_image[name] = (cls, app_ids, is_secondary)
             return cls
         return decorator
 

--- a/albam/registry.py
+++ b/albam/registry.py
@@ -11,7 +11,6 @@ class BlenderRegistry:
         self.import_options_custom_poll_funcs = {}
         self.import_operator_poll_funcs = {}
         self.custom_properties_material = {}
-        self.custom_properties_material_secondary = {}
         self.custom_properties_mesh = {}
         self.custom_properties_image = {}
         self.file_categories = {}
@@ -78,21 +77,25 @@ class BlenderRegistry:
 
         return decorator
 
-    def register_custom_properties_material(self, name, app_ids, is_secondary=False):
+    def register_custom_properties_material(self, name, app_ids, is_secondary=False, display_name=""):
         def decorator(cls):
-            self.custom_properties_material[name] = (cls, app_ids, is_secondary)
+            for app_id in app_ids:
+                self.custom_properties_material.setdefault(
+                    app_id, {})[name] = (cls, is_secondary, display_name)
             return cls
         return decorator
 
-    def register_custom_properties_mesh(self, name, app_ids, is_secondary=False):
+    def register_custom_properties_mesh(self, name, app_ids, is_secondary=False, display_name=""):
         def decorator(cls):
-            self.custom_properties_mesh[name] = (cls, app_ids, is_secondary)
+            for app_id in app_ids:
+                self.custom_properties_mesh.setdefault(app_id, {})[name] = (cls, is_secondary, display_name)
             return cls
         return decorator
 
-    def register_custom_properties_image(self, name, app_ids, is_secondary=False):
+    def register_custom_properties_image(self, name, app_ids, is_secondary=False, display_name=""):
         def decorator(cls):
-            self.custom_properties_image[name] = (cls, app_ids, is_secondary)
+            for app_id in app_ids:
+                self.custom_properties_image.setdefault(app_id, {})[name] = (cls, is_secondary, display_name)
             return cls
         return decorator
 

--- a/albam/vfs.py
+++ b/albam/vfs.py
@@ -109,6 +109,12 @@ class VirtualFileSystemBase:
         file_id = self.SEPARATOR.join((app_id,) + path.parts)
         return self.file_list[file_id]
 
+    def select_vfile(self, app_id, relative_path):
+        path = PureWindowsPath(relative_path)
+        file_id = self.SEPARATOR.join((app_id,) + path.parts)
+        self.file_list_selected_index = self.file_list.find(file_id)
+        return self.file_list[file_id]
+
     def add_real_file(self, app_id, absolute_path):
         path = PureWindowsPath(absolute_path)
         vf = self.file_list.add()

--- a/albam/vfs.py
+++ b/albam/vfs.py
@@ -143,9 +143,9 @@ class VirtualFileSystemBase:
 
         return vf
 
-    def add_vfiles_as_tree(self, root_vfile_data, vfiles_data):
-        root_id = f"{root_vfile_data.app_id}::{root_vfile_data.name}"
-        tree = Tree(root_id)
+    def add_vfiles_as_tree(self, app_id, root_vfile_data, vfiles_data):
+        root_id = f"{app_id}::{root_vfile_data.name}"
+        tree = Tree(root_id, app_id)
         bl_vf = self.add_vfile(root_vfile_data)
         bl_vf.is_expandable = True
         bl_vf.is_root = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = {file = "LICENSE"}
 keywords = ["blender", "blender-addon", "import", "3d models", "3d formats"]
 
 dependencies = [
-  "bpy",
+  "bpy==3.6",
 ]
 
 [project.optional-dependencies]
@@ -18,6 +18,7 @@ test = [
   "flake8-pyproject",
   "pytest",
   "pytest-xdist",
+  "pytest-subtests"
 #  "pybc7",
 #  "zstd"
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ def pytest_addoption(parser):
         "--arcdir",
         action="append",
         help="Format: <app-id>::<dir>: Directory to look for arc files "
-        "to test with the app-id provieded. Can be passed multiple times",
+        "to test with the app-id provided. Can be passed multiple times",
     )
 
 

--- a/tests/mtfw/conftest.py
+++ b/tests/mtfw/conftest.py
@@ -1,6 +1,7 @@
 import os
 import io
 
+import bpy
 import pytest
 
 
@@ -9,7 +10,86 @@ class FileWrapper:
         self.name = os.path.basename(file_path)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
+def loaded_arcs(pytestconfig):
+    """
+    Loads all the arcs found in the config option --arcdir
+    with the corresponding app-id to the vfs.
+    Equivalent to selecting an app, clicking "Add files"
+    and selecting all files ending in .arc in a directory
+    """
+    # TODO: recursive walk in directories
+    arc_dirs = pytestconfig.getoption("arcdir")
+    if not arc_dirs:
+        pytest.skip("No arc directory or app_id supplied")
+        return
+
+    for app_id_and_arc_dir in arc_dirs:
+        app_id, arc_dir = app_id_and_arc_dir.split("::")
+        bpy.context.scene.albam.apps.app_selected = app_id
+        files = [{'name': name} for name in os.listdir(arc_dir)]
+        bpy.ops.albam.add_files(directory=arc_dir, files=files)
+
+
+@pytest.fixture(scope="session")
+def mod_export(loaded_arcs):
+    from albam.engines.mtfw.mesh import APPID_CLASS_MAPPER
+    from albam.engines.mtfw.structs.mrl import Mrl
+    from kaitaistruct import KaitaiStream
+    app_id = "re1"  # FIXME: un-hardcode
+    mod_path = "model/pl/pl00/pl00.mod"
+    mrl_path = "model/pl/pl00/pl00.mrl"
+
+    bpy.context.scene.albam.apps.app_selected = app_id
+
+    vfile_mod = bpy.context.scene.albam.vfs.select_vfile(app_id, mod_path)
+    vfile_mrl = bpy.context.scene.albam.vfs.get_vfile(app_id, mrl_path)
+    assert vfile_mod and vfile_mrl
+
+    result = bpy.ops.albam.import_vfile()
+    assert result == {"FINISHED"}
+    result = bpy.ops.albam.export()  # FIXME: won't capture failures
+    print("Exported")
+    assert result == {"FINISHED"}
+
+    vfile_mod_exported = bpy.context.scene.albam.exported.select_vfile(app_id, mod_path)
+    vfile_mrl_exported = bpy.context.scene.albam.exported.get_vfile(app_id, mrl_path)
+    assert vfile_mod_exported and vfile_mrl_exported
+
+    Mod = APPID_CLASS_MAPPER[app_id]
+    src_mod = Mod.from_bytes(vfile_mod.get_bytes())
+    dst_mod = Mod.from_bytes(vfile_mod_exported.get_bytes())
+    src_mod._read()
+    dst_mod._read()
+
+    src_mrl = Mrl(2, KaitaiStream(io.BytesIO(vfile_mrl.get_bytes())))
+    dst_mrl = Mrl(2, KaitaiStream(io.BytesIO(vfile_mrl_exported.get_bytes())))
+    src_mrl._read()
+    dst_mrl._read()
+
+    return src_mod, dst_mod, src_mrl, dst_mrl
+
+
+@pytest.fixture(scope="session")
+def mod_imported(mod_export):
+    return mod_export[0]
+
+
+@pytest.fixture(scope="session")
+def mod_exported(mod_export):
+    return mod_export[1]
+
+
+@pytest.fixture(scope="session")
+def mrl_imported(mod_export):
+    return mod_export[2]
+
+
+@pytest.fixture(scope="session")
+def mrl_exported(mod_export):
+    return mod_export[3]
+
+
 def lmt(request):
     # test collection before calling register() in pytest_session_start
     # doesn't have sys.path modified for albam_vendor, so kaitaistruct

--- a/tests/mtfw/conftest.py
+++ b/tests/mtfw/conftest.py
@@ -122,6 +122,7 @@ def mrl_exported(mod_export):
     return mod_export[3]
 
 
+@pytest.fixture
 def lmt(request):
     # test collection before calling register() in pytest_session_start
     # doesn't have sys.path modified for albam_vendor, so kaitaistruct
@@ -146,15 +147,13 @@ def mrl(request):
     # doesn't have sys.path modified for albam_vendor, so kaitaistruct
     # not found
     from albam.engines.mtfw.structs.mrl import Mrl
-    from albam.engines.mtfw.material import MRL_APPID_CB_GLOBALS_VERSION
     from kaitaistruct import KaitaiStream
     arc = request.param[0]
     mrl_file_entry = request.param[1]
     app_id = request.param[2]
 
     mrl_bytes = arc.get_file(mrl_file_entry.file_path, mrl_file_entry.file_type)
-    cb_globals_version = MRL_APPID_CB_GLOBALS_VERSION[app_id]
-    parsed_mrl = Mrl(cb_globals_version, KaitaiStream(io.BytesIO(mrl_bytes)))
+    parsed_mrl = Mrl(app_id, KaitaiStream(io.BytesIO(mrl_bytes)))
     parsed_mrl.app_id = app_id
     parsed_mrl._read()
     parsed_mrl._arc_name = os.path.basename(arc.file_path)

--- a/tests/mtfw/conftest.py
+++ b/tests/mtfw/conftest.py
@@ -43,6 +43,7 @@ def mrl(request):
     mrl_bytes = arc.get_file(mrl_file_entry.file_path, mrl_file_entry.file_type)
     cb_globals_version = MRL_APPID_CB_GLOBALS_VERSION[app_id]
     parsed_mrl = Mrl(cb_globals_version, KaitaiStream(io.BytesIO(mrl_bytes)))
+    parsed_mrl.app_id = app_id
     parsed_mrl._read()
     parsed_mrl._arc_name = os.path.basename(arc.file_path)
     parsed_mrl._mrl_path = mrl_file_entry.file_path

--- a/tests/mtfw/test_mod_serialization.py
+++ b/tests/mtfw/test_mod_serialization.py
@@ -1,5 +1,7 @@
 import pytest
 
+pytest.skip(reason="WIP", allow_module_level=True)
+
 
 def test_export_header(mod_imported, mod_exported):
     sheader = mod_imported.header

--- a/tests/mtfw/test_mod_serialization.py
+++ b/tests/mtfw/test_mod_serialization.py
@@ -1,0 +1,155 @@
+import pytest
+
+
+def test_export_header(mod_imported, mod_exported):
+    sheader = mod_imported.header
+    dheader = mod_exported.header
+
+    assert sheader.ident == dheader.ident == b"MOD\x00"
+    assert sheader.version == dheader.version
+    assert sheader.revision == dheader.revision
+    assert sheader.num_bones == dheader.num_bones
+    assert sheader.num_materials == dheader.num_materials
+    assert sheader.reserved_01 == dheader.reserved_01
+    assert sheader.num_groups == dheader.num_groups
+    assert sheader.offset_bones_data == dheader.offset_bones_data
+    assert sheader.offset_groups == dheader.offset_groups
+    assert sheader.offset_materials_data == dheader.offset_materials_data
+    assert sheader.offset_meshes_data == dheader.offset_meshes_data
+    assert sheader.offset_vertex_buffer == dheader.offset_vertex_buffer
+    assert sheader.offset_index_buffer == dheader.offset_index_buffer
+    assert sheader.num_meshes == dheader.num_meshes
+    assert sheader.num_vertices == dheader.num_vertices
+    assert sheader.size_vertex_buffer == dheader.size_vertex_buffer
+
+
+def test_export_top_level(mod_imported, mod_exported):
+
+    # assert mod_imported.bsphere.x == pytest.approx(mod_exported.bsphere.x, rel=0.5)
+    assert mod_imported.bsphere.y == pytest.approx(mod_exported.bsphere.y, rel=0.001)
+    assert mod_imported.bsphere.z == pytest.approx(mod_exported.bsphere.z, rel=0.001)
+    assert mod_imported.bsphere.w == pytest.approx(mod_exported.bsphere.w, rel=0.001)
+
+    assert mod_imported.bbox_min.x == pytest.approx(mod_exported.bbox_min.x, rel=0.001)
+    assert mod_imported.bbox_min.y == pytest.approx(mod_exported.bbox_min.y, rel=0.001)
+    assert mod_imported.bbox_min.z == pytest.approx(mod_exported.bbox_min.z, rel=0.001)
+    assert mod_imported.bbox_min.w == pytest.approx(mod_exported.bbox_min.w, rel=0.001)
+
+    assert mod_imported.bbox_max.x == pytest.approx(mod_exported.bbox_max.x, rel=0.001)
+    assert mod_imported.bbox_max.y == pytest.approx(mod_exported.bbox_max.y, rel=0.001)
+    assert mod_imported.bbox_max.z == pytest.approx(mod_exported.bbox_max.z, rel=0.001)
+    assert mod_imported.bbox_max.w == pytest.approx(mod_exported.bbox_max.w, rel=0.001)
+
+    assert mod_imported.unk_01 == mod_exported.unk_01
+    assert mod_imported.unk_02 == mod_exported.unk_02
+    assert mod_imported.unk_03 == mod_exported.unk_03
+    assert mod_imported.unk_04 == mod_exported.unk_04
+
+
+def test_export_bones_data(mod_imported, mod_exported):
+    # TODO: matrices
+    sbd = mod_imported.bones_data
+    dbd = mod_exported.bones_data
+
+    assert mod_imported.bones_data_size_ == mod_exported.bones_data_size_
+
+    assert (
+        [b.idx_anim_map for b in sbd.bones_hierarchy] ==
+        [b.idx_anim_map for b in dbd.bones_hierarchy])
+    assert (
+        [b.idx_parent for b in sbd.bones_hierarchy] ==
+        [b.idx_parent for b in dbd.bones_hierarchy])
+    assert (
+        [b.idx_mirror for b in sbd.bones_hierarchy] ==
+        [b.idx_mirror for b in dbd.bones_hierarchy])
+    assert (
+        [b.idx_mapping for b in sbd.bones_hierarchy] ==
+        [b.idx_mapping for b in dbd.bones_hierarchy])
+    assert (
+        [b.unk_01 for b in sbd.bones_hierarchy] ==
+        [b.unk_01 for b in dbd.bones_hierarchy])
+    assert (
+        [b.parent_distance for b in sbd.bones_hierarchy] ==
+        [b.parent_distance for b in dbd.bones_hierarchy])
+    assert (
+        [(b.location.x, b.location.y, b.location.z) for b in sbd.bones_hierarchy] ==
+        [(b.location.x, b.location.y, b.location.z) for b in dbd.bones_hierarchy])
+
+    assert sbd.bone_map == dbd.bone_map
+
+
+def test_export_groups(mod_imported, mod_exported):
+
+    assert mod_imported.groups_size_ == mod_exported.groups_size_
+
+    assert [g.group_index for g in mod_imported.groups] == [g.group_index for g in mod_exported.groups]
+    assert [g.unk_02 for g in mod_imported.groups] == [g.unk_02 for g in mod_exported.groups]
+    assert [g.unk_03 for g in mod_imported.groups] == [g.unk_03 for g in mod_exported.groups]
+    assert [g.unk_04 for g in mod_imported.groups] == [g.unk_04 for g in mod_exported.groups]
+    assert [g.unk_05 for g in mod_imported.groups] == [g.unk_05 for g in mod_exported.groups]
+    assert [g.unk_06 for g in mod_imported.groups] == [g.unk_06 for g in mod_exported.groups]
+    assert [g.unk_07 for g in mod_imported.groups] == [g.unk_07 for g in mod_exported.groups]
+    assert [g.unk_08 for g in mod_imported.groups] == [g.unk_08 for g in mod_exported.groups]
+
+
+def test_materials_data(mod_imported, mod_exported):
+
+    assert mod_imported.materials_data.size_ == mod_exported.materials_data.size_
+    assert (mod_imported.header.version == 210 and
+            mod_imported.materials_data.material_names == mod_exported.materials_data.material_names)
+
+
+def test_meshes_data(mod_imported, mod_exported, subtests):
+
+    for i, mesh in enumerate(mod_imported.meshes_data.meshes):
+        src_mesh = mesh
+        dst_mesh = mod_exported.meshes_data.meshes[i]
+        with subtests.test(mesh_index=i):
+            assert src_mesh.idx_group == dst_mesh.idx_group
+            assert src_mesh.num_vertices == dst_mesh.num_vertices
+            assert src_mesh.unk_01 == dst_mesh.unk_01
+            assert src_mesh.idx_material == dst_mesh.idx_material
+            assert src_mesh.level_of_detail == dst_mesh.level_of_detail
+            assert src_mesh.type_mesh == dst_mesh.type_mesh
+            assert src_mesh.unk_class_mesh == dst_mesh.unk_class_mesh
+            # assert src_mesh.vertex_stride == dst_mesh.vertex_stride
+            assert src_mesh.unk_render_mode == dst_mesh.unk_render_mode
+            # assert src_mesh.vertex_format == dst_mesh.vertex_format
+            assert src_mesh.bone_id_start == dst_mesh.bone_id_start
+            assert src_mesh.num_unique_bone_ids == dst_mesh.num_unique_bone_ids
+            assert src_mesh.mesh_index == dst_mesh.mesh_index
+            assert src_mesh.min_index == dst_mesh.min_index
+            assert src_mesh.max_index == dst_mesh.max_index
+            assert src_mesh.hash == dst_mesh.hash
+
+    assert mod_imported.header.version == 210 and (
+        mod_imported.num_weight_bounds == mod_exported.num_weight_bounds)
+
+
+@pytest.mark.xfail(reason="WIP")
+def test_header_xfail(pl0000_roundtrip):
+    """
+    Tests to fix
+    """
+    src_mod, dst_mod = pl0000_roundtrip
+    sheader = src_mod.header
+    dheader = dst_mod.header
+
+    assert sheader.num_faces == dheader.num_faces
+    assert sheader.num_edges == dheader.num_edges
+    assert sheader.size_file == dheader.size_file
+
+
+@pytest.mark.xfail(reason="WIP")
+def test_meshes_data_xfail(mod_imported, mod_exported, subtests):
+
+    assert mod_imported.meshes_data.num_weight_bounds == mod_exported.meshes_data.num_weight_bounds
+    for i, mesh in enumerate(mod_imported.meshes_data.meshes):
+        src_mesh = mesh
+        dst_mesh = mod_exported.meshes_data.meshes[i]
+        with subtests.test(i=i):
+            assert src_mesh.vertex_position == dst_mesh.vertex_position
+            assert src_mesh.vertex_offset == dst_mesh.vertex_offset
+            assert src_mesh.face_position == dst_mesh.face_position
+            assert src_mesh.num_indices == dst_mesh.num_indices
+            assert src_mesh.face_offset == dst_mesh.face_offset

--- a/tests/mtfw/test_mod_serialization.py
+++ b/tests/mtfw/test_mod_serialization.py
@@ -12,14 +12,15 @@ def test_export_header(mod_imported, mod_exported):
     assert sheader.num_materials == dheader.num_materials
     assert sheader.reserved_01 == dheader.reserved_01
     assert sheader.num_groups == dheader.num_groups
+    assert sheader.num_meshes == dheader.num_meshes
+    assert sheader.num_vertices == dheader.num_vertices
+
     assert sheader.offset_bones_data == dheader.offset_bones_data
     assert sheader.offset_groups == dheader.offset_groups
     assert sheader.offset_materials_data == dheader.offset_materials_data
     assert sheader.offset_meshes_data == dheader.offset_meshes_data
     assert sheader.offset_vertex_buffer == dheader.offset_vertex_buffer
     assert sheader.offset_index_buffer == dheader.offset_index_buffer
-    assert sheader.num_meshes == dheader.num_meshes
-    assert sheader.num_vertices == dheader.num_vertices
     assert sheader.size_vertex_buffer == dheader.size_vertex_buffer
 
 
@@ -99,7 +100,9 @@ def test_materials_data(mod_imported, mod_exported):
             mod_imported.materials_data.material_names == mod_exported.materials_data.material_names)
 
 
-def test_meshes_data(mod_imported, mod_exported, subtests):
+def test_meshes_data_21(mod_imported, mod_exported, subtests):
+    if not mod_imported.header.version == 210:
+        pytest.skip()
 
     for i, mesh in enumerate(mod_imported.meshes_data.meshes):
         src_mesh = mesh

--- a/tests/mtfw/test_mrl_serialization.py
+++ b/tests/mtfw/test_mrl_serialization.py
@@ -1,6 +1,9 @@
 import pytest
 
 
+pytest.skip(reason="WIP", allow_module_level=True)
+
+
 def test_export_mrl_top_level(mrl_imported, mrl_exported):
     src_mrl = mrl_imported
     dst_mrl = mrl_exported

--- a/tests/mtfw/test_mrl_serialization.py
+++ b/tests/mtfw/test_mrl_serialization.py
@@ -1,16 +1,23 @@
+import pytest
 
 
 def test_export_mrl_top_level(mrl_imported, mrl_exported):
     src_mrl = mrl_imported
     dst_mrl = mrl_exported
+    num_missing_materials = len(src_mrl.materials) - len(dst_mrl.materials)
+    error_no_padding = (
+        src_mrl.ofs_resources_calculated_no_padding - dst_mrl.ofs_resources_calculated_no_padding)
 
+    assert num_missing_materials * src_mrl.materials[0].size_ == error_no_padding
     assert src_mrl.id_magic == dst_mrl.id_magic
     assert src_mrl.version == dst_mrl.version
-    assert src_mrl.num_materials == dst_mrl.num_materials
-    # assert src_mrl.num_textures == dst_mrl.num_textures
+    assert src_mrl.num_textures == dst_mrl.num_textures
+    assert src_mrl.num_materials == dst_mrl.num_materials + num_missing_materials
     assert src_mrl.unk_01 == dst_mrl.unk_01
     assert src_mrl.ofs_textures == dst_mrl.ofs_textures
-    # assert src_mrl.ofs_materials == dst_mrl.ofs_materials
+    assert src_mrl.ofs_materials == dst_mrl.ofs_materials
+    assert (src_mrl.ofs_resources_calculated_no_padding ==
+            dst_mrl.ofs_resources_calculated_no_padding + error_no_padding)
 
 
 def test_textures(mrl_imported, mrl_exported, subtests):
@@ -27,52 +34,98 @@ def test_textures(mrl_imported, mrl_exported, subtests):
             assert dst_texture.filler == src_texture.filler
 
 
-def _test_materials(mrl_imported, mrl_exported, subtests):
+@pytest.mark.xfail()
+def test_offsets(mrl_imported, mrl_exported, subtests):
+    # TODO: try to export materials in order and get accumulated error
+    # that way we can pontentially tests all offsets for float buffers
     src_mrl = mrl_imported
     dst_mrl = mrl_exported
 
+    for mi, mat in enumerate(src_mrl.materials):
+        if mi > len(dst_mrl.materials):
+            continue
+        with subtests.test(material_index=mi):
+            assert mat.name_hash_crcjam32 == dst_mrl.materials[mi].name_hash_crcjam32
+
+
+def test_materials(mrl_imported, mrl_exported, subtests):
+    src_mrl = mrl_imported
+    src_hashes = [m.name_hash_crcjam32 for m in src_mrl.materials]
+    dst_mrl = mrl_exported
+    num_missing_materials = len(src_mrl.materials) - len(dst_mrl.materials)
+    error_no_padding = (
+        src_mrl.ofs_resources_calculated_no_padding - dst_mrl.ofs_resources_calculated_no_padding)
+    assert num_missing_materials * src_mrl.materials[0].size_ == error_no_padding
+
     for i, dst_material in enumerate(dst_mrl.materials):
-        src_material = src_mrl.materials[i]
+        src_material = src_mrl.materials[src_hashes.index(dst_material.name_hash_crcjam32)]
 
         with subtests.test(material_index=i):
             assert src_material.type_hash == dst_material.type_hash
-            # assert src_material.name_hash_crcjam32 == dst_material.name_hash_crcjam32
-            # assert src_material.cmd_buffer_size == dst_material.cmd_buffer_size
+            assert src_material.name_hash_crcjam32 == dst_material.name_hash_crcjam32
+            assert src_material.cmd_buffer_size == dst_material.cmd_buffer_size
             assert src_material.blend_state_hash == dst_material.blend_state_hash
             assert src_material.depth_stencil_state_hash == dst_material.depth_stencil_state_hash
             assert src_material.rasterizer_state_hash == dst_material.rasterizer_state_hash
             assert src_material.num_resources == dst_material.num_resources
-            # assert src_material.unused == dst_material.unused
+            assert src_material.unused == dst_material.unused
             assert src_material.material_info_flags == dst_material.material_info_flags
             assert src_material.unk_nulls == dst_material.unk_nulls
-            # assert src_material.anim_data_size == dst_material.anim_data_size
-            # assert src_material.ofs_cmd == dst_material.ofs_cmd
-            # assert src_material.ofs_anim_data == dst_material.ofs_anim_data
+        with subtests.test(material_index=i):
+            if error_no_padding:
+                pytest.xfail(reason="Difference in offset expected due to missing materials")
+            assert src_material.anim_data_size == dst_material.anim_data_size
+            assert src_material.ofs_anim_data == dst_material.ofs_anim_data
 
 
 def test_resource_names(mrl_imported, mrl_exported, subtests):
     src_mrl = mrl_imported
+    src_hashes = [m.name_hash_crcjam32 for m in src_mrl.materials]
     dst_mrl = mrl_exported
 
     for mi, dst_material in enumerate(dst_mrl.materials):
-        if mi != 1:
-            continue
-        src_material = src_mrl.materials[mi]
+        src_material = src_mrl.materials[src_hashes.index(dst_material.name_hash_crcjam32)]
         src_resource_names = [r.shader_object_hash.name for r in src_material.resources]
         dst_resource_names = [r.shader_object_hash.name for r in dst_material.resources]
 
         with subtests.test(material_index=mi):
             assert sorted(src_resource_names) == sorted(dst_resource_names)
-        break
 
 
 def test_resources(mrl_imported, mrl_exported, subtests):
     src_mrl = mrl_imported
+    src_hashes = [m.name_hash_crcjam32 for m in src_mrl.materials]
     dst_mrl = mrl_exported
 
     for mi, dst_material in enumerate(dst_mrl.materials):
-        src_material = src_mrl.materials[mi]
+        src_material = src_mrl.materials[src_hashes.index(dst_material.name_hash_crcjam32)]
+
         for ri, dst_resource in enumerate(dst_material.resources):
             src_resource = src_material.resources[ri]
             with subtests.test(material_index=mi, resource_index=ri):
                 assert src_resource.cmd_type == dst_resource.cmd_type
+
+
+@pytest.mark.parametrize("float_buffer_name", ["globals", "cbmaterial"])
+def test_resource_float_buffer(mrl_imported, mrl_exported, subtests, float_buffer_name):
+    src_mrl = mrl_imported
+    src_hashes = [m.name_hash_crcjam32 for m in src_mrl.materials]
+    dst_mrl = mrl_exported
+    Mrl = mrl_imported.__class__
+
+    for mi, dst_material in enumerate(dst_mrl.materials):
+        src_material = src_mrl.materials[src_hashes.index(dst_material.name_hash_crcjam32)]
+        src_shader_object = [r for r in src_material.resources
+                             if r.shader_object_hash == getattr(Mrl.ShaderObjectHash, float_buffer_name)]
+        dst_shader_object = [r for r in dst_material.resources
+                             if r.shader_object_hash == getattr(Mrl.ShaderObjectHash, float_buffer_name)]
+        # TODO: ignore buffers not present
+        src_float_buffer = src_shader_object[0].float_buffer.app_specific
+        dst_float_buffer = dst_shader_object[0].float_buffer.app_specific
+
+        assert len(src_float_buffer.__dict__.keys()) == len(dst_float_buffer.__dict__.keys())
+        for attr_name, attr_value in dst_float_buffer.__dict__.items():
+            if attr_name.startswith("_"):
+                continue
+            with subtests.test(material_index=mi, float_buffer=float_buffer_name, attribute=attr_name):
+                assert getattr(src_float_buffer, attr_name) == attr_value

--- a/tests/mtfw/test_mrl_serialization.py
+++ b/tests/mtfw/test_mrl_serialization.py
@@ -1,0 +1,78 @@
+
+
+def test_export_mrl_top_level(mrl_imported, mrl_exported):
+    src_mrl = mrl_imported
+    dst_mrl = mrl_exported
+
+    assert src_mrl.id_magic == dst_mrl.id_magic
+    assert src_mrl.version == dst_mrl.version
+    assert src_mrl.num_materials == dst_mrl.num_materials
+    # assert src_mrl.num_textures == dst_mrl.num_textures
+    assert src_mrl.unk_01 == dst_mrl.unk_01
+    assert src_mrl.ofs_textures == dst_mrl.ofs_textures
+    # assert src_mrl.ofs_materials == dst_mrl.ofs_materials
+
+
+def test_textures(mrl_imported, mrl_exported, subtests):
+    # Some textures are not exported
+    src_mrl = mrl_imported
+    dst_mrl = mrl_exported
+    for i, dst_texture in enumerate(dst_mrl.textures):
+        src_texture = [t for t in src_mrl.textures if t.texture_path == dst_texture.texture_path][0]
+        with subtests.test(texture_index=i):
+            assert dst_texture.type_hash == src_texture.type_hash
+            assert dst_texture.unk_02 == src_texture.unk_02
+            assert dst_texture.unk_03 == src_texture.unk_03
+            assert dst_texture.texture_path == src_texture.texture_path
+            assert dst_texture.filler == src_texture.filler
+
+
+def _test_materials(mrl_imported, mrl_exported, subtests):
+    src_mrl = mrl_imported
+    dst_mrl = mrl_exported
+
+    for i, dst_material in enumerate(dst_mrl.materials):
+        src_material = src_mrl.materials[i]
+
+        with subtests.test(material_index=i):
+            assert src_material.type_hash == dst_material.type_hash
+            # assert src_material.name_hash_crcjam32 == dst_material.name_hash_crcjam32
+            # assert src_material.cmd_buffer_size == dst_material.cmd_buffer_size
+            assert src_material.blend_state_hash == dst_material.blend_state_hash
+            assert src_material.depth_stencil_state_hash == dst_material.depth_stencil_state_hash
+            assert src_material.rasterizer_state_hash == dst_material.rasterizer_state_hash
+            assert src_material.num_resources == dst_material.num_resources
+            # assert src_material.unused == dst_material.unused
+            assert src_material.material_info_flags == dst_material.material_info_flags
+            assert src_material.unk_nulls == dst_material.unk_nulls
+            # assert src_material.anim_data_size == dst_material.anim_data_size
+            # assert src_material.ofs_cmd == dst_material.ofs_cmd
+            # assert src_material.ofs_anim_data == dst_material.ofs_anim_data
+
+
+def test_resource_names(mrl_imported, mrl_exported, subtests):
+    src_mrl = mrl_imported
+    dst_mrl = mrl_exported
+
+    for mi, dst_material in enumerate(dst_mrl.materials):
+        if mi != 1:
+            continue
+        src_material = src_mrl.materials[mi]
+        src_resource_names = [r.shader_object_hash.name for r in src_material.resources]
+        dst_resource_names = [r.shader_object_hash.name for r in dst_material.resources]
+
+        with subtests.test(material_index=mi):
+            assert sorted(src_resource_names) == sorted(dst_resource_names)
+        break
+
+
+def test_resources(mrl_imported, mrl_exported, subtests):
+    src_mrl = mrl_imported
+    dst_mrl = mrl_exported
+
+    for mi, dst_material in enumerate(dst_mrl.materials):
+        src_material = src_mrl.materials[mi]
+        for ri, dst_resource in enumerate(dst_material.resources):
+            src_resource = src_material.resources[ri]
+            with subtests.test(material_index=mi, resource_index=ri):
+                assert src_resource.cmd_type == dst_resource.cmd_type

--- a/tests/mtfw/test_parsing_mrl.py
+++ b/tests/mtfw/test_parsing_mrl.py
@@ -7,6 +7,37 @@ KNOWN_BLEND_STATE_STENSIL_HASH = [
     0xc4064,  # BSRevSubAlpha
 ]
 
+KNOWN_CONSTANT_BUFFERS = {
+    "re0": {
+        Mrl.ShaderObjectHash.cbmaterial,
+        Mrl.ShaderObjectHash.globals,
+    },
+    "re1": {
+        Mrl.ShaderObjectHash.cbmaterial,
+        Mrl.ShaderObjectHash.cbdistortion,
+        Mrl.ShaderObjectHash.cbdistortionrefract,
+        Mrl.ShaderObjectHash.globals,
+    },
+    "rev1": {
+        Mrl.ShaderObjectHash.cbmaterial,
+        Mrl.ShaderObjectHash.cbdistortion,
+        Mrl.ShaderObjectHash.cbdistortionrefract,
+        Mrl.ShaderObjectHash.globals,
+    },
+    "rev2": {
+        Mrl.ShaderObjectHash.cbmaterial,
+        Mrl.ShaderObjectHash.cbbalphaclip,
+        Mrl.ShaderObjectHash.cbdistortion,
+        Mrl.ShaderObjectHash.cbcolormask,
+        Mrl.ShaderObjectHash.cbdistortionrefract,
+        Mrl.ShaderObjectHash.cbvertexdisplacement,
+        Mrl.ShaderObjectHash.cbvertexdisplacement2,
+        Mrl.ShaderObjectHash.cbvertexdisplacement3,
+        Mrl.ShaderObjectHash.cbvertexdispmaskuv,
+        Mrl.ShaderObjectHash.globals,
+    }
+}
+
 
 def test_global_resources_mandatory(mrl):
     """
@@ -18,3 +49,12 @@ def test_global_resources_mandatory(mrl):
         assert (m.blend_state_hash >> 12) in KNOWN_BLEND_STATE_STENSIL_HASH
         assert not hashes or Mrl.ShaderObjectHash.globals.value in hashes
         assert not hashes or Mrl.ShaderObjectHash.cbmaterial.value in hashes
+
+
+def test_known_constant_buffers(mrl, subtests):
+    for mat_idx, mat in enumerate(mrl.materials):
+        for r_idx, res in enumerate(mat.resources):
+            if not res.cmd_type == Mrl.CmdType.set_constant_buffer:
+                continue
+            with subtests.test(material_index=mat_idx, resource_index=r_idx):
+                assert res.shader_object_hash in KNOWN_CONSTANT_BUFFERS[mrl.app_id]


### PR DESCRIPTION
Refactor Albam custom properties to allow sub-panels for better organization.

Constant buffers in MRL (e.g. `$Globals` and `CBMaterial`) are now separated into their own custom props, separate for the top-level custom props, `mrl_params`. This allows fine tuning per app, which was shown to be needed for RE6 support.
Now each app has their own custom props for `$Globals`, although to the user they look the same.

Things still to do: 

* ~~Update copy/paste and import/export of custom properties~~
* Use padding between fields in constant buffers instead of zero extra fields. E.g. leave RGB values as a FloatProperty of size 3 instead of size 4 with 4 always zero. Hide this padding fields from the UI
* Create Globals custom props for apps that have one field of difference
* Add other constant buffers like Vertex Displacement
* Parametrize refactored tests

Bonus: the UI of custom props have been improved, using the same names of the MFX shader pacakge, defining subtypes such as color, and removing the animatable option.

### Before

All MRL fields together, all shared between apps
![image](https://github.com/Brachi/albam/assets/6393834/2eb814c1-82ff-4eaf-9f25-f533d6c61a38)

### After

* Subpanels and top level, only shared between apps if explicitly declared
* Better names and color wheels
![image](https://github.com/Brachi/albam/assets/6393834/71e614ef-a69d-4cac-8c75-ec538a1b00d6)

