### PR TITLE
Fix CI: combine coverage files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,8 +43,6 @@ jobs:
         # Ignore segfault in bpy==4.1.0; there's no way around it yet.
         if  [ $exitcode == 139 ];then exitcode=0;
         fi
-        ls -lha
-        ls .coverage.${{ matrix.bpy.bpy-version }}
         exit "$exitcode"
     - name: "Upload coverage data"
       uses: actions/upload-artifact@v4
@@ -77,10 +75,7 @@ jobs:
           merge-multiple: true
       - name: "Combine"
         run: |
-          ls -lha
-          ls -lha .covdata
           coverage combine .covdata/
-          ls -lha
           coverage json -o .coverage.json
           export TOTAL=$(python -c "import json;print(json.load(open('.coverage.json'))['totals']['percent_covered_display'])")
           echo "total=$TOTAL" >> $GITHUB_ENV

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Test with pytest  # don't use xdist (-n auto) without checking coverage report
       run: |
         set +e
-        coverage run --append --data-file=.coverage.${{ matrix.bpy.bpy-version }} -m pytest --mtfw-dataset=tests/mtfw/datasets/ci.json --arcdir=re1::${ALBAM_RE1_ARC_DIR} --arcdir=re5::${ALBAM_RE5_ARC_DIR}
+        coverage run --data-file=.coverage.${{ matrix.bpy.bpy-version }} -m pytest --mtfw-dataset=tests/mtfw/datasets/ci.json --arcdir=re1::${ALBAM_RE1_ARC_DIR} --arcdir=re5::${ALBAM_RE5_ARC_DIR}
         exitcode="$?"
         # Ignore segfault in bpy==4.1.0; there's no way around it yet.
         if  [ $exitcode == 139 ];then exitcode=0;

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,8 +47,8 @@ jobs:
     - name: "Upload coverage data"
       uses: actions/upload-artifact@v4
       with:
-        name: .coverage-${{ matrix.bpy.bpy-version }}
-        path: .coverage-${{ matrix.bpy.bpy-version }}
+        name: .coverage.${{ matrix.bpy.bpy-version }}
+        path: .coverage.${{ matrix.bpy.bpy-version }}
         include-hidden-files: true
         if-no-files-found: error
   coverage:
@@ -72,7 +72,6 @@ jobs:
         with:
           marge-multiple: true
           path: .covdata
-          pattern: .coverage-*
       - name: "Combine"
         run: |
           ls -lha

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Test with pytest  # don't use xdist (-n auto) without checking coverage report
       run: |
         set +e
-        coverage run --append --data-file=.coverage-${{ matrix.bpy.bpy-version }} -m pytest --mtfw-dataset=tests/mtfw/datasets/ci.json --arcdir=re1::${ALBAM_RE1_ARC_DIR} --arcdir=re5::${ALBAM_RE5_ARC_DIR}
+        coverage run --append --data-file=.coverage.${{ matrix.bpy.bpy-version }} -m pytest --mtfw-dataset=tests/mtfw/datasets/ci.json --arcdir=re1::${ALBAM_RE1_ARC_DIR} --arcdir=re5::${ALBAM_RE5_ARC_DIR}
         exitcode="$?"
         # Ignore segfault in bpy==4.1.0; there's no way around it yet.
         if  [ $exitcode == 139 ];then exitcode=0;

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,11 +43,13 @@ jobs:
         # Ignore segfault in bpy==4.1.0; there's no way around it yet.
         if  [ $exitcode == 139 ];then exitcode=0;
         fi
+        ls -lha
+        ls .coverage.${{ matrix.bpy.bpy-version }}
         exit "$exitcode"
     - name: "Upload coverage data"
       uses: actions/upload-artifact@v4
       with:
-        name: .coverage.${{ matrix.bpy.bpy-version }}
+          # name: .coverage.${{ matrix.bpy.bpy-version }}
         path: .coverage.${{ matrix.bpy.bpy-version }}
         include-hidden-files: true
         if-no-files-found: error

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,18 +38,17 @@ jobs:
     - name: Test with pytest  # don't use xdist (-n auto) without checking coverage report
       run: |
         set +e
-        coverage run -m pytest --mtfw-dataset=tests/mtfw/datasets/ci.json --arcdir=re1::${ALBAM_RE1_ARC_DIR} --arcdir=re5::${ALBAM_RE5_ARC_DIR}
+        coverage run --append --data-file=.coverage-${{ matrix.bpy.bpy-version }} -m pytest --mtfw-dataset=tests/mtfw/datasets/ci.json --arcdir=re1::${ALBAM_RE1_ARC_DIR} --arcdir=re5::${ALBAM_RE5_ARC_DIR}
         exitcode="$?"
         # Ignore segfault in bpy==4.1.0; there's no way around it yet.
         if  [ $exitcode == 139 ];then exitcode=0;
         fi
-        coverage json -o .coverage.json
         exit "$exitcode"
     - name: "Upload coverage data"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: covdata
-        path: .coverage*
+        path: .coverage-${{ matrix.bpy.bpy-version }}
   coverage:
     # thanks: https://nedbatchelder.com/blog/202209/making_a_coverage_badge.html
     runs-on: ubuntu-latest
@@ -69,9 +68,14 @@ jobs:
       - name: "Download coverage data"
         uses: actions/download-artifact@v4.1.7
         with:
-          name: covdata
+          marge-multiple: true
+          pattern: .coverage-*
       - name: "Combine"
         run: |
+          ls -lha
+          coverage combine
+          ls -lha
+          coverage json -o .coverage.json
           export TOTAL=$(python -c "import json;print(json.load(open('.coverage.json'))['totals']['percent_covered_display'])")
           echo "total=$TOTAL" >> $GITHUB_ENV
           echo "### Total coverage: ${TOTAL}%" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
     - name: "Upload coverage data"
       uses: actions/upload-artifact@v4
       with:
-          # name: .coverage.${{ matrix.bpy.bpy-version }}
+        name: .coverage.${{ matrix.bpy.bpy-version }}
         path: .coverage.${{ matrix.bpy.bpy-version }}
         include-hidden-files: true
         if-no-files-found: error
@@ -72,8 +72,9 @@ jobs:
       - name: "Download coverage data"
         uses: actions/download-artifact@v4.1.7
         with:
-          marge-multiple: true
           path: .covdata
+          pattern: .coverage.*
+          marge-multiple: true
       - name: "Combine"
         run: |
           ls -lha

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,8 +47,10 @@ jobs:
     - name: "Upload coverage data"
       uses: actions/upload-artifact@v4
       with:
-        name: covdata
+        name: .coverage-${{ matrix.bpy.bpy-version }}
         path: .coverage-${{ matrix.bpy.bpy-version }}
+        include-hidden-files: true
+        if-no-files-found: error
   coverage:
     # thanks: https://nedbatchelder.com/blog/202209/making_a_coverage_badge.html
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           path: .covdata
           pattern: .coverage.*
-          marge-multiple: true
+          merge-multiple: true
       - name: "Combine"
         run: |
           ls -lha

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,11 +71,13 @@ jobs:
         uses: actions/download-artifact@v4.1.7
         with:
           marge-multiple: true
+          path: .covdata
           pattern: .coverage-*
       - name: "Combine"
         run: |
           ls -lha
-          coverage combine
+          ls -lha .covdata
+          coverage combine .covdata/
           ls -lha
           coverage json -o .coverage.json
           export TOTAL=$(python -c "import json;print(json.load(open('.coverage.json'))['totals']['percent_covered_display'])")


### PR DESCRIPTION
Bump download and upload actions to v4, and fix previous hidden bug where artifacts of different jobs in a matrix were overwritten. Now coverage data from runs in bpy 3.6 and 4.1 are combined.