### PR TITLE
Add better error message when selecting wrong app

### DIFF
--- a/albam/apps.py
+++ b/albam/apps.py
@@ -1,6 +1,15 @@
 import os
 
 
+def get_app_description(app_id):
+    app_desc = None
+    for stored_app_id, stored_app_desc, _, _ in APPS:
+        if stored_app_id == app_id:
+            app_desc = stored_app_desc
+            break
+    return app_desc
+
+
 APPS = [
     ("re0", "Resident Evil 0", "", 0),
     ("re1", "Resident Evil 1", "", 1),


### PR DESCRIPTION
Fixes #84
If one selected, for example, re6 as app_id and tries to import a re5 file, now the error message is descriptive instead of a generic traceback.

![image](https://github.com/user-attachments/assets/f930df30-913a-4aa3-875b-1f36047812d0)
