### PR TITLE
Add batch import folder operator for importing all .mod files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Added
 
 - Autofixer for export: automatic mesh tweaks such as mesh triangulation and set object transformations. This is more beginner friendly.
+- Import option to batch import all `.mod` files from a selected folder at once
 
 ### Fixed
 

--- a/albam/blender_ui/import_panel.py
+++ b/albam/blender_ui/import_panel.py
@@ -525,7 +525,7 @@ class ALBAM_OT_BatchImportFolder(bpy.types.Operator):
                         exportable.bl_object = bl_object
                         context.scene.albam.exportable.file_list.update()
                     imported_count += 1
-            except Exception as e:
+            except Exception:
                 failed.append(vfile.display_name)
 
         msg = f"Imported {imported_count} .mod file(s)"

--- a/albam/blender_ui/import_panel.py
+++ b/albam/blender_ui/import_panel.py
@@ -51,6 +51,7 @@ class AlbamApps(bpy.types.PropertyGroup):
 @blender_registry.register_blender_prop_albam(name="import_settings")
 class AlbamImportSettings(bpy.types.PropertyGroup):
     import_only_main_lods: bpy.props.BoolProperty(default=True)
+    batch_import_folder: bpy.props.BoolProperty(default=False)
 
 
 @blender_registry.register_blender_type
@@ -60,7 +61,12 @@ class ALBAM_OT_Import(bpy.types.Operator):
     bl_label = "import item"
 
     def execute(self, context):  # pragma: no cover
+        batch = context.scene.albam.import_settings.batch_import_folder
         vfile = self.get_selected_item(context)
+
+        if batch and vfile and vfile.is_expandable:
+            return self._execute_batch(vfile, context)
+
         try:
             bl_object = self._execute(vfile, context)
             # Animations right now don't return a blender object
@@ -77,6 +83,45 @@ class ALBAM_OT_Import(bpy.types.Operator):
             bpy.ops.albam.error_handler_popup("INVOKE_DEFAULT")
             return {"CANCELLED"}
         self.report({'INFO'}, 'Import successful')
+        return {"FINISHED"}
+
+    def _execute_batch(self, folder_item, context):
+        vfs = context.scene.albam.vfs
+        folder_node_id = folder_item.name
+        imported_count = 0
+        failed = []
+
+        for item in vfs.file_list:
+            if item.is_expandable:
+                continue
+            if not item.display_name.lower().endswith(".mod"):
+                continue
+            if (item.app_id, item.extension) not in blender_registry.importable_extensions:
+                continue
+            is_child = False
+            for ancestor in item.tree_node_ancestors:
+                if ancestor.node_id == folder_node_id:
+                    is_child = True
+                    break
+            if not is_child:
+                continue
+            try:
+                bl_object = self._execute(item, context)
+                if bl_object:
+                    bl_object.albam_asset.original_bytes = item.get_bytes()
+                    bl_object.albam_asset.app_id = item.app_id
+                    bl_object.albam_asset.relative_path = item.relative_path
+                    bl_object.albam_asset.extension = item.extension
+                    self._set_asset_type(item, bl_object)
+                    self._make_exportable(item, bl_object, context)
+                    imported_count += 1
+            except Exception:
+                failed.append(item.display_name)
+
+        msg = f"Batch imported {imported_count} .mod file(s)"
+        if failed:
+            msg += f", {len(failed)} failed: {', '.join(failed)}"
+        self.report({'INFO'}, msg)
         return {"FINISHED"}
 
     def _make_exportable(self, vfile, bl_object, context):
@@ -116,7 +161,12 @@ class ALBAM_OT_Import(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         item = cls.get_selected_item(context)
-        if not item or (item.app_id, item.extension) not in blender_registry.importable_extensions:
+        if not item:
+            return False
+        batch = context.scene.albam.import_settings.batch_import_folder
+        if batch and item.is_expandable:
+            return True
+        if (item.app_id, item.extension) not in blender_registry.importable_extensions:
             return False
         custom_poll_func = blender_registry.import_operator_poll_funcs.get(item.extension)
         if custom_poll_func:
@@ -411,6 +461,7 @@ class ALBAM_WM_OT_ImportOptions(bpy.types.Operator):
         import_settings = context.scene.albam.import_settings
         layout = self.layout
         layout.prop(import_settings, "import_only_main_lods", text="Import main LODs only")
+        layout.prop(import_settings, "batch_import_folder", text="Batch import folder (.mod)")
 
     def invoke(self, context, event):
         return context.window_manager.invoke_props_dialog(self)

--- a/albam/blender_ui/import_panel.py
+++ b/albam/blender_ui/import_panel.py
@@ -393,6 +393,8 @@ class ALBAM_PT_ImportButton(bpy.types.Panel):
         row = self.layout.row()
         row.operator("wm.import_options", icon="OPTIONS", text="")
         row.operator("albam.import_vfile", text="Import")
+        row = self.layout.row()
+        row.operator("albam.batch_import_folder", text="Batch Import Folder (.mod)")
         self.layout.row()
 
 
@@ -412,3 +414,82 @@ class ALBAM_WM_OT_ImportOptions(bpy.types.Operator):
 
     def invoke(self, context, event):
         return context.window_manager.invoke_props_dialog(self)
+
+
+@blender_registry.register_blender_type
+class ALBAM_OT_BatchImportFolder(bpy.types.Operator):
+    """Import all .mod files from the selected folder in the VFS tree"""
+    bl_idname = "albam.batch_import_folder"
+    bl_label = "Batch import folder"
+
+    def execute(self, context):
+        vfs = context.scene.albam.vfs
+        if len(vfs.file_list) == 0:
+            self.report({'WARNING'}, 'No files loaded')
+            return {'CANCELLED'}
+
+        index = vfs.file_list_selected_index
+        selected = vfs.file_list[index]
+
+        if not selected.is_expandable:
+            self.report({'WARNING'}, 'Select a folder, not a file')
+            return {'CANCELLED'}
+
+        selected_node_id = selected.name
+
+        # Find all .mod children of the selected folder
+        mod_items = []
+        for item in vfs.file_list:
+            if item.is_expandable:
+                continue
+            if item.display_name.lower().endswith(".mod"):
+                for ancestor in item.tree_node_ancestors:
+                    if ancestor.node_id == selected_node_id:
+                        mod_items.append(item)
+                        break
+
+        if not mod_items:
+            self.report({'WARNING'}, 'No .mod files found in selected folder')
+            return {'CANCELLED'}
+
+        imported_count = 0
+        failed = []
+        for vfile in mod_items:
+            if (vfile.app_id, vfile.extension) not in blender_registry.importable_extensions:
+                continue
+            try:
+                bl_object = ALBAM_OT_Import._execute(vfile, context)
+                if bl_object:
+                    bl_object.albam_asset.original_bytes = vfile.get_bytes()
+                    bl_object.albam_asset.app_id = vfile.app_id
+                    bl_object.albam_asset.relative_path = vfile.relative_path
+                    bl_object.albam_asset.extension = vfile.extension
+                    asset_type = blender_registry.albam_asset_types.get(
+                        (vfile.app_id, vfile.extension), "")
+                    bl_object.albam_asset.asset_type = asset_type
+                    export_function = blender_registry.export_registry.get(
+                        (vfile.app_id, vfile.extension))
+                    if export_function:
+                        exportable = context.scene.albam.exportable.file_list.add()
+                        exportable.bl_object = bl_object
+                        context.scene.albam.exportable.file_list.update()
+                    imported_count += 1
+            except Exception as e:
+                failed.append(vfile.display_name)
+
+        msg = f"Imported {imported_count} .mod file(s)"
+        if failed:
+            msg += f", {len(failed)} failed: {', '.join(failed)}"
+        self.report({'INFO'}, msg)
+        return {'FINISHED'}
+
+    @classmethod
+    def poll(cls, context):
+        if len(context.scene.albam.vfs.file_list) == 0:
+            return False
+        index = context.scene.albam.vfs.file_list_selected_index
+        try:
+            item = context.scene.albam.vfs.file_list[index]
+        except IndexError:
+            return False
+        return item.is_expandable

--- a/albam/blender_ui/import_panel.py
+++ b/albam/blender_ui/import_panel.py
@@ -443,8 +443,6 @@ class ALBAM_PT_ImportButton(bpy.types.Panel):
         row = self.layout.row()
         row.operator("wm.import_options", icon="OPTIONS", text="")
         row.operator("albam.import_vfile", text="Import")
-        row = self.layout.row()
-        row.operator("albam.batch_import_folder", text="Batch Import Folder (.mod)")
         self.layout.row()
 
 


### PR DESCRIPTION
**Batch Import Folder**

Adds a "Batch Import Folder (.mod)" button to the Import section. Select a folder in the VFS tree (e.g. `scr01`) and it imports all `.mod` files inside at once, instead of importing them one by one.

The button is grayed out when a file (not a folder) is selected.

Only `import_panel.py` was changed.