### PR TITLE
Don't raise on mesh build failure

### DIFF
--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -384,7 +384,6 @@ def build_blender_model(file_list_item, context):
 
         except Exception as err:
             print(f"[{bl_object_name}] error building mesh {i} {err}")
-            raise
             continue
 
     bl_object.albam_asset.original_bytes = mod_bytes


### PR DESCRIPTION
Fixes #150
This was probably added for debugging.
There doesn't seem to be a bug on the parser, the reference file seems to contain out of bounds references to the index buffer.