### PR TITLE
Add LOD selection dialog

### DIFF
--- a/albam/blender_ui/import_panel.py
+++ b/albam/blender_ui/import_panel.py
@@ -50,7 +50,7 @@ class AlbamApps(bpy.types.PropertyGroup):
 
 @blender_registry.register_blender_prop_albam(name="import_settings")
 class AlbamImportSettings(bpy.types.PropertyGroup):
-    import_lods: bpy.props.IntProperty(default=1)
+    import_only_main_lods : bpy.props.BoolProperty(default=True)
 
 
 @blender_registry.register_blender_type
@@ -354,22 +354,15 @@ class ALBAM_WM_OT_ImportOptions(bpy.types.Operator):
     bl_label = "Import Options"
     bl_idname = "wm.import_options"
 
-    import_lods_enum = bpy.props.EnumProperty(
-        name="Import LODs",
-        description="Select what LODs do you want to import",
-        items=[
-            ("0", "All", "Import all LODs", 1),
-            ("1", "Essential", "Only LODs 1 and 255", 2),
-            ("2", "Extended", "LODs 1, 3 and 255", 3),
-        ],
-        default="1",
-        options=set()
-    )
-    import_lods: import_lods_enum
+    import_main_lods_bool = bpy.props.BoolProperty(
+        name="Import main LODs only",
+        description="Allows to import only the most detailed meshes",
+        default=True)
+    import_only_main_lods: import_main_lods_bool
 
     def execute(self, context):
         import_settings = context.scene.albam.import_settings
-        import_settings.import_lods = int(self.import_lods)
+        import_settings.import_only_main_lods = self.import_only_main_lods
         return {'FINISHED'}
 
     def invoke(self, context, event):

--- a/albam/blender_ui/import_panel.py
+++ b/albam/blender_ui/import_panel.py
@@ -50,7 +50,7 @@ class AlbamApps(bpy.types.PropertyGroup):
 
 @blender_registry.register_blender_prop_albam(name="import_settings")
 class AlbamImportSettings(bpy.types.PropertyGroup):
-    import_only_main_lods : bpy.props.BoolProperty(default=True)
+    import_lods: bpy.props.IntProperty(default = 1)
 
 
 @blender_registry.register_blender_type
@@ -344,4 +344,32 @@ class ALBAM_PT_ImportButton(bpy.types.Panel):
         self.layout.separator()
         row = self.layout.row()
         row.operator("albam.import_vfile", text="Import")
+        row.operator("wm.import_options", icon="OPTIONS", text="")
         self.layout.row()
+
+
+@blender_registry.register_blender_type
+class ALBAM_WM_OT_ImportOptions(bpy.types.Operator):
+    """Set settings for importing"""
+    bl_label = "Import Options"
+    bl_idname = "wm.import_options"
+
+    import_lods: bpy.props.EnumProperty(
+        name="Import LODs",
+        description="Select what LODs do you want to import",
+        items=[
+            ("0", "All", "Import all LODs", 1),
+            ("1", "Essential", "Only LODs 1 and 255", 2),
+            ("2", "Extended", "LODs 1, 3 and 255", 3),
+        ],
+        default="1",
+        options=set()
+    )
+
+    def execute(self, context):
+        import_settings = context.scene.albam.import_settings
+        import_settings.import_lods = int(self.import_lods)
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self)

--- a/albam/blender_ui/import_panel.py
+++ b/albam/blender_ui/import_panel.py
@@ -50,7 +50,7 @@ class AlbamApps(bpy.types.PropertyGroup):
 
 @blender_registry.register_blender_prop_albam(name="import_settings")
 class AlbamImportSettings(bpy.types.PropertyGroup):
-    import_lods: bpy.props.IntProperty(default = 1)
+    import_lods: bpy.props.IntProperty(default=1)
 
 
 @blender_registry.register_blender_type
@@ -354,7 +354,7 @@ class ALBAM_WM_OT_ImportOptions(bpy.types.Operator):
     bl_label = "Import Options"
     bl_idname = "wm.import_options"
 
-    import_lods: bpy.props.EnumProperty(
+    import_lods_enum = bpy.props.EnumProperty(
         name="Import LODs",
         description="Select what LODs do you want to import",
         items=[
@@ -365,6 +365,7 @@ class ALBAM_WM_OT_ImportOptions(bpy.types.Operator):
         default="1",
         options=set()
     )
+    import_lods: import_lods_enum
 
     def execute(self, context):
         import_settings = context.scene.albam.import_settings

--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -281,9 +281,12 @@ VERSIONS_USE_BONE_PALETTES = {156}
 VERSIONS_BONES_BBOX_AFFECTED = {210, 211}
 VERSIONS_USE_TRISTRIPS = {156}
 MAIN_LODS = {
-    0: [],
-    1: [1, 255],
-    2: [1, 3, 255],
+    "re0": [1, 255],
+    "re1": [1, 255],
+    "re5": [1, 255],
+    "re6": [1, 3, 255],
+    "rev1": [1, 255],
+    "rev2": [1, 255],
 }
 
 
@@ -311,10 +314,10 @@ def build_blender_model(file_list_item, context):
     bl_object = skeleton or bpy.data.objects.new(bl_object_name, None)
     materials = build_blender_materials(
         file_list_item, context, mod, bl_object_name)
-    imported_lods = MAIN_LODS.get(import_settings.import_lods, 0)
+    imported_lods = MAIN_LODS.get(app_id)
 
     for i, mesh in enumerate(mod.meshes_data.meshes):
-        if imported_lods and mesh.level_of_detail not in imported_lods:
+        if import_settings.import_only_main_lods and mesh.level_of_detail not in imported_lods:
             continue
         try:
             name = f"{bl_object_name}_{str(i).zfill(4)}"

--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -280,7 +280,11 @@ BBOX_AFFECTED = [
 VERSIONS_USE_BONE_PALETTES = {156}
 VERSIONS_BONES_BBOX_AFFECTED = {210, 211}
 VERSIONS_USE_TRISTRIPS = {156}
-MAIN_LODS = {1, 255}
+MAIN_LODS = {
+    0: [],
+    1: [1, 255],
+    2: [1, 3, 255],
+}
 
 
 @blender_registry.register_import_function(app_id="re0", extension="mod", file_category="MESH")
@@ -307,9 +311,10 @@ def build_blender_model(file_list_item, context):
     bl_object = skeleton or bpy.data.objects.new(bl_object_name, None)
     materials = build_blender_materials(
         file_list_item, context, mod, bl_object_name)
+    imported_lods = MAIN_LODS.get(import_settings.import_lods, 0)
 
     for i, mesh in enumerate(mod.meshes_data.meshes):
-        if import_settings.import_only_main_lods and mesh.level_of_detail not in MAIN_LODS:
+        if imported_lods and mesh.level_of_detail not in imported_lods:
             continue
         try:
             name = f"{bl_object_name}_{str(i).zfill(4)}"

--- a/albam/engines/mtfw/texture.py
+++ b/albam/engines/mtfw/texture.py
@@ -308,7 +308,7 @@ def assign_textures(mtfw_material, bl_material, textures, mrl):
             if texture_target is not None:
                 texture_node.image = texture_target
             texture_code_to_blender_texture(tex_type_blender.value, texture_node, bl_material, None)
-            if tex_type_blender.value in NON_SRGB_IMAGE_TYPE:
+            if tex_index and tex_type_blender.value in NON_SRGB_IMAGE_TYPE:
                 texture_node.image.colorspace_settings.name = "Non-Color"
         except IndexError:
             print(f"tex_index {tex_index} not found. Texture len(): {len(textures)}")

--- a/tests/mtfw/conftest.py
+++ b/tests/mtfw/conftest.py
@@ -69,7 +69,7 @@ def mod_export(loaded_arcs, app_id, mod_path, mrl_path):
     from kaitaistruct import KaitaiStream
 
     bpy.context.scene.albam.apps.app_selected = app_id
-    bpy.context.scene.albam.import_settings.import_only_main_lod = False
+    bpy.context.scene.albam.import_settings.import_only_main_lods = False
 
     vfile_mod = bpy.context.scene.albam.vfs.select_vfile(app_id, mod_path)
     vfile_mrl = bpy.context.scene.albam.vfs.get_vfile(app_id, mrl_path) if mrl_path else None

--- a/tests/mtfw/conftest.py
+++ b/tests/mtfw/conftest.py
@@ -69,7 +69,7 @@ def mod_export(loaded_arcs, app_id, mod_path, mrl_path):
     from kaitaistruct import KaitaiStream
 
     bpy.context.scene.albam.apps.app_selected = app_id
-    bpy.context.scene.import_only_main_lod = False
+    bpy.context.scene.albam.import_settings.import_only_main_lod = False
 
     vfile_mod = bpy.context.scene.albam.vfs.select_vfile(app_id, mod_path)
     vfile_mrl = bpy.context.scene.albam.vfs.get_vfile(app_id, mrl_path) if mrl_path else None

--- a/tests/mtfw/conftest.py
+++ b/tests/mtfw/conftest.py
@@ -69,7 +69,7 @@ def mod_export(loaded_arcs, app_id, mod_path, mrl_path):
     from kaitaistruct import KaitaiStream
 
     bpy.context.scene.albam.apps.app_selected = app_id
-    bpy.context.scene.albam.import_settings.import_lods = 0
+    bpy.context.scene.import_only_main_lod = False
 
     vfile_mod = bpy.context.scene.albam.vfs.select_vfile(app_id, mod_path)
     vfile_mrl = bpy.context.scene.albam.vfs.get_vfile(app_id, mrl_path) if mrl_path else None

--- a/tests/mtfw/conftest.py
+++ b/tests/mtfw/conftest.py
@@ -69,7 +69,7 @@ def mod_export(loaded_arcs, app_id, mod_path, mrl_path):
     from kaitaistruct import KaitaiStream
 
     bpy.context.scene.albam.apps.app_selected = app_id
-    bpy.context.scene.albam.import_settings.import_only_main_lods = False
+    bpy.context.scene.albam.import_settings.import_lods = 0
 
     vfile_mod = bpy.context.scene.albam.vfs.select_vfile(app_id, mod_path)
     vfile_mrl = bpy.context.scene.albam.vfs.get_vfile(app_id, mrl_path) if mrl_path else None


### PR DESCRIPTION
RE6 has a problem, unlike other games it uses LOD3 for storing hands, so just to import them a user needs to enable all LODs, so this PR adds an option to import all LODs and uses per game presets for loading main LODS
