### PR TITLE
Render target implementation adapted for the main branch

### DIFF
--- a/albam/blender_ui/asset.py
+++ b/albam/blender_ui/asset.py
@@ -10,6 +10,7 @@ class AlbamAsset(bpy.types.PropertyGroup):
     original_bytes: bpy.props.StringProperty(subtype="BYTE_STRING")  # noqa: F821
     relative_path : bpy.props.StringProperty()
     extension: bpy.props.StringProperty()
+    render_target: bpy.props.BoolProperty(default=False)
 
 
 @blender_registry.register_blender_type
@@ -42,6 +43,7 @@ class ALBAM_PT_AssetImage(bpy.types.Panel):
 
         self.layout.row().prop(im.albam_asset, "app_id")
         self.layout.row().prop(im.albam_asset, "relative_path")
+        self.layout.row().prop(im.albam_asset, "render_target")
 
         app_id = im.albam_asset.app_id
         custom_props = im.albam_custom_properties.get_custom_properties_for_appid(app_id)

--- a/albam/engines/mtfw/material.py
+++ b/albam/engines/mtfw/material.py
@@ -694,6 +694,7 @@ def _gather_tex_types(bl_mat, exported_textures, textures_list, mrl=None):
         image_name = im_node.image.name
         vfile = exported_textures[image_name]["serialized_vfile"]
         relative_path_no_ext = vfile.relative_path.replace(".tex", "")
+        relative_path_no_ext = relative_path_no_ext.replace(".rtex", "")
         if not mrl:
             try:
                 real_tex_idx = textures_list.index(relative_path_no_ext)

--- a/albam/engines/mtfw/material.py
+++ b/albam/engines/mtfw/material.py
@@ -706,7 +706,10 @@ def _gather_tex_types(bl_mat, exported_textures, textures_list, mrl=None):
             except ValueError:
 
                 tex = mrl.TextureSlot(_parent=mrl, _root=mrl._root)
-                tex.type_hash = mrl.TextureType.type_r_texture
+                if im_node.image.albam_asset.render_target is True:
+                    tex.type_hash = 2013850128  # TYPE_rRenderTargetTexture
+                else:
+                    tex.type_hash = mrl.TextureType.type_r_texture
                 tex.unk_02 = 0  # TODO: research
                 tex.unk_03 = 0  # TODO: research
                 tex.texture_path = relative_path_no_ext

--- a/albam/engines/mtfw/structs/rtex-112.ksy
+++ b/albam/engines/mtfw/structs/rtex-112.ksy
@@ -21,3 +21,7 @@ seq:
   - {id: green, type: f4}
   - {id: blue, type: f4}
   - {id: alpha, type: f4}
+
+instances:
+  size_before_data_:
+    value: 40

--- a/albam/engines/mtfw/structs/rtex-112.ksy
+++ b/albam/engines/mtfw/structs/rtex-112.ksy
@@ -1,0 +1,23 @@
+meta:
+  endian: le
+  file-extension: rtex
+  id: rtex_112
+  ks-version: 0.11
+  title: MTFramework texture format version 112
+
+seq:
+  - {id: id_magic, contents: [0x52, 0x54, 0x58, 0x00]}
+  - {id: version, type: u2}
+  - {id: revision, type: u2}
+  - {id: num_mipmaps_per_image, type: u1}
+  - {id: num_images, type: u1}
+  - {id: unk_02, type: u1}
+  - {id: unk_03, type: u1}
+  - {id: width, type: u2}
+  - {id: height, type: u2}
+  - {id: reserved, type: u4}
+  - {id: compression_format, type: str, encoding: ASCII, size: 4}
+  - {id: red, type: f4}
+  - {id: green, type: f4}
+  - {id: blue, type: f4}
+  - {id: alpha, type: f4}

--- a/albam/engines/mtfw/structs/rtex-157.ksy
+++ b/albam/engines/mtfw/structs/rtex-157.ksy
@@ -1,0 +1,40 @@
+meta:
+  endian: le
+  file-extension: rtex
+  id: rtex_157
+  ks-version: 0.11
+  title: MTFramework texture render target format version 157
+
+seq:
+  - {id: id_magic, contents: [0x52, 0x54, 0x58, 0x00]}
+  - {id: packed_data_1, type: u4}
+  - {id: packed_data_2, type: u4}
+  - {id: packed_data_3, type: u4}
+
+instances:
+  size_before_data_:
+    value: "num_images == 1 ? 16 + (4 * num_mipmaps_per_image * num_images) : 16 + (4 * num_mipmaps_per_image * num_images)  + 36 * 3"
+  unk_type:
+    value: packed_data_1 & 0xffff
+  reserved_01:
+    value: (packed_data_1  >> 16) & 0x00ff
+  shift:
+    value: (packed_data_1 >> 24) & 0x000f
+  dimension:
+    value: (packed_data_1 >> 28) & 0x000f
+
+  num_mipmaps_per_image:
+    value: packed_data_2 & 0x3f
+  width:
+    value: (packed_data_2 >> 6) & 0x1fff
+  height:
+    value: (packed_data_2 >> 19) & 0x1fff
+
+  num_images:
+    value: (packed_data_3) & 0xff
+  compression_format:
+    value: (packed_data_3 >> 8) & 0xff
+  constant:
+    value: (packed_data_3 >> 16) & 0x1fff
+  reserved_02:
+    value: (packed_data_3 >> 29) & 0x003

--- a/albam/engines/mtfw/structs/rtex-157.ksy
+++ b/albam/engines/mtfw/structs/rtex-157.ksy
@@ -13,7 +13,7 @@ seq:
 
 instances:
   size_before_data_:
-    value: "num_images == 1 ? 16 + (4 * num_mipmaps_per_image * num_images) : 16 + (4 * num_mipmaps_per_image * num_images)  + 36 * 3"
+    value: 16
   unk_type:
     value: packed_data_1 & 0xffff
   reserved_01:

--- a/albam/engines/mtfw/structs/rtex_112.py
+++ b/albam/engines/mtfw/structs/rtex_112.py
@@ -66,4 +66,14 @@ class Rtex112(ReadWriteKaitaiStruct):
         if (len((self.compression_format).encode(u"ASCII")) != 4):
             raise kaitaistruct.ConsistencyError(u"compression_format", len((self.compression_format).encode(u"ASCII")), 4)
 
+    @property
+    def size_before_data_(self):
+        if hasattr(self, '_m_size_before_data_'):
+            return self._m_size_before_data_
+
+        self._m_size_before_data_ = 40
+        return getattr(self, '_m_size_before_data_', None)
+
+    def _invalidate_size_before_data_(self):
+        del self._m_size_before_data_
 

--- a/albam/engines/mtfw/structs/rtex_112.py
+++ b/albam/engines/mtfw/structs/rtex_112.py
@@ -1,0 +1,69 @@
+# This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
+# type: ignore
+
+import kaitaistruct
+from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
+
+
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+
+class Rtex112(ReadWriteKaitaiStruct):
+    def __init__(self, _io=None, _parent=None, _root=None):
+        self._io = _io
+        self._parent = _parent
+        self._root = _root if _root else self
+
+    def _read(self):
+        self.id_magic = self._io.read_bytes(4)
+        if not (self.id_magic == b"\x52\x54\x58\x00"):
+            raise kaitaistruct.ValidationNotEqualError(b"\x52\x54\x58\x00", self.id_magic, self._io, u"/seq/0")
+        self.version = self._io.read_u2le()
+        self.revision = self._io.read_u2le()
+        self.num_mipmaps_per_image = self._io.read_u1()
+        self.num_images = self._io.read_u1()
+        self.unk_02 = self._io.read_u1()
+        self.unk_03 = self._io.read_u1()
+        self.width = self._io.read_u2le()
+        self.height = self._io.read_u2le()
+        self.reserved = self._io.read_u4le()
+        self.compression_format = (self._io.read_bytes(4)).decode("ASCII")
+        self.red = self._io.read_f4le()
+        self.green = self._io.read_f4le()
+        self.blue = self._io.read_f4le()
+        self.alpha = self._io.read_f4le()
+
+
+    def _fetch_instances(self):
+        pass
+
+
+    def _write__seq(self, io=None):
+        super(Rtex112, self)._write__seq(io)
+        self._io.write_bytes(self.id_magic)
+        self._io.write_u2le(self.version)
+        self._io.write_u2le(self.revision)
+        self._io.write_u1(self.num_mipmaps_per_image)
+        self._io.write_u1(self.num_images)
+        self._io.write_u1(self.unk_02)
+        self._io.write_u1(self.unk_03)
+        self._io.write_u2le(self.width)
+        self._io.write_u2le(self.height)
+        self._io.write_u4le(self.reserved)
+        self._io.write_bytes((self.compression_format).encode(u"ASCII"))
+        self._io.write_f4le(self.red)
+        self._io.write_f4le(self.green)
+        self._io.write_f4le(self.blue)
+        self._io.write_f4le(self.alpha)
+
+
+    def _check(self):
+        pass
+        if (len(self.id_magic) != 4):
+            raise kaitaistruct.ConsistencyError(u"id_magic", len(self.id_magic), 4)
+        if not (self.id_magic == b"\x52\x54\x58\x00"):
+            raise kaitaistruct.ValidationNotEqualError(b"\x52\x54\x58\x00", self.id_magic, None, u"/seq/0")
+        if (len((self.compression_format).encode(u"ASCII")) != 4):
+            raise kaitaistruct.ConsistencyError(u"compression_format", len((self.compression_format).encode(u"ASCII")), 4)
+
+

--- a/albam/engines/mtfw/structs/rtex_157.py
+++ b/albam/engines/mtfw/structs/rtex_157.py
@@ -1,0 +1,165 @@
+# This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
+# type: ignore
+
+import kaitaistruct
+from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
+
+
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+
+class Rtex157(ReadWriteKaitaiStruct):
+    def __init__(self, _io=None, _parent=None, _root=None):
+        self._io = _io
+        self._parent = _parent
+        self._root = _root if _root else self
+
+    def _read(self):
+        self.id_magic = self._io.read_bytes(4)
+        if not (self.id_magic == b"\x52\x54\x58\x00"):
+            raise kaitaistruct.ValidationNotEqualError(b"\x52\x54\x58\x00", self.id_magic, self._io, u"/seq/0")
+        self.packed_data_1 = self._io.read_u4le()
+        self.packed_data_2 = self._io.read_u4le()
+        self.packed_data_3 = self._io.read_u4le()
+
+
+    def _fetch_instances(self):
+        pass
+
+
+    def _write__seq(self, io=None):
+        super(Rtex157, self)._write__seq(io)
+        self._io.write_bytes(self.id_magic)
+        self._io.write_u4le(self.packed_data_1)
+        self._io.write_u4le(self.packed_data_2)
+        self._io.write_u4le(self.packed_data_3)
+
+
+    def _check(self):
+        pass
+        if (len(self.id_magic) != 4):
+            raise kaitaistruct.ConsistencyError(u"id_magic", len(self.id_magic), 4)
+        if not (self.id_magic == b"\x52\x54\x58\x00"):
+            raise kaitaistruct.ValidationNotEqualError(b"\x52\x54\x58\x00", self.id_magic, None, u"/seq/0")
+
+    @property
+    def num_mipmaps_per_image(self):
+        if hasattr(self, '_m_num_mipmaps_per_image'):
+            return self._m_num_mipmaps_per_image
+
+        self._m_num_mipmaps_per_image = (self.packed_data_2 & 63)
+        return getattr(self, '_m_num_mipmaps_per_image', None)
+
+    def _invalidate_num_mipmaps_per_image(self):
+        del self._m_num_mipmaps_per_image
+    @property
+    def num_images(self):
+        if hasattr(self, '_m_num_images'):
+            return self._m_num_images
+
+        self._m_num_images = (self.packed_data_3 & 255)
+        return getattr(self, '_m_num_images', None)
+
+    def _invalidate_num_images(self):
+        del self._m_num_images
+    @property
+    def height(self):
+        if hasattr(self, '_m_height'):
+            return self._m_height
+
+        self._m_height = ((self.packed_data_2 >> 19) & 8191)
+        return getattr(self, '_m_height', None)
+
+    def _invalidate_height(self):
+        del self._m_height
+    @property
+    def constant(self):
+        if hasattr(self, '_m_constant'):
+            return self._m_constant
+
+        self._m_constant = ((self.packed_data_3 >> 16) & 8191)
+        return getattr(self, '_m_constant', None)
+
+    def _invalidate_constant(self):
+        del self._m_constant
+    @property
+    def unk_type(self):
+        if hasattr(self, '_m_unk_type'):
+            return self._m_unk_type
+
+        self._m_unk_type = (self.packed_data_1 & 65535)
+        return getattr(self, '_m_unk_type', None)
+
+    def _invalidate_unk_type(self):
+        del self._m_unk_type
+    @property
+    def dimension(self):
+        if hasattr(self, '_m_dimension'):
+            return self._m_dimension
+
+        self._m_dimension = ((self.packed_data_1 >> 28) & 15)
+        return getattr(self, '_m_dimension', None)
+
+    def _invalidate_dimension(self):
+        del self._m_dimension
+    @property
+    def width(self):
+        if hasattr(self, '_m_width'):
+            return self._m_width
+
+        self._m_width = ((self.packed_data_2 >> 6) & 8191)
+        return getattr(self, '_m_width', None)
+
+    def _invalidate_width(self):
+        del self._m_width
+    @property
+    def compression_format(self):
+        if hasattr(self, '_m_compression_format'):
+            return self._m_compression_format
+
+        self._m_compression_format = ((self.packed_data_3 >> 8) & 255)
+        return getattr(self, '_m_compression_format', None)
+
+    def _invalidate_compression_format(self):
+        del self._m_compression_format
+    @property
+    def reserved_01(self):
+        if hasattr(self, '_m_reserved_01'):
+            return self._m_reserved_01
+
+        self._m_reserved_01 = ((self.packed_data_1 >> 16) & 255)
+        return getattr(self, '_m_reserved_01', None)
+
+    def _invalidate_reserved_01(self):
+        del self._m_reserved_01
+    @property
+    def reserved_02(self):
+        if hasattr(self, '_m_reserved_02'):
+            return self._m_reserved_02
+
+        self._m_reserved_02 = ((self.packed_data_3 >> 29) & 3)
+        return getattr(self, '_m_reserved_02', None)
+
+    def _invalidate_reserved_02(self):
+        del self._m_reserved_02
+    @property
+    def shift(self):
+        if hasattr(self, '_m_shift'):
+            return self._m_shift
+
+        self._m_shift = ((self.packed_data_1 >> 24) & 15)
+        return getattr(self, '_m_shift', None)
+
+    def _invalidate_shift(self):
+        del self._m_shift
+    @property
+    def size_before_data_(self):
+        if hasattr(self, '_m_size_before_data_'):
+            return self._m_size_before_data_
+
+        self._m_size_before_data_ = ((16 + ((4 * self.num_mipmaps_per_image) * self.num_images)) if (self.num_images == 1) else ((16 + ((4 * self.num_mipmaps_per_image) * self.num_images)) + (36 * 3)))
+        return getattr(self, '_m_size_before_data_', None)
+
+    def _invalidate_size_before_data_(self):
+        del self._m_size_before_data_
+

--- a/albam/engines/mtfw/structs/rtex_157.py
+++ b/albam/engines/mtfw/structs/rtex_157.py
@@ -157,7 +157,7 @@ class Rtex157(ReadWriteKaitaiStruct):
         if hasattr(self, '_m_size_before_data_'):
             return self._m_size_before_data_
 
-        self._m_size_before_data_ = ((16 + ((4 * self.num_mipmaps_per_image) * self.num_images)) if (self.num_images == 1) else ((16 + ((4 * self.num_mipmaps_per_image) * self.num_images)) + (36 * 3)))
+        self._m_size_before_data_ = 16
         return getattr(self, '_m_size_before_data_', None)
 
     def _invalidate_size_before_data_(self):

--- a/albam/engines/mtfw/texture.py
+++ b/albam/engines/mtfw/texture.py
@@ -551,7 +551,7 @@ def _serialize_texture_21(app_id, dict_tex):
 
     width = bl_im.size[0]
     if is_rtex:
-        image_count = 1 # curently hardcoded
+        image_count = 1  # curently hardcoded
         height = bl_im.size[1]
         num_mipmaps = 8  # curently hardcoded
     else:


### PR DESCRIPTION
Complex effects use render-to-texture render targets, the .rtex file looks like a regular .tex texture that contains a header only.
This pull request adds parsers and serialization code for both rtex-112 and rtex-157 formats. MRL uses a type hash that allows detection render targets, RE5, unfortunately, had to use brute force by trying to find .rtex if .tex is missing