### PR TITLE
Fix RE6 texture export

### DIFF
--- a/albam/engines/mtfw/structs/tex-157.ksy
+++ b/albam/engines/mtfw/structs/tex-157.ksy
@@ -17,7 +17,7 @@ seq:
 instances:
   size_before_data_:
     value: "num_images == 1 ? 16 + (4 * num_mipmaps_per_image * num_images) : 16 + (4 * num_mipmaps_per_image * num_images)  + 36 * 3"
-  type:
+  unk_type:
     value: packed_data_1 & 0xffff
   reserved_01:
     value: (packed_data_1  >> 16) & 0x00ff

--- a/albam/engines/mtfw/structs/tex_157.py
+++ b/albam/engines/mtfw/structs/tex_157.py
@@ -5,8 +5,8 @@ import kaitaistruct
 from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
 
 
-if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 11):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.11 or later is required, but you have %s" % (kaitaistruct.__version__))
 
 class Tex157(ReadWriteKaitaiStruct):
     def __init__(self, _io=None, _parent=None, _root=None):
@@ -78,7 +78,7 @@ class Tex157(ReadWriteKaitaiStruct):
         if (len(self.id_magic) != 4):
             raise kaitaistruct.ConsistencyError(u"id_magic", len(self.id_magic), 4)
         if not (self.id_magic == b"\x54\x45\x58\x00"):
-            raise kaitaistruct.ValidationNotEqualError(b"\x54\x45\x58\x00", self.id_magic, self._io, u"/seq/0")
+            raise kaitaistruct.ValidationNotEqualError(b"\x54\x45\x58\x00", self.id_magic, None, u"/seq/0")
         if (self.num_images == 6):
             pass
             if (len(self.cube_faces) != 3):
@@ -219,6 +219,16 @@ class Tex157(ReadWriteKaitaiStruct):
     def _invalidate_constant(self):
         del self._m_constant
     @property
+    def unk_type(self):
+        if hasattr(self, '_m_unk_type'):
+            return self._m_unk_type
+
+        self._m_unk_type = (self.packed_data_1 & 65535)
+        return getattr(self, '_m_unk_type', None)
+
+    def _invalidate_unk_type(self):
+        del self._m_unk_type
+    @property
     def dimension(self):
         if hasattr(self, '_m_dimension'):
             return self._m_dimension
@@ -258,16 +268,6 @@ class Tex157(ReadWriteKaitaiStruct):
 
     def _invalidate_reserved_01(self):
         del self._m_reserved_01
-    @property
-    def type(self):
-        if hasattr(self, '_m_type'):
-            return self._m_type
-
-        self._m_type = (self.packed_data_1 & 65535)
-        return getattr(self, '_m_type', None)
-
-    def _invalidate_type(self):
-        del self._m_type
     @property
     def reserved_02(self):
         if hasattr(self, '_m_reserved_02'):

--- a/tests/mtfw/test_mrl_parsing.py
+++ b/tests/mtfw/test_mrl_parsing.py
@@ -34,6 +34,18 @@ KNOWN_CONSTANT_BUFFERS = {
         Mrl.ShaderObjectHash.cbvertexdisplacement3,
         Mrl.ShaderObjectHash.cbvertexdispmaskuv,
         Mrl.ShaderObjectHash.globals,
+    },
+    "re6": {
+        Mrl.ShaderObjectHash.cbmaterial,
+        Mrl.ShaderObjectHash.cbbalphaclip,
+        Mrl.ShaderObjectHash.cbdistortion,
+        Mrl.ShaderObjectHash.cbcolormask,
+        Mrl.ShaderObjectHash.cbdistortionrefract,
+        Mrl.ShaderObjectHash.cbvertexdisplacement,
+        Mrl.ShaderObjectHash.cbvertexdisplacement2,
+        Mrl.ShaderObjectHash.cbvertexdisplacement3,
+        Mrl.ShaderObjectHash.cbvertexdispmaskuv,
+        Mrl.ShaderObjectHash.globals,
     }
 }
 

--- a/tests/mtfw/test_tex_parsing.py
+++ b/tests/mtfw/test_tex_parsing.py
@@ -19,7 +19,7 @@ def test_parse_tex(parsed_tex_from_arc):
     assert tex.compression_format in TEX_FORMAT_MAPPER  # TODO: rename compression_format
     assert 0 < tex.num_mipmaps_per_image <= 11  # XXX FAILS sometimes
 
-    assert type(tex) is not Tex157 or (type(tex) is Tex157 and tex.type in TEX_TYPES_157)
+    assert type(tex) is not Tex157 or (type(tex) is Tex157 and tex.unk_type in TEX_TYPES_157)
     assert type(tex) is not Tex157 or (type(tex) is Tex157 and tex.reserved_01 == 0)
     assert type(tex) is not Tex157 or (type(tex) is Tex157 and tex.shift == 0)
     assert type(tex) is not Tex157 or (type(tex) is Tex157 and tex.dimension in (2, 3, 6))


### PR DESCRIPTION
This fixes infinite loading when using an exported packed arc. Renamed "type" in texture 157 to unk_type and used an enum to choose from the verified ones via tests.
No checks for app compatibility with each type are made yet.