### PR TITLE
Add version 155 to tex enumerator and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Fixed
 
 - Import of meshes with Nan UVs
-
+- Missed value in .tex `value` enumerator for RE6 render targets
 
 ### Changed
 

--- a/albam/engines/mtfw/texture.py
+++ b/albam/engines/mtfw/texture.py
@@ -128,9 +128,11 @@ TEX_FORMAT_MAPPER = {
     31: b"DXT5",  # NM/Normal
     32: b"DXT5",
     35: b"DXT5",
+    37: b"DXT1",  # FIXME: unchecked
     39: b"",  # uncompressed
     40: b"",  # uncompressed
     43: b"DXT1",  # FIXME: unchecked
+    47: b"DXT1",  # FIXME: unchecked
     "DXT1": b"DXT1",
     "DXT3": b"DXT3",
     "DXT5": b"DXT5",
@@ -828,6 +830,7 @@ class Tex157CustomProperties(bpy.types.PropertyGroup):  # noqa: F821
             ("0x9a", "154", "", 2),
             ("0x9d", "157", "", 3),
             ("0x9e", "158", "", 4),
+            ("0x9b", "155", "", 5),
         ],
         default="0x9d",
         options=set()

--- a/albam/engines/mtfw/texture.py
+++ b/albam/engines/mtfw/texture.py
@@ -815,6 +815,17 @@ class Tex112CustomProperties(bpy.types.PropertyGroup):
             setattr(dst, name, hex(src_value))
 
 
+TEX_VERSION = {
+    "0x99": 153,
+    "0x9a": 154,
+    "0x9b": 155,
+    "0x9d": 157,
+    "0x9e": 158,
+}
+
+tex_version_enum_items = [(key, str(label), "", idx) for idx, (key, label) in enumerate(TEX_VERSION.items())]
+
+
 @blender_registry.register_custom_properties_image("tex_157", ("re0", "re1", "re6", "rev1", "rev2", "dd",))
 @blender_registry.register_blender_prop
 class Tex157CustomProperties(bpy.types.PropertyGroup):  # noqa: F821
@@ -825,13 +836,7 @@ class Tex157CustomProperties(bpy.types.PropertyGroup):  # noqa: F821
     )
     version: bpy.props.EnumProperty(  # noqa: F821
         name="Tex format version",
-        items=[
-            ("0x99", "153", "", 1),
-            ("0x9a", "154", "", 2),
-            ("0x9d", "157", "", 3),
-            ("0x9e", "158", "", 4),
-            ("0x9b", "155", "", 5),
-        ],
+        items=tex_version_enum_items,
         default="0x9d",
         options=set()
     )

--- a/tests/mtfw/test_rtex_parsing.py
+++ b/tests/mtfw/test_rtex_parsing.py
@@ -1,4 +1,5 @@
 from albam.engines.mtfw.texture import TEX_FORMAT_MAPPER
+TEX_VERSIONS_157 = {153, 154, 155, 157, 158}
 
 
 def test_parse_rtex(parsed_rtex_from_arc):
@@ -9,3 +10,5 @@ def test_parse_rtex(parsed_rtex_from_arc):
         assert rtex.num_images == 6
     assert rtex.num_images in (1, 6)
     assert rtex.compression_format in TEX_FORMAT_MAPPER  # TODO: rename compression_format
+    if rtex_version != 112:
+        assert rtex.version in TEX_VERSIONS_157

--- a/tests/mtfw/test_rtex_parsing.py
+++ b/tests/mtfw/test_rtex_parsing.py
@@ -1,5 +1,4 @@
-from albam.engines.mtfw.texture import TEX_FORMAT_MAPPER
-TEX_VERSIONS_157 = {153, 154, 155, 157, 158}
+from albam.engines.mtfw.texture import TEX_FORMAT_MAPPER, TEX_VERSION
 
 
 def test_parse_rtex(parsed_rtex_from_arc):
@@ -11,4 +10,4 @@ def test_parse_rtex(parsed_rtex_from_arc):
     assert rtex.num_images in (1, 6)
     assert rtex.compression_format in TEX_FORMAT_MAPPER  # TODO: rename compression_format
     if rtex_version != 112:
-        assert rtex.version in TEX_VERSIONS_157
+        assert rtex.version in TEX_VERSION.values()

--- a/tests/mtfw/test_tex_parsing.py
+++ b/tests/mtfw/test_tex_parsing.py
@@ -1,5 +1,6 @@
 from albam.engines.mtfw.texture import (
     TEX_FORMAT_MAPPER,
+    TEX_VERSION,
     Tex157,
     Tex112
 )
@@ -13,7 +14,6 @@ ACCEPTABLE_SIZES.add(768)
 ACCEPTABLE_SIZES.add(1280)
 ACCEPTABLE_SIZES.add(1920)
 ACCEPTABLE_SIZES.add(1080)
-TEX_VERSIONS_157 = {153, 154, 157, 158}
 TEX_TYPES_157 = {0x2, 0x3, 0x6}
 TEX_ATTR_157 = {0x0}
 UNK = {0, 32, 160}
@@ -29,7 +29,7 @@ def test_parse_tex(parsed_tex_from_arc):
     assert 0 < tex.num_mipmaps_per_image <= 13  # XXX FAILS sometimes
 
     if type(tex) is Tex157:
-        assert tex.version in TEX_VERSIONS_157
+        assert tex.version in TEX_VERSION.values()
         assert tex.unk in UNK
         assert tex.attr == 0
         assert tex.prebias in TEX_PREBIAS_157


### PR DESCRIPTION
Turned out RE6 uses a unique version number for .rtex render targets, it's 155. Test didn't catch it because rtex test didn't use version check