### PR TITLE
Feature/re4uhd importer

### DIFF
--- a/albam/__init__.py
+++ b/albam/__init__.py
@@ -36,6 +36,7 @@ def register():
     importlib.import_module(".engines.mtfw.collision", __package__)
     importlib.import_module(".engines.mtfw.archive", __package__)
     importlib.import_module(".engines.mtfw.mesh", __package__)
+    importlib.import_module(".engines.cie.archive", __package__)
     if os.getenv("ALBAM_ENABLE_REEN"):
         importlib.import_module(".engines.reng.archive", __package__)
         importlib.import_module(".engines.reng.mesh", __package__)

--- a/albam/__init__.py
+++ b/albam/__init__.py
@@ -37,6 +37,7 @@ def register():
     importlib.import_module(".engines.mtfw.archive", __package__)
     importlib.import_module(".engines.mtfw.mesh", __package__)
     importlib.import_module(".engines.cie.archive", __package__)
+    importlib.import_module(".engines.cie.mesh", __package__)
     if os.getenv("ALBAM_ENABLE_REEN"):
         importlib.import_module(".engines.reng.archive", __package__)
         importlib.import_module(".engines.reng.mesh", __package__)

--- a/albam/albam_vendor/xcompress.py
+++ b/albam/albam_vendor/xcompress.py
@@ -64,8 +64,8 @@ def xcompress_decompress(compressed_data, decompressed_size):
     xsettings.Flags = 0
     xsettings.WindowSize = 0x8000
     xsettings.CompressionPartitionSize = 0
-    setting = ctypes.byref(xsettings) if xflag else None
-    result = XMemCreateDecompressionContext(1, setting, 0, ctypes.byref(context))
+    settings = ctypes.byref(xsettings) if xflag else None
+    result = XMemCreateDecompressionContext(1, settings, 0, ctypes.byref(context))
     if result != 0:
         raise RuntimeError(f"Failed to create decompression context. Error code: {result}")
 
@@ -75,10 +75,54 @@ def xcompress_decompress(compressed_data, decompressed_size):
         src_size = len(compressed_data)
         src_buffer = (ctypes.c_ubyte * src_size).from_buffer_copy(compressed_data)
 
-        result = XMemDecompress(context, dest_buffer, ctypes.byref(dest_size), src_buffer, src_size)
+        result = XMemDecompress(context,
+                                dest_buffer,
+                                ctypes.byref(dest_size),
+                                src_buffer,
+                                src_size)
         if result != 0:
             raise RuntimeError(f"Decompression failed. Error code: {result}")
 
         return bytes(dest_buffer)[:dest_size.value]
     finally:
         XMemDestroyDecompressionContext(context)
+
+
+LFS_CHUNK_SIZE = 0x10000
+
+
+def xcompress_decompress_re4hd(file_entries):
+    dec_data = bytearray()
+    ctx = ctypes.c_void_p()
+    # create decompression context
+    ret = XMemCreateDecompressionContext(1, None, 0, ctypes.byref(ctx))
+    if ret != 0:
+        raise RuntimeError("Failed to create decompression context")
+
+    for i, fe in enumerate(file_entries):
+        src_size = LFS_CHUNK_SIZE if fe.size_compressed == 0 else fe.size_compressed
+        expected_size = LFS_CHUNK_SIZE if fe.size_decompressed == 0 else fe.size_decompressed
+
+        if fe.offset != 0:
+            # compressed: call XMemDecompress
+            src_buffer = ctypes.create_string_buffer(fe.raw_data)
+            dest_bufer = ctypes.create_string_buffer(LFS_CHUNK_SIZE)
+            dest_size = ctypes.c_size_t(LFS_CHUNK_SIZE)
+            ret = XMemDecompress(ctx,
+                                 ctypes.cast(dest_bufer, ctypes.c_void_p),
+                                 ctypes.byref(dest_size),
+                                 ctypes.cast(src_buffer, ctypes.c_void_p),
+                                 ctypes.c_size_t(src_size))
+            if ctypes.c_int(ret).value < 0:
+                XMemDestroyDecompressionContext(ctx)
+                raise RuntimeError(f"Chunk {i} failed to decompress (ret={ret})")
+            if dest_size.value != expected_size:
+                XMemDestroyDecompressionContext(ctx)
+                raise RuntimeError(
+                    f"Chunk {i} output size mismatch (got {dest_size.value}, expected {expected_size})")
+            dec_data.extend(dest_bufer.raw[:expected_size])
+        else:
+            dec_data.extend(fe.raw_data)
+
+    XMemDestroyDecompressionContext(ctx)
+    return dec_data

--- a/albam/albam_vendor/xcompress.py
+++ b/albam/albam_vendor/xcompress.py
@@ -1,0 +1,84 @@
+import os
+import ctypes
+
+# wrapper for xcompress64.dll library based on https://github.com/emoose/re4-research/blob/master/re4lfs.cpp
+# ctypes bindings for xcompress64.dll
+dll_path = os.path.join(os.path.dirname(__file__), "xcompress64.dll")
+print("path to xcompress: ", dll_path)
+xcompress = ctypes.WinDLL(dll_path)
+
+XMemCreateDecompressionContext = xcompress.XMemCreateDecompressionContext
+XMemCreateDecompressionContext.restype = ctypes.c_uint32
+# int algo, void* params, uint32_t param_size, void** context
+XMemCreateDecompressionContext.argtypes = [ctypes.c_int,
+                                           ctypes.c_void_p,
+                                           ctypes.c_uint32,
+                                           ctypes.POINTER(ctypes.c_void_p)]
+
+XMemDestroyDecompressionContext = xcompress.XMemDestroyDecompressionContext
+XMemDestroyDecompressionContext.restype = None
+XMemDestroyDecompressionContext.argtypes = [ctypes.c_void_p]
+
+XMemDecompress = xcompress.XMemDecompress
+XMemDecompress.restype = ctypes.c_uint32
+# void* context, void* destination buffer, size_t* dest size, void* source buffer, size_t source size
+XMemDecompress.argtypes = [ctypes.c_void_p,
+                           ctypes.c_void_p,
+                           ctypes.POINTER(ctypes.c_size_t),
+                           ctypes.c_void_p,
+                           ctypes.c_size_t]
+
+XMemCreateCompressionContext = getattr(xcompress, "XMemCreateCompressionContext", None)
+XMemCompress = getattr(xcompress, "XMemCompress", None)
+XMemDestroyCompressionContext = getattr(xcompress, "XMemDestroyCompressionContext", None)
+if XMemCreateCompressionContext:
+    XMemCreateCompressionContext.restype = ctypes.c_uint32
+    XMemCreateCompressionContext.argtypes = [ctypes.c_int,
+                                             ctypes.c_void_p,
+                                             ctypes.c_uint32,
+                                             ctypes.POINTER(ctypes.c_void_p)]
+if XMemCompress:
+    XMemCompress.restype = ctypes.c_uint32
+    XMemCompress.argtypes = [ctypes.c_void_p,
+                             ctypes.c_void_p,
+                             ctypes.POINTER(ctypes.c_size_t),
+                             ctypes.c_void_p,
+                             ctypes.c_size_t]
+if XMemDestroyCompressionContext:
+    XMemDestroyCompressionContext.restype = None
+    XMemDestroyCompressionContext.argtypes = [ctypes.c_void_p]
+
+
+class CompressionSettings(ctypes.Structure):
+    _fields_ = [
+        ("Flags", ctypes.c_uint),
+        ("WindowSize", ctypes.c_uint),
+        ("CompressionPartitionSize", ctypes.c_uint),
+    ]
+
+
+def xcompress_decompress(compressed_data, decompressed_size):
+    context = ctypes.c_void_p()
+    xflag = False
+    xsettings = CompressionSettings()
+    xsettings.Flags = 0
+    xsettings.WindowSize = 0x8000
+    xsettings.CompressionPartitionSize = 0
+    setting = ctypes.byref(xsettings) if xflag else None
+    result = XMemCreateDecompressionContext(1, setting, 0, ctypes.byref(context))
+    if result != 0:
+        raise RuntimeError(f"Failed to create decompression context. Error code: {result}")
+
+    try:
+        dest_size = ctypes.c_size_t(decompressed_size)
+        dest_buffer = (ctypes.c_ubyte * decompressed_size)()
+        src_size = len(compressed_data)
+        src_buffer = (ctypes.c_ubyte * src_size).from_buffer_copy(compressed_data)
+
+        result = XMemDecompress(context, dest_buffer, ctypes.byref(dest_size), src_buffer, src_size)
+        if result != 0:
+            raise RuntimeError(f"Decompression failed. Error code: {result}")
+
+        return bytes(dest_buffer)[:dest_size.value]
+    finally:
+        XMemDestroyDecompressionContext(context)

--- a/albam/apps.py
+++ b/albam/apps.py
@@ -18,6 +18,7 @@ APPS = [
     ("rev1", "Resident Evil: Revelations 1", "", 4),
     ("rev2", "Resident Evil: Revelations 2", "", 5),
     ("dd", "Dragon's Dogma", "", 11),
+    ("re4hd", "Resident Evil 4 HD", "", 12),
 ]
 
 REENGINE_APPS = [

--- a/albam/apps.py
+++ b/albam/apps.py
@@ -18,7 +18,7 @@ APPS = [
     ("rev1", "Resident Evil: Revelations 1", "", 4),
     ("rev2", "Resident Evil: Revelations 2", "", 5),
     ("dd", "Dragon's Dogma", "", 11),
-    ("re4hd", "Resident Evil 4 HD", "", 12),
+    ("re4uhd", "Resident Evil 4 UHD", "", 12),
 ]
 
 REENGINE_APPS = [

--- a/albam/engines/cie/archive.py
+++ b/albam/engines/cie/archive.py
@@ -1,0 +1,31 @@
+from ...registry import blender_registry
+
+import bpy
+from kaitaistruct import KaitaiStream
+from .structs.lfs import Lfs
+from .structs.udas import Udas
+
+
+@blender_registry.register_archive_loader(app_id="re4hd", extension="lfs")
+def lfs_loader(vfile):
+    lfs = LfsWrapper(file_path=vfile.absolute_path)
+    for file_entry in lfs.get_file_entries():
+        yield file_entry.file_path_with_ext
+
+
+@blender_registry.register_archive_accessor(app_id="rehd", extension="lfs")
+def arc_accessor(vfile, context):
+    lfs = LfsWrapper(vfile.root_vfile.absolute_path)
+
+
+class LfsWrapper:
+    PATH_SEPARATOR = "\\"
+
+    def __init__(self, file_path):
+        self.file_path = file_path
+        self.compressed = Lfs.from_file(file_path)
+        self.compressed._read()
+
+    def get_file_entries(self):
+        file_entries = []
+        return file_entries

--- a/albam/engines/cie/archive.py
+++ b/albam/engines/cie/archive.py
@@ -4,6 +4,7 @@ import bpy
 from kaitaistruct import KaitaiStream
 from .structs.lfs import Lfs
 from .structs.udas import Udas
+from ...albam_vendor import xcompress
 
 
 @blender_registry.register_archive_loader(app_id="re4hd", extension="lfs")

--- a/albam/engines/cie/archive.py
+++ b/albam/engines/cie/archive.py
@@ -1,21 +1,22 @@
 from ...registry import blender_registry
 
-import bpy
-from kaitaistruct import KaitaiStream
+import os
 from .structs.lfs import Lfs
 from .structs.udas import Udas
 from ...albam_vendor import xcompress
 
 
 @blender_registry.register_archive_loader(app_id="re4hd", extension="lfs")
-def lfs_loader(vfile):
+def lfs_loader(vfile, context=None):
+    print(vfile.absolute_path)
     lfs = LfsWrapper(file_path=vfile.absolute_path)
     for file_entry in lfs.get_file_entries():
         yield file_entry.file_path_with_ext
 
 
-@blender_registry.register_archive_accessor(app_id="rehd", extension="lfs")
+@blender_registry.register_archive_accessor(app_id="re4hd", extension="lfs")
 def arc_accessor(vfile, context):
+    print("accsessor")
     lfs = LfsWrapper(vfile.root_vfile.absolute_path)
 
 
@@ -24,9 +25,31 @@ class LfsWrapper:
 
     def __init__(self, file_path):
         self.file_path = file_path
+        self.file_type = self._get_all_extensions(file_path)[0]
         self.compressed = Lfs.from_file(file_path)
         self.compressed._read()
+        self.parsed = None
 
     def get_file_entries(self):
         file_entries = []
+        if self.file_type == ".udas":
+            decompressed = xcompress.xcompress_decompress_re4hd(self.compressed.file_entries)
+            udas = Udas.from_bytes(decompressed)
+            udas._read()
+            self.parsed = udas
+            for i, fe in enumerate(udas.header.data_blocks.file_entries):
+                ext = udas.header.data_blocks.file_extension[i].ext
+                fe.file_path_with_ext = f"{str(i)}.{ext}"
+                file_entries.append(fe)
         return file_entries
+
+    def _get_all_extensions(self, filepath):
+        exts = []
+        base = filepath
+        while True:
+            base, ext = os.path.splitext(base)
+            if ext:
+                exts.insert(0, ext)
+            else:
+                break
+        return exts

--- a/albam/engines/cie/archive.py
+++ b/albam/engines/cie/archive.py
@@ -6,7 +6,7 @@ from .structs.udas import Udas
 from ...albam_vendor import xcompress
 
 
-@blender_registry.register_archive_loader(app_id="re4hd", extension="lfs")
+@blender_registry.register_archive_loader(app_id="re4uhd", extension="lfs")
 def lfs_loader(vfile, context=None):
     print(vfile.absolute_path)
     lfs = LfsWrapper(file_path=vfile.absolute_path)
@@ -14,7 +14,7 @@ def lfs_loader(vfile, context=None):
         yield file_entry.file_path_with_ext
 
 
-@blender_registry.register_archive_accessor(app_id="re4hd", extension="lfs")
+@blender_registry.register_archive_accessor(app_id="re4uhd", extension="lfs")
 def arc_accessor(vfile, context):
     print("accsessor")
     lfs = LfsWrapper(vfile.root_vfile.absolute_path)
@@ -37,9 +37,11 @@ class LfsWrapper:
             udas = Udas.from_bytes(decompressed)
             udas._read()
             self.parsed = udas
+            fe_base_name = os.path.basename(self.file_path)
+            fe_base_name = fe_base_name.split(".")[0] + "_"
             for i, fe in enumerate(udas.header.data_blocks.file_entries):
                 ext = udas.header.data_blocks.file_extension[i].ext
-                fe.file_path_with_ext = f"{str(i)}.{ext}"
+                fe.file_path_with_ext = f"{fe_base_name}{str(i).zfill(3)}.{ext}"
                 file_entries.append(fe)
         return file_entries
 

--- a/albam/engines/cie/archive.py
+++ b/albam/engines/cie/archive.py
@@ -19,6 +19,14 @@ def arc_accessor(vfile, context):
     print("accsessor")
     lfs = LfsWrapper(vfile.root_vfile.absolute_path)
 
+    path = vfile.relative_path_windows
+    path_no_ext = str(vfile.relative_path_windows_no_ext)
+    ext = path.suffix.replace(".", "")
+    file_type = ext
+    file_bytes = lfs.get_file(path_no_ext, file_type)
+
+    return file_bytes
+
 
 class LfsWrapper:
     PATH_SEPARATOR = "\\"
@@ -28,15 +36,19 @@ class LfsWrapper:
         self.file_type = self._get_all_extensions(file_path)[0]
         self.compressed = Lfs.from_file(file_path)
         self.compressed._read()
-        self.parsed = None
+        self.parsed = self.decompress()
 
-    def get_file_entries(self):
-        file_entries = []
+    def decompress(self):
         if self.file_type == ".udas":
             decompressed = xcompress.xcompress_decompress_re4hd(self.compressed.file_entries)
             udas = Udas.from_bytes(decompressed)
             udas._read()
-            self.parsed = udas
+            return udas
+
+    def get_file_entries(self):
+        file_entries = []
+        if self.file_type == ".udas":
+            udas = self.parsed
             fe_base_name = os.path.basename(self.file_path)
             fe_base_name = fe_base_name.split(".")[0] + "_"
             for i, fe in enumerate(udas.header.data_blocks.file_entries):
@@ -44,6 +56,14 @@ class LfsWrapper:
                 fe.file_path_with_ext = f"{fe_base_name}{str(i).zfill(3)}.{ext}"
                 file_entries.append(fe)
         return file_entries
+
+    def get_file(self, file_path_no_ext, file_type):
+        file_id = int(file_path_no_ext.split("_")[-1])
+        if self.file_type == ".udas":
+            for i,  fe in enumerate(self.parsed.header.data_blocks.file_entries):
+                if i == file_id and self.parsed.header.data_blocks.file_extension[i].ext == file_type:
+                    return fe.raw_data
+        raise RuntimeError(f"File {file_path_no_ext} with type {file_type} not found in {self.file_path}")
 
     def _get_all_extensions(self, filepath):
         exts = []

--- a/albam/engines/cie/archive.py
+++ b/albam/engines/cie/archive.py
@@ -5,6 +5,10 @@ from .structs.lfs import Lfs
 from .structs.udas import Udas
 from ...albam_vendor import xcompress
 
+# RE4 UHD mesh BIN header is 80 bytes. BINs smaller than this are other types
+# (camera, lighting, collision, etc.) and should not be exposed as importable models.
+RE4_UHD_MESH_BIN_MIN_SIZE = 80
+
 
 @blender_registry.register_archive_loader(app_id="re4uhd", extension="lfs")
 def lfs_loader(vfile, context=None):
@@ -16,7 +20,6 @@ def lfs_loader(vfile, context=None):
 
 @blender_registry.register_archive_accessor(app_id="re4uhd", extension="lfs")
 def arc_accessor(vfile, context):
-    print("accsessor")
     lfs = LfsWrapper(vfile.root_vfile.absolute_path)
 
     path = vfile.relative_path_windows
@@ -24,6 +27,11 @@ def arc_accessor(vfile, context):
     ext = path.suffix.replace(".", "")
     file_type = ext
     file_bytes = lfs.get_file(path_no_ext, file_type)
+
+    print(
+        f"[re4uhd] accessor: {vfile.display_name} "
+        f"({len(file_bytes)} bytes, header: {file_bytes[:16].hex() if len(file_bytes) >= 16 else file_bytes.hex()})"
+    )
 
     return file_bytes
 
@@ -53,6 +61,19 @@ class LfsWrapper:
             fe_base_name = fe_base_name.split(".")[0] + "_"
             for i, fe in enumerate(udas.header.data_blocks.file_entries):
                 ext = udas.header.data_blocks.file_extension[i].ext
+                file_size = len(fe.raw_data)
+                print(f"[re4uhd] UDAS entry {i:03d}: .{ext.upper()} ({file_size} bytes)")
+
+                # Skip BIN entries that are too small to be mesh BINs.
+                # Non-mesh BINs (camera, lighting, etc.) live alongside mesh BINs in the
+                # same UDAS but have a completely different, shorter format.
+                if ext.upper() == "BIN" and file_size < RE4_UHD_MESH_BIN_MIN_SIZE:
+                    print(
+                        f"[re4uhd]   -> skipped: BIN too small to be a mesh "
+                        f"({file_size} bytes < {RE4_UHD_MESH_BIN_MIN_SIZE} minimum)"
+                    )
+                    continue
+
                 fe.file_path_with_ext = f"{fe_base_name}{str(i).zfill(3)}.{ext}"
                 file_entries.append(fe)
         return file_entries
@@ -60,7 +81,7 @@ class LfsWrapper:
     def get_file(self, file_path_no_ext, file_type):
         file_id = int(file_path_no_ext.split("_")[-1])
         if self.file_type == ".udas":
-            for i,  fe in enumerate(self.parsed.header.data_blocks.file_entries):
+            for i, fe in enumerate(self.parsed.header.data_blocks.file_entries):
                 if i == file_id and self.parsed.header.data_blocks.file_extension[i].ext == file_type:
                     return fe.raw_data
         raise RuntimeError(f"File {file_path_no_ext} with type {file_type} not found in {self.file_path}")

--- a/albam/engines/cie/mesh.py
+++ b/albam/engines/cie/mesh.py
@@ -1,9 +1,54 @@
 import bpy
 from ...registry import blender_registry
 from ...vfs import VirtualFileData, VirtualFile
+from ...lib.misc import chunks
 from .structs.re4_uhd_bin import Re4UhdBin
+from ...lib.blender import strip_triangles_to_triangles_list
 
 
 @blender_registry.register_import_function(app_id="re4uhd", extension="BIN", albam_asset_type="MODEL")
 def build_blender_model(vfile: VirtualFile, context: bpy.types.Context) -> bpy.types.Object:
-    print("importing model from bin")
+    app_id = vfile.app_id
+    bin_bytes = vfile.get_bytes()
+    bin = Re4UhdBin.from_bytes(bin_bytes)
+    bin._read()
+    bl_object_name = vfile.display_name
+
+    locations = [_process_locations(vertex) for vertex in bin.vertex_positions]
+    indices = bin.indexes
+    faces = []
+    buffer = {}
+    lookup_indices = {
+        0: [],
+        1: [],
+        2: [],
+    }
+    # for vindex, findex in enumerate(indices):
+    #    lookup_indices[findex].append(vindex)
+
+
+    for vindex, findex in enumerate(indices):
+        buffer[findex] = vindex
+        if len(buffer) == 3:
+            tri = (buffer[0], buffer[1], buffer[2])
+            faces.append(tri)
+            buffer = {}
+
+    bl_object = bpy.data.objects.new(bl_object_name, None)
+
+    name = f"{bl_object_name}_test "
+    me_ob = bpy.data.meshes.new(vfile.display_name)
+    me_ob.from_pydata(locations, [], faces)
+    ob = bpy.data.objects.new(name, me_ob)
+
+    ob.parent = bl_object
+    return bl_object
+
+
+def _process_locations(vertex):
+    x = vertex.x
+    y = vertex.y
+    z = vertex.z
+
+    # Y-up to z-up and cm to m
+    return (x * 0.01, -z * 0.01, y * 0.01)

--- a/albam/engines/cie/mesh.py
+++ b/albam/engines/cie/mesh.py
@@ -1,0 +1,9 @@
+import bpy
+from ...registry import blender_registry
+from ...vfs import VirtualFileData, VirtualFile
+from .structs.re4_uhd_bin import Re4UhdBin
+
+
+@blender_registry.register_import_function(app_id="re4uhd", extension="BIN", albam_asset_type="MODEL")
+def build_blender_model(vfile: VirtualFile, context: bpy.types.Context) -> bpy.types.Object:
+    print("importing model from bin")

--- a/albam/engines/cie/mesh.py
+++ b/albam/engines/cie/mesh.py
@@ -1,54 +1,365 @@
 import bpy
+from mathutils import Vector
 from ...registry import blender_registry
-from ...vfs import VirtualFileData, VirtualFile
+from ...vfs import VirtualFile
 from ...lib.misc import chunks
 from .structs.re4_uhd_bin import Re4UhdBin
-from ...lib.blender import strip_triangles_to_triangles_list
+from .textures import load_textures_for_model
 
+# RE4 UHD mesh BIN header is exactly 80 bytes.
+# Smaller files are other BIN types inside the UDAS (camera, lighting, collision, etc.)
+RE4_UHD_BIN_HEADER_SIZE = 80
+
+# face_index primitive types (RE4 UHD BIN format, same as DirectX D3DPT_* values)
+FTYPE_TRIANGLE_LIST  = 5  # fcount/3 triangles, 3 sequential verts per triangle
+FTYPE_TRIANGLE_STRIP = 6  # fcount-2 triangles, alternating winding
+FTYPE_TRIANGLE_FAN   = 7  # fcount-2 triangles, fan around first vertex
+FTYPE_QUAD_LIST      = 8  # fcount/4 quads, each split into 2 triangles
 
 @blender_registry.register_import_function(app_id="re4uhd", extension="BIN", albam_asset_type="MODEL")
 def build_blender_model(vfile: VirtualFile, context: bpy.types.Context) -> bpy.types.Object:
-    app_id = vfile.app_id
     bin_bytes = vfile.get_bytes()
-    bin = Re4UhdBin.from_bytes(bin_bytes)
-    bin._read()
     bl_object_name = vfile.display_name
 
-    locations = [_process_locations(vertex) for vertex in bin.vertex_positions]
-    indices = bin.indexes
+    # Guard: UDAS containers hold many BIN types (camera, lighting, collision, etc.).
+    # A mesh BIN header requires at least 80 bytes. Anything smaller is a different format.
+    if len(bin_bytes) < RE4_UHD_BIN_HEADER_SIZE:
+        raise ValueError(
+            f"'{bl_object_name}' is not a mesh BIN "
+            f"({len(bin_bytes)} bytes — minimum for a mesh header is {RE4_UHD_BIN_HEADER_SIZE}). "
+            f"This file is likely a non-geometry BIN from the UDAS container (camera, lighting, etc.)."
+        )
+
+    bin = Re4UhdBin.from_bytes(bin_bytes)
+    bin._read()
+
+    print(
+        f"[re4uhd] {bl_object_name}: "
+        f"{bin.header.num_vertices} verts, "
+        f"{bin.header.num_materials} materials, "
+        f"{bin.header.num_bones} bones, "
+        f"{bin.header.num_weights} weight maps"
+    )
+
+    # -- 1. Vertex positions ------------------------------------------------
+    locations = [_yz_flip(v.x, v.y, v.z) for v in bin.vertex_positions]
+
+    # -- 2. Build faces from material strips --------------------------------
+    # RE4 UHD uses a non-indexed mesh layout: vertex_positions has one entry
+    # per face-corner (no vertex sharing). Faces are formed by consuming vertices
+    # sequentially, grouped per material and per strip within each material.
+    faces, mat_face_ranges = _build_faces(bin)
+    print(f"[re4uhd] {bl_object_name}: {len(faces)} faces across {len(mat_face_ranges)} materials")
+
+    # -- 3. Create mesh -----------------------------------------------------
+    me = bpy.data.meshes.new(bl_object_name)
+    me.from_pydata(locations, [], faces)
+    me.update()
+
+    # -- 4. UV coordinates --------------------------------------------------
+    if bin.texcoords:
+        uv_layer = me.uv_layers.new(name="UVMap")
+        for loop in me.loops:
+            uv = bin.texcoords[loop.vertex_index]
+            uv_layer.data[loop.index].uv = (uv.u, 1.0 - uv.v)  # flip V for Blender
+
+    # -- 5. Split normals ---------------------------------------------------
+    if bin.normals:
+        loop_normals = []
+        for loop in me.loops:
+            n = bin.normals[loop.vertex_index]
+            loop_normals.append(_yz_flip(n.x, n.y, n.z))
+        me.normals_split_custom_set(loop_normals)
+
+    # -- 6. Per-material face assignment ------------------------------------
+    _apply_materials(me, bin, mat_face_ranges)
+
+    # -- 7. Create mesh object ---------------------------------------------
+    mesh_ob = bpy.data.objects.new(f"{bl_object_name}_mesh", me)
+
+    # -- 8. Armature + bones -----------------------------------------------
+    arm_ob = _build_armature(bl_object_name, bin, context)
+
+    if arm_ob:
+        # -- 9. Vertex groups (skin weights) --------------------------------
+        _apply_weights(mesh_ob, bin)
+
+        mesh_ob.parent = arm_ob
+        arm_mod = mesh_ob.modifiers.new("Armature", 'ARMATURE')
+        arm_mod.object = arm_ob
+        arm_mod.use_vertex_groups = True
+
+        # -- 10. Textures (optional, requires .pack.lfs in same dir) ----------
+        try:
+            load_textures_for_model(mesh_ob, bin, vfile, context)
+        except Exception as e:
+            print(f"[re4uhd] textures: skipped ({e})")
+
+        return arm_ob
+    else:
+        root = bpy.data.objects.new(bl_object_name, None)
+        mesh_ob.parent = root
+
+        try:
+            load_textures_for_model(mesh_ob, bin, vfile, context)
+        except Exception as e:
+            print(f"[re4uhd] textures: skipped ({e})")
+
+        return root
+
+# -- Face building -----------------------------------------------------------
+
+def _build_faces(bin):
+    """
+    Build the face list and per-material face ranges from material.face_index strips.
+
+    Returns:
+        faces           - list of (i1, i2, i3) tuples
+        mat_face_ranges - list of (start, end) face indices per material
+    """
     faces = []
-    buffer = {}
-    lookup_indices = {
-        0: [],
-        1: [],
-        2: [],
-    }
-    # for vindex, findex in enumerate(indices):
-    #    lookup_indices[findex].append(vindex)
+    mat_face_ranges = []
+    vertex_offset = 0
+
+    for mat_i, material in enumerate(bin.materials):
+        fi = material.face_index
+        mat_start = len(faces)
+
+        for strip in fi.strips:
+            verts = list(range(vertex_offset, vertex_offset + strip.fcount))
+            vertex_offset += strip.fcount
+            _process_strip(faces, verts, strip.ftype)
+
+        mat_face_ranges.append((mat_start, len(faces)))
+
+    return faces, mat_face_ranges
+
+def _process_strip(faces, verts, ftype):
+    """Append triangles from a single strip to the faces list."""
+    if ftype == FTYPE_TRIANGLE_LIST:
+        # Each consecutive triplet = one triangle
+        for tri in chunks(verts, 3):
+            if len(tri) == 3 and tri[0] != tri[1] and tri[0] != tri[2] and tri[1] != tri[2]:
+                faces.append(tuple(tri))
+
+    elif ftype == FTYPE_TRIANGLE_STRIP:
+        # Triangle strip with alternating winding
+        if len(verts) < 3:
+            return
+        bkface = -1
+        p1, p2, p3 = verts[0], verts[1], verts[2]
+        bkface = -bkface  # -> 1
+        if p1 != p2 and p1 != p3 and p2 != p3:
+            faces.append((p1, p2, p3))
+        for i in range(1, len(verts) - 2):
+            bkface = -bkface
+            p1, p2, p3 = p2, p3, verts[i + 2]
+            if p1 != p2 and p1 != p3 and p2 != p3:
+                if bkface == 1:
+                    faces.append((p1, p2, p3))
+                else:
+                    faces.append((p3, p2, p1))
+
+    elif ftype == FTYPE_TRIANGLE_FAN:
+        # Fan around the first vertex
+        center = verts[0]
+        for i in range(2, len(verts)):
+            p1, p2, p3 = center, verts[i - 1], verts[i]
+            if p1 != p2 and p1 != p3 and p2 != p3:
+                faces.append((p1, p2, p3))
+
+    elif ftype == FTYPE_QUAD_LIST:
+        # Each group of 4 verts = 1 quad = 2 triangles
+        for quad in chunks(verts, 4):
+            if len(quad) == 4:
+                p1, p2, p3, p4 = quad
+                if p1 != p2 and p1 != p3 and p2 != p3:
+                    faces.append((p1, p2, p3))
+                if p1 != p3 and p1 != p4 and p3 != p4:
+                    faces.append((p1, p3, p4))
+    else:
+        print(f"[re4uhd] WARNING: unknown ftype={ftype}, {len(verts)} verts skipped")
+
+# -- Materials ---------------------------------------------------------------
+
+def _apply_materials(me, bin, mat_face_ranges):
+    """
+    Create one Blender material per BIN material and assign to face ranges.
+
+    material.raw (24 bytes, MaterialPart struct):
+      bytes 0-11  : unknown
+      byte  12    : diffuse_map  (TPL slot index)
+      byte  13    : bump_map     (TPL slot index)
+      byte  14    : opacity_map  (TPL slot index)
+      byte  15    : generic_specular_map
+      bytes 16-18 : specular RGB intensity
+      byte  21    : specular_scale
+      byte  23    : custom_specular_map
+    """
+    for mat_i, material in enumerate(bin.materials):
+        raw = bytes(material.raw)
+        diffuse_slot = raw[12]
+        bump_slot    = raw[13]
+        opacity_slot = raw[14]
+
+        bl_mat = bpy.data.materials.new(name=f"re4uhd_mat_{mat_i}_diff{diffuse_slot}")
+        bl_mat["re4uhd_diffuse_tpl_slot"]  = diffuse_slot
+        bl_mat["re4uhd_bump_tpl_slot"]     = bump_slot
+        bl_mat["re4uhd_opacity_tpl_slot"]  = opacity_slot
+        me.materials.append(bl_mat)
+
+    for mat_i, (start, end) in enumerate(mat_face_ranges):
+        for fi in range(start, end):
+            me.polygons[fi].material_index = mat_i
+
+# -- Armature ----------------------------------------------------------------
+
+def _find_existing_armature(bin, context):
+    """
+    Look for an armature in the current collection that can be reused for this BIN.
+
+    RE4 UHD characters are split across multiple BINs (body, head, hands, etc.).
+    Each BIN carries only the bones relevant to that part — a subset of the full
+    skeleton. The body BIN (typically _000) imports the full armature first.
+    Subsequent BINs (head, hands, etc.) need a subset of those bones, so we
+    reuse the existing armature when all required bones are already present.
+    """
+    needed = {f"bone_{b.bone_id:03d}" for b in bin.bones}
+    for obj in context.collection.objects:
+        if obj.type != 'ARMATURE':
+            continue
+        existing = {b.name for b in obj.data.bones}
+        # Reuse if all needed bones are present (subset: head/hands ⊆ full body)
+        if needed.issubset(existing):
+            return obj
+    return None
 
 
-    for vindex, findex in enumerate(indices):
-        buffer[findex] = vindex
-        if len(buffer) == 3:
-            tri = (buffer[0], buffer[1], buffer[2])
-            faces.append(tri)
-            buffer = {}
+# Bones are stored as LOCAL offsets from parent in millimeters (confirmed via debug:
+# bone_000 raw_y=1140 = 1.14m hip height, bone_004 accumulated = 1.65m chest).
+# Vertices are in centimeters (*0.01). Both produce ~1.7m scale in Blender.
+BONE_SCALE = 0.01  # same raw unit as vertex positions (*0.01 = Blender meters)
 
-    bl_object = bpy.data.objects.new(bl_object_name, None)
+def _build_armature(bl_object_name, bin, context):
+    """Create an armature object from BIN bones and return it, or None if no bones."""
+    if not bin.bones:
+        return None
 
-    name = f"{bl_object_name}_test "
-    me_ob = bpy.data.meshes.new(vfile.display_name)
-    me_ob.from_pydata(locations, [], faces)
-    ob = bpy.data.objects.new(name, me_ob)
+    # Reuse an existing armature if the scene already has one with matching bones.
+    # This avoids duplicates when importing multiple BINs from the same character.
+    existing = _find_existing_armature(bin, context)
+    if existing:
+        print(f"[re4uhd] armature: reusing '{existing.name}' ({len(bin.bones)} bones)")
+        return existing
 
-    ob.parent = bl_object
-    return bl_object
+    bone_data = {b.bone_id: b for b in bin.bones}
 
+    def world_pos(bone_id, visited=None):
+        """Recursively accumulate local offsets (same unit as vertices) to world position."""
+        if visited is None:
+            visited = set()
+        if bone_id in visited:
+            return Vector((0.0, 0.0, 0.0))
+        visited.add(bone_id)
+        b = bone_data[bone_id]
+        # Y-up (RE4) -> Z-up (Blender), game units -> Blender meters
+        local = Vector((b.x * BONE_SCALE, -b.z * BONE_SCALE, b.y * BONE_SCALE))
+        if b.parent == b.bone_id or b.parent not in bone_data:
+            return local
+        return world_pos(b.parent, visited) + local
 
-def _process_locations(vertex):
-    x = vertex.x
-    y = vertex.y
-    z = vertex.z
+    world_positions = {b.bone_id: world_pos(b.bone_id) for b in bin.bones}
 
-    # Y-up to z-up and cm to m
+    arm_data = bpy.data.armatures.new(f"{bl_object_name}_armature")
+    arm_ob = bpy.data.objects.new(f"{bl_object_name}_armature", arm_data)
+    context.collection.objects.link(arm_ob)
+
+    # Use bpy.ops with a reliable override to enter edit mode
+    prev_active = context.view_layer.objects.active
+
+    context.view_layer.objects.active = arm_ob
+    bpy.ops.object.mode_set(mode='EDIT')
+
+    edit_bone_map = {}
+
+    for b in bin.bones:
+        eb = arm_data.edit_bones.new(f"bone_{b.bone_id:03d}")
+        head = world_positions[b.bone_id]
+        eb.head = head
+
+        children = [c for c in bin.bones
+                    if c.parent == b.bone_id and c.bone_id != b.bone_id]
+        if children:
+            child_avg = sum((world_positions[c.bone_id] for c in children), Vector((0, 0, 0)))
+            child_avg /= len(children)
+            eb.tail = child_avg if (child_avg - head).length > 0.001 else head + Vector((0, 0, 0.02))
+        else:
+            eb.tail = head + Vector((0, 0, 0.02))
+
+        edit_bone_map[b.bone_id] = eb
+
+    for b in bin.bones:
+        if b.parent != b.bone_id and b.parent in edit_bone_map:
+            edit_bone_map[b.bone_id].parent = edit_bone_map[b.parent]
+            edit_bone_map[b.bone_id].use_connect = False
+
+    bpy.ops.object.mode_set(mode='OBJECT')
+    context.view_layer.objects.active = prev_active
+
+    # Show bones in front of the mesh (same style as MT Framework armatures in albam)
+    arm_ob.show_in_front = True
+    arm_data.display_type = 'OCTAHEDRAL'
+
+    print(f"[re4uhd] armature: {len(bin.bones)} bones")
+    return arm_ob
+
+# -- Vertex weights ----------------------------------------------------------
+
+def _apply_weights(mesh_ob, bin):
+    """
+    Create vertex groups and assign bone weights.
+
+    bin.indexes[i]  = WeightMap index for vertex i (vertex_weight_index_offset)
+    bin.weights[j]  = WeightMap entry: up to 3 (bone_id, weight/255) pairs;
+                      count tells how many bones are active (1-3).
+    """
+    if not bin.weights or not bin.indexes:
+        return
+
+    weight_index = list(bin.indexes)
+    weight_maps  = list(bin.weights)
+    vg_cache     = {}  # bone_id -> VertexGroup
+
+    def get_vg(bone_id):
+        name = f"bone_{bone_id:03d}"
+        if name not in vg_cache:
+            vg_cache[name] = mesh_ob.vertex_groups.new(name=name)
+        return vg_cache[name]
+
+    for vert_i, wm_idx in enumerate(weight_index):
+        if wm_idx >= len(weight_maps):
+            continue
+        wm = weight_maps[wm_idx]
+
+        # Collect active bone weights and normalize so they sum to 1.0.
+        # Weights are stored as raw bytes (0-255) whose sum may not equal 255.
+        # Dividing by actual sum ensures full vertex coverage.
+        active = []
+        if wm.count >= 1: active.append((wm.bone_id1, wm.weight1))
+        if wm.count >= 2: active.append((wm.bone_id2, wm.weight2))
+        if wm.count >= 3: active.append((wm.bone_id3, wm.weight3))
+
+        total = sum(w for _, w in active)
+        if total == 0:
+            continue
+
+        for bone_id, raw_w in active:
+            get_vg(bone_id).add([vert_i], raw_w / total, 'REPLACE')
+
+    print(f"[re4uhd] weights: {len(weight_index)} verts, {len(vg_cache)} vertex groups")
+
+# -- Coordinate conversion ---------------------------------------------------
+
+def _yz_flip(x, y, z):
+    """Convert Y-up (RE4, centimeters) to Z-up (Blender, meters)."""
     return (x * 0.01, -z * 0.01, y * 0.01)

--- a/albam/engines/cie/structs/lfs.ksy
+++ b/albam/engines/cie/structs/lfs.ksy
@@ -1,0 +1,35 @@
+meta:
+  id: lfs
+  file-extension: lfs
+  bit-endian: le
+  endian: le
+  
+  
+seq:
+   - {id: lfs_header, type: header}
+   - {id: data_chunks, type: data_chunk, repeat: expr, repeat-expr: lfs_header.num_chunks }
+  
+
+types:
+  header:
+    seq:
+    - {id: id_magic, contents: [0x52, 0x44, 0x4c, 0x58]}
+    - {id: id_magic_2, type: u4}
+    - {id: size_decompressed, type: u4}
+    - {id: size_compressed, type: u4}
+    - {id: num_chunks, type: u4}
+    instances:
+      size:
+        value: 20
+      
+  data_chunk:
+    seq:
+      - {id: size_compressed, type: u2}
+      - {id: size_decompressed, type: u2}
+      - {id: offset, type: u4}
+    instances:
+      comp_offset:
+         value: offset & ~1 # one bit "is compressed?" flag
+      chunk:
+        pos: comp_offset + _root.lfs_header.size
+        size: size_compressed

--- a/albam/engines/cie/structs/lfs.ksy
+++ b/albam/engines/cie/structs/lfs.ksy
@@ -1,35 +1,28 @@
 meta:
   id: lfs
   file-extension: lfs
-  bit-endian: le
   endian: le
-  
+  bit-endian: le
+  ks-version: "0.11"
+  title: RE4UHD archive compressed with xcompression
   
 seq:
-   - {id: lfs_header, type: header}
-   - {id: data_chunks, type: data_chunk, repeat: expr, repeat-expr: lfs_header.num_chunks }
+  - {id: header, type: lfs_header}
+  - {id: file_entries, type: file_entry, repeat: expr, repeat-expr: header.num_files}
   
-
 types:
-  header:
+  lfs_header:
     seq:
     - {id: id_magic, contents: [0x52, 0x44, 0x4c, 0x58]}
-    - {id: id_magic_2, type: u4}
+    - {id: file_id, type: u4} # 0xaabaeefe
     - {id: size_decompressed, type: u4}
     - {id: size_compressed, type: u4}
-    - {id: num_chunks, type: u4}
-    instances:
-      size:
-        value: 20
-      
-  data_chunk:
+    - {id: num_files, type: u4}
+  file_entry:
     seq:
-      - {id: size_compressed, type: u2}
-      - {id: size_decompressed, type: u2}
-      - {id: offset, type: u4}
+    - {id: size_compressed, type: u2}
+    - {id: size_decompressed, type: u2}
+    - {id: offset, type: u4}
     instances:
-      comp_offset:
-         value: offset & ~1 # one bit "is compressed?" flag
-      chunk:
-        pos: comp_offset + _root.lfs_header.size
-        size: size_compressed
+      raw_data:
+        {pos: (offset & ~1) + 20, size: size_compressed}

--- a/albam/engines/cie/structs/lfs.py
+++ b/albam/engines/cie/structs/lfs.py
@@ -1,0 +1,180 @@
+# This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
+# type: ignore
+
+import kaitaistruct
+from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
+
+
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+
+class Lfs(ReadWriteKaitaiStruct):
+    def __init__(self, _io=None, _parent=None, _root=None):
+        self._io = _io
+        self._parent = _parent
+        self._root = _root if _root else self
+
+    def _read(self):
+        self.lfs_header = Lfs.Header(self._io, self, self._root)
+        self.lfs_header._read()
+        self.data_chunks = []
+        for i in range(self.lfs_header.num_chunks):
+            _t_data_chunks = Lfs.DataChunk(self._io, self, self._root)
+            _t_data_chunks._read()
+            self.data_chunks.append(_t_data_chunks)
+
+
+
+    def _fetch_instances(self):
+        pass
+        self.lfs_header._fetch_instances()
+        for i in range(len(self.data_chunks)):
+            pass
+            self.data_chunks[i]._fetch_instances()
+
+
+
+    def _write__seq(self, io=None):
+        super(Lfs, self)._write__seq(io)
+        self.lfs_header._write__seq(self._io)
+        for i in range(len(self.data_chunks)):
+            pass
+            self.data_chunks[i]._write__seq(self._io)
+
+
+
+    def _check(self):
+        pass
+        if self.lfs_header._root != self._root:
+            raise kaitaistruct.ConsistencyError(u"lfs_header", self.lfs_header._root, self._root)
+        if self.lfs_header._parent != self:
+            raise kaitaistruct.ConsistencyError(u"lfs_header", self.lfs_header._parent, self)
+        if (len(self.data_chunks) != self.lfs_header.num_chunks):
+            raise kaitaistruct.ConsistencyError(u"data_chunks", len(self.data_chunks), self.lfs_header.num_chunks)
+        for i in range(len(self.data_chunks)):
+            pass
+            if self.data_chunks[i]._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"data_chunks", self.data_chunks[i]._root, self._root)
+            if self.data_chunks[i]._parent != self:
+                raise kaitaistruct.ConsistencyError(u"data_chunks", self.data_chunks[i]._parent, self)
+
+
+    class Header(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.id_magic = self._io.read_bytes(4)
+            if not (self.id_magic == b"\x52\x44\x4C\x58"):
+                raise kaitaistruct.ValidationNotEqualError(b"\x52\x44\x4C\x58", self.id_magic, self._io, u"/types/header/seq/0")
+            self.id_magic_2 = self._io.read_u4le()
+            self.size_decompressed = self._io.read_u4le()
+            self.size_compressed = self._io.read_u4le()
+            self.num_chunks = self._io.read_u4le()
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Lfs.Header, self)._write__seq(io)
+            self._io.write_bytes(self.id_magic)
+            self._io.write_u4le(self.id_magic_2)
+            self._io.write_u4le(self.size_decompressed)
+            self._io.write_u4le(self.size_compressed)
+            self._io.write_u4le(self.num_chunks)
+
+
+        def _check(self):
+            pass
+            if (len(self.id_magic) != 4):
+                raise kaitaistruct.ConsistencyError(u"id_magic", len(self.id_magic), 4)
+            if not (self.id_magic == b"\x52\x44\x4C\x58"):
+                raise kaitaistruct.ValidationNotEqualError(b"\x52\x44\x4C\x58", self.id_magic, None, u"/types/header/seq/0")
+
+        @property
+        def size(self):
+            if hasattr(self, '_m_size'):
+                return self._m_size
+
+            self._m_size = 20
+            return getattr(self, '_m_size', None)
+
+        def _invalidate_size(self):
+            del self._m_size
+
+    class DataChunk(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root
+            self._should_write_chunk = False
+            self.chunk__to_write = True
+
+        def _read(self):
+            self.size_compressed = self._io.read_u2le()
+            self.size_decompressed = self._io.read_u2le()
+            self.offset = self._io.read_u4le()
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.chunk
+
+
+        def _write__seq(self, io=None):
+            super(Lfs.DataChunk, self)._write__seq(io)
+            self._should_write_chunk = self.chunk__to_write
+            self._io.write_u2le(self.size_compressed)
+            self._io.write_u2le(self.size_decompressed)
+            self._io.write_u4le(self.offset)
+
+
+        def _check(self):
+            pass
+
+        @property
+        def comp_offset(self):
+            if hasattr(self, '_m_comp_offset'):
+                return self._m_comp_offset
+
+            self._m_comp_offset = (self.offset & ~1)
+            return getattr(self, '_m_comp_offset', None)
+
+        def _invalidate_comp_offset(self):
+            del self._m_comp_offset
+        @property
+        def chunk(self):
+            if self._should_write_chunk:
+                self._write_chunk()
+            if hasattr(self, '_m_chunk'):
+                return self._m_chunk
+
+            _pos = self._io.pos()
+            self._io.seek((self.comp_offset + self._root.lfs_header.size))
+            self._m_chunk = self._io.read_bytes(self.size_compressed)
+            self._io.seek(_pos)
+            return getattr(self, '_m_chunk', None)
+
+        @chunk.setter
+        def chunk(self, v):
+            self._m_chunk = v
+
+        def _write_chunk(self):
+            self._should_write_chunk = False
+            _pos = self._io.pos()
+            self._io.seek((self.comp_offset + self._root.lfs_header.size))
+            self._io.write_bytes(self.chunk)
+            self._io.seek(_pos)
+
+
+        def _check_chunk(self):
+            pass
+            if (len(self.chunk) != self.size_compressed):
+                raise kaitaistruct.ConsistencyError(u"chunk", len(self.chunk), self.size_compressed)
+
+
+

--- a/albam/engines/cie/structs/lfs.py
+++ b/albam/engines/cie/structs/lfs.py
@@ -5,176 +5,167 @@ import kaitaistruct
 from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
 
 
-if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 11):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.11 or later is required, but you have %s" % (kaitaistruct.__version__))
 
 class Lfs(ReadWriteKaitaiStruct):
     def __init__(self, _io=None, _parent=None, _root=None):
-        self._io = _io
+        super(Lfs, self).__init__(_io)
         self._parent = _parent
-        self._root = _root if _root else self
+        self._root = _root or self
 
     def _read(self):
-        self.lfs_header = Lfs.Header(self._io, self, self._root)
-        self.lfs_header._read()
-        self.data_chunks = []
-        for i in range(self.lfs_header.num_chunks):
-            _t_data_chunks = Lfs.DataChunk(self._io, self, self._root)
-            _t_data_chunks._read()
-            self.data_chunks.append(_t_data_chunks)
+        self.header = Lfs.LfsHeader(self._io, self, self._root)
+        self.header._read()
+        self.file_entries = []
+        for i in range(self.header.num_files):
+            _t_file_entries = Lfs.FileEntry(self._io, self, self._root)
+            try:
+                _t_file_entries._read()
+            finally:
+                self.file_entries.append(_t_file_entries)
 
+        self._dirty = False
 
 
     def _fetch_instances(self):
         pass
-        self.lfs_header._fetch_instances()
-        for i in range(len(self.data_chunks)):
+        self.header._fetch_instances()
+        for i in range(len(self.file_entries)):
             pass
-            self.data_chunks[i]._fetch_instances()
+            self.file_entries[i]._fetch_instances()
 
 
 
     def _write__seq(self, io=None):
         super(Lfs, self)._write__seq(io)
-        self.lfs_header._write__seq(self._io)
-        for i in range(len(self.data_chunks)):
+        self.header._write__seq(self._io)
+        for i in range(len(self.file_entries)):
             pass
-            self.data_chunks[i]._write__seq(self._io)
+            self.file_entries[i]._write__seq(self._io)
 
 
 
     def _check(self):
-        pass
-        if self.lfs_header._root != self._root:
-            raise kaitaistruct.ConsistencyError(u"lfs_header", self.lfs_header._root, self._root)
-        if self.lfs_header._parent != self:
-            raise kaitaistruct.ConsistencyError(u"lfs_header", self.lfs_header._parent, self)
-        if (len(self.data_chunks) != self.lfs_header.num_chunks):
-            raise kaitaistruct.ConsistencyError(u"data_chunks", len(self.data_chunks), self.lfs_header.num_chunks)
-        for i in range(len(self.data_chunks)):
+        if self.header._root != self._root:
+            raise kaitaistruct.ConsistencyError(u"header", self._root, self.header._root)
+        if self.header._parent != self:
+            raise kaitaistruct.ConsistencyError(u"header", self, self.header._parent)
+        if len(self.file_entries) != self.header.num_files:
+            raise kaitaistruct.ConsistencyError(u"file_entries", self.header.num_files, len(self.file_entries))
+        for i in range(len(self.file_entries)):
             pass
-            if self.data_chunks[i]._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"data_chunks", self.data_chunks[i]._root, self._root)
-            if self.data_chunks[i]._parent != self:
-                raise kaitaistruct.ConsistencyError(u"data_chunks", self.data_chunks[i]._parent, self)
+            if self.file_entries[i]._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"file_entries", self._root, self.file_entries[i]._root)
+            if self.file_entries[i]._parent != self:
+                raise kaitaistruct.ConsistencyError(u"file_entries", self, self.file_entries[i]._parent)
 
+        self._dirty = False
 
-    class Header(ReadWriteKaitaiStruct):
+    class FileEntry(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Lfs.FileEntry, self).__init__(_io)
             self._parent = _parent
             self._root = _root
-
-        def _read(self):
-            self.id_magic = self._io.read_bytes(4)
-            if not (self.id_magic == b"\x52\x44\x4C\x58"):
-                raise kaitaistruct.ValidationNotEqualError(b"\x52\x44\x4C\x58", self.id_magic, self._io, u"/types/header/seq/0")
-            self.id_magic_2 = self._io.read_u4le()
-            self.size_decompressed = self._io.read_u4le()
-            self.size_compressed = self._io.read_u4le()
-            self.num_chunks = self._io.read_u4le()
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Lfs.Header, self)._write__seq(io)
-            self._io.write_bytes(self.id_magic)
-            self._io.write_u4le(self.id_magic_2)
-            self._io.write_u4le(self.size_decompressed)
-            self._io.write_u4le(self.size_compressed)
-            self._io.write_u4le(self.num_chunks)
-
-
-        def _check(self):
-            pass
-            if (len(self.id_magic) != 4):
-                raise kaitaistruct.ConsistencyError(u"id_magic", len(self.id_magic), 4)
-            if not (self.id_magic == b"\x52\x44\x4C\x58"):
-                raise kaitaistruct.ValidationNotEqualError(b"\x52\x44\x4C\x58", self.id_magic, None, u"/types/header/seq/0")
-
-        @property
-        def size(self):
-            if hasattr(self, '_m_size'):
-                return self._m_size
-
-            self._m_size = 20
-            return getattr(self, '_m_size', None)
-
-        def _invalidate_size(self):
-            del self._m_size
-
-    class DataChunk(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-            self._should_write_chunk = False
-            self.chunk__to_write = True
+            self._should_write_raw_data = False
+            self.raw_data__enabled = True
 
         def _read(self):
             self.size_compressed = self._io.read_u2le()
             self.size_decompressed = self._io.read_u2le()
             self.offset = self._io.read_u4le()
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
-            _ = self.chunk
+            _ = self.raw_data
+            if hasattr(self, '_m_raw_data'):
+                pass
+
 
 
         def _write__seq(self, io=None):
-            super(Lfs.DataChunk, self)._write__seq(io)
-            self._should_write_chunk = self.chunk__to_write
+            super(Lfs.FileEntry, self)._write__seq(io)
+            self._should_write_raw_data = self.raw_data__enabled
             self._io.write_u2le(self.size_compressed)
             self._io.write_u2le(self.size_decompressed)
             self._io.write_u4le(self.offset)
 
 
         def _check(self):
-            pass
+            if self.raw_data__enabled:
+                pass
+                if len(self._m_raw_data) != self.size_compressed:
+                    raise kaitaistruct.ConsistencyError(u"raw_data", self.size_compressed, len(self._m_raw_data))
+
+            self._dirty = False
 
         @property
-        def comp_offset(self):
-            if hasattr(self, '_m_comp_offset'):
-                return self._m_comp_offset
+        def raw_data(self):
+            if self._should_write_raw_data:
+                self._write_raw_data()
+            if hasattr(self, '_m_raw_data'):
+                return self._m_raw_data
 
-            self._m_comp_offset = (self.offset & ~1)
-            return getattr(self, '_m_comp_offset', None)
-
-        def _invalidate_comp_offset(self):
-            del self._m_comp_offset
-        @property
-        def chunk(self):
-            if self._should_write_chunk:
-                self._write_chunk()
-            if hasattr(self, '_m_chunk'):
-                return self._m_chunk
+            if not self.raw_data__enabled:
+                return None
 
             _pos = self._io.pos()
-            self._io.seek((self.comp_offset + self._root.lfs_header.size))
-            self._m_chunk = self._io.read_bytes(self.size_compressed)
+            self._io.seek((self.offset & ~1) + 20)
+            self._m_raw_data = self._io.read_bytes(self.size_compressed)
             self._io.seek(_pos)
-            return getattr(self, '_m_chunk', None)
+            return getattr(self, '_m_raw_data', None)
 
-        @chunk.setter
-        def chunk(self, v):
-            self._m_chunk = v
+        @raw_data.setter
+        def raw_data(self, v):
+            self._dirty = True
+            self._m_raw_data = v
 
-        def _write_chunk(self):
-            self._should_write_chunk = False
+        def _write_raw_data(self):
+            self._should_write_raw_data = False
             _pos = self._io.pos()
-            self._io.seek((self.comp_offset + self._root.lfs_header.size))
-            self._io.write_bytes(self.chunk)
+            self._io.seek((self.offset & ~1) + 20)
+            self._io.write_bytes(self._m_raw_data)
             self._io.seek(_pos)
 
 
-        def _check_chunk(self):
+    class LfsHeader(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Lfs.LfsHeader, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.id_magic = self._io.read_bytes(4)
+            if not self.id_magic == b"\x52\x44\x4C\x58":
+                raise kaitaistruct.ValidationNotEqualError(b"\x52\x44\x4C\x58", self.id_magic, self._io, u"/types/lfs_header/seq/0")
+            self.file_id = self._io.read_u4le()
+            self.size_decompressed = self._io.read_u4le()
+            self.size_compressed = self._io.read_u4le()
+            self.num_files = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
             pass
-            if (len(self.chunk) != self.size_compressed):
-                raise kaitaistruct.ConsistencyError(u"chunk", len(self.chunk), self.size_compressed)
+
+
+        def _write__seq(self, io=None):
+            super(Lfs.LfsHeader, self)._write__seq(io)
+            self._io.write_bytes(self.id_magic)
+            self._io.write_u4le(self.file_id)
+            self._io.write_u4le(self.size_decompressed)
+            self._io.write_u4le(self.size_compressed)
+            self._io.write_u4le(self.num_files)
+
+
+        def _check(self):
+            if len(self.id_magic) != 4:
+                raise kaitaistruct.ConsistencyError(u"id_magic", 4, len(self.id_magic))
+            if not self.id_magic == b"\x52\x44\x4C\x58":
+                raise kaitaistruct.ValidationNotEqualError(b"\x52\x44\x4C\x58", self.id_magic, None, u"/types/lfs_header/seq/0")
+            self._dirty = False
 
 
 

--- a/albam/engines/cie/structs/re4-bin.ksy
+++ b/albam/engines/cie/structs/re4-bin.ksy
@@ -1,0 +1,158 @@
+
+meta:
+  id: re4_uhd_bin
+  endian: le
+  ks-version: "0.11"
+  title: Capcom Internal Engine 3d model file
+
+seq:
+  - {id: header, type: uhd_bin_header}
+
+instances:
+  bones:
+    {pos: header.offset_bones, type: bone, repeat: expr, repeat-expr: header.num_bones}
+  weights:
+    pos: header.offset_weights
+    type:
+      switch-on: header.num_weights2 > 255
+      cases:
+        true: fmtbin_weight_ext
+        false: fmtbin_weight
+    repeat: expr
+    repeat-expr: header.num_weights
+  bone_pairs:
+    {pos: header.offset_bonepairs, type: bone_pair, if: header.offset_bonepairs > 0}
+  adjacent:
+    {pos: header.offset_adjacents, type: bone_adj, if: header.offset_adjacents > 0}
+  vertex_positions:
+    {pos: header.offset_vertex_position, type: vec3, repeat: expr, repeat-expr: header.num_vertices}
+  normals:
+    {pos: header.offset_vertex_normals, type: vec3, repeat: expr, repeat-expr: header.num_vertex_normals}
+  indexes:
+    {pos: header.offset_index_buffer, type: u2, repeat: expr, repeat-expr: header.num_vertices, if: header.offset_index_buffer > 0}
+  indexes2:
+    {pos: header.offset_index_buffer2, type: u2, repeat: expr ,repeat-expr: header.num_vertices, if: header.offset_index_buffer2 > 0}
+  vertex_colors:
+    {pos: header.offset_vertex_colors, type: rgba, repeat: expr, repeat-expr: header.num_vertices, if: header.offset_vertex_colors > 0}
+  texcoords:
+    {pos: header.offset_vertex_texcoord, type: uv, repeat: expr ,repeat-expr: header.num_vertices}
+
+  materials:
+    pos: header.offset_materials
+    type: material
+    repeat: expr
+    repeat-expr: header.num_materials
+
+types:
+  uhd_bin_header:
+    seq:
+      - {id: offset_bones, type: u4} # bone_offset
+      - {id: unk_00, type: u4}
+      - {id: unk_01, type: u4}
+      - {id: offset_vertex_colors, type: u4} # vertex_colour_offset
+      - {id: offset_vertex_texcoord, type: u4} # vertex_texcoord_offset
+      - {id: offset_weights, type: u4} # weight_offset
+      - {id: num_weights, type: u1} # weights_count
+      - {id: num_bones, type: u1} # bone_count
+      - {id: num_materials, type: u2} # material_count
+      - {id: offset_materials, type: u4} # material_offset
+      - {id: texture1_flags, type: u2}
+      - {id: texture2_flags, type: u2}
+      - {id: num_tpl, type: u4} # tpl_count
+      - {id: vertex_scale, type: u1}
+      - {id: unk_02, type: u1}
+      - {id: num_weights2, type: u2} # weight2_count
+      - {id: offset_morphs, type: u4} # morph_offset
+      - {id: offset_vertex_position, type: u4} # vertex_position_offset
+      - {id: offset_vertex_normals, type: u4} # vertex_normal_offset
+      - {id: num_vertices, type: u2} #  vertex_position_count
+      - {id: num_vertex_normals, type: u2} # vertex_normal_count
+      - {id: version_flags, type: u4}
+      - {id: offset_bonepairs, type: u4} # bonepair_offset
+      - {id: offset_adjacents, type: u4} # adjacent_offset
+      - {id: offset_index_buffer, type: u4} # vertex_weight_index_offset
+      - {id: offset_index_buffer2, type: u4} # vertex_weight2_index_offset
+
+  vec3:
+    seq:
+      - {id: x, type: f4}
+      - {id: y, type: f4}
+      - {id: z, type: f4}
+
+  uv:
+    seq:
+      - {id: u, type: f4}
+      - {id: v, type: f4}
+
+  rgba:
+    seq:
+      - {id: a, type: u1}
+      - {id: r, type: u1}
+      - {id: g, type: u1}
+      - {id: b, type: u1}
+
+  strip:
+    seq:
+      - {id: ftype, type: u2}
+      - {id: fcount, type: u2}
+
+  face_index:
+    seq:
+      - {id: buffer_size, type: u4}
+      - {id: count, type: u4}
+      - {id: strip_count, type: u4}
+      - {id: strips, type: strip, repeat: expr, repeat-expr: strip_count}
+      - {id: padding, size: buffer_size - (strip_count * 4 + 4)}
+
+  fmtbin_weight_ext:
+    seq:
+      - {id: bone_id1, type: u2}
+      - {id: bone_id2, type: u2}
+      - {id: bone_id3, type: u2}
+      - {id: count, type: u2}
+      - {id: weight1, type: u1}
+      - {id: weight2, type: u1}
+      - {id: weight3, type: u1}
+      - {id: unk00, type: u1}
+
+  fmtbin_weight:
+    seq:
+      - {id: bone_id1, type: u1}
+      - {id: bone_id2, type: u1}
+      - {id: bone_id3, type: u1}
+      - {id: count, type: u1}
+      - {id: weight1, type: u1}
+      - {id: weight2, type: u1}
+      - {id: weight3, type: u1}
+      - {id: unk00, type: u1}
+
+  material:
+    seq:
+      - {id: raw, size: 24} # todo
+      - {id: face_index, type: face_index}
+
+  bone:
+    seq:
+      - {id: bone_id, type: u1}
+      - {id: parent, type: u1}
+      - {id: filler, type: u2}
+      - {id: x, type: f4}
+      - {id: y, type: f4}
+      - {id: z, type: f4}
+
+  pair_line:
+    seq:
+      - {id: data, size: 8}
+
+  bone_pair:
+    seq:
+      - {id: num_pair, type: u4}
+      - {id: line, type: pair_line, repeat: expr, repeat-expr: num_pair}
+
+  bone_adj:
+    seq:
+      - {id: count, type: u1, repeat: expr, repeat-expr: 4}
+      - id: adj
+        type: u2
+        repeat: expr
+        repeat-expr: count[3]

--- a/albam/engines/cie/structs/re4_uhd_bin.py
+++ b/albam/engines/cie/structs/re4_uhd_bin.py
@@ -1,0 +1,1249 @@
+# This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
+# type: ignore
+
+import kaitaistruct
+from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
+
+
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 11):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.11 or later is required, but you have %s" % (kaitaistruct.__version__))
+
+class Re4UhdBin(ReadWriteKaitaiStruct):
+    def __init__(self, _io=None, _parent=None, _root=None):
+        super(Re4UhdBin, self).__init__(_io)
+        self._parent = _parent
+        self._root = _root or self
+        self._should_write_adjacent = False
+        self.adjacent__enabled = True
+        self._should_write_bone_pairs = False
+        self.bone_pairs__enabled = True
+        self._should_write_bones = False
+        self.bones__enabled = True
+        self._should_write_indexes = False
+        self.indexes__enabled = True
+        self._should_write_indexes2 = False
+        self.indexes2__enabled = True
+        self._should_write_materials = False
+        self.materials__enabled = True
+        self._should_write_normals = False
+        self.normals__enabled = True
+        self._should_write_texcoords = False
+        self.texcoords__enabled = True
+        self._should_write_vertex_colors = False
+        self.vertex_colors__enabled = True
+        self._should_write_vertex_positions = False
+        self.vertex_positions__enabled = True
+        self._should_write_weights = False
+        self.weights__enabled = True
+
+    def _read(self):
+        self.header = Re4UhdBin.UhdBinHeader(self._io, self, self._root)
+        self.header._read()
+        self._dirty = False
+
+
+    def _fetch_instances(self):
+        pass
+        self.header._fetch_instances()
+        _ = self.adjacent
+        if hasattr(self, '_m_adjacent'):
+            pass
+            self._m_adjacent._fetch_instances()
+
+        _ = self.bone_pairs
+        if hasattr(self, '_m_bone_pairs'):
+            pass
+            self._m_bone_pairs._fetch_instances()
+
+        _ = self.bones
+        if hasattr(self, '_m_bones'):
+            pass
+            for i in range(len(self._m_bones)):
+                pass
+                self._m_bones[i]._fetch_instances()
+
+
+        _ = self.indexes
+        if hasattr(self, '_m_indexes'):
+            pass
+            for i in range(len(self._m_indexes)):
+                pass
+
+
+        _ = self.indexes2
+        if hasattr(self, '_m_indexes2'):
+            pass
+            for i in range(len(self._m_indexes2)):
+                pass
+
+
+        _ = self.materials
+        if hasattr(self, '_m_materials'):
+            pass
+            for i in range(len(self._m_materials)):
+                pass
+                self._m_materials[i]._fetch_instances()
+
+
+        _ = self.normals
+        if hasattr(self, '_m_normals'):
+            pass
+            for i in range(len(self._m_normals)):
+                pass
+                self._m_normals[i]._fetch_instances()
+
+
+        _ = self.texcoords
+        if hasattr(self, '_m_texcoords'):
+            pass
+            for i in range(len(self._m_texcoords)):
+                pass
+                self._m_texcoords[i]._fetch_instances()
+
+
+        _ = self.vertex_colors
+        if hasattr(self, '_m_vertex_colors'):
+            pass
+            for i in range(len(self._m_vertex_colors)):
+                pass
+                self._m_vertex_colors[i]._fetch_instances()
+
+
+        _ = self.vertex_positions
+        if hasattr(self, '_m_vertex_positions'):
+            pass
+            for i in range(len(self._m_vertex_positions)):
+                pass
+                self._m_vertex_positions[i]._fetch_instances()
+
+
+        _ = self.weights
+        if hasattr(self, '_m_weights'):
+            pass
+            for i in range(len(self._m_weights)):
+                pass
+                _on = self.header.num_weights2 > 255
+                if _on == False:
+                    pass
+                    self._m_weights[i]._fetch_instances()
+                elif _on == True:
+                    pass
+                    self._m_weights[i]._fetch_instances()
+
+
+
+
+    def _write__seq(self, io=None):
+        super(Re4UhdBin, self)._write__seq(io)
+        self._should_write_adjacent = self.adjacent__enabled
+        self._should_write_bone_pairs = self.bone_pairs__enabled
+        self._should_write_bones = self.bones__enabled
+        self._should_write_indexes = self.indexes__enabled
+        self._should_write_indexes2 = self.indexes2__enabled
+        self._should_write_materials = self.materials__enabled
+        self._should_write_normals = self.normals__enabled
+        self._should_write_texcoords = self.texcoords__enabled
+        self._should_write_vertex_colors = self.vertex_colors__enabled
+        self._should_write_vertex_positions = self.vertex_positions__enabled
+        self._should_write_weights = self.weights__enabled
+        self.header._write__seq(self._io)
+
+
+    def _check(self):
+        if self.header._root != self._root:
+            raise kaitaistruct.ConsistencyError(u"header", self._root, self.header._root)
+        if self.header._parent != self:
+            raise kaitaistruct.ConsistencyError(u"header", self, self.header._parent)
+        if self.adjacent__enabled:
+            pass
+            if self.header.offset_adjacents > 0:
+                pass
+                if self._m_adjacent._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"adjacent", self._root, self._m_adjacent._root)
+                if self._m_adjacent._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"adjacent", self, self._m_adjacent._parent)
+
+
+        if self.bone_pairs__enabled:
+            pass
+            if self.header.offset_bonepairs > 0:
+                pass
+                if self._m_bone_pairs._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"bone_pairs", self._root, self._m_bone_pairs._root)
+                if self._m_bone_pairs._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"bone_pairs", self, self._m_bone_pairs._parent)
+
+
+        if self.bones__enabled:
+            pass
+            if len(self._m_bones) != self.header.num_bones:
+                raise kaitaistruct.ConsistencyError(u"bones", self.header.num_bones, len(self._m_bones))
+            for i in range(len(self._m_bones)):
+                pass
+                if self._m_bones[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"bones", self._root, self._m_bones[i]._root)
+                if self._m_bones[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"bones", self, self._m_bones[i]._parent)
+
+
+        if self.indexes__enabled:
+            pass
+            if self.header.offset_index_buffer > 0:
+                pass
+                if len(self._m_indexes) != self.header.num_vertices:
+                    raise kaitaistruct.ConsistencyError(u"indexes", self.header.num_vertices, len(self._m_indexes))
+                for i in range(len(self._m_indexes)):
+                    pass
+
+
+
+        if self.indexes2__enabled:
+            pass
+            if self.header.offset_index_buffer2 > 0:
+                pass
+                if len(self._m_indexes2) != self.header.num_vertices:
+                    raise kaitaistruct.ConsistencyError(u"indexes2", self.header.num_vertices, len(self._m_indexes2))
+                for i in range(len(self._m_indexes2)):
+                    pass
+
+
+
+        if self.materials__enabled:
+            pass
+            if len(self._m_materials) != self.header.num_materials:
+                raise kaitaistruct.ConsistencyError(u"materials", self.header.num_materials, len(self._m_materials))
+            for i in range(len(self._m_materials)):
+                pass
+                if self._m_materials[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"materials", self._root, self._m_materials[i]._root)
+                if self._m_materials[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"materials", self, self._m_materials[i]._parent)
+
+
+        if self.normals__enabled:
+            pass
+            if len(self._m_normals) != self.header.num_vertex_normals:
+                raise kaitaistruct.ConsistencyError(u"normals", self.header.num_vertex_normals, len(self._m_normals))
+            for i in range(len(self._m_normals)):
+                pass
+                if self._m_normals[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"normals", self._root, self._m_normals[i]._root)
+                if self._m_normals[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"normals", self, self._m_normals[i]._parent)
+
+
+        if self.texcoords__enabled:
+            pass
+            if len(self._m_texcoords) != self.header.num_vertices:
+                raise kaitaistruct.ConsistencyError(u"texcoords", self.header.num_vertices, len(self._m_texcoords))
+            for i in range(len(self._m_texcoords)):
+                pass
+                if self._m_texcoords[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"texcoords", self._root, self._m_texcoords[i]._root)
+                if self._m_texcoords[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"texcoords", self, self._m_texcoords[i]._parent)
+
+
+        if self.vertex_colors__enabled:
+            pass
+            if self.header.offset_vertex_colors > 0:
+                pass
+                if len(self._m_vertex_colors) != self.header.num_vertices:
+                    raise kaitaistruct.ConsistencyError(u"vertex_colors", self.header.num_vertices, len(self._m_vertex_colors))
+                for i in range(len(self._m_vertex_colors)):
+                    pass
+                    if self._m_vertex_colors[i]._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"vertex_colors", self._root, self._m_vertex_colors[i]._root)
+                    if self._m_vertex_colors[i]._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"vertex_colors", self, self._m_vertex_colors[i]._parent)
+
+
+
+        if self.vertex_positions__enabled:
+            pass
+            if len(self._m_vertex_positions) != self.header.num_vertices:
+                raise kaitaistruct.ConsistencyError(u"vertex_positions", self.header.num_vertices, len(self._m_vertex_positions))
+            for i in range(len(self._m_vertex_positions)):
+                pass
+                if self._m_vertex_positions[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"vertex_positions", self._root, self._m_vertex_positions[i]._root)
+                if self._m_vertex_positions[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"vertex_positions", self, self._m_vertex_positions[i]._parent)
+
+
+        if self.weights__enabled:
+            pass
+            if len(self._m_weights) != self.header.num_weights:
+                raise kaitaistruct.ConsistencyError(u"weights", self.header.num_weights, len(self._m_weights))
+            for i in range(len(self._m_weights)):
+                pass
+                _on = self.header.num_weights2 > 255
+                if _on == False:
+                    pass
+                    if self._m_weights[i]._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"weights", self._root, self._m_weights[i]._root)
+                    if self._m_weights[i]._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"weights", self, self._m_weights[i]._parent)
+                elif _on == True:
+                    pass
+                    if self._m_weights[i]._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"weights", self._root, self._m_weights[i]._root)
+                    if self._m_weights[i]._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"weights", self, self._m_weights[i]._parent)
+
+
+        self._dirty = False
+
+    class Bone(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Re4UhdBin.Bone, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.bone_id = self._io.read_u1()
+            self.parent = self._io.read_u1()
+            self.filler = self._io.read_u2le()
+            self.x = self._io.read_f4le()
+            self.y = self._io.read_f4le()
+            self.z = self._io.read_f4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Re4UhdBin.Bone, self)._write__seq(io)
+            self._io.write_u1(self.bone_id)
+            self._io.write_u1(self.parent)
+            self._io.write_u2le(self.filler)
+            self._io.write_f4le(self.x)
+            self._io.write_f4le(self.y)
+            self._io.write_f4le(self.z)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class BoneAdj(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Re4UhdBin.BoneAdj, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.count = []
+            for i in range(4):
+                self.count.append(self._io.read_u1())
+
+            self.adj = []
+            for i in range(self.count[3]):
+                self.adj.append(self._io.read_u2le())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.count)):
+                pass
+
+            for i in range(len(self.adj)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Re4UhdBin.BoneAdj, self)._write__seq(io)
+            for i in range(len(self.count)):
+                pass
+                self._io.write_u1(self.count[i])
+
+            for i in range(len(self.adj)):
+                pass
+                self._io.write_u2le(self.adj[i])
+
+
+
+        def _check(self):
+            if len(self.count) != 4:
+                raise kaitaistruct.ConsistencyError(u"count", 4, len(self.count))
+            for i in range(len(self.count)):
+                pass
+
+            if len(self.adj) != self.count[3]:
+                raise kaitaistruct.ConsistencyError(u"adj", self.count[3], len(self.adj))
+            for i in range(len(self.adj)):
+                pass
+
+            self._dirty = False
+
+
+    class BonePair(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Re4UhdBin.BonePair, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.num_pair = self._io.read_u4le()
+            self.line = []
+            for i in range(self.num_pair):
+                _t_line = Re4UhdBin.PairLine(self._io, self, self._root)
+                try:
+                    _t_line._read()
+                finally:
+                    self.line.append(_t_line)
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.line)):
+                pass
+                self.line[i]._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Re4UhdBin.BonePair, self)._write__seq(io)
+            self._io.write_u4le(self.num_pair)
+            for i in range(len(self.line)):
+                pass
+                self.line[i]._write__seq(self._io)
+
+
+
+        def _check(self):
+            if len(self.line) != self.num_pair:
+                raise kaitaistruct.ConsistencyError(u"line", self.num_pair, len(self.line))
+            for i in range(len(self.line)):
+                pass
+                if self.line[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"line", self._root, self.line[i]._root)
+                if self.line[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"line", self, self.line[i]._parent)
+
+            self._dirty = False
+
+
+    class FaceIndex(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Re4UhdBin.FaceIndex, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.buffer_size = self._io.read_u4le()
+            self.count = self._io.read_u4le()
+            self.strip_count = self._io.read_u4le()
+            self.strips = []
+            for i in range(self.strip_count):
+                _t_strips = Re4UhdBin.Strip(self._io, self, self._root)
+                try:
+                    _t_strips._read()
+                finally:
+                    self.strips.append(_t_strips)
+
+            self.padding = self._io.read_bytes(self.buffer_size - (self.strip_count * 4 + 4))
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.strips)):
+                pass
+                self.strips[i]._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Re4UhdBin.FaceIndex, self)._write__seq(io)
+            self._io.write_u4le(self.buffer_size)
+            self._io.write_u4le(self.count)
+            self._io.write_u4le(self.strip_count)
+            for i in range(len(self.strips)):
+                pass
+                self.strips[i]._write__seq(self._io)
+
+            self._io.write_bytes(self.padding)
+
+
+        def _check(self):
+            if len(self.strips) != self.strip_count:
+                raise kaitaistruct.ConsistencyError(u"strips", self.strip_count, len(self.strips))
+            for i in range(len(self.strips)):
+                pass
+                if self.strips[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"strips", self._root, self.strips[i]._root)
+                if self.strips[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"strips", self, self.strips[i]._parent)
+
+            if len(self.padding) != self.buffer_size - (self.strip_count * 4 + 4):
+                raise kaitaistruct.ConsistencyError(u"padding", self.buffer_size - (self.strip_count * 4 + 4), len(self.padding))
+            self._dirty = False
+
+
+    class FmtbinWeight(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Re4UhdBin.FmtbinWeight, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.bone_id1 = self._io.read_u1()
+            self.bone_id2 = self._io.read_u1()
+            self.bone_id3 = self._io.read_u1()
+            self.count = self._io.read_u1()
+            self.weight1 = self._io.read_u1()
+            self.weight2 = self._io.read_u1()
+            self.weight3 = self._io.read_u1()
+            self.unk00 = self._io.read_u1()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Re4UhdBin.FmtbinWeight, self)._write__seq(io)
+            self._io.write_u1(self.bone_id1)
+            self._io.write_u1(self.bone_id2)
+            self._io.write_u1(self.bone_id3)
+            self._io.write_u1(self.count)
+            self._io.write_u1(self.weight1)
+            self._io.write_u1(self.weight2)
+            self._io.write_u1(self.weight3)
+            self._io.write_u1(self.unk00)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class FmtbinWeightExt(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Re4UhdBin.FmtbinWeightExt, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.bone_id1 = self._io.read_u2le()
+            self.bone_id2 = self._io.read_u2le()
+            self.bone_id3 = self._io.read_u2le()
+            self.count = self._io.read_u2le()
+            self.weight1 = self._io.read_u1()
+            self.weight2 = self._io.read_u1()
+            self.weight3 = self._io.read_u1()
+            self.unk00 = self._io.read_u1()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Re4UhdBin.FmtbinWeightExt, self)._write__seq(io)
+            self._io.write_u2le(self.bone_id1)
+            self._io.write_u2le(self.bone_id2)
+            self._io.write_u2le(self.bone_id3)
+            self._io.write_u2le(self.count)
+            self._io.write_u1(self.weight1)
+            self._io.write_u1(self.weight2)
+            self._io.write_u1(self.weight3)
+            self._io.write_u1(self.unk00)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Material(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Re4UhdBin.Material, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.raw = self._io.read_bytes(24)
+            self.face_index = Re4UhdBin.FaceIndex(self._io, self, self._root)
+            self.face_index._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.face_index._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Re4UhdBin.Material, self)._write__seq(io)
+            self._io.write_bytes(self.raw)
+            self.face_index._write__seq(self._io)
+
+
+        def _check(self):
+            if len(self.raw) != 24:
+                raise kaitaistruct.ConsistencyError(u"raw", 24, len(self.raw))
+            if self.face_index._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"face_index", self._root, self.face_index._root)
+            if self.face_index._parent != self:
+                raise kaitaistruct.ConsistencyError(u"face_index", self, self.face_index._parent)
+            self._dirty = False
+
+
+    class PairLine(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Re4UhdBin.PairLine, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.data = self._io.read_bytes(8)
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Re4UhdBin.PairLine, self)._write__seq(io)
+            self._io.write_bytes(self.data)
+
+
+        def _check(self):
+            if len(self.data) != 8:
+                raise kaitaistruct.ConsistencyError(u"data", 8, len(self.data))
+            self._dirty = False
+
+
+    class Rgba(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Re4UhdBin.Rgba, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.a = self._io.read_u1()
+            self.r = self._io.read_u1()
+            self.g = self._io.read_u1()
+            self.b = self._io.read_u1()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Re4UhdBin.Rgba, self)._write__seq(io)
+            self._io.write_u1(self.a)
+            self._io.write_u1(self.r)
+            self._io.write_u1(self.g)
+            self._io.write_u1(self.b)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Strip(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Re4UhdBin.Strip, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.ftype = self._io.read_u2le()
+            self.fcount = self._io.read_u2le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Re4UhdBin.Strip, self)._write__seq(io)
+            self._io.write_u2le(self.ftype)
+            self._io.write_u2le(self.fcount)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class UhdBinHeader(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Re4UhdBin.UhdBinHeader, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.offset_bones = self._io.read_u4le()
+            self.unk_00 = self._io.read_u4le()
+            self.unk_01 = self._io.read_u4le()
+            self.offset_vertex_colors = self._io.read_u4le()
+            self.offset_vertex_texcoord = self._io.read_u4le()
+            self.offset_weights = self._io.read_u4le()
+            self.num_weights = self._io.read_u1()
+            self.num_bones = self._io.read_u1()
+            self.num_materials = self._io.read_u2le()
+            self.offset_materials = self._io.read_u4le()
+            self.texture1_flags = self._io.read_u2le()
+            self.texture2_flags = self._io.read_u2le()
+            self.num_tpl = self._io.read_u4le()
+            self.vertex_scale = self._io.read_u1()
+            self.unk_02 = self._io.read_u1()
+            self.num_weights2 = self._io.read_u2le()
+            self.offset_morphs = self._io.read_u4le()
+            self.offset_vertex_position = self._io.read_u4le()
+            self.offset_vertex_normals = self._io.read_u4le()
+            self.num_vertices = self._io.read_u2le()
+            self.num_vertex_normals = self._io.read_u2le()
+            self.version_flags = self._io.read_u4le()
+            self.offset_bonepairs = self._io.read_u4le()
+            self.offset_adjacents = self._io.read_u4le()
+            self.offset_index_buffer = self._io.read_u4le()
+            self.offset_index_buffer2 = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Re4UhdBin.UhdBinHeader, self)._write__seq(io)
+            self._io.write_u4le(self.offset_bones)
+            self._io.write_u4le(self.unk_00)
+            self._io.write_u4le(self.unk_01)
+            self._io.write_u4le(self.offset_vertex_colors)
+            self._io.write_u4le(self.offset_vertex_texcoord)
+            self._io.write_u4le(self.offset_weights)
+            self._io.write_u1(self.num_weights)
+            self._io.write_u1(self.num_bones)
+            self._io.write_u2le(self.num_materials)
+            self._io.write_u4le(self.offset_materials)
+            self._io.write_u2le(self.texture1_flags)
+            self._io.write_u2le(self.texture2_flags)
+            self._io.write_u4le(self.num_tpl)
+            self._io.write_u1(self.vertex_scale)
+            self._io.write_u1(self.unk_02)
+            self._io.write_u2le(self.num_weights2)
+            self._io.write_u4le(self.offset_morphs)
+            self._io.write_u4le(self.offset_vertex_position)
+            self._io.write_u4le(self.offset_vertex_normals)
+            self._io.write_u2le(self.num_vertices)
+            self._io.write_u2le(self.num_vertex_normals)
+            self._io.write_u4le(self.version_flags)
+            self._io.write_u4le(self.offset_bonepairs)
+            self._io.write_u4le(self.offset_adjacents)
+            self._io.write_u4le(self.offset_index_buffer)
+            self._io.write_u4le(self.offset_index_buffer2)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Uv(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Re4UhdBin.Uv, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.u = self._io.read_f4le()
+            self.v = self._io.read_f4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Re4UhdBin.Uv, self)._write__seq(io)
+            self._io.write_f4le(self.u)
+            self._io.write_f4le(self.v)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Vec3(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Re4UhdBin.Vec3, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.x = self._io.read_f4le()
+            self.y = self._io.read_f4le()
+            self.z = self._io.read_f4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Re4UhdBin.Vec3, self)._write__seq(io)
+            self._io.write_f4le(self.x)
+            self._io.write_f4le(self.y)
+            self._io.write_f4le(self.z)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    @property
+    def adjacent(self):
+        if self._should_write_adjacent:
+            self._write_adjacent()
+        if hasattr(self, '_m_adjacent'):
+            return self._m_adjacent
+
+        if not self.adjacent__enabled:
+            return None
+
+        if self.header.offset_adjacents > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_adjacents)
+            self._m_adjacent = Re4UhdBin.BoneAdj(self._io, self, self._root)
+            self._m_adjacent._read()
+            self._io.seek(_pos)
+
+        return getattr(self, '_m_adjacent', None)
+
+    @adjacent.setter
+    def adjacent(self, v):
+        self._dirty = True
+        self._m_adjacent = v
+
+    def _write_adjacent(self):
+        self._should_write_adjacent = False
+        if self.header.offset_adjacents > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_adjacents)
+            self._m_adjacent._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    @property
+    def bone_pairs(self):
+        if self._should_write_bone_pairs:
+            self._write_bone_pairs()
+        if hasattr(self, '_m_bone_pairs'):
+            return self._m_bone_pairs
+
+        if not self.bone_pairs__enabled:
+            return None
+
+        if self.header.offset_bonepairs > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_bonepairs)
+            self._m_bone_pairs = Re4UhdBin.BonePair(self._io, self, self._root)
+            self._m_bone_pairs._read()
+            self._io.seek(_pos)
+
+        return getattr(self, '_m_bone_pairs', None)
+
+    @bone_pairs.setter
+    def bone_pairs(self, v):
+        self._dirty = True
+        self._m_bone_pairs = v
+
+    def _write_bone_pairs(self):
+        self._should_write_bone_pairs = False
+        if self.header.offset_bonepairs > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_bonepairs)
+            self._m_bone_pairs._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    @property
+    def bones(self):
+        if self._should_write_bones:
+            self._write_bones()
+        if hasattr(self, '_m_bones'):
+            return self._m_bones
+
+        if not self.bones__enabled:
+            return None
+
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_bones)
+        self._m_bones = []
+        for i in range(self.header.num_bones):
+            _t__m_bones = Re4UhdBin.Bone(self._io, self, self._root)
+            try:
+                _t__m_bones._read()
+            finally:
+                self._m_bones.append(_t__m_bones)
+
+        self._io.seek(_pos)
+        return getattr(self, '_m_bones', None)
+
+    @bones.setter
+    def bones(self, v):
+        self._dirty = True
+        self._m_bones = v
+
+    def _write_bones(self):
+        self._should_write_bones = False
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_bones)
+        for i in range(len(self._m_bones)):
+            pass
+            self._m_bones[i]._write__seq(self._io)
+
+        self._io.seek(_pos)
+
+    @property
+    def indexes(self):
+        if self._should_write_indexes:
+            self._write_indexes()
+        if hasattr(self, '_m_indexes'):
+            return self._m_indexes
+
+        if not self.indexes__enabled:
+            return None
+
+        if self.header.offset_index_buffer > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_index_buffer)
+            self._m_indexes = []
+            for i in range(self.header.num_vertices):
+                self._m_indexes.append(self._io.read_u2le())
+
+            self._io.seek(_pos)
+
+        return getattr(self, '_m_indexes', None)
+
+    @indexes.setter
+    def indexes(self, v):
+        self._dirty = True
+        self._m_indexes = v
+
+    def _write_indexes(self):
+        self._should_write_indexes = False
+        if self.header.offset_index_buffer > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_index_buffer)
+            for i in range(len(self._m_indexes)):
+                pass
+                self._io.write_u2le(self._m_indexes[i])
+
+            self._io.seek(_pos)
+
+
+    @property
+    def indexes2(self):
+        if self._should_write_indexes2:
+            self._write_indexes2()
+        if hasattr(self, '_m_indexes2'):
+            return self._m_indexes2
+
+        if not self.indexes2__enabled:
+            return None
+
+        if self.header.offset_index_buffer2 > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_index_buffer2)
+            self._m_indexes2 = []
+            for i in range(self.header.num_vertices):
+                self._m_indexes2.append(self._io.read_u2le())
+
+            self._io.seek(_pos)
+
+        return getattr(self, '_m_indexes2', None)
+
+    @indexes2.setter
+    def indexes2(self, v):
+        self._dirty = True
+        self._m_indexes2 = v
+
+    def _write_indexes2(self):
+        self._should_write_indexes2 = False
+        if self.header.offset_index_buffer2 > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_index_buffer2)
+            for i in range(len(self._m_indexes2)):
+                pass
+                self._io.write_u2le(self._m_indexes2[i])
+
+            self._io.seek(_pos)
+
+
+    @property
+    def materials(self):
+        if self._should_write_materials:
+            self._write_materials()
+        if hasattr(self, '_m_materials'):
+            return self._m_materials
+
+        if not self.materials__enabled:
+            return None
+
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_materials)
+        self._m_materials = []
+        for i in range(self.header.num_materials):
+            _t__m_materials = Re4UhdBin.Material(self._io, self, self._root)
+            try:
+                _t__m_materials._read()
+            finally:
+                self._m_materials.append(_t__m_materials)
+
+        self._io.seek(_pos)
+        return getattr(self, '_m_materials', None)
+
+    @materials.setter
+    def materials(self, v):
+        self._dirty = True
+        self._m_materials = v
+
+    def _write_materials(self):
+        self._should_write_materials = False
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_materials)
+        for i in range(len(self._m_materials)):
+            pass
+            self._m_materials[i]._write__seq(self._io)
+
+        self._io.seek(_pos)
+
+    @property
+    def normals(self):
+        if self._should_write_normals:
+            self._write_normals()
+        if hasattr(self, '_m_normals'):
+            return self._m_normals
+
+        if not self.normals__enabled:
+            return None
+
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_vertex_normals)
+        self._m_normals = []
+        for i in range(self.header.num_vertex_normals):
+            _t__m_normals = Re4UhdBin.Vec3(self._io, self, self._root)
+            try:
+                _t__m_normals._read()
+            finally:
+                self._m_normals.append(_t__m_normals)
+
+        self._io.seek(_pos)
+        return getattr(self, '_m_normals', None)
+
+    @normals.setter
+    def normals(self, v):
+        self._dirty = True
+        self._m_normals = v
+
+    def _write_normals(self):
+        self._should_write_normals = False
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_vertex_normals)
+        for i in range(len(self._m_normals)):
+            pass
+            self._m_normals[i]._write__seq(self._io)
+
+        self._io.seek(_pos)
+
+    @property
+    def texcoords(self):
+        if self._should_write_texcoords:
+            self._write_texcoords()
+        if hasattr(self, '_m_texcoords'):
+            return self._m_texcoords
+
+        if not self.texcoords__enabled:
+            return None
+
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_vertex_texcoord)
+        self._m_texcoords = []
+        for i in range(self.header.num_vertices):
+            _t__m_texcoords = Re4UhdBin.Uv(self._io, self, self._root)
+            try:
+                _t__m_texcoords._read()
+            finally:
+                self._m_texcoords.append(_t__m_texcoords)
+
+        self._io.seek(_pos)
+        return getattr(self, '_m_texcoords', None)
+
+    @texcoords.setter
+    def texcoords(self, v):
+        self._dirty = True
+        self._m_texcoords = v
+
+    def _write_texcoords(self):
+        self._should_write_texcoords = False
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_vertex_texcoord)
+        for i in range(len(self._m_texcoords)):
+            pass
+            self._m_texcoords[i]._write__seq(self._io)
+
+        self._io.seek(_pos)
+
+    @property
+    def vertex_colors(self):
+        if self._should_write_vertex_colors:
+            self._write_vertex_colors()
+        if hasattr(self, '_m_vertex_colors'):
+            return self._m_vertex_colors
+
+        if not self.vertex_colors__enabled:
+            return None
+
+        if self.header.offset_vertex_colors > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_vertex_colors)
+            self._m_vertex_colors = []
+            for i in range(self.header.num_vertices):
+                _t__m_vertex_colors = Re4UhdBin.Rgba(self._io, self, self._root)
+                try:
+                    _t__m_vertex_colors._read()
+                finally:
+                    self._m_vertex_colors.append(_t__m_vertex_colors)
+
+            self._io.seek(_pos)
+
+        return getattr(self, '_m_vertex_colors', None)
+
+    @vertex_colors.setter
+    def vertex_colors(self, v):
+        self._dirty = True
+        self._m_vertex_colors = v
+
+    def _write_vertex_colors(self):
+        self._should_write_vertex_colors = False
+        if self.header.offset_vertex_colors > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_vertex_colors)
+            for i in range(len(self._m_vertex_colors)):
+                pass
+                self._m_vertex_colors[i]._write__seq(self._io)
+
+            self._io.seek(_pos)
+
+
+    @property
+    def vertex_positions(self):
+        if self._should_write_vertex_positions:
+            self._write_vertex_positions()
+        if hasattr(self, '_m_vertex_positions'):
+            return self._m_vertex_positions
+
+        if not self.vertex_positions__enabled:
+            return None
+
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_vertex_position)
+        self._m_vertex_positions = []
+        for i in range(self.header.num_vertices):
+            _t__m_vertex_positions = Re4UhdBin.Vec3(self._io, self, self._root)
+            try:
+                _t__m_vertex_positions._read()
+            finally:
+                self._m_vertex_positions.append(_t__m_vertex_positions)
+
+        self._io.seek(_pos)
+        return getattr(self, '_m_vertex_positions', None)
+
+    @vertex_positions.setter
+    def vertex_positions(self, v):
+        self._dirty = True
+        self._m_vertex_positions = v
+
+    def _write_vertex_positions(self):
+        self._should_write_vertex_positions = False
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_vertex_position)
+        for i in range(len(self._m_vertex_positions)):
+            pass
+            self._m_vertex_positions[i]._write__seq(self._io)
+
+        self._io.seek(_pos)
+
+    @property
+    def weights(self):
+        if self._should_write_weights:
+            self._write_weights()
+        if hasattr(self, '_m_weights'):
+            return self._m_weights
+
+        if not self.weights__enabled:
+            return None
+
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_weights)
+        self._m_weights = []
+        for i in range(self.header.num_weights):
+            _on = self.header.num_weights2 > 255
+            if _on == False:
+                pass
+                _t__m_weights = Re4UhdBin.FmtbinWeight(self._io, self, self._root)
+                try:
+                    _t__m_weights._read()
+                finally:
+                    self._m_weights.append(_t__m_weights)
+            elif _on == True:
+                pass
+                _t__m_weights = Re4UhdBin.FmtbinWeightExt(self._io, self, self._root)
+                try:
+                    _t__m_weights._read()
+                finally:
+                    self._m_weights.append(_t__m_weights)
+
+        self._io.seek(_pos)
+        return getattr(self, '_m_weights', None)
+
+    @weights.setter
+    def weights(self, v):
+        self._dirty = True
+        self._m_weights = v
+
+    def _write_weights(self):
+        self._should_write_weights = False
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_weights)
+        for i in range(len(self._m_weights)):
+            pass
+            _on = self.header.num_weights2 > 255
+            if _on == False:
+                pass
+                self._m_weights[i]._write__seq(self._io)
+            elif _on == True:
+                pass
+                self._m_weights[i]._write__seq(self._io)
+
+        self._io.seek(_pos)
+
+

--- a/albam/engines/cie/structs/udas.ksy
+++ b/albam/engines/cie/structs/udas.ksy
@@ -1,0 +1,48 @@
+meta:
+  id: udas
+  file-extension: udas
+  endian: le
+  ks-version: "0.11"
+  title: Capcom Internal Engine file container 
+
+seq:
+ - {id: header, type: udas_header}
+  
+types:
+  udas_header:
+    seq:
+    - {id: id_magic, type: u4, repeat: expr, repeat-expr: 8}
+    - {id: unk_00, type: u4}
+    - {id: file_size, type: u4}
+    - {id: unk_01, type: u4}
+    - {id: data_offset, type: u4}
+    instances:
+     data_bloc:
+      {pos: data_offset, type: udas_data}
+  
+  udas_data:
+    seq:
+    - {id: num_files, type: u4}
+    - {id: padding, type: u4, repeat: expr, repeat-expr: 3}
+    - {id: offsets, type: u4, repeat: expr, repeat-expr: num_files}
+    - {id: file_extension, type: extension, repeat: expr, repeat-expr: num_files}
+    instances:
+     file_entries:
+      type: file_entry(_index) # <= pass `_index` into file_body
+      repeat: expr
+      repeat-expr: num_files
+
+  file_entry:
+    params:
+      - id: i               # => receive `_index` as `i` here
+        type: s4
+    instances:
+      raw_data:
+        pos: _parent.offsets[i] + _root.header.data_offset
+        size: "i == _parent.num_files - 1 ? 
+              (_root.header.file_size - _parent.offsets[i]) :
+              (_parent.offsets[i + 1] - _parent.offsets[i])"
+        
+  extension:
+    seq:
+      - {id: ext, type: str ,terminator: 0, encoding: UTF-8}

--- a/albam/engines/cie/structs/udas.ksy
+++ b/albam/engines/cie/structs/udas.ksy
@@ -17,7 +17,7 @@ types:
     - {id: unk_01, type: u4}
     - {id: data_offset, type: u4}
     instances:
-     data_bloc:
+     data_blocks:
       {pos: data_offset, type: udas_data}
   
   udas_data:

--- a/albam/engines/cie/structs/udas.py
+++ b/albam/engines/cie/structs/udas.py
@@ -1,0 +1,332 @@
+# This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
+# type: ignore
+
+import kaitaistruct
+from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
+
+
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+
+class Udas(ReadWriteKaitaiStruct):
+    def __init__(self, _io=None, _parent=None, _root=None):
+        self._io = _io
+        self._parent = _parent
+        self._root = _root if _root else self
+
+    def _read(self):
+        self.header = Udas.UdasHeader(self._io, self, self._root)
+        self.header._read()
+
+
+    def _fetch_instances(self):
+        pass
+        self.header._fetch_instances()
+
+
+    def _write__seq(self, io=None):
+        super(Udas, self)._write__seq(io)
+        self.header._write__seq(self._io)
+
+
+    def _check(self):
+        pass
+        if self.header._root != self._root:
+            raise kaitaistruct.ConsistencyError(u"header", self.header._root, self._root)
+        if self.header._parent != self:
+            raise kaitaistruct.ConsistencyError(u"header", self.header._parent, self)
+
+    class UdasHeader(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root
+            self._should_write_data_bloc = False
+            self.data_bloc__to_write = True
+
+        def _read(self):
+            self.id_magic = []
+            for i in range(8):
+                self.id_magic.append(self._io.read_u4le())
+
+            self.unk_00 = self._io.read_u4le()
+            self.file_size = self._io.read_u4le()
+            self.unk_01 = self._io.read_u4le()
+            self.data_offset = self._io.read_u4le()
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.id_magic)):
+                pass
+
+            _ = self.data_bloc
+            self.data_bloc._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Udas.UdasHeader, self)._write__seq(io)
+            self._should_write_data_bloc = self.data_bloc__to_write
+            for i in range(len(self.id_magic)):
+                pass
+                self._io.write_u4le(self.id_magic[i])
+
+            self._io.write_u4le(self.unk_00)
+            self._io.write_u4le(self.file_size)
+            self._io.write_u4le(self.unk_01)
+            self._io.write_u4le(self.data_offset)
+
+
+        def _check(self):
+            pass
+            if (len(self.id_magic) != 8):
+                raise kaitaistruct.ConsistencyError(u"id_magic", len(self.id_magic), 8)
+            for i in range(len(self.id_magic)):
+                pass
+
+
+        @property
+        def data_bloc(self):
+            if self._should_write_data_bloc:
+                self._write_data_bloc()
+            if hasattr(self, '_m_data_bloc'):
+                return self._m_data_bloc
+
+            _pos = self._io.pos()
+            self._io.seek(self.data_offset)
+            self._m_data_bloc = Udas.UdasData(self._io, self, self._root)
+            self._m_data_bloc._read()
+            self._io.seek(_pos)
+            return getattr(self, '_m_data_bloc', None)
+
+        @data_bloc.setter
+        def data_bloc(self, v):
+            self._m_data_bloc = v
+
+        def _write_data_bloc(self):
+            self._should_write_data_bloc = False
+            _pos = self._io.pos()
+            self._io.seek(self.data_offset)
+            self.data_bloc._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+        def _check_data_bloc(self):
+            pass
+            if self.data_bloc._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"data_bloc", self.data_bloc._root, self._root)
+            if self.data_bloc._parent != self:
+                raise kaitaistruct.ConsistencyError(u"data_bloc", self.data_bloc._parent, self)
+
+
+    class UdasData(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root
+            self._should_write_file_entries = False
+            self.file_entries__to_write = True
+
+        def _read(self):
+            self.num_files = self._io.read_u4le()
+            self.padding = []
+            for i in range(3):
+                self.padding.append(self._io.read_u4le())
+
+            self.offsets = []
+            for i in range(self.num_files):
+                self.offsets.append(self._io.read_u4le())
+
+            self.file_extension = []
+            for i in range(self.num_files):
+                _t_file_extension = Udas.Extension(self._io, self, self._root)
+                _t_file_extension._read()
+                self.file_extension.append(_t_file_extension)
+
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.padding)):
+                pass
+
+            for i in range(len(self.offsets)):
+                pass
+
+            for i in range(len(self.file_extension)):
+                pass
+                self.file_extension[i]._fetch_instances()
+
+            _ = self.file_entries
+            for i in range(len(self._m_file_entries)):
+                pass
+                self.file_entries[i]._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Udas.UdasData, self)._write__seq(io)
+            self._should_write_file_entries = self.file_entries__to_write
+            self._io.write_u4le(self.num_files)
+            for i in range(len(self.padding)):
+                pass
+                self._io.write_u4le(self.padding[i])
+
+            for i in range(len(self.offsets)):
+                pass
+                self._io.write_u4le(self.offsets[i])
+
+            for i in range(len(self.file_extension)):
+                pass
+                self.file_extension[i]._write__seq(self._io)
+
+
+
+        def _check(self):
+            pass
+            if (len(self.padding) != 3):
+                raise kaitaistruct.ConsistencyError(u"padding", len(self.padding), 3)
+            for i in range(len(self.padding)):
+                pass
+
+            if (len(self.offsets) != self.num_files):
+                raise kaitaistruct.ConsistencyError(u"offsets", len(self.offsets), self.num_files)
+            for i in range(len(self.offsets)):
+                pass
+
+            if (len(self.file_extension) != self.num_files):
+                raise kaitaistruct.ConsistencyError(u"file_extension", len(self.file_extension), self.num_files)
+            for i in range(len(self.file_extension)):
+                pass
+                if self.file_extension[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"file_extension", self.file_extension[i]._root, self._root)
+                if self.file_extension[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"file_extension", self.file_extension[i]._parent, self)
+
+
+        @property
+        def file_entries(self):
+            if self._should_write_file_entries:
+                self._write_file_entries()
+            if hasattr(self, '_m_file_entries'):
+                return self._m_file_entries
+
+            self._m_file_entries = []
+            for i in range(self.num_files):
+                _t__m_file_entries = Udas.FileEntry(i, self._io, self, self._root)
+                _t__m_file_entries._read()
+                self._m_file_entries.append(_t__m_file_entries)
+
+            return getattr(self, '_m_file_entries', None)
+
+        @file_entries.setter
+        def file_entries(self, v):
+            self._m_file_entries = v
+
+        def _write_file_entries(self):
+            self._should_write_file_entries = False
+            for i in range(len(self._m_file_entries)):
+                pass
+                self.file_entries[i]._write__seq(self._io)
+
+
+
+        def _check_file_entries(self):
+            pass
+            if (len(self.file_entries) != self.num_files):
+                raise kaitaistruct.ConsistencyError(u"file_entries", len(self.file_entries), self.num_files)
+            for i in range(len(self._m_file_entries)):
+                pass
+                if self.file_entries[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"file_entries", self.file_entries[i]._root, self._root)
+                if self.file_entries[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"file_entries", self.file_entries[i]._parent, self)
+                if (self.file_entries[i].i != i):
+                    raise kaitaistruct.ConsistencyError(u"file_entries", self.file_entries[i].i, i)
+
+
+
+    class FileEntry(ReadWriteKaitaiStruct):
+        def __init__(self, i, _io=None, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root
+            self.i = i
+            self._should_write_raw_data = False
+            self.raw_data__to_write = True
+
+        def _read(self):
+            pass
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.raw_data
+
+
+        def _write__seq(self, io=None):
+            super(Udas.FileEntry, self)._write__seq(io)
+            self._should_write_raw_data = self.raw_data__to_write
+
+
+        def _check(self):
+            pass
+
+        @property
+        def raw_data(self):
+            if self._should_write_raw_data:
+                self._write_raw_data()
+            if hasattr(self, '_m_raw_data'):
+                return self._m_raw_data
+
+            _pos = self._io.pos()
+            self._io.seek((self._parent.offsets[self.i] + self._root.header.data_offset))
+            self._m_raw_data = self._io.read_bytes(((self._root.header.file_size - self._parent.offsets[self.i]) if (self.i == (self._parent.num_files - 1)) else (self._parent.offsets[(self.i + 1)] - self._parent.offsets[self.i])))
+            self._io.seek(_pos)
+            return getattr(self, '_m_raw_data', None)
+
+        @raw_data.setter
+        def raw_data(self, v):
+            self._m_raw_data = v
+
+        def _write_raw_data(self):
+            self._should_write_raw_data = False
+            _pos = self._io.pos()
+            self._io.seek((self._parent.offsets[self.i] + self._root.header.data_offset))
+            self._io.write_bytes(self.raw_data)
+            self._io.seek(_pos)
+
+
+        def _check_raw_data(self):
+            pass
+            if (len(self.raw_data) != ((self._root.header.file_size - self._parent.offsets[self.i]) if (self.i == (self._parent.num_files - 1)) else (self._parent.offsets[(self.i + 1)] - self._parent.offsets[self.i]))):
+                raise kaitaistruct.ConsistencyError(u"raw_data", len(self.raw_data), ((self._root.header.file_size - self._parent.offsets[self.i]) if (self.i == (self._parent.num_files - 1)) else (self._parent.offsets[(self.i + 1)] - self._parent.offsets[self.i])))
+
+
+    class Extension(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.ext = (self._io.read_bytes_term(0, False, True, True)).decode("UTF-8")
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Udas.Extension, self)._write__seq(io)
+            self._io.write_bytes((self.ext).encode(u"UTF-8"))
+            self._io.write_u1(0)
+
+
+        def _check(self):
+            pass
+            if (KaitaiStream.byte_array_index_of((self.ext).encode(u"UTF-8"), 0) != -1):
+                raise kaitaistruct.ConsistencyError(u"ext", KaitaiStream.byte_array_index_of((self.ext).encode(u"UTF-8"), 0), -1)
+
+
+

--- a/albam/engines/cie/structs/udas.py
+++ b/albam/engines/cie/structs/udas.py
@@ -5,18 +5,19 @@ import kaitaistruct
 from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
 
 
-if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 11):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.11 or later is required, but you have %s" % (kaitaistruct.__version__))
 
 class Udas(ReadWriteKaitaiStruct):
     def __init__(self, _io=None, _parent=None, _root=None):
-        self._io = _io
+        super(Udas, self).__init__(_io)
         self._parent = _parent
-        self._root = _root if _root else self
+        self._root = _root or self
 
     def _read(self):
         self.header = Udas.UdasHeader(self._io, self, self._root)
         self.header._read()
+        self._dirty = False
 
 
     def _fetch_instances(self):
@@ -30,102 +31,110 @@ class Udas(ReadWriteKaitaiStruct):
 
 
     def _check(self):
-        pass
         if self.header._root != self._root:
-            raise kaitaistruct.ConsistencyError(u"header", self.header._root, self._root)
+            raise kaitaistruct.ConsistencyError(u"header", self._root, self.header._root)
         if self.header._parent != self:
-            raise kaitaistruct.ConsistencyError(u"header", self.header._parent, self)
+            raise kaitaistruct.ConsistencyError(u"header", self, self.header._parent)
+        self._dirty = False
 
-    class UdasHeader(ReadWriteKaitaiStruct):
+    class Extension(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Udas.Extension, self).__init__(_io)
             self._parent = _parent
             self._root = _root
-            self._should_write_data_bloc = False
-            self.data_bloc__to_write = True
 
         def _read(self):
-            self.id_magic = []
-            for i in range(8):
-                self.id_magic.append(self._io.read_u4le())
-
-            self.unk_00 = self._io.read_u4le()
-            self.file_size = self._io.read_u4le()
-            self.unk_01 = self._io.read_u4le()
-            self.data_offset = self._io.read_u4le()
+            self.ext = (self._io.read_bytes_term(0, False, True, True)).decode(u"UTF-8")
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
-            for i in range(len(self.id_magic)):
-                pass
-
-            _ = self.data_bloc
-            self.data_bloc._fetch_instances()
 
 
         def _write__seq(self, io=None):
-            super(Udas.UdasHeader, self)._write__seq(io)
-            self._should_write_data_bloc = self.data_bloc__to_write
-            for i in range(len(self.id_magic)):
-                pass
-                self._io.write_u4le(self.id_magic[i])
-
-            self._io.write_u4le(self.unk_00)
-            self._io.write_u4le(self.file_size)
-            self._io.write_u4le(self.unk_01)
-            self._io.write_u4le(self.data_offset)
+            super(Udas.Extension, self)._write__seq(io)
+            self._io.write_bytes((self.ext).encode(u"UTF-8"))
+            self._io.write_u1(0)
 
 
         def _check(self):
+            if KaitaiStream.byte_array_index_of((self.ext).encode(u"UTF-8"), 0) != -1:
+                raise kaitaistruct.ConsistencyError(u"ext", -1, KaitaiStream.byte_array_index_of((self.ext).encode(u"UTF-8"), 0))
+            self._dirty = False
+
+
+    class FileEntry(ReadWriteKaitaiStruct):
+        def __init__(self, i, _io=None, _parent=None, _root=None):
+            super(Udas.FileEntry, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self.i = i
+            self._should_write_raw_data = False
+            self.raw_data__enabled = True
+
+        def _read(self):
             pass
-            if (len(self.id_magic) != 8):
-                raise kaitaistruct.ConsistencyError(u"id_magic", len(self.id_magic), 8)
-            for i in range(len(self.id_magic)):
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.raw_data
+            if hasattr(self, '_m_raw_data'):
                 pass
 
 
+
+        def _write__seq(self, io=None):
+            super(Udas.FileEntry, self)._write__seq(io)
+            self._should_write_raw_data = self.raw_data__enabled
+
+
+        def _check(self):
+            if self.raw_data__enabled:
+                pass
+                if len(self._m_raw_data) != (self._root.header.file_size - self._parent.offsets[self.i] if self.i == self._parent.num_files - 1 else self._parent.offsets[self.i + 1] - self._parent.offsets[self.i]):
+                    raise kaitaistruct.ConsistencyError(u"raw_data", (self._root.header.file_size - self._parent.offsets[self.i] if self.i == self._parent.num_files - 1 else self._parent.offsets[self.i + 1] - self._parent.offsets[self.i]), len(self._m_raw_data))
+
+            self._dirty = False
+
         @property
-        def data_bloc(self):
-            if self._should_write_data_bloc:
-                self._write_data_bloc()
-            if hasattr(self, '_m_data_bloc'):
-                return self._m_data_bloc
+        def raw_data(self):
+            if self._should_write_raw_data:
+                self._write_raw_data()
+            if hasattr(self, '_m_raw_data'):
+                return self._m_raw_data
+
+            if not self.raw_data__enabled:
+                return None
 
             _pos = self._io.pos()
-            self._io.seek(self.data_offset)
-            self._m_data_bloc = Udas.UdasData(self._io, self, self._root)
-            self._m_data_bloc._read()
+            self._io.seek(self._parent.offsets[self.i] + self._root.header.data_offset)
+            self._m_raw_data = self._io.read_bytes((self._root.header.file_size - self._parent.offsets[self.i] if self.i == self._parent.num_files - 1 else self._parent.offsets[self.i + 1] - self._parent.offsets[self.i]))
             self._io.seek(_pos)
-            return getattr(self, '_m_data_bloc', None)
+            return getattr(self, '_m_raw_data', None)
 
-        @data_bloc.setter
-        def data_bloc(self, v):
-            self._m_data_bloc = v
+        @raw_data.setter
+        def raw_data(self, v):
+            self._dirty = True
+            self._m_raw_data = v
 
-        def _write_data_bloc(self):
-            self._should_write_data_bloc = False
+        def _write_raw_data(self):
+            self._should_write_raw_data = False
             _pos = self._io.pos()
-            self._io.seek(self.data_offset)
-            self.data_bloc._write__seq(self._io)
+            self._io.seek(self._parent.offsets[self.i] + self._root.header.data_offset)
+            self._io.write_bytes(self._m_raw_data)
             self._io.seek(_pos)
-
-
-        def _check_data_bloc(self):
-            pass
-            if self.data_bloc._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"data_bloc", self.data_bloc._root, self._root)
-            if self.data_bloc._parent != self:
-                raise kaitaistruct.ConsistencyError(u"data_bloc", self.data_bloc._parent, self)
 
 
     class UdasData(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Udas.UdasData, self).__init__(_io)
             self._parent = _parent
             self._root = _root
             self._should_write_file_entries = False
-            self.file_entries__to_write = True
+            self.file_entries__enabled = True
 
         def _read(self):
             self.num_files = self._io.read_u4le()
@@ -140,9 +149,12 @@ class Udas(ReadWriteKaitaiStruct):
             self.file_extension = []
             for i in range(self.num_files):
                 _t_file_extension = Udas.Extension(self._io, self, self._root)
-                _t_file_extension._read()
-                self.file_extension.append(_t_file_extension)
+                try:
+                    _t_file_extension._read()
+                finally:
+                    self.file_extension.append(_t_file_extension)
 
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -158,15 +170,18 @@ class Udas(ReadWriteKaitaiStruct):
                 self.file_extension[i]._fetch_instances()
 
             _ = self.file_entries
-            for i in range(len(self._m_file_entries)):
+            if hasattr(self, '_m_file_entries'):
                 pass
-                self.file_entries[i]._fetch_instances()
+                for i in range(len(self._m_file_entries)):
+                    pass
+                    self._m_file_entries[i]._fetch_instances()
+
 
 
 
         def _write__seq(self, io=None):
             super(Udas.UdasData, self)._write__seq(io)
-            self._should_write_file_entries = self.file_entries__to_write
+            self._should_write_file_entries = self.file_entries__enabled
             self._io.write_u4le(self.num_files)
             for i in range(len(self.padding)):
                 pass
@@ -183,26 +198,40 @@ class Udas(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
-            if (len(self.padding) != 3):
-                raise kaitaistruct.ConsistencyError(u"padding", len(self.padding), 3)
+            if len(self.padding) != 3:
+                raise kaitaistruct.ConsistencyError(u"padding", 3, len(self.padding))
             for i in range(len(self.padding)):
                 pass
 
-            if (len(self.offsets) != self.num_files):
-                raise kaitaistruct.ConsistencyError(u"offsets", len(self.offsets), self.num_files)
+            if len(self.offsets) != self.num_files:
+                raise kaitaistruct.ConsistencyError(u"offsets", self.num_files, len(self.offsets))
             for i in range(len(self.offsets)):
                 pass
 
-            if (len(self.file_extension) != self.num_files):
-                raise kaitaistruct.ConsistencyError(u"file_extension", len(self.file_extension), self.num_files)
+            if len(self.file_extension) != self.num_files:
+                raise kaitaistruct.ConsistencyError(u"file_extension", self.num_files, len(self.file_extension))
             for i in range(len(self.file_extension)):
                 pass
                 if self.file_extension[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"file_extension", self.file_extension[i]._root, self._root)
+                    raise kaitaistruct.ConsistencyError(u"file_extension", self._root, self.file_extension[i]._root)
                 if self.file_extension[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"file_extension", self.file_extension[i]._parent, self)
+                    raise kaitaistruct.ConsistencyError(u"file_extension", self, self.file_extension[i]._parent)
 
+            if self.file_entries__enabled:
+                pass
+                if len(self._m_file_entries) != self.num_files:
+                    raise kaitaistruct.ConsistencyError(u"file_entries", self.num_files, len(self._m_file_entries))
+                for i in range(len(self._m_file_entries)):
+                    pass
+                    if self._m_file_entries[i]._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"file_entries", self._root, self._m_file_entries[i]._root)
+                    if self._m_file_entries[i]._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"file_entries", self, self._m_file_entries[i]._parent)
+                    if self._m_file_entries[i].i != i:
+                        raise kaitaistruct.ConsistencyError(u"file_entries", i, self._m_file_entries[i].i)
+
+
+            self._dirty = False
 
         @property
         def file_entries(self):
@@ -211,122 +240,120 @@ class Udas(ReadWriteKaitaiStruct):
             if hasattr(self, '_m_file_entries'):
                 return self._m_file_entries
 
+            if not self.file_entries__enabled:
+                return None
+
             self._m_file_entries = []
             for i in range(self.num_files):
                 _t__m_file_entries = Udas.FileEntry(i, self._io, self, self._root)
-                _t__m_file_entries._read()
-                self._m_file_entries.append(_t__m_file_entries)
+                try:
+                    _t__m_file_entries._read()
+                finally:
+                    self._m_file_entries.append(_t__m_file_entries)
 
             return getattr(self, '_m_file_entries', None)
 
         @file_entries.setter
         def file_entries(self, v):
+            self._dirty = True
             self._m_file_entries = v
 
         def _write_file_entries(self):
             self._should_write_file_entries = False
             for i in range(len(self._m_file_entries)):
                 pass
-                self.file_entries[i]._write__seq(self._io)
+                self._m_file_entries[i]._write__seq(self._io)
 
 
 
-        def _check_file_entries(self):
-            pass
-            if (len(self.file_entries) != self.num_files):
-                raise kaitaistruct.ConsistencyError(u"file_entries", len(self.file_entries), self.num_files)
-            for i in range(len(self._m_file_entries)):
-                pass
-                if self.file_entries[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"file_entries", self.file_entries[i]._root, self._root)
-                if self.file_entries[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"file_entries", self.file_entries[i]._parent, self)
-                if (self.file_entries[i].i != i):
-                    raise kaitaistruct.ConsistencyError(u"file_entries", self.file_entries[i].i, i)
-
-
-
-    class FileEntry(ReadWriteKaitaiStruct):
-        def __init__(self, i, _io=None, _parent=None, _root=None):
-            self._io = _io
+    class UdasHeader(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Udas.UdasHeader, self).__init__(_io)
             self._parent = _parent
             self._root = _root
-            self.i = i
-            self._should_write_raw_data = False
-            self.raw_data__to_write = True
+            self._should_write_data_blocks = False
+            self.data_blocks__enabled = True
 
         def _read(self):
-            pass
+            self.id_magic = []
+            for i in range(8):
+                self.id_magic.append(self._io.read_u4le())
+
+            self.unk_00 = self._io.read_u4le()
+            self.file_size = self._io.read_u4le()
+            self.unk_01 = self._io.read_u4le()
+            self.data_offset = self._io.read_u4le()
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
-            _ = self.raw_data
+            for i in range(len(self.id_magic)):
+                pass
+
+            _ = self.data_blocks
+            if hasattr(self, '_m_data_blocks'):
+                pass
+                self._m_data_blocks._fetch_instances()
+
 
 
         def _write__seq(self, io=None):
-            super(Udas.FileEntry, self)._write__seq(io)
-            self._should_write_raw_data = self.raw_data__to_write
+            super(Udas.UdasHeader, self)._write__seq(io)
+            self._should_write_data_blocks = self.data_blocks__enabled
+            for i in range(len(self.id_magic)):
+                pass
+                self._io.write_u4le(self.id_magic[i])
+
+            self._io.write_u4le(self.unk_00)
+            self._io.write_u4le(self.file_size)
+            self._io.write_u4le(self.unk_01)
+            self._io.write_u4le(self.data_offset)
 
 
         def _check(self):
-            pass
+            if len(self.id_magic) != 8:
+                raise kaitaistruct.ConsistencyError(u"id_magic", 8, len(self.id_magic))
+            for i in range(len(self.id_magic)):
+                pass
+
+            if self.data_blocks__enabled:
+                pass
+                if self._m_data_blocks._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"data_blocks", self._root, self._m_data_blocks._root)
+                if self._m_data_blocks._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"data_blocks", self, self._m_data_blocks._parent)
+
+            self._dirty = False
 
         @property
-        def raw_data(self):
-            if self._should_write_raw_data:
-                self._write_raw_data()
-            if hasattr(self, '_m_raw_data'):
-                return self._m_raw_data
+        def data_blocks(self):
+            if self._should_write_data_blocks:
+                self._write_data_blocks()
+            if hasattr(self, '_m_data_blocks'):
+                return self._m_data_blocks
+
+            if not self.data_blocks__enabled:
+                return None
 
             _pos = self._io.pos()
-            self._io.seek((self._parent.offsets[self.i] + self._root.header.data_offset))
-            self._m_raw_data = self._io.read_bytes(((self._root.header.file_size - self._parent.offsets[self.i]) if (self.i == (self._parent.num_files - 1)) else (self._parent.offsets[(self.i + 1)] - self._parent.offsets[self.i])))
+            self._io.seek(self.data_offset)
+            self._m_data_blocks = Udas.UdasData(self._io, self, self._root)
+            self._m_data_blocks._read()
             self._io.seek(_pos)
-            return getattr(self, '_m_raw_data', None)
+            return getattr(self, '_m_data_blocks', None)
 
-        @raw_data.setter
-        def raw_data(self, v):
-            self._m_raw_data = v
+        @data_blocks.setter
+        def data_blocks(self, v):
+            self._dirty = True
+            self._m_data_blocks = v
 
-        def _write_raw_data(self):
-            self._should_write_raw_data = False
+        def _write_data_blocks(self):
+            self._should_write_data_blocks = False
             _pos = self._io.pos()
-            self._io.seek((self._parent.offsets[self.i] + self._root.header.data_offset))
-            self._io.write_bytes(self.raw_data)
+            self._io.seek(self.data_offset)
+            self._m_data_blocks._write__seq(self._io)
             self._io.seek(_pos)
-
-
-        def _check_raw_data(self):
-            pass
-            if (len(self.raw_data) != ((self._root.header.file_size - self._parent.offsets[self.i]) if (self.i == (self._parent.num_files - 1)) else (self._parent.offsets[(self.i + 1)] - self._parent.offsets[self.i]))):
-                raise kaitaistruct.ConsistencyError(u"raw_data", len(self.raw_data), ((self._root.header.file_size - self._parent.offsets[self.i]) if (self.i == (self._parent.num_files - 1)) else (self._parent.offsets[(self.i + 1)] - self._parent.offsets[self.i])))
-
-
-    class Extension(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.ext = (self._io.read_bytes_term(0, False, True, True)).decode("UTF-8")
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Udas.Extension, self)._write__seq(io)
-            self._io.write_bytes((self.ext).encode(u"UTF-8"))
-            self._io.write_u1(0)
-
-
-        def _check(self):
-            pass
-            if (KaitaiStream.byte_array_index_of((self.ext).encode(u"UTF-8"), 0) != -1):
-                raise kaitaistruct.ConsistencyError(u"ext", KaitaiStream.byte_array_index_of((self.ext).encode(u"UTF-8"), 0), -1)
 
 
 

--- a/albam/engines/cie/textures.py
+++ b/albam/engines/cie/textures.py
@@ -1,0 +1,340 @@
+"""
+RE4 UHD texture loading: TPL metadata + PACK pixel data -> Blender images.
+
+Flow:
+  1. The UDAS contains .TPL file entries alongside the mesh .BINs.
+     Each TPL holds metadata: PackID, TextureID, width, height.
+  2. A .pack.lfs file (same directory as the .lfs) contains the actual image data.
+     Its first u32 = PackID, matching the TPL entry.
+  3. TextureID indexes into the pack's offset table -> raw image bytes.
+  4. Image bytes start with a magic: 0x20534444 = DDS, 0x00020000 = TGA.
+  5. Written to a temp file and loaded via bpy.data.images.load().
+
+Limitations:
+  - TPL slot indices in each BIN's materials are relative to the set of TPL entries
+    that belong to that BIN. Currently all TPL entries in the UDAS are read together
+    and treated as a global list, which works correctly for the main body BIN (_000)
+    but may assign incorrect textures to secondary BINs (head, hands, etc.) if their
+    TPL entries are not at the start of the global list.
+  - Mods such as the HD Project route certain textures (e.g. Leon's head) through a
+    separate .pack.lfs file (e.g. 07000000.pack.lfs). The code will find this file if
+    it is placed in the same directory, but only if the TPL entry for that BIN is
+    correctly identified in the UDAS — which is not guaranteed with the current
+    global-list approach. See README for details.
+"""
+
+import os
+import struct
+import tempfile
+import bpy
+from ...albam_vendor import xcompress
+from .structs.lfs import Lfs
+
+RE4UHD_NORMAL_GROUP_NAME = "RE4 UHD Normal Map"
+
+
+def load_textures_for_model(mesh_ob, bin, vfile, context):
+    """
+    Entry point: find pack files, parse TPLs from UDAS, assign to materials.
+    """
+    lfs_path = vfile.root_vfile.absolute_path
+    lfs_dir  = os.path.dirname(lfs_path)
+
+    pack_db = _build_pack_db(lfs_dir)
+    if not pack_db:
+        print("[re4uhd] textures: no .pack.lfs files found — skipping texture load")
+        return
+
+    print(f"[re4uhd] textures: found {len(pack_db)} pack file(s): "
+          f"{[hex(k) for k in pack_db]}")
+
+    tpl_list = _read_tpl_entries(lfs_path)
+    if not tpl_list:
+        print("[re4uhd] textures: no TPL entries found in UDAS")
+        return
+
+    print(f"[re4uhd] textures: {len(tpl_list)} TPL entries parsed")
+
+    image_cache = {}
+    for slot_i, tpl in enumerate(tpl_list):
+        pack_id = tpl["pack_id"]
+        tex_id  = tpl["texture_id"]
+        if pack_id not in pack_db:
+            print(
+                f"[re4uhd]   slot {slot_i}: pack_id=0x{pack_id:08X} not found "
+                f"(available: {[hex(k) for k in pack_db]}). "
+                f"Place the matching .pack.lfs in the same directory."
+            )
+            continue
+        img = _load_image_from_pack(pack_db[pack_id], tex_id, slot_i, pack_id)
+        if img:
+            image_cache[slot_i] = img
+            print(f"[re4uhd]   slot {slot_i}: loaded '{img.name}' "
+                  f"({tpl['width']}x{tpl['height']})")
+
+    if not image_cache:
+        print("[re4uhd] textures: no images loaded")
+        return
+
+    me = mesh_ob.data
+    for bl_mat in me.materials:
+        if bl_mat is None:
+            continue
+        diffuse_slot = bl_mat.get("re4uhd_diffuse_tpl_slot", -1)
+        bump_slot    = bl_mat.get("re4uhd_bump_tpl_slot",    -1)
+        opacity_slot = bl_mat.get("re4uhd_opacity_tpl_slot", -1)
+        _setup_material_nodes(bl_mat, image_cache, diffuse_slot, bump_slot, opacity_slot)
+
+    print("[re4uhd] textures: materials set up")
+
+
+# -- Pack database -------------------------------------------------------------
+
+def _build_pack_db(directory):
+    """
+    Scan directory for *.pack.lfs files, decompress each, read PackID.
+    Returns dict: {pack_id (int) -> raw_pack_bytes}
+    """
+    pack_db = {}
+    for fname in os.listdir(directory):
+        if not fname.lower().endswith(".pack.lfs"):
+            continue
+        fpath = os.path.join(directory, fname)
+        try:
+            raw = _decompress_lfs(fpath)
+            if len(raw) < 8:
+                continue
+            pack_id = struct.unpack_from("<I", raw, 0)[0]
+            pack_db[pack_id] = raw
+            print(f"[re4uhd]   pack: {fname} -> PackID=0x{pack_id:08X}")
+        except Exception as e:
+            print(f"[re4uhd]   pack: failed to read {fname}: {e}")
+    return pack_db
+
+
+def _decompress_lfs(file_path):
+    lfs = Lfs.from_file(file_path)
+    lfs._read()
+    return xcompress.xcompress_decompress_re4hd(lfs.file_entries)
+
+
+# -- TPL parsing ---------------------------------------------------------------
+
+def _read_tpl_entries(lfs_path):
+    """
+    Read all TPL entries from the UDAS, in order of appearance.
+
+    The returned list is used as a global texture slot table: material fields
+    diffuse_slot, bump_slot and opacity_slot are indices into this list.
+    """
+    from .structs.udas import Udas
+    raw_lfs = _decompress_lfs(lfs_path)
+    udas = Udas.from_bytes(raw_lfs)
+    udas._read()
+
+    tpl_entries = []
+    entries = udas.header.data_blocks.file_entries
+    exts    = udas.header.data_blocks.file_extension
+
+    for fe, ext_obj in zip(entries, exts):
+        if ext_obj.ext.upper() != "TPL":
+            continue
+        raw = bytes(fe.raw_data)
+        if len(raw) < 12:
+            continue
+        tpl = _parse_tpl(raw)
+        if tpl:
+            tpl_entries.extend(tpl)
+
+    return tpl_entries
+
+
+def _parse_tpl(raw):
+    """
+    Parse a single TPL blob. Returns list of {pack_id, texture_id, width, height}.
+
+    TPL layout:
+      u4 magic  (0x78563412 or 0x12345678)
+      u4 TplAmount
+      u4 offsetToOffsetArea
+      -- at offsetToOffsetArea --
+      TplAmount * (u4 image_data_offset, u4 palette_offset)
+      -- at each image_data_offset --
+      u2 height, u2 width, u4 PixelFormatType, u4 secondaryOffset
+      u4 Wrap_S, u4 Wrap_T, u4 Min_Filter, u4 Mag_Filter
+      f4 Lod_Bias, u1 Enable_Lod, u1 Min_Lod, u1 Max_Lod, u1 Is_Compressed
+      -- at secondaryOffset --
+      u4 PackID, u4 TextureID
+    """
+    if len(raw) < 12:
+        return []
+    magic = struct.unpack_from("<I", raw, 0)[0]
+    if magic not in (0x78563412, 0x12345678):
+        return []
+    tpl_amount, offset_area = struct.unpack_from("<II", raw, 4)
+    if tpl_amount == 0 or tpl_amount > 0x10000:
+        return []
+
+    results = []
+    pos = offset_area
+    for _ in range(tpl_amount):
+        if pos + 8 > len(raw):
+            break
+        img_offset, _ = struct.unpack_from("<II", raw, pos)
+        pos += 8
+        if img_offset == 0 or img_offset + 20 > len(raw):
+            results.append(None)
+            continue
+        height, width, _, sec_offset = struct.unpack_from("<HHII", raw, img_offset)
+        if sec_offset == 0 or sec_offset + 8 > len(raw):
+            results.append(None)
+            continue
+        pack_id, texture_id = struct.unpack_from("<II", raw, sec_offset)
+        results.append({"pack_id": pack_id, "texture_id": texture_id,
+                        "width": width, "height": height})
+
+    return [r for r in results if r is not None]
+
+
+# -- Image extraction ----------------------------------------------------------
+
+def _load_image_from_pack(pack_raw, texture_id, slot_i, pack_id):
+    if len(pack_raw) < 8:
+        return None
+    amount = struct.unpack_from("<I", pack_raw, 4)[0]
+    if texture_id >= amount:
+        return None
+    offset_pos = 8 + texture_id * 4
+    if offset_pos + 4 > len(pack_raw):
+        return None
+    data_offset = struct.unpack_from("<I", pack_raw, offset_pos)[0]
+    if data_offset == 0 or data_offset + 16 >= len(pack_raw):
+        return None
+    file_length = struct.unpack_from("<I", pack_raw, data_offset)[0]
+    image_start = data_offset + 16
+    image_end   = min(image_start + file_length, len(pack_raw))
+    image_bytes = pack_raw[image_start:image_end]
+    if len(image_bytes) < 4:
+        return None
+    magic = struct.unpack_from("<I", image_bytes, 0)[0]
+    if magic == 0x20534444:
+        ext = ".dds"
+    elif magic in (0x00020000, 0x000A0000):
+        ext = ".tga"
+    else:
+        print(f"[re4uhd]   slot {slot_i}: unknown image magic 0x{magic:08X}")
+        return None
+    tmp_path = os.path.join(
+        tempfile.gettempdir(),
+        f"re4uhd_p{pack_id:08x}_t{texture_id:04d}{ext}"
+    )
+    with open(tmp_path, "wb") as f:
+        f.write(image_bytes)
+    try:
+        img = bpy.data.images.load(tmp_path, check_existing=True)
+        img.name = f"re4uhd_p{pack_id:08x}_t{texture_id:04d}"
+        img.pack()
+        os.remove(tmp_path)
+        return img
+    except Exception as e:
+        print(f"[re4uhd]   slot {slot_i}: failed to load image: {e}")
+        return None
+
+
+# -- Material node setup -------------------------------------------------------
+
+def _get_or_create_normal_group():
+    """
+    Create (once) a node group for RE4 UHD's swizzled normal map format.
+
+    RE4 UHD stores normals with X in the R channel (G and B are identical to R)
+    and Y in the Alpha channel. Z is not stored and must be approximated.
+    Using B=1.0 as the Z approximation is accurate for typical surface normals
+    and avoids unnecessary math node complexity.
+
+    Compatible with Blender 4.x and 5.x (no deprecated RGB nodes).
+    """
+    existing = bpy.data.node_groups.get(RE4UHD_NORMAL_GROUP_NAME)
+    if existing:
+        return existing
+
+    g = bpy.data.node_groups.new(RE4UHD_NORMAL_GROUP_NAME, "ShaderNodeTree")
+
+    def new_socket(name, in_out, stype):
+        if hasattr(g, "interface"):
+            return g.interface.new_socket(name=name, in_out=in_out, socket_type=stype)
+        col = g.inputs if in_out == "INPUT" else g.outputs
+        return col.new(stype, name)
+
+    new_socket("Color",  "INPUT",  "NodeSocketColor")
+    new_socket("Alpha",  "INPUT",  "NodeSocketFloat")
+    new_socket("Normal", "OUTPUT", "NodeSocketVector")
+
+    def n(node_type, loc):
+        nd = g.nodes.new(node_type)
+        nd.location = loc
+        return nd
+
+    lk = g.links.new
+
+    group_in  = n("NodeGroupInput",  (-600, 0))
+    group_out = n("NodeGroupOutput", (600, 0))
+
+    # X from Red channel, Y from Alpha, Z approximated as 1.0 (neutral forward)
+    sep = n("ShaderNodeSeparateColor", (-350, 0))
+    lk(group_in.outputs["Color"], sep.inputs["Color"])
+
+    combine = n("ShaderNodeCombineColor", (0, 0))
+    combine.inputs["Blue"].default_value = 1.0
+    lk(sep.outputs["Red"],        combine.inputs["Red"])
+    lk(group_in.outputs["Alpha"], combine.inputs["Green"])
+
+    nm = n("ShaderNodeNormalMap", (300, 0))
+    lk(combine.outputs["Color"], nm.inputs["Color"])
+    lk(nm.outputs["Normal"], group_out.inputs["Normal"])
+
+    return g
+
+
+def _setup_material_nodes(bl_mat, image_cache, diffuse_slot, bump_slot, opacity_slot):
+    """
+    Build a clean Principled BSDF material with textures wired correctly.
+    Compatible with Blender 4.x and 5.x.
+    """
+    bl_mat.use_nodes = True
+    bl_mat.blend_method = "CLIP"
+    nodes = bl_mat.node_tree.nodes
+    links = bl_mat.node_tree.links
+    nodes.clear()
+
+    out = nodes.new("ShaderNodeOutputMaterial")
+    out.location = (600, 0)
+
+    bsdf = nodes.new("ShaderNodeBsdfPrincipled")
+    bsdf.location = (300, 0)
+    links.new(bsdf.outputs["BSDF"], out.inputs["Surface"])
+
+    diffuse_img = image_cache.get(diffuse_slot)
+    if diffuse_img:
+        diff = nodes.new("ShaderNodeTexImage")
+        diff.image = diffuse_img
+        diff.location = (-200, 250)
+        links.new(diff.outputs["Color"], bsdf.inputs["Base Color"])
+        links.new(diff.outputs["Alpha"], bsdf.inputs["Alpha"])
+
+    bump_img = image_cache.get(bump_slot) if bump_slot >= 0 else None
+    if bump_img:
+        bump = nodes.new("ShaderNodeTexImage")
+        bump.image = bump_img
+        bump.image.colorspace_settings.name = "Non-Color"
+        bump.location = (-500, -150)
+
+        ng = _get_or_create_normal_group()
+        nm_group = nodes.new("ShaderNodeGroup")
+        nm_group.node_tree = ng
+        nm_group.label = "RE4 UHD Normal"
+        nm_group.location = (-100, -150)
+
+        links.new(bump.outputs["Color"], nm_group.inputs["Color"])
+        links.new(bump.outputs["Alpha"], nm_group.inputs["Alpha"])
+        links.new(nm_group.outputs["Normal"], bsdf.inputs["Normal"])

--- a/albam/vfs.py
+++ b/albam/vfs.py
@@ -216,7 +216,7 @@ class ALBAM_OT_VirtualFileSystemAddFiles(bpy.types.Operator):
     directory: bpy.props.StringProperty(subtype="DIR_PATH")  # NOQA
     files: bpy.props.CollectionProperty(name="added_files", type=bpy.types.OperatorFileListElement)  # NOQA
     # FIXME: use registry, un-hardcode
-    filter_glob: bpy.props.StringProperty(default="*.arc;*.pak", options={"HIDDEN"})  # NOQA
+    filter_glob: bpy.props.StringProperty(default="*.arc;*.pak;*.lfs", options={"HIDDEN"})  # NOQA
 
     def invoke(self, context, event):  # pragma: no cover
         wm = context.window_manager

--- a/albam/vfs.py
+++ b/albam/vfs.py
@@ -57,8 +57,8 @@ class VirtualFile(bpy.types.PropertyGroup):
         e.g. texname.tex.34 -> tex.34
         """
         SEP = "."
-        name , _ , extension = self.display_name.rpartition(SEP)
-        if SEP in name:
+        name, _, extension = self.display_name.rpartition(SEP)
+        if SEP in name and extension != "lfs":
             _, __, extension0 = name.rpartition(SEP)
             extension = SEP.join((extension0, extension))
         return extension
@@ -98,8 +98,8 @@ class VirtualFile(bpy.types.PropertyGroup):
 
 
 class VirtualFileSystemBase:
-    file_list : bpy.props.CollectionProperty(type=VirtualFile)
-    file_list_selected_index : bpy.props.IntProperty()
+    file_list: bpy.props.CollectionProperty(type=VirtualFile)
+    file_list_selected_index: bpy.props.IntProperty()
 
     SEPARATOR = "::"
     VFS_ID = "vfs"
@@ -381,10 +381,11 @@ class VirtualFileData:
         e.g. texname.tex.34 -> tex.34
         """
         SEP = "."
-        name , _ , extension = self.relative_path.rpartition(SEP)
+        name, _, extension = self.relative_path.rpartition(SEP)
         if SEP in name:
             _, __, extension0 = name.rpartition(SEP)
-            extension = SEP.join((extension0, extension))
+            if extension0 != "lfs":  # TODO implement something smarter
+                extension = SEP.join((extension0, extension))
         return extension
 
 


### PR DESCRIPTION
Implements the initial RE4 UHD mesh importer, building on the existing CIE engine structure.

## What's included

- **Mesh**: face building from non-indexed vertex layout, ftype 5 (triangle list), 6 (strip), 7 (fan), 8 (quad list)
- **Armature**: world-space bone positions computed from local hierarchy offsets, reuses existing armature when importing multiple BINs from the same character
- **Vertex weights**: normalized bone weight assignment (up to 3 bones per vertex)
- **UVs and normals**: UV coordinates with V-flip, split normals
- **Materials**: diffuse, bump and opacity slot indices stored as custom properties
- **Textures**: TPL metadata + PACK pixel data loaded into Blender materials, with a custom node group for RE4 UHD's swizzled normal map format (R=X, Alpha=Y)
- **UDAS filter**: non-mesh BINs (camera, lighting, etc.) are skipped automatically

## Known limitations

Texture loading works for vanilla RE4 UHD where all textures are in a single `.pack.lfs`. Mods that split textures across multiple pack files (e.g. the HD Project stores Leon's head textures in a separate pack '07000000.pack') are not fully supported. The code will find additional pack files if placed in the same directory, but per-BIN TPL mapping is not yet implemented.

## Tested with

- `pl10.udas.lfs` (Leon Special 1)
- `pl08.udas.lfs` (Leon no-jacket)
- Multiple BINs imported in sequence (body + head)
- Blender 5.1