### PR TITLE
Fix copy/paste of custom props

### DIFF
--- a/albam/blender_ui/custom_properties.py
+++ b/albam/blender_ui/custom_properties.py
@@ -119,7 +119,7 @@ def AlbamCustomPropertiesFactory(kind: str):
         try:
             property_names = self.APPID_MAP_SECONDARY[app_id]
         except KeyError:
-            return
+            return {}
 
         return {pn: getattr(self, f"{app_id}__{pn}") for pn in property_names}
 


### PR DESCRIPTION
It was failing in meshes since they don't have secondary props yet