### PR TITLE
New operator: app settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Error message for the case when there is no mesh to export
 - Support for navigation mesh import-export (Resident Evil 5)
 - Autosorter tool to automatically set `alpha priority` values ​​for hair cards
+- App Settings button next to App selection. Allows to set the root folder of an app. Its content is stored in apps-userdata.ini, in Albam's extension directory.
 
 ### Fixed
 

--- a/albam/__init__.py
+++ b/albam/__init__.py
@@ -7,6 +7,7 @@ import bpy
 from .blender_ui.data import AlbamDataFactory
 from .blender_ui.asset import AlbamAsset
 from .blender_ui.custom_properties import AlbamCustomPropertiesFactory
+from .data_loading import populate_albam_data
 from .registry import blender_registry
 from .__version__ import __version__ as version
 
@@ -68,6 +69,9 @@ def register():
     bpy.types.Mesh.albam_custom_properties = bpy.props.PointerProperty(type=AlbamCustomPropertiesMesh)
     bpy.types.Image.albam_custom_properties = bpy.props.PointerProperty(type=AlbamCustomPropertiesImage)
     bpy.types.Object.albam_custom_properties = bpy.props.PointerProperty(type=AlbamCustomPropertiesObject)
+
+    # Load data from user's config files
+    bpy.app.handlers.load_post.append(populate_albam_data)
 
 
 def unregister():

--- a/albam/blender_ui/import_panel.py
+++ b/albam/blender_ui/import_panel.py
@@ -357,13 +357,9 @@ class ALBAM_OT_AppConfigPopup(bpy.types.Operator):
         layout = self.layout
 
         apps = context.scene.albam.apps
-        try:
-            app_index = apps["app_selected"]
-        except KeyError:
-            # default, before actually selecting
-            app_index = 0
-        app_selected_name = apps.bl_rna.properties["app_selected"].enum_items[app_index].name
-        layout.label(text=f"{app_selected_name}")
+        current_app = context.scene.albam.apps.app_selected
+        current_app_name = apps.bl_rna.properties["app_selected"].enum_items[current_app].name
+        layout.label(text=f"{current_app_name}")
         layout.row()
 
         row = self.layout.row(heading="App Folder:", align=True)

--- a/albam/blender_ui/import_panel.py
+++ b/albam/blender_ui/import_panel.py
@@ -5,6 +5,7 @@ import bpy
 from ..apps import APPS
 from ..registry import blender_registry
 from ..vfs import ALBAM_OT_VirtualFileSystemCollapseToggle, VirtualFile
+from ..data_loading import AppsUserDataConfigManager
 
 # FIXME: store in app data
 APP_DIRS_CACHE = {}
@@ -12,35 +13,35 @@ APP_DIRS_CACHE = {}
 APP_CONFIG_FILE_CACHE = {}
 
 
-def update_app_data(self, context):
+
+def get_app_dir_from_config(self, context):
     current_app = context.scene.albam.apps.app_selected
-    cached_dir = APP_DIRS_CACHE.get(current_app)
-    cached_file = APP_CONFIG_FILE_CACHE.get(current_app)
-    if cached_dir:
-        context.scene.albam.apps.app_dir = cached_dir
+    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
+    if current_app_userdata:
+        context.scene.albam.apps.app_dir = current_app_userdata.get("app_dir", "")
     else:
         context.scene.albam.apps.app_dir = ""
 
-    if cached_file:
-        context.scene.albam.apps.app_config_filepath = cached_file
-    else:
-        context.scene.albam.apps.app_config_filepath = ""
 
-
-def update_app_caches(self, context):
+def set_app_dir_config(self, context):
     current_app = context.scene.albam.apps.app_selected
     current_dir = context.scene.albam.apps.app_dir
-    current_file = context.scene.albam.apps.app_config_filepath
 
-    APP_DIRS_CACHE[current_app] = current_dir
-    APP_CONFIG_FILE_CACHE[current_app] = current_file
+    config_mgr = AppsUserDataConfigManager()
+    app_section = config_mgr.get_app_section(current_app)
+    if not app_section:
+        config_mgr.config.add_section(f"app.{current_app}")
+        app_section = config_mgr.get_app_section(current_app)
+    app_section["app_dir"] = current_dir
+
+    config_mgr.save()
 
 
 @blender_registry.register_blender_prop_albam(name="apps")
 class AlbamApps(bpy.types.PropertyGroup):
-    app_selected : bpy.props.EnumProperty(name="", items=APPS, update=update_app_data)
-    app_dir : bpy.props.StringProperty(name="", description="", update=update_app_caches)
-    app_config_filepath : bpy.props.StringProperty(name="", update=update_app_caches)
+    app_selected : bpy.props.EnumProperty(name="", items=APPS, update=get_app_dir_from_config)
+    app_dir : bpy.props.StringProperty(name="", description="", update=set_app_dir_config)
+    app_config_filepath : bpy.props.StringProperty(name="")
     mouse_x: bpy.props.IntProperty()
     mouse_y: bpy.props.IntProperty()
 
@@ -269,10 +270,8 @@ class ALBAM_PT_ImportSection(bpy.types.Panel):
 
     def draw(self, context):
         row = self.layout.row()
+        row.operator("albam.app_config_popup", icon="OPTIONS")
         row.prop(context.scene.albam.apps, "app_selected")
-        # Experimental for reengine
-        if os.getenv("ALBAM_ENABLE_REEN"):
-            row.operator("albam.app_config_popup", icon="OPTIONS")
 
 
 @blender_registry.register_blender_type

--- a/albam/blender_ui/import_panel.py
+++ b/albam/blender_ui/import_panel.py
@@ -1,17 +1,9 @@
-import os
-
 import bpy
 
 from ..apps import APPS
 from ..registry import blender_registry
 from ..vfs import ALBAM_OT_VirtualFileSystemCollapseToggle, VirtualFile
 from ..data_loading import AppsUserDataConfigManager
-
-# FIXME: store in app data
-APP_DIRS_CACHE = {}
-# FIXME: store in app data
-APP_CONFIG_FILE_CACHE = {}
-
 
 
 def get_app_dir_from_config(self, context):
@@ -41,12 +33,8 @@ def set_app_dir_config(self, context):
 class AlbamApps(bpy.types.PropertyGroup):
     app_selected : bpy.props.EnumProperty(name="", items=APPS, update=get_app_dir_from_config)
     app_dir : bpy.props.StringProperty(name="", description="", update=set_app_dir_config)
-    app_config_filepath : bpy.props.StringProperty(name="")
     mouse_x: bpy.props.IntProperty()
     mouse_y: bpy.props.IntProperty()
-
-    def get_app_config_filepath(self, app_id):
-        return APP_CONFIG_FILE_CACHE.get(app_id)
 
 
 @blender_registry.register_blender_prop_albam(name="import_settings")
@@ -379,9 +367,6 @@ class ALBAM_OT_AppConfigPopup(bpy.types.Operator):
         row.prop(context.scene.albam.apps, "app_dir")
         row.operator("albam.app_dir_setter", text="", icon="FILEBROWSER")
 
-        row = self.layout.row(heading="App Config:", align=True)
-        row.prop(context.scene.albam.apps, "app_config_filepath")
-        row.operator("albam.app_config_filepath_setter", text="", icon="FILEBROWSER")
 
 
 @blender_registry.register_blender_type
@@ -399,27 +384,6 @@ class ALBAM_OT_AppDirSetter(bpy.types.Operator):
 
     def execute(self, context):
         context.scene.albam.apps.app_dir = self.directory
-        bpy.ops.albam.app_config_popup("INVOKE_DEFAULT")
-        return {"FINISHED"}
-
-    def cancel(self, context):
-        bpy.ops.albam.app_config_popup("INVOKE_DEFAULT")
-
-
-@blender_registry.register_blender_type
-class ALBAM_OT_SetAppConfigPath(bpy.types.Operator):
-    bl_idname = "albam.app_config_filepath_setter"
-    bl_label = "Select App Config"
-
-    filepath: bpy.props.StringProperty(subtype="FILE_PATH")  # NOQA
-
-    def invoke(self, context, event):
-        wm = context.window_manager
-        wm.fileselect_add(self)
-        return {"RUNNING_MODAL"}
-
-    def execute(self, context):
-        context.scene.albam.apps.app_config_filepath = self.filepath
         bpy.ops.albam.app_config_popup("INVOKE_DEFAULT")
         return {"FINISHED"}
 

--- a/albam/blender_ui/import_panel.py
+++ b/albam/blender_ui/import_panel.py
@@ -332,6 +332,7 @@ class ALBAM_PT_ImportOptionsCustom(bpy.types.Panel):
 
 @blender_registry.register_blender_type
 class ALBAM_OT_AppConfigPopup(bpy.types.Operator):
+    """App settings"""
     bl_label = ""
     bl_idname = "albam.app_config_popup"
 

--- a/albam/blender_ui/import_panel.py
+++ b/albam/blender_ui/import_panel.py
@@ -18,11 +18,13 @@ def get_app_dir_from_config(self, context):
 def set_app_dir_config(self, context):
     current_app = context.scene.albam.apps.app_selected
     current_dir = context.scene.albam.apps.app_dir
+    if not current_dir:
+        return
 
     config_mgr = AppsUserDataConfigManager()
     app_section = config_mgr.get_app_section(current_app)
     if not app_section:
-        config_mgr.config.add_section(f"app.{current_app}")
+        config_mgr.config.add_section(current_app)
         app_section = config_mgr.get_app_section(current_app)
     app_section["app_dir"] = current_dir
 
@@ -366,7 +368,6 @@ class ALBAM_OT_AppConfigPopup(bpy.types.Operator):
         row = self.layout.row(heading="App Folder:", align=True)
         row.prop(context.scene.albam.apps, "app_dir")
         row.operator("albam.app_dir_setter", text="", icon="FILEBROWSER")
-
 
 
 @blender_registry.register_blender_type

--- a/albam/data_loading.py
+++ b/albam/data_loading.py
@@ -1,0 +1,78 @@
+import configparser
+from pathlib import Path
+import os
+
+import bpy
+from bpy.app.handlers import persistent
+
+
+APPS_USERDATA_FILENAME = "apps-userdata.ini"
+
+
+class AppsUserDataConfigManager:
+    _instance = None
+    _config = None
+    _filepath = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
+
+            cls._instance = super(AppsUserDataConfigManager, cls).__new__(cls)
+            cls._filepath = Path(ALBAM_EXTENSION_PATH) / APPS_USERDATA_FILENAME
+            cls._config = configparser.ConfigParser()
+
+            # Read file if it exists, otherwise initialize an empty config
+            if os.path.exists(str(cls._filepath)):
+                cls._config.read(str(cls._filepath))
+
+        return cls._instance
+
+    @property
+    def config(self):
+        """Exposes the internal ConfigParser instance."""
+        return self._config
+
+    def save(self):
+        """Saves current memory state back to the original file path."""
+        with open(self._filepath, 'w') as configfile:
+            self._config.write(configfile)
+
+    def get_app_section(self, app_id):
+        app_section = None
+        for section in self.config.sections():
+            _, _, section_app_id = section.partition(".")
+            if section_app_id == app_id:
+                app_section = self.config[section]
+        return app_section
+
+
+@persistent
+def populate_albam_data(dummy):
+
+    _populate_apps_userdata()
+
+    # Add here future presets shipped with Albam
+
+
+def _populate_apps_userdata():
+    """
+    Populate the initial app_dir attribute, removing a
+    value if there's nothing in the config file.
+    This avoids revealing the path when a Blend file is shared
+    """
+    apps_userdata_config = AppsUserDataConfigManager().config
+    current_app = bpy.context.scene.albam.apps.app_selected
+
+    for section in apps_userdata_config.sections():
+        _, _, app_id = section.partition(".")
+        print(section, app_id, current_app)
+        if app_id == current_app:
+            app_dir = apps_userdata_config[section].get("app_dir")
+            if app_dir:  # TODO: check validity, convert to system path
+                bpy.context.scene.albam.apps.app_dir = app_dir
+                break
+    else:
+        # Delete potential existing app_dir saved in blend-file if not backed
+        # by a ini file
+        bpy.context.scene.albam.apps.app_dir = ""

--- a/albam/data_loading.py
+++ b/albam/data_loading.py
@@ -41,8 +41,7 @@ class AppsUserDataConfigManager:
     def get_app_section(self, app_id):
         app_section = None
         for section in self.config.sections():
-            _, _, section_app_id = section.partition(".")
-            if section_app_id == app_id:
+            if section == app_id:
                 app_section = self.config[section]
         return app_section
 
@@ -65,9 +64,7 @@ def _populate_apps_userdata():
     current_app = bpy.context.scene.albam.apps.app_selected
 
     for section in apps_userdata_config.sections():
-        _, _, app_id = section.partition(".")
-        print(section, app_id, current_app)
-        if app_id == current_app:
+        if section == current_app:
             app_dir = apps_userdata_config[section].get("app_dir")
             if app_dir:  # TODO: check validity, convert to system path
                 bpy.context.scene.albam.apps.app_dir = app_dir


### PR DESCRIPTION
[Screencast_20260803_182224.webm](https://github.com/user-attachments/assets/8e4b4e13-74e4-48e8-b218-5e2788e98429)

Adds a new button that displays a pop-up with a list of app-settings.
For now, it only add one field, `App folder`.

The idea is to set the base root folder of an app for other parts of Albam to use it.
The first need came from RE:ORC to look up absolute paths to build a level.

The settings are stored in a file called `apps-userdata.ini` stored in `<extensions-path>/.user/user_default/albam`.
It contains a list of app-ids as section, and the attribute "app_dir". For example:

```
[re5]
app_dir = /home/seba/.local/share/Steam/steamapps/common/Resident Evil 5/

[re6]
app_dir = /home/seba/.local/share/Steam/steamapps/common/Resident Evil 6/
```

The field string for each "App Folder" is populated first on startup only if the file and the entry exists in `apps-userdata.ini`. This avoids having a wrong path when sharing an blend file with Albam settings across different computer.

Validation of the existence and correctness of the app will be left for a next iteration.