### PR TITLE
Add option menu for Export panel

### DIFF
--- a/albam/blender_ui/export_panel.py
+++ b/albam/blender_ui/export_panel.py
@@ -21,8 +21,8 @@ class AlbamExportSettings(bpy.types.PropertyGroup):
     # since many models can share a name and the blender database
     # is not cleaned in each test.
     remove_duplicate_materials_suffix : bpy.props.BoolProperty(default=True)
-    export_visible : bpy.props.BoolProperty(default=True)
-    force_lod255 : bpy.props.BoolProperty(default=True)
+    export_visible : bpy.props.BoolProperty(default=False)
+    force_lod255 : bpy.props.BoolProperty(default=False)
 
 
 @blender_registry.register_blender_prop
@@ -76,19 +76,28 @@ class ALBAM_PT_ExportSection(bpy.types.Panel):
             rows=1,
             maxrows=3,
         )
-        self.layout.row().operator("albam.export", text="Export")
         row = self.layout.row()
-        row.prop(
-            context.scene.albam.export_settings,
-            "export_visible",
-            text="Export only visible meshes",
-        )
-        row = self.layout.row()
-        row.prop(
-            context.scene.albam.export_settings,
-            "force_lod255",
-            text="Set LOD=255 for exported meshes",
-        )
+        row.operator("albam.export", text="Export")
+        row.operator("wm.export_options", icon="OPTIONS", text="")
+
+
+@blender_registry.register_blender_type
+class ALBAM_WM_OT_ExportOptions(bpy.types.Operator):
+    """Set settings for exporting"""
+    bl_label = "Export Options"
+    bl_idname = "wm.export_options"
+
+    export_visible :  bpy.props.BoolProperty(name="Export only visible meshes", default=False)
+    force_lod255 : bpy.props.BoolProperty(name="Set LOD=255 for exported meshes", default=False)
+
+    def execute(self, context):
+        export_settings = context.scene.albam.export_settings
+        export_settings.export_visible = self.export_visible
+        export_settings.force_lod255 = self.force_lod255
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self)
 
 
 @blender_registry.register_blender_type

--- a/albam/blender_ui/export_panel.py
+++ b/albam/blender_ui/export_panel.py
@@ -87,8 +87,8 @@ class ALBAM_WM_OT_ExportOptions(bpy.types.Operator):
     bl_label = "Export Options"
     bl_idname = "wm.export_options"
 
-    export_visible :  bpy.props.BoolProperty(name="Export only visible meshes", default=False)
-    force_lod255 : bpy.props.BoolProperty(name="Set LOD=255 for exported meshes", default=False)
+    export_visible: bpy.props.BoolProperty(name="Export only visible meshes", default=False)
+    force_lod255: bpy.props.BoolProperty(name="Set LOD=255 for exported meshes", default=False)
 
     def execute(self, context):
         export_settings = context.scene.albam.export_settings

--- a/albam/blender_ui/export_panel.py
+++ b/albam/blender_ui/export_panel.py
@@ -21,6 +21,8 @@ class AlbamExportSettings(bpy.types.PropertyGroup):
     # since many models can share a name and the blender database
     # is not cleaned in each test.
     remove_duplicate_materials_suffix : bpy.props.BoolProperty(default=True)
+    export_visible : bpy.props.BoolProperty(default=True)
+    force_lod255 : bpy.props.BoolProperty(default=True)
 
 
 @blender_registry.register_blender_prop
@@ -75,6 +77,18 @@ class ALBAM_PT_ExportSection(bpy.types.Panel):
             maxrows=3,
         )
         self.layout.row().operator("albam.export", text="Export")
+        row = self.layout.row()
+        row.prop(
+            context.scene.albam.export_settings,
+            "export_visible",
+            text="Export only visible meshes",
+        )
+        row = self.layout.row()
+        row.prop(
+            context.scene.albam.export_settings,
+            "force_lod255",
+            text="Set LOD=255 for exported meshes",
+        )
 
 
 @blender_registry.register_blender_type

--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -744,6 +744,7 @@ def _get_material_hash(mod, mesh):
 @check_dds_textures
 @check_mtfw_shader_group
 def export_mod(bl_obj):
+    export_settings = bpy.context.scene.albam.export_settings
     asset = bl_obj.albam_asset
     app_id = asset.app_id
     Mod = APPID_CLASS_MAPPER[app_id]
@@ -754,6 +755,8 @@ def export_mod(bl_obj):
     dst_mod = Mod()
     # TODO: export options like visibility
     bl_meshes = [c for c in bl_obj.children_recursive if c.type == "MESH"]
+    if export_settings.export_visible:
+        bl_meshes = [mesh for mesh in bl_meshes if mesh.visible_get()]
 
     _serialize_top_level_mod(bl_meshes, src_mod, dst_mod)
     _init_mod_header(bl_obj, src_mod, dst_mod)
@@ -1095,6 +1098,7 @@ def _serialize_groups(src_mod, dst_mod):
 
 
 def _serialize_meshes_data(bl_obj, bl_meshes, src_mod, dst_mod, materials_map, bone_palettes=None):
+    export_settings = bpy.context.scene.albam.export_settings
     app_id = bl_obj.albam_asset.app_id
     dst_mod.header.num_meshes = len(bl_meshes)
     meshes_data = dst_mod.MeshesData(_parent=dst_mod, _root=dst_mod._root)
@@ -1157,6 +1161,8 @@ def _serialize_meshes_data(bl_obj, bl_meshes, src_mod, dst_mod, materials_map, b
         # Beware of vertex_format being a string type, overriden below
         custom_properties = bl_mesh.data.albam_custom_properties.get_custom_properties_for_appid(
             app_id)
+        if export_settings.force_lod255:
+            custom_properties.level_of_detail = 255
         custom_properties.copy_custom_properties_to(mesh)
 
         # TODO: pre-check for no materials


### PR DESCRIPTION
Includes 2 options:
-export only visible
Allows to ignore hidden meshes
-set lod255 for exported meshes
Makes all exported meshes "always visible" like in Reloaded
![image](https://github.com/Brachi/albam/assets/18252816/b16c0572-cfa3-407c-9f4d-2dc315f46fd6)
