### PR TITLE
[Autofixer] A few improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Fixed
 
 - Import of meshes with Nan UVs
+- Triangulation function(now it keeps custom normals)
 
 
 ### Changed

--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -2108,8 +2108,11 @@ def _duplicate_vtx_by_attr(src_obj):
             for g in v.groups:
                 group_tuple.append((groups[g.group].name, round(g.weight, 6)))
 
-            # compare only by vtx index and uv[(u1,v1),(u2,v2),...]
-            comparison_key = (loop.vertex_index, *uv_tuple)
+            # Split normal attribute, duplicate in case of Blender's hard edges
+            normal_tuple = tuple(round(x, 6) for x in n)
+
+            # compare by vtx index, uv[(u1,v1),(u2,v2),...] + split normals
+            comparison_key = (loop.vertex_index, *uv_tuple, normal_tuple)
 
             if comparison_key not in comparison_vtx_map:
                 idx = len(new_vertices)
@@ -2126,7 +2129,7 @@ def _duplicate_vtx_by_attr(src_obj):
             new_face.append(comparison_vtx_map[comparison_key])
         new_faces.append(new_face)
 
-    # Set new mew with duplicated vertices
+    # Set new mesh with duplicated vertices
     dst_mesh = bpy.data.meshes.new("temp_" + src_obj.name)
     dst_mesh.from_pydata(new_vertices, [], new_faces)
     dst_mesh.update()

--- a/albam/lib/common_op.py
+++ b/albam/lib/common_op.py
@@ -173,8 +173,9 @@ def triangulate_meshes(bl_objects):
         bm = bmesh.new()
         bm.from_mesh(mesh)
         # In theory it should save time if we skip already triangulated meshes
-        # adds overhead  ~0.0002 seconds for the test mesh
+        # the check adds overhead  ~0.0002 seconds for the test mesh
         if not any(len(f.verts) >= 4 for f in bm.faces):
+            bm.free()
             continue
         # Create a custom BMesh float vector layer for loops to hold the original normals
         # BMesh automatically ensures this data persists across structural splits
@@ -204,7 +205,6 @@ def triangulate_meshes(bl_objects):
 def triangulate_meshes_modifier(bl_objects):
     unselect()
     for ob in bl_objects:
-
         ob.select_set(True)
         bpy.context.view_layer.objects.active = ob
 

--- a/albam/lib/common_op.py
+++ b/albam/lib/common_op.py
@@ -166,11 +166,56 @@ def copy_faces(sourceMesh, targetMesh, numVertices, materialsMap):
 def triangulate_meshes(bl_objects):
     for ob in bl_objects:
         mesh = ob.data
+
+        # bmesh ignores custom normals, so we need to manually transfer them
+        original_corner_normals = [n.vector[:] for n in mesh.corner_normals]
+
         bm = bmesh.new()
         bm.from_mesh(mesh)
-        bmesh.ops.triangulate(bm, faces=bm.faces[:], quad_method='BEAUTY', ngon_method='BEAUTY')
+        # In theory it should save time if we skip already triangulated meshes
+        # adds overhead  ~0.0002 seconds for the test mesh
+        if not any(len(f.verts) >= 4 for f in bm.faces):
+            continue
+        # Create a custom BMesh float vector layer for loops to hold the original normals
+        # BMesh automatically ensures this data persists across structural splits
+        normal_layer = bm.loops.layers.float_vector.new("original_custom_normals")
+
+        loop_index = 0
+        for face in bm.faces:
+            for loop in face.loops:
+                loop[normal_layer] = original_corner_normals[loop_index]
+                loop_index += 1
+
+        bmesh.ops.triangulate(bm, faces=bm.faces, quad_method='BEAUTY', ngon_method='BEAUTY')
         bm.to_mesh(mesh)
+
+        new_custom_normals = []
+        for face in bm.faces:
+            for loop in face.loops:
+                new_custom_normals.append(loop[normal_layer])
+
+        bm.free()
+
+        mesh.normals_split_custom_set(new_custom_normals)
         mesh.update()
+
+
+# Works but slower ~+ 0.015 seconds for the test mesh
+def triangulate_meshes_modifier(bl_objects):
+    unselect()
+    for ob in bl_objects:
+
+        ob.select_set(True)
+        bpy.context.view_layer.objects.active = ob
+
+        tri_mod = ob.modifiers.new(name="Triangulate", type='TRIANGULATE')
+        tri_mod.quad_method = 'BEAUTY'
+        tri_mod.ngon_method = 'BEAUTY'
+        tri_mod.keep_custom_normals = True
+
+        bpy.ops.object.modifier_apply(modifier=tri_mod.name)
+
+        ob.select_set(False)
 
 
 def move_to_collection(bl_objects, col_name):


### PR DESCRIPTION
Turned out triangulation with bmesh doesn't transfer normals, so this pull request
- adds a fix for storing and restoring normals after triangulation (still not sure if it's better than the modifier)
- adds split normals to the comparison key, so now vertices will be duplicated in case of the Sharp Edge attribute