### PR TITLE
Migrate MT Framework's VFS onto a fs.base.FS backend (MTFW_FS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ pytest
 ```
 Note: you need application data to run most useful tests.
 
+### Running against a real Blender in development mode
+
+Blender's own bundled Python doesn't have this addon's pip-installed dependencies,
+only the `.venv` above does. Launch Blender with
+[`--python-use-system-env`](https://docs.blender.org/manual/en/latest/advanced/command_line/arguments.html)
+with `.venv` active, so Blender's Python resolves imports through it:
+
+```
+source .venv/bin/activate
+blender --python-use-system-env
+```
+
 ## Supported Engines
 
 * [MT Framework](https://en.wikipedia.org/wiki/MT_Framework)

--- a/albam/__init__.py
+++ b/albam/__init__.py
@@ -8,6 +8,7 @@ from .blender_ui.data import AlbamDataFactory
 from .blender_ui.asset import AlbamAsset
 from .blender_ui.custom_properties import AlbamCustomPropertiesFactory
 from .data_loading import populate_albam_data
+from .lib import fs_registry
 from .registry import blender_registry
 from .__version__ import __version__ as version
 
@@ -75,6 +76,8 @@ def register():
 
 
 def unregister():
+    fs_registry.clear()
+
     for _, cls in reversed(blender_registry.props):
         bpy.utils.unregister_class(cls)
 

--- a/albam/blender_ui/export_panel.py
+++ b/albam/blender_ui/export_panel.py
@@ -2,6 +2,7 @@ import time
 import os
 import bpy
 
+from ..lib import fs_registry
 from ..registry import blender_registry
 from ..vfs import (
     ALBAM_OT_VirtualFileSystemSaveFileBase,
@@ -366,11 +367,22 @@ class ALBAM_OT_Pack(bpy.types.Operator):
         # necessary for kaitaistruct unavailable when registering
         # blender types
         from ..engines.mtfw.archive import update_arc
+        from ..engines.mtfw.arc_fs import origin_arc_path
         vfs_i = context.scene.albam.vfs
         index_i = vfs_i.file_list_selected_index
         item_i = vfs_i.file_list[index_i]
         if item_i.is_archive:
-            path_i = item_i.absolute_path
+            if item_i.fs_key:
+                # Resolves correctly whether this root is a single
+                # ArcFS-wrapped .arc (always returns that arc's own path) or
+                # a whole MTFW_FS game-folder root (resolves the specific
+                # .arc this path actually came from) - see origin_arc_path.
+                path_i = origin_arc_path(fs_registry.get(item_i.fs_key), item_i.fs_path)
+                if path_i is None:
+                    self.report({'ERROR'}, "Selected archive isn't backed by a packed .arc file")
+                    return
+            else:
+                path_i = item_i.absolute_path
         else:
             arc_name = (item_i.tree_node_ancestors[0].node_id).split("::")[1]
             arc_node = [item for item in vfs_i.file_list

--- a/albam/blender_ui/export_panel.py
+++ b/albam/blender_ui/export_panel.py
@@ -8,7 +8,6 @@ from ..vfs import (
     ALBAM_OT_VirtualFileSystemCollapseToggleBase,
     ALBAM_OT_VirtualFileSystemRemoveRootVFileBase,
     VirtualFileSystemBase,
-    VirtualFileData,
 )
 from .import_panel import ALBAM_UL_VirtualFileSystemUIBase
 
@@ -302,9 +301,8 @@ class ALBAM_OT_Export(bpy.types.Operator):
         vfiles = export_function(item.bl_object)
 
         root_id = f"{app_id}-{bl_obj.name}-{round(time.time())}"
-        vfile_root = VirtualFileData(app_id, root_id)
         vfs = context.scene.albam.exported
-        vfs.add_vfiles_as_tree(app_id, vfile_root, vfiles)
+        vfs.add_export_root(app_id, root_id, vfiles)
 
     @classmethod
     def poll(cls, context):

--- a/albam/engines/mtfw/arc_fs.py
+++ b/albam/engines/mtfw/arc_fs.py
@@ -144,6 +144,23 @@ def _BytesFile(data):
     return io.BytesIO(data)
 
 
+def origin_arc_path(fs_instance, path):
+    """Which .arc `path` resolves to under `fs_instance`, or None if it's a
+    loose/real file (or `fs_instance` doesn't track archive origins at all).
+
+    `ArcFS` always resolves to its own single arc; `MTFW_FS` may overlay many,
+    so it defers to its own `origin_of()`. Used by callers (e.g. Pack/Patch)
+    that need to write back into the specific archive a file came from,
+    without caring whether the VFS root behind it was a single `.arc` or a
+    whole recursively-scanned game folder.
+    """
+    if isinstance(fs_instance, MTFW_FS):
+        return fs_instance.origin_of(path)
+    if isinstance(fs_instance, ArcFS):
+        return fs_instance.arc_path
+    return None
+
+
 def find_arc_files(game_root):
     """Recursively find every .arc under `game_root`, case-insensitively.
 

--- a/albam/engines/mtfw/arc_fs.py
+++ b/albam/engines/mtfw/arc_fs.py
@@ -46,7 +46,7 @@ class ArcFS(FS):
     """
 
     _meta = {
-        "case_insensitive": False,  # TODO: arc paths are effectively case-insensitive
+        "case_insensitive": False,
         "network": False,
         "read_only": True,
         "supports_rename": False,

--- a/albam/engines/mtfw/arc_fs.py
+++ b/albam/engines/mtfw/arc_fs.py
@@ -1,14 +1,13 @@
 """
-Prototype: PyFilesystem2 adapter for MTFramework .arc archives.
+PyFilesystem2 adapter for MTFramework .arc archives.
 
-An .arc is a flat, zip-like container (see structs/arc.ksy): a header followed
-by fixed-size file entries (path, type-hash, sizes, offset), each pointing to
-a zlib-compressed blob later in the file. `ArcFS` exposes a single .arc as a
-read-only PyFilesystem2 filesystem; `MTFW_FS` represents one game install:
-given the game's root folder, it finds every .arc recursively and overlays
-them - plus the loose files sitting directly on disk - into a single `MultiFS`,
-so callers can ask for a relative path without knowing which archive (or
-whether an unpacked/modded loose file) it actually comes from.
+An .arc is a flat, zip-like container (see structs/arc.ksy): a header
+followed by fixed-size file entries (path, type-hash, sizes, offset), each
+pointing to a zlib-compressed blob later in the file. `ArcFS` exposes a
+single .arc as a read-only PyFilesystem2 filesystem; `MTFW_FS` overlays every
+.arc under a game root - plus its loose files - into one `MultiFS`, so
+callers can ask for a relative path without knowing which archive (or loose
+file) it comes from.
 """
 import os
 import zlib
@@ -40,10 +39,10 @@ def _local_opener(path):
 class ArcFS(FS):
     """Read-only PyFilesystem2 view of a single .arc file.
 
-    `arc_path` is just an opaque identifier passed to `opener(arc_path)` to
-    get a seekable, readable file-like object - it doesn't have to be a local
-    filesystem path. Defaults to plain `open()`, so local usage is unchanged;
-    `MTFW_FS.from_s3()` passes an S3/R2-backed opener instead (see there).
+    `arc_path` is an opaque identifier passed to `opener(arc_path)` to get a
+    seekable, readable file-like object - not necessarily a local path.
+    Defaults to plain `open()`; `MTFW_FS.from_s3()` passes an S3/R2-backed
+    opener instead.
     """
 
     _meta = {
@@ -61,14 +60,11 @@ class ArcFS(FS):
         self.arc_path = str(arc_path)
         self._opener = opener or _local_opener
 
-        # entries indexed the same way they're exposed as paths, so getinfo/
-        # openbin don't need to recompute _entry_path or re-scan file_entries.
-        # Only the plain fields read below (offset/zsize/size) are kept -
-        # openbin() re-opens/re-fetches per read (see there) rather than
-        # holding a persistent handle. Locally that avoids exhausting the
-        # process's file descriptor limit when a game install layers ~1200 of
-        # these at once; over S3/R2 it means __init__ only ever fetches the
-        # small header+table region, never the whole (possibly huge) archive.
+        # entries indexed by their exposed path, so getinfo/openbin don't
+        # rescan file_entries. openbin() re-opens/re-fetches per read rather
+        # than holding a persistent handle - avoids exhausting fd limits
+        # locally (~1200 arcs in a full game install) and, over S3/R2, keeps
+        # __init__ to just the small header+table region.
         f = self._opener(self.arc_path)
         try:
             arc = Arc(KaitaiStream(f))
@@ -146,13 +142,12 @@ def _BytesFile(data):
 
 def origin_arc_path(fs_instance, path):
     """Which .arc `path` resolves to under `fs_instance`, or None if it's a
-    loose/real file (or `fs_instance` doesn't track archive origins at all).
+    loose/real file (or `fs_instance` doesn't track archive origins).
 
-    `ArcFS` always resolves to its own single arc; `MTFW_FS` may overlay many,
-    so it defers to its own `origin_of()`. Used by callers (e.g. Pack/Patch)
-    that need to write back into the specific archive a file came from,
-    without caring whether the VFS root behind it was a single `.arc` or a
-    whole recursively-scanned game folder.
+    `ArcFS` always resolves to its own single arc; `MTFW_FS` defers to its
+    own `origin_of()`. Lets callers (e.g. Pack/Patch) write back into the
+    right archive without caring whether the VFS root was a single `.arc` or
+    a whole game folder.
     """
     if isinstance(fs_instance, MTFW_FS):
         return fs_instance.origin_of(path)
@@ -185,23 +180,17 @@ def find_arc_keys_s3(client, bucket, prefix=""):
 
 
 def _s3_opener(client, bucket, range_chunk_size=1024 * 1024):
-    """Build an ArcFS `opener` backed by an S3-compatible bucket (R2 works
-    here too - just point `client` at R2's endpoint, see MTFW_FS.from_s3).
-    Uses smart_open so seek()/read() become real HTTP Range requests instead
-    of downloading the whole (possibly huge) archive: `defer_seek=True` means
-    opening the file doesn't even issue a request until the first read.
+    """Build an ArcFS `opener` backed by an S3-compatible bucket (R2 too -
+    just point `client` at R2's endpoint, see MTFW_FS.from_s3). Uses
+    smart_open so seek()/read() become bounded HTTP Range requests instead
+    of downloading the whole archive; `defer_seek=True` avoids a request
+    until the first read.
 
-    range_chunk_size matters more than it looks: smart_open's default
-    (`None`) issues an *open-ended* Range request (`bytes=N-`) whose
-    Content-Length covers everything from N to EOF - i.e. reading 8 bytes
-    from the start of a 40MB archive asks the server for the full remaining
-    40MB (confirmed against real fixture .arc files, not just guessed).
-    Setting range_chunk_size bounds every underlying GET to that span;
-    reads larger than one chunk transparently issue more (still bounded)
-    requests. 1MiB is a reasonable default for this format - large enough
-    that a typical archive's whole header+file-table fits in one request,
-    small enough that reading one compressed entry only costs a handful of
-    requests instead of one that could be tens of MB.
+    range_chunk_size matters: smart_open's default issues an *open-ended*
+    Range request (`bytes=N-`), so reading 8 bytes from a 40MB archive would
+    otherwise fetch the full remaining 40MB (confirmed against real fixture
+    files). 1MiB keeps a typical header+file-table in one request while
+    keeping a single compressed entry's read to a handful of bounded ones.
     """
     import smart_open
 
@@ -224,22 +213,16 @@ class S3LooseFS(FS):
     local OSFS(game_root) layer, reusing the same boto3 `client` as the arc
     layer (no separate credentials needed, unlike fs_s3fs.S3FS).
 
-    Deliberately matches local MTFW_FS behavior in one easy-to-miss way:
-    .arc keys are NOT filtered out here. A game install's .arc files remain
-    reachable as raw whole blobs at their own key, same as they are locally
-    through OSFS - alongside, and independent from, their unpacked content
-    exposed through the arc layer at completely different paths. This is
-    harmless (the two views never collide - see MTFW_FS.from_s3's docstring
-    for why) and is what makes e.g. re-uploading/backing up an archive
-    unchanged possible through this same filesystem.
+    Matches local MTFW_FS behavior in one easy-to-miss way: .arc keys are
+    NOT filtered out here, so they stay reachable as raw blobs at their own
+    key alongside their unpacked content exposed through the arc layer -
+    harmless since the two views never collide (see MTFW_FS.from_s3).
 
-    Reads fetch whole objects, not ranges - unlike ArcFS, a loose file's
-    entire content is needed anyway, there's no "one entry out of a huge
-    archive" situation to be careful about.
+    Reads fetch whole objects, not ranges - a loose file's entire content is
+    needed anyway, unlike one entry out of a huge archive.
 
-    Assumes a plain folder-sync-style bucket (a straight upload/mirror of a
-    real directory tree): "directories" are inferred purely from key
-    prefixes via list_objects_v2's Delimiter, not from explicit zero-byte
+    Assumes a plain folder-sync-style bucket: "directories" come from key
+    prefixes via list_objects_v2's Delimiter, not explicit zero-byte
     directory-marker objects some other S3 tooling creates.
     """
 
@@ -403,9 +386,9 @@ class MTFW_FS(MultiFS):
         include_loose=True,
     ):
         """Alternate constructor: source .arc files from an S3-compatible
-        bucket instead of a local game install - tested against a mocked S3
-        (moto); works against Cloudflare R2 as-is, just pass R2's
-        account-specific endpoint_url and an R2 API token as access key/secret:
+        bucket instead of a local game install. Works against Cloudflare R2
+        as-is - pass R2's account-specific endpoint_url and an R2 API token
+        as access key/secret:
 
             game_fs = MTFW_FS.from_s3(
                 bucket="my-bucket",
@@ -414,45 +397,29 @@ class MTFW_FS(MultiFS):
                 aws_secret_access_key=...,
             )
 
-        Credential params default to None/"auto" and are forwarded straight
-        to boto3.client("s3", ...) - leave them unset to fall back to
-        boto3's normal credential resolution (env vars, ~/.aws/credentials,
-        etc.) instead of passing secrets explicitly. One client gets built
-        internally and reused for both the arc layer and (when enabled) the
-        loose layer, so there's only one place credentials are handled.
+        Credential params forward straight to boto3.client("s3", ...) -
+        leave unset to fall back to boto3's normal credential resolution.
+        One client is built internally and reused for both the arc and
+        loose layers.
 
-        Reads are real HTTP Range requests (via smart_open) - constructing
-        this and reading individual files never downloads a whole .arc.
+        Reads are real HTTP Range requests (via smart_open) - never a full
+        .arc download.
 
-        IMPORTANT: `prefix` must be the game *root*, not the folder your
-        .arc files happen to live in. It's used both to find arcs (recursive
-        key listing, like local find_arc_files()/os.walk - arcs nested a few
-        levels down under `prefix`, e.g. "nativePC_MT/Image/Archive/*.arc",
-        are found fine) and, when `include_loose` is on, as the root loose
-        file paths are resolved relative to. Narrowing `prefix` down to just
-        the archive folder (an easy mistake - it looks like a reasonable
-        "scope arc discovery tighter" optimization) silently breaks loose
-        resolution instead: every loose lookup gets `prefix` prepended twice
-        or resolves under the wrong root and just won't be found. If your
-        bucket mirrors the whole game root exactly, `prefix=""` is what you
-        want, exactly like `game_root` locally.
-
-        Separately: the paths MTFW_FS *exposes* for content inside an arc
-        (e.g. "/pawn/pl/pl00/model/pl0000.mod") come entirely from the arc's
-        own internal file table - nothing to do with the arc's own key or
-        `prefix` at all.
+        IMPORTANT: `prefix` must be the game *root*, not the archive folder.
+        It's used both to find arcs (recursive key listing, so arcs nested
+        under `prefix` are found fine) and, when `include_loose` is on, as
+        the root loose paths resolve relative to - narrowing it to just the
+        archive folder silently breaks loose resolution. `prefix=""` if
+        your bucket mirrors the whole game root, same as `game_root`
+        locally. The paths MTFW_FS exposes for arc content come entirely
+        from the arc's own internal file table, independent of `prefix`.
 
         `include_loose=True` (default) layers an S3LooseFS over `bucket`/
-        `prefix` on top, with the same highest-priority-wins semantics the
-        local OSFS layer has - assumes the bucket mirrors a real game root
-        exactly (see S3LooseFS's docstring for what that assumes away: no
-        explicit directory-marker objects, and everything under `prefix`,
-        including .arc files themselves, is legitimately part of the game
-        data). Uses the same internally-built client as the arc layer, so
-        no separate credentials are needed for it. An unpacked/override
-        loose file needs its own key equal to the exposed path itself (e.g.
-        a key literally named "pawn/pl/pl00/model/pl0000.mod", not inside
-        the Archive/ prefix) to actually shadow the packed copy of that path.
+        `prefix`, same highest-priority-wins semantics as the local OSFS
+        layer (see S3LooseFS's docstring for what it assumes about the
+        bucket). An override loose file needs its own key equal to the
+        exposed path itself (not inside the Archive/ prefix) to shadow the
+        packed copy.
         """
         import boto3
 
@@ -500,13 +467,11 @@ class MTFW_FS(MultiFS):
     def _ensure_index(self):
         """Build a flat path->owner index plus a directory-topology-only
         MemoryFS, on first use. MultiFS's own listdir/scandir ask every
-        layered filesystem per directory it visits - O(directories x
+        layered filesystem per directory visited - O(directories x
         filesystems), ~9.5M calls / ~70s for a full RE5 walk over ~1200
-        archives. This replaces that with one upfront O(total entries) pass
-        (a few seconds) and O(1) lookups after, for listdir/scandir/walk only.
-        Point lookups (openbin/getinfo on a known path) already go through
-        MultiFS's own _delegate and stay fast without this, so they don't
-        trigger it.
+        archives. Replaced with one upfront O(total entries) pass and O(1)
+        lookups after, for listdir/scandir/walk only - point lookups already
+        go through MultiFS's own _delegate and stay fast without this.
         """
         if self._owner is not None:
             return
@@ -547,10 +512,10 @@ class MTFW_FS(MultiFS):
 
     def origin_of(self, path):
         """The .arc path `path` resolves to, or None if it's a loose/real
-        file (or doesn't resolve at all). Uses the lazy index (O(1)) if it's
-        already been built by a prior listdir/scandir/walk call; otherwise
-        falls back to MultiFS.which()'s linear scan rather than forcing the
-        index build itself, keeping point lookups index-free.
+        file. Uses the lazy index (O(1)) if already built by a prior
+        listdir/scandir/walk; otherwise falls back to MultiFS.which()'s
+        linear scan rather than forcing an index build, keeping point
+        lookups index-free.
         """
         self.check()
         _path = self.validatepath(path)

--- a/albam/engines/mtfw/arc_fs.py
+++ b/albam/engines/mtfw/arc_fs.py
@@ -1,0 +1,544 @@
+"""
+Prototype: PyFilesystem2 adapter for MTFramework .arc archives.
+
+An .arc is a flat, zip-like container (see structs/arc.ksy): a header followed
+by fixed-size file entries (path, type-hash, sizes, offset), each pointing to
+a zlib-compressed blob later in the file. `ArcFS` exposes a single .arc as a
+read-only PyFilesystem2 filesystem; `MTFW_FS` represents one game install:
+given the game's root folder, it finds every .arc recursively and overlays
+them - plus the loose files sitting directly on disk - into a single `MultiFS`,
+so callers can ask for a relative path without knowing which archive (or
+whether an unpacked/modded loose file) it actually comes from.
+"""
+import os
+import zlib
+
+from fs.base import FS
+from fs.enums import ResourceType
+from fs.errors import CreateFailed, DirectoryExpected, ResourceNotFound, ResourceReadOnly
+from fs.info import Info
+from fs.memoryfs import MemoryFS
+from fs.multifs import MultiFS
+from fs.osfs import OSFS
+from fs.path import basename, dirname, join
+from kaitaistruct import KaitaiStream
+
+from . import FILE_ID_TO_EXTENSION
+from .structs.arc import Arc
+
+
+def _entry_path(file_entry):
+    ext = FILE_ID_TO_EXTENSION.get(file_entry.file_type, str(file_entry.file_type))
+    posix_path = file_entry.file_path.replace("\\", "/").lstrip("/")
+    return f"/{posix_path}.{ext}"
+
+
+def _local_opener(path):
+    return open(path, "rb")
+
+
+class ArcFS(FS):
+    """Read-only PyFilesystem2 view of a single .arc file.
+
+    `arc_path` is just an opaque identifier passed to `opener(arc_path)` to
+    get a seekable, readable file-like object - it doesn't have to be a local
+    filesystem path. Defaults to plain `open()`, so local usage is unchanged;
+    `MTFW_FS.from_s3()` passes an S3/R2-backed opener instead (see there).
+    """
+
+    _meta = {
+        "case_insensitive": False,  # TODO: arc paths are effectively case-insensitive
+        "network": False,
+        "read_only": True,
+        "supports_rename": False,
+        "thread_safe": True,
+        "unicode_paths": True,
+        "virtual": False,
+    }
+
+    def __init__(self, arc_path, opener=None):
+        super().__init__()
+        self.arc_path = str(arc_path)
+        self._opener = opener or _local_opener
+
+        # entries indexed the same way they're exposed as paths, so getinfo/
+        # openbin don't need to recompute _entry_path or re-scan file_entries.
+        # Only the plain fields read below (offset/zsize/size) are kept -
+        # openbin() re-opens/re-fetches per read (see there) rather than
+        # holding a persistent handle. Locally that avoids exhausting the
+        # process's file descriptor limit when a game install layers ~1200 of
+        # these at once; over S3/R2 it means __init__ only ever fetches the
+        # small header+table region, never the whole (possibly huge) archive.
+        f = self._opener(self.arc_path)
+        try:
+            arc = Arc(KaitaiStream(f))
+            arc._read()
+            self._entries = {}
+            self._directory = MemoryFS()
+            for file_entry in arc.file_entries:
+                path = _entry_path(file_entry)
+                self._entries[path] = file_entry
+                self._directory.makedirs(dirname(path), recreate=True)
+                self._directory.create(path)
+        finally:
+            f.close()
+
+    def __repr__(self):
+        return f"ArcFS({self.arc_path!r})"
+
+    def getinfo(self, path, namespaces=None):
+        self.check()
+        _path = self.validatepath(path)
+        namespaces = namespaces or ()
+        basic_info = self._directory.getinfo(_path)
+        raw_info = {"basic": {"name": basic_info.name, "is_dir": basic_info.is_dir}}
+
+        if "details" in namespaces:
+            file_entry = self._entries.get(_path)
+            resource_type = ResourceType.directory if basic_info.is_dir else ResourceType.file
+            raw_info["details"] = {
+                "type": int(resource_type),
+                "size": file_entry.size if file_entry else 0,
+            }
+        return Info(raw_info)
+
+    def listdir(self, path):
+        self.check()
+        return self._directory.listdir(path)
+
+    def openbin(self, path, mode="r", buffering=-1, **options):
+        self.check()
+        if "w" in mode or "+" in mode or "a" in mode:
+            raise ResourceReadOnly(path)
+
+        _path = self.validatepath(path)
+        file_entry = self._entries.get(_path)
+        if file_entry is None:
+            raise ResourceNotFound(path)
+
+        f = self._opener(self.arc_path)
+        try:
+            f.seek(file_entry.offset)
+            raw = f.read(file_entry.zsize)
+        finally:
+            f.close()
+        data = zlib.decompress(raw)
+        return _BytesFile(data)
+
+    def makedir(self, path, permissions=None, recreate=False):
+        raise ResourceReadOnly(path)
+
+    def remove(self, path):
+        raise ResourceReadOnly(path)
+
+    def removedir(self, path):
+        raise ResourceReadOnly(path)
+
+    def setinfo(self, path, info):
+        raise ResourceReadOnly(path)
+
+
+def _BytesFile(data):
+    import io
+
+    return io.BytesIO(data)
+
+
+def find_arc_files(game_root):
+    """Recursively find every .arc under `game_root`, case-insensitively.
+
+    os.walk already uses os.scandir under the hood, so this is a single
+    scandir-based traversal - no extra stat() calls per file.
+    """
+    for current_dir, _dirs, files in os.walk(game_root):
+        for name in files:
+            if name.lower().endswith(".arc"):
+                yield os.path.join(current_dir, name)
+
+
+def find_arc_keys_s3(client, bucket, prefix=""):
+    """S3/R2 equivalent of find_arc_files(): paginated key listing under
+    `prefix`, filtered to .arc keys, case-insensitively."""
+    paginator = client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            if key.lower().endswith(".arc"):
+                yield key
+
+
+def _s3_opener(client, bucket, range_chunk_size=1024 * 1024):
+    """Build an ArcFS `opener` backed by an S3-compatible bucket (R2 works
+    here too - just point `client` at R2's endpoint, see MTFW_FS.from_s3).
+    Uses smart_open so seek()/read() become real HTTP Range requests instead
+    of downloading the whole (possibly huge) archive: `defer_seek=True` means
+    opening the file doesn't even issue a request until the first read.
+
+    range_chunk_size matters more than it looks: smart_open's default
+    (`None`) issues an *open-ended* Range request (`bytes=N-`) whose
+    Content-Length covers everything from N to EOF - i.e. reading 8 bytes
+    from the start of a 40MB archive asks the server for the full remaining
+    40MB (confirmed against real fixture .arc files, not just guessed).
+    Setting range_chunk_size bounds every underlying GET to that span;
+    reads larger than one chunk transparently issue more (still bounded)
+    requests. 1MiB is a reasonable default for this format - large enough
+    that a typical archive's whole header+file-table fits in one request,
+    small enough that reading one compressed entry only costs a handful of
+    requests instead of one that could be tens of MB.
+    """
+    import smart_open
+
+    def opener(key):
+        return smart_open.open(
+            f"s3://{bucket}/{key}",
+            "rb",
+            transport_params={
+                "client": client,
+                "defer_seek": True,
+                "range_chunk_size": range_chunk_size,
+            },
+        )
+
+    return opener
+
+
+class S3LooseFS(FS):
+    """Loose-file layer for MTFW_FS.from_s3 - the remote equivalent of the
+    local OSFS(game_root) layer, reusing the same boto3 `client` as the arc
+    layer (no separate credentials needed, unlike fs_s3fs.S3FS).
+
+    Deliberately matches local MTFW_FS behavior in one easy-to-miss way:
+    .arc keys are NOT filtered out here. A game install's .arc files remain
+    reachable as raw whole blobs at their own key, same as they are locally
+    through OSFS - alongside, and independent from, their unpacked content
+    exposed through the arc layer at completely different paths. This is
+    harmless (the two views never collide - see MTFW_FS.from_s3's docstring
+    for why) and is what makes e.g. re-uploading/backing up an archive
+    unchanged possible through this same filesystem.
+
+    Reads fetch whole objects, not ranges - unlike ArcFS, a loose file's
+    entire content is needed anyway, there's no "one entry out of a huge
+    archive" situation to be careful about.
+
+    Assumes a plain folder-sync-style bucket (a straight upload/mirror of a
+    real directory tree): "directories" are inferred purely from key
+    prefixes via list_objects_v2's Delimiter, not from explicit zero-byte
+    directory-marker objects some other S3 tooling creates.
+    """
+
+    _meta = {
+        "case_insensitive": False,
+        "network": True,
+        "read_only": True,
+        "supports_rename": False,
+        "thread_safe": True,
+        "unicode_paths": True,
+        "virtual": False,
+    }
+
+    def __init__(self, client, bucket, prefix=""):
+        super().__init__()
+        self.client = client
+        self.bucket = bucket
+        self.prefix = prefix.strip("/")
+
+    def __repr__(self):
+        return f"S3LooseFS({self.bucket!r}, prefix={self.prefix!r})"
+
+    def _key(self, path):
+        _path = self.validatepath(path).strip("/")
+        if self.prefix:
+            return f"{self.prefix}/{_path}" if _path else self.prefix
+        return _path
+
+    def getinfo(self, path, namespaces=None):
+        self.check()
+        _path = self.validatepath(path)
+        namespaces = namespaces or ()
+
+        if _path == "/":
+            return Info({"basic": {"name": "", "is_dir": True}})
+
+        key = self._key(_path)
+        try:
+            head = self.client.head_object(Bucket=self.bucket, Key=key)
+        except Exception:
+            head = None
+
+        if head is not None:
+            raw_info = {"basic": {"name": basename(_path), "is_dir": False}}
+            if "details" in namespaces:
+                raw_info["details"] = {"type": int(ResourceType.file), "size": head["ContentLength"]}
+            return Info(raw_info)
+
+        # not a real object at this exact key - does anything live "under" it?
+        resp = self.client.list_objects_v2(Bucket=self.bucket, Prefix=key + "/", MaxKeys=1)
+        if resp.get("KeyCount", 0) > 0:
+            raw_info = {"basic": {"name": basename(_path), "is_dir": True}}
+            if "details" in namespaces:
+                raw_info["details"] = {"type": int(ResourceType.directory), "size": 0}
+            return Info(raw_info)
+
+        raise ResourceNotFound(path)
+
+    def listdir(self, path):
+        return [info.name for info in self.scandir(path)]
+
+    def scandir(self, path, namespaces=None, page=None):
+        self.check()
+        _path = self.validatepath(path)
+        namespaces = namespaces or ()
+
+        if not self.getinfo(_path).is_dir:
+            raise DirectoryExpected(path)
+
+        key_prefix = self._key(_path)
+        if key_prefix and not key_prefix.endswith("/"):
+            key_prefix += "/"
+
+        entries = []
+        paginator = self.client.get_paginator("list_objects_v2")
+        for result in paginator.paginate(Bucket=self.bucket, Prefix=key_prefix, Delimiter="/"):
+            for common_prefix in result.get("CommonPrefixes", ()):
+                name = common_prefix["Prefix"][len(key_prefix):].rstrip("/")
+                if name:
+                    entries.append(Info({"basic": {"name": name, "is_dir": True}}))
+            for obj in result.get("Contents", ()):
+                name = obj["Key"][len(key_prefix):]
+                if name:
+                    raw_info = {"basic": {"name": name, "is_dir": False}}
+                    if "details" in namespaces:
+                        raw_info["details"] = {"type": int(ResourceType.file), "size": obj["Size"]}
+                    entries.append(Info(raw_info))
+
+        if page is not None:
+            start, end = page
+            entries = entries[start:end]
+        return iter(entries)
+
+    def openbin(self, path, mode="r", buffering=-1, **options):
+        self.check()
+        if "w" in mode or "+" in mode or "a" in mode:
+            raise ResourceReadOnly(path)
+
+        _path = self.validatepath(path)
+        key = self._key(_path)
+        try:
+            response = self.client.get_object(Bucket=self.bucket, Key=key)
+        except Exception:
+            raise ResourceNotFound(path)
+        return _BytesFile(response["Body"].read())
+
+    def makedir(self, path, permissions=None, recreate=False):
+        raise ResourceReadOnly(path)
+
+    def remove(self, path):
+        raise ResourceReadOnly(path)
+
+    def removedir(self, path):
+        raise ResourceReadOnly(path)
+
+    def setinfo(self, path, info):
+        raise ResourceReadOnly(path)
+
+
+class MTFW_FS(MultiFS):
+    """Virtual filesystem for one MTFW game install.
+
+    Given the game's root folder, finds every .arc recursively and overlays
+    them into a single filesystem, keyed by the path each entry decodes to.
+    Loose files living directly on disk under `game_root` are layered on top
+    with the highest priority, since that's how the engine's own patch/mod
+    loading works (an unpacked file shadows the packed one).
+    """
+
+    def __init__(self, game_root, auto_close=True):
+        # super().__init__() first: FS.__del__ calls close() unconditionally
+        # on GC, and MultiFS.close() needs self._auto_close/_filesystems to
+        # already exist. Raising CreateFailed before this would leave a
+        # half-initialized object that errors on garbage collection.
+        super().__init__(auto_close=auto_close)
+        self._init_common()
+
+        game_root = str(game_root)
+        if not os.path.isdir(game_root):
+            raise CreateFailed(f"game_root does not exist or is not a directory: {game_root!r}")
+        self.game_root = game_root
+
+        arc_specs = ((p, _local_opener) for p in sorted(find_arc_files(game_root)))
+        self._load_arcs(arc_specs)
+
+        # added last -> highest default priority -> wins over packed archives
+        self.add_fs("<loose>", OSFS(game_root))
+
+    @classmethod
+    def from_s3(
+        cls,
+        bucket,
+        prefix="",
+        *,
+        aws_access_key_id=None,
+        aws_secret_access_key=None,
+        aws_session_token=None,
+        endpoint_url=None,
+        region_name="auto",
+        auto_close=True,
+        include_loose=True,
+    ):
+        """Alternate constructor: source .arc files from an S3-compatible
+        bucket instead of a local game install - tested against a mocked S3
+        (moto); works against Cloudflare R2 as-is, just pass R2's
+        account-specific endpoint_url and an R2 API token as access key/secret:
+
+            game_fs = MTFW_FS.from_s3(
+                bucket="my-bucket",
+                endpoint_url=f"https://{account_id}.r2.cloudflarestorage.com",
+                aws_access_key_id=...,
+                aws_secret_access_key=...,
+            )
+
+        Credential params default to None/"auto" and are forwarded straight
+        to boto3.client("s3", ...) - leave them unset to fall back to
+        boto3's normal credential resolution (env vars, ~/.aws/credentials,
+        etc.) instead of passing secrets explicitly. One client gets built
+        internally and reused for both the arc layer and (when enabled) the
+        loose layer, so there's only one place credentials are handled.
+
+        Reads are real HTTP Range requests (via smart_open) - constructing
+        this and reading individual files never downloads a whole .arc.
+
+        IMPORTANT: `prefix` must be the game *root*, not the folder your
+        .arc files happen to live in. It's used both to find arcs (recursive
+        key listing, like local find_arc_files()/os.walk - arcs nested a few
+        levels down under `prefix`, e.g. "nativePC_MT/Image/Archive/*.arc",
+        are found fine) and, when `include_loose` is on, as the root loose
+        file paths are resolved relative to. Narrowing `prefix` down to just
+        the archive folder (an easy mistake - it looks like a reasonable
+        "scope arc discovery tighter" optimization) silently breaks loose
+        resolution instead: every loose lookup gets `prefix` prepended twice
+        or resolves under the wrong root and just won't be found. If your
+        bucket mirrors the whole game root exactly, `prefix=""` is what you
+        want, exactly like `game_root` locally.
+
+        Separately: the paths MTFW_FS *exposes* for content inside an arc
+        (e.g. "/pawn/pl/pl00/model/pl0000.mod") come entirely from the arc's
+        own internal file table - nothing to do with the arc's own key or
+        `prefix` at all.
+
+        `include_loose=True` (default) layers an S3LooseFS over `bucket`/
+        `prefix` on top, with the same highest-priority-wins semantics the
+        local OSFS layer has - assumes the bucket mirrors a real game root
+        exactly (see S3LooseFS's docstring for what that assumes away: no
+        explicit directory-marker objects, and everything under `prefix`,
+        including .arc files themselves, is legitimately part of the game
+        data). Uses the same internally-built client as the arc layer, so
+        no separate credentials are needed for it. An unpacked/override
+        loose file needs its own key equal to the exposed path itself (e.g.
+        a key literally named "pawn/pl/pl00/model/pl0000.mod", not inside
+        the Archive/ prefix) to actually shadow the packed copy of that path.
+        """
+        import boto3
+
+        client = boto3.client(
+            "s3",
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
+            endpoint_url=endpoint_url,
+            region_name=region_name,
+        )
+
+        self = cls.__new__(cls)
+        MultiFS.__init__(self, auto_close=auto_close)
+        self._init_common()
+        self.game_root = f"s3://{bucket}/{prefix}"
+
+        opener = _s3_opener(client, bucket)
+        arc_specs = ((key, opener) for key in sorted(find_arc_keys_s3(client, bucket, prefix)))
+        self._load_arcs(arc_specs)
+
+        if include_loose:
+            # added last -> highest default priority -> wins over packed archives
+            self.add_fs("<loose>", S3LooseFS(client, bucket, prefix))
+        return self
+
+    def _init_common(self):
+        # (arc_path, exception) for archives that didn't parse - a handful of
+        # RE5's .arc files use a different/unsupported layout (see arc.ksy);
+        # skipped rather than failing the whole game filesystem.
+        self.failed_arcs = []
+        # lazily built - see _ensure_index()
+        self._owner = None
+        self._topology = None
+
+    def _load_arcs(self, arc_specs):
+        for arc_path, opener in arc_specs:
+            try:
+                arc_fs = ArcFS(arc_path, opener=opener)
+            except Exception as e:
+                self.failed_arcs.append((arc_path, e))
+                continue
+            self.add_fs(arc_path, arc_fs)
+
+    def _ensure_index(self):
+        """Build a flat path->owner index plus a directory-topology-only
+        MemoryFS, on first use. MultiFS's own listdir/scandir ask every
+        layered filesystem per directory it visits - O(directories x
+        filesystems), ~9.5M calls / ~70s for a full RE5 walk over ~1200
+        archives. This replaces that with one upfront O(total entries) pass
+        (a few seconds) and O(1) lookups after, for listdir/scandir/walk only.
+        Point lookups (openbin/getinfo on a known path) already go through
+        MultiFS's own _delegate and stay fast without this, so they don't
+        trigger it.
+        """
+        if self._owner is not None:
+            return
+
+        owner = {}
+        topology = MemoryFS()
+        # iterate_fs() yields (name, fs) in priority order, highest first;
+        # first writer for a path wins, matching MultiFS's own semantics.
+        for _name, fs_ in self.iterate_fs():
+            for path in fs_.walk.files():
+                if path in owner:
+                    continue
+                owner[path] = fs_
+                topology.makedirs(dirname(path), recreate=True)
+                topology.create(path)
+
+        self._owner = owner
+        self._topology = topology
+
+    def listdir(self, path):
+        self.check()
+        self._ensure_index()
+        return self._topology.listdir(path)
+
+    def scandir(self, path, namespaces=None, page=None):
+        self.check()
+        self._ensure_index()
+        _path = self.validatepath(path)
+        namespaces = namespaces or ()
+        for info in self._topology.scandir(_path, namespaces=("basic",), page=page):
+            if info.is_dir or not namespaces:
+                yield info
+                continue
+            # topology only knows the name/is_dir placeholder; fetch real
+            # info (size, etc.) from whichever filesystem actually owns it.
+            child_path = join(_path, info.name)
+            yield self._owner[child_path].getinfo(child_path, namespaces=namespaces)
+
+    def origin_of(self, path):
+        """The .arc path `path` resolves to, or None if it's a loose/real
+        file (or doesn't resolve at all). Uses the lazy index (O(1)) if it's
+        already been built by a prior listdir/scandir/walk call; otherwise
+        falls back to MultiFS.which()'s linear scan rather than forcing the
+        index build itself, keeping point lookups index-free.
+        """
+        self.check()
+        _path = self.validatepath(path)
+        if self._owner is not None:
+            owner_fs = self._owner.get(_path)
+        else:
+            _name, owner_fs = self.which(_path)
+        return owner_fs.arc_path if isinstance(owner_fs, ArcFS) else None

--- a/albam/engines/mtfw/archive.py
+++ b/albam/engines/mtfw/archive.py
@@ -138,7 +138,7 @@ def _sort_arc_entries(entries, vfile=True):
 
 
 def _get_file_entry(vfile):
-    vf_data = vfile.data_bytes
+    vf_data = vfile.get_bytes()
     chunk = zlib.compress(vf_data)
     path = ntpath.normpath(vfile.relative_path)
     file_path = ntpath.splitext(path)[0]
@@ -308,7 +308,7 @@ def update_arc(filepath, vfiles, remove_unused_textures=False):
 
     # patch dictionary with imported files
     for vf in vf_sorted:
-        vf_data = vf.data_bytes
+        vf_data = vf.get_bytes()
         chunk = zlib.compress(vf_data)
         path = ntpath.normpath(vf.relative_path)
         file_path = ntpath.splitext(path)[0]
@@ -392,7 +392,7 @@ def find_and_replace_in_arc(filepath, vfile, file_name, add_new):
             if name == file_name and vfile.extension == extension:
                 show_message_box("File: {} was found and replaced in the archive".format(file_name))
                 found = True
-                vf_data = vfile.data_bytes
+                vf_data = vfile.get_bytes()
                 chunk = zlib.compress(vf_data)
                 fe.zsize = len(chunk)
                 fe.size = len(vf_data)

--- a/albam/engines/mtfw/archive.py
+++ b/albam/engines/mtfw/archive.py
@@ -8,10 +8,40 @@ from kaitaistruct import KaitaiStream
 
 from ...registry import blender_registry
 from . import EXTENSION_TO_FILE_ID, FILE_ID_TO_EXTENSION
+from .arc_fs import ArcFS, MTFW_FS
 from .structs.arc import Arc
 from ...blender_ui.tools import show_message_box
 
+MTFW_APP_IDS = ("re0", "re1", "re5", "re6", "rev1", "rev2", "dd", "dmc4")
 
+
+@blender_registry.register_fs_root_loader(app_id="re0", extension="arc")
+@blender_registry.register_fs_root_loader(app_id="re1", extension="arc")
+@blender_registry.register_fs_root_loader(app_id="re5", extension="arc")
+@blender_registry.register_fs_root_loader(app_id="re6", extension="arc")
+@blender_registry.register_fs_root_loader(app_id="rev1", extension="arc")
+@blender_registry.register_fs_root_loader(app_id="rev2", extension="arc")
+@blender_registry.register_fs_root_loader(app_id="dd", extension="arc")
+@blender_registry.register_fs_root_loader(app_id="dmc4", extension="arc")
+def arc_fs_root_loader(absolute_path):
+    return ArcFS(absolute_path)
+
+
+@blender_registry.register_fs_root_loader(app_id="re0", extension=None)
+@blender_registry.register_fs_root_loader(app_id="re1", extension=None)
+@blender_registry.register_fs_root_loader(app_id="re5", extension=None)
+@blender_registry.register_fs_root_loader(app_id="re6", extension=None)
+@blender_registry.register_fs_root_loader(app_id="rev1", extension=None)
+@blender_registry.register_fs_root_loader(app_id="rev2", extension=None)
+@blender_registry.register_fs_root_loader(app_id="dd", extension=None)
+@blender_registry.register_fs_root_loader(app_id="dmc4", extension=None)
+def game_fs_root_loader(absolute_path):
+    return MTFW_FS(absolute_path)
+
+
+# TODO: superseded by arc_fs_root_loader/game_fs_root_loader above + the
+# fs_key-backed branch of VirtualFile.get_bytes(); remove once vfs.py's
+# add_real_file() consumes fs_root_loader_registry for mtfw app_ids.
 @blender_registry.register_archive_loader(app_id="re0", extension="arc")
 @blender_registry.register_archive_loader(app_id="re1", extension="arc")
 @blender_registry.register_archive_loader(app_id="re5", extension="arc")

--- a/albam/engines/mtfw/archive.py
+++ b/albam/engines/mtfw/archive.py
@@ -12,8 +12,6 @@ from .arc_fs import ArcFS, MTFW_FS
 from .structs.arc import Arc
 from ...blender_ui.tools import show_message_box
 
-MTFW_APP_IDS = ("re0", "re1", "re5", "re6", "rev1", "rev2", "dd", "dmc4")
-
 
 @blender_registry.register_fs_root_loader(app_id="re0", extension="arc")
 @blender_registry.register_fs_root_loader(app_id="re1", extension="arc")
@@ -37,49 +35,6 @@ def arc_fs_root_loader(absolute_path):
 @blender_registry.register_fs_root_loader(app_id="dmc4", extension=None)
 def game_fs_root_loader(absolute_path):
     return MTFW_FS(absolute_path)
-
-
-# TODO: superseded by arc_fs_root_loader/game_fs_root_loader above + the
-# fs_key-backed branch of VirtualFile.get_bytes(); remove once vfs.py's
-# add_real_file() consumes fs_root_loader_registry for mtfw app_ids.
-@blender_registry.register_archive_loader(app_id="re0", extension="arc")
-@blender_registry.register_archive_loader(app_id="re1", extension="arc")
-@blender_registry.register_archive_loader(app_id="re5", extension="arc")
-@blender_registry.register_archive_loader(app_id="re6", extension="arc")
-@blender_registry.register_archive_loader(app_id="rev1", extension="arc")
-@blender_registry.register_archive_loader(app_id="rev2", extension="arc")
-@blender_registry.register_archive_loader(app_id="dd", extension="arc")
-@blender_registry.register_archive_loader(app_id="dmc4", extension="arc")
-def arc_loader(vfile, context=None):  # XXX context DEPRECATED
-    arc = ArcWrapper(file_path=vfile.absolute_path)
-    for file_entry in arc.get_file_entries():
-        yield file_entry.file_path_with_ext
-
-
-@blender_registry.register_archive_accessor(app_id="re0", extension="arc")
-@blender_registry.register_archive_accessor(app_id="re1", extension="arc")
-@blender_registry.register_archive_accessor(app_id="re5", extension="arc")
-@blender_registry.register_archive_accessor(app_id="re6", extension="arc")
-@blender_registry.register_archive_accessor(app_id="rev1", extension="arc")
-@blender_registry.register_archive_accessor(app_id="rev2", extension="arc")
-@blender_registry.register_archive_accessor(app_id="dd", extension="arc")
-@blender_registry.register_archive_accessor(app_id="dmc4", extension="arc")
-def arc_accessor(vfile, context):
-    arc = ArcWrapper(vfile.root_vfile.absolute_path)
-    arc.app_id = vfile.app_id
-
-    path = vfile.relative_path_windows
-    path_no_ext = str(vfile.relative_path_windows_no_ext)
-    ext = path.suffix.replace(".", "")
-
-    # TODO: error handling, e.g. when file_path doesn't exist
-    try:
-        file_type = EXTENSION_TO_FILE_ID[ext]
-    except KeyError:
-        file_type = int(ext)
-    file_bytes = arc.get_file(path_no_ext, file_type)
-
-    return file_bytes
 
 
 class ArcWrapper:

--- a/albam/lib/fs_registry.py
+++ b/albam/lib/fs_registry.py
@@ -1,0 +1,36 @@
+"""
+Session-lifetime registry of live PyFilesystem2 `FS` instances.
+
+`bpy.types.PropertyGroup` can only hold `bpy.props.*` fields - it can't hold a
+live Python object such as an `MTFW_FS`/`ArcFS`/`MemoryFS` instance. This is
+the plain-Python side-table that VFS roots point at (via a string key stored
+on the root `VirtualFile`) instead of smuggling state into Blender types.
+"""
+
+import uuid
+
+_REGISTRY = {}
+
+
+def register(fs_instance):
+    """Store `fs_instance` under a fresh key and return that key."""
+    key = uuid.uuid4().hex
+    _REGISTRY[key] = fs_instance
+    return key
+
+
+def get(key):
+    return _REGISTRY[key]
+
+
+def unregister(key):
+    """Remove and close the FS instance stored under `key`, if any."""
+    fs_instance = _REGISTRY.pop(key, None)
+    if fs_instance is not None:
+        fs_instance.close()
+
+
+def clear():
+    """Close and remove every registered FS instance."""
+    for key in list(_REGISTRY):
+        unregister(key)

--- a/albam/registry.py
+++ b/albam/registry.py
@@ -6,6 +6,7 @@ class BlenderRegistry:
         self.export_registry = {}
         self.archive_loader_registry = {}
         self.archive_accessor_registry = {}
+        self.fs_root_loader_registry = {}
         self.props = []  # order is meaningful for dependencies
         self.types = []  # order is meaningufl for dependencies
         self.import_options_custom_draw_funcs = {}
@@ -78,6 +79,18 @@ class BlenderRegistry:
             self.archive_accessor_registry[(app_id, extension)] = f
             return f
 
+        return decorator
+
+    def register_fs_root_loader(self, app_id, extension=None):
+        """
+        Decorated function must be `absolute_path -> fs.base.FS`.
+        `extension=None` registers a whole-folder loader for app_id
+        (e.g. a recursive game install root); otherwise the loader is
+        keyed to a single file's extension (e.g. one archive file).
+        """
+        def decorator(f):
+            self.fs_root_loader_registry[(app_id, extension)] = f
+            return f
         return decorator
 
     def register_custom_properties_material(self, name, app_ids, is_secondary=False,

--- a/albam/vfs.py
+++ b/albam/vfs.py
@@ -3,6 +3,8 @@ import os
 from pathlib import PureWindowsPath, Path
 
 import bpy
+from fs.memoryfs import MemoryFS
+from fs.path import dirname
 
 from .apps import APPS
 from .lib import fs_registry
@@ -205,32 +207,28 @@ class VirtualFileSystemBase:
         for node in tree.flatten():
             self._add_vf_from_treenode(app_id, root_id, node)
 
-        return vf
+        # Re-fetch: further file_list.add() calls above can invalidate the
+        # `vf` reference taken before the loop (same Blender CollectionProperty
+        # quirk _expand_archive's comment warns about) - look it up fresh by
+        # the plain-string root_id instead of trusting the stale object.
+        return self.file_list[root_id]
 
-    def add_vfile(self, vfile_data):
-        vf = self.file_list.add()
-        vf.vfs_id = self.VFS_ID
-        vf.app_id = vfile_data.app_id
-        vf.name = f"{vfile_data.app_id}::{vfile_data.name}"
-        vf.display_name = vfile_data.name
-        vf.data_bytes = vfile_data.data_bytes or b""
-
-        return vf
-
-    def add_vfiles_as_tree(self, app_id, root_vfile_data, vfiles_data):
-        root_id = f"{app_id}::{root_vfile_data.name}"
-        tree = Tree(root_id, app_id)
-        bl_vf = self.add_vfile(root_vfile_data)
-        bl_vf.is_expandable = True
-        bl_vf.is_root = True
-
+    def add_export_root(self, app_id, display_name, vfiles_data):
+        """
+        Stage freshly-exported bytes (VirtualFileData, as returned by an
+        engine's export function) in a writable in-memory FS and register it
+        as a new root via add_fs_root() - the export-side counterpart of its
+        read-only archive/game-folder roots, sharing the same tree-building
+        and get_bytes() machinery instead of duplicating bytes into
+        data_bytes.
+        """
+        mem_fs = MemoryFS()
         for vfile_data in vfiles_data:
-            tree.add_node_from_path(vfile_data.relative_path, vfile_data)
+            path = "/" + str(vfile_data.relative_path).replace("\\", "/")
+            mem_fs.makedirs(dirname(path), recreate=True)
+            mem_fs.writebytes(path, vfile_data.data_bytes or b"")
 
-        for node in tree.flatten():
-            self._add_vf_from_treenode(bl_vf.app_id, root_id, node)
-
-        return bl_vf
+        return self.add_fs_root(app_id, mem_fs, display_name=display_name)
 
     def _expand_archive(self, archive_loader_func, vf, app_id):
         # Beware of chaning this, it was observed the reference
@@ -277,9 +275,6 @@ class VirtualFileSystemBase:
         child_vf.display_name = node["name"]
         child_vf.is_expandable = bool(node["children"])
         child_vf.albam_asset_type = blender_registry.albam_asset_types.get((app_id, child_vf.extension), "")
-        vfile = node["vfile"]
-        if vfile:
-            child_vf.data_bytes = vfile.data_bytes
         child_vf.tree_node.depth = node["depth"] + 1
         child_vf.tree_node.root_id = root_id
         for ancestor_id in node["ancestors_ids"]:
@@ -528,7 +523,7 @@ class Tree:
                 break
         return node_found
 
-    def add_node_from_path(self, full_path, vfile=None, absolute_path=""):
+    def add_node_from_path(self, full_path, absolute_path=""):
         p = PureWindowsPath(full_path)
         path_parts = p.parts
         # FIXME: adding a single root node doesn't work
@@ -550,7 +545,6 @@ class Tree:
                     "name": path_part,
                     "children": [],
                     "depth": current_level,
-                    "vfile": vfile,
                     "node_id": self.generate_node_id(path_parts[0 : i + 1], use_prefix=True),
                     "relative_path": self.generate_node_id(path_parts[0 : i + 1], use_prefix=False),
                     "full_path": absolute_path,
@@ -569,7 +563,6 @@ class Tree:
             "name": leaf_name,
             "children": [],
             "depth": current_level,
-            "vfile": vfile,
             "node_id": node_id,
             "relative_path": self.generate_node_id(path_parts, use_prefix=False),
             "full_path": absolute_path,

--- a/albam/vfs.py
+++ b/albam/vfs.py
@@ -454,15 +454,20 @@ class ALBAM_OT_VirtualFileSystemRemoveRootVFileBase:
         vfiles_to_remove = []
         root_node_index = vfs.file_list_selected_index
         archive_node = vfs.file_list[root_node_index]
+        archive_node_name = archive_node.name
+        archive_node_fs_key = archive_node.fs_key
         for i in range(len(vfs.file_list)):
             parent = vfs.file_list[i].tree_node.root_id
-            if parent == archive_node.name:
+            if parent == archive_node_name:
                 vfiles_to_remove.append(i)
 
         vfiles_to_remove.reverse()
         for i in range(len(vfiles_to_remove)):
             vfs.file_list.remove(vfiles_to_remove[i])
         vfs.file_list.remove(root_node_index)
+
+        if archive_node_fs_key:
+            fs_registry.unregister(archive_node_fs_key)
 
         return {'FINISHED'}
 

--- a/albam/vfs.py
+++ b/albam/vfs.py
@@ -5,7 +5,21 @@ from pathlib import PureWindowsPath, Path
 import bpy
 
 from .apps import APPS
+from .lib import fs_registry
 from .registry import blender_registry
+
+
+def _extension_from_name(name):
+    """
+    Same "up to 2 dots" rule as VirtualFile.extension/VirtualFileData.extension,
+    usable before a VirtualFile exists yet (add_real_file's FS-root dispatch).
+    """
+    SEP = "."
+    stem, _, extension = name.rpartition(SEP)
+    if SEP in stem:
+        _, __, extension0 = stem.rpartition(SEP)
+        extension = SEP.join((extension0, extension))
+    return extension
 
 
 @blender_registry.register_blender_prop
@@ -33,6 +47,11 @@ class VirtualFile(bpy.types.PropertyGroup):
     vfs_id: bpy.props.StringProperty()
 
     data_bytes: bpy.props.StringProperty(subtype="BYTE_STRING")  # noqa: F821
+    # Set on root nodes created via add_fs_root(): key into fs_registry for
+    # the live fs.base.FS instance backing this root (bpy.types.PropertyGroup
+    # can't hold that object directly). Empty for roots/nodes still going
+    # through the legacy archive_loader/archive_accessor registries.
+    fs_key: bpy.props.StringProperty()
 
     @property
     def relative_path_windows(self):
@@ -63,7 +82,14 @@ class VirtualFile(bpy.types.PropertyGroup):
             extension = SEP.join((extension0, extension))
         return extension
 
+    @property
+    def fs_path(self):
+        return "/" + str(self.relative_path).replace("\\", "/")
+
     def get_bytes(self):
+        root = self.root_vfile
+        if root and root.fs_key:
+            return fs_registry.get(root.fs_key).readbytes(self.fs_path)
         accessor = self.get_accessor()
         return accessor(self, bpy.context)
 
@@ -117,6 +143,20 @@ class VirtualFileSystemBase:
 
     def add_real_file(self, app_id, absolute_path):
         path = PureWindowsPath(absolute_path)
+        extension = _extension_from_name(path.name)
+
+        # A single archived file (e.g. one .arc) has its own loader keyed by
+        # extension; a folder has none (no meaningful extension), so it falls
+        # through to the whole-folder loader keyed by (app_id, None), if any.
+        fs_loader = (blender_registry.fs_root_loader_registry.get((app_id, extension)) or
+                     blender_registry.fs_root_loader_registry.get((app_id, None)))
+        if fs_loader:
+            self.add_fs_root(
+                app_id, fs_loader(absolute_path), display_name=path.name,
+                is_archive=bool(extension), absolute_path=absolute_path,
+            )
+            return
+
         vf = self.file_list.add()
         vf.is_root = True
         vf.name = f"{app_id}::{path.name}"
@@ -136,6 +176,36 @@ class VirtualFileSystemBase:
             vf.is_expandable = True
             vf.is_archive = False
             self._expand_directory(absolute_path, vf, app_id)
+
+    def add_fs_root(self, app_id, fs_instance, display_name, is_archive=False, absolute_path=""):
+        """
+        Register `fs_instance` (any fs.base.FS) as a new root, sourcing its
+        whole file tree via one fs_instance.walk() pass instead of an
+        engine-specific archive_loader/archive_accessor. Bytes for every node
+        under this root are read on demand straight from `fs_instance`
+        (see VirtualFile.get_bytes()), never duplicated into a bpy property.
+        """
+        fs_key = fs_registry.register(fs_instance)
+
+        root_id = f"{app_id}::{display_name}"
+        vf = self.file_list.add()
+        vf.is_root = True
+        vf.name = root_id
+        vf.vfs_id = self.VFS_ID
+        vf.app_id = app_id
+        vf.display_name = display_name
+        vf.absolute_path = absolute_path
+        vf.fs_key = fs_key
+        vf.is_expandable = True
+        vf.is_archive = is_archive
+
+        tree = Tree(root_id=root_id, app_id=app_id)
+        for file_path in fs_instance.walk.files():
+            tree.add_node_from_path(file_path.lstrip("/"))
+        for node in tree.flatten():
+            self._add_vf_from_treenode(app_id, root_id, node)
+
+        return vf
 
     def add_vfile(self, vfile_data):
         vf = self.file_list.add()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,12 @@ dependencies = [
   # unconditionally (mtfw's VFS reads go through it), so it's a hard
   # dependency, not just for the optional S3/R2-backed path below.
   "fs",
+  # `fs` (last released 2021, unmaintained) unconditionally does
+  # `pkg_resources.declare_namespace(...)` at import time - setuptools 81+
+  # removed pkg_resources entirely, breaking `import fs` outright (confirmed:
+  # ModuleNotFoundError: No module named 'pkg_resources'). No newer `fs`
+  # release exists to fix this on their side, so pin setuptools here instead.
+  "setuptools<81",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,16 @@ tests = [
   "pytest-subtests",
   "coverage[toml]",
   "flake8-pyproject",
+  "moto[s3]>=5.0.0",
+  "python-dotenv",
+]
+
+# albam.engines.mtfw.arc_fs: PyFilesystem2-based virtual filesystem over
+# MTFramework .arc archives (+ loose files), local or S3/R2-backed.
+s3 = [
+  "fs",
+  "boto3",
+  "smart-open[s3]>=7.0.0",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,11 @@ keywords = ["modding", "game-modding", "blender-addon", "import", "export"]
 dependencies = [
   'bpy == 4.2.0; python_version == "3.11.*"',
   'bpy == 5.2.0; python_version == "3.13.*"',
+  # albam.engines.mtfw.arc_fs (ArcFS/MTFW_FS): PyFilesystem2-based VFS over
+  # MTFramework .arc archives + loose files. archive.py imports it
+  # unconditionally (mtfw's VFS reads go through it), so it's a hard
+  # dependency, not just for the optional S3/R2-backed path below.
+  "fs",
 ]
 
 [project.optional-dependencies]
@@ -24,10 +29,9 @@ tests = [
   "python-dotenv",
 ]
 
-# albam.engines.mtfw.arc_fs: PyFilesystem2-based virtual filesystem over
-# MTFramework .arc archives (+ loose files), local or S3/R2-backed.
+# albam.engines.mtfw.arc_fs.MTFW_FS.from_s3: sourcing .arc files from an
+# S3/R2-compatible bucket instead of a local game folder.
 s3 = [
-  "fs",
   "boto3",
   "smart-open[s3]>=7.0.0",
 ]

--- a/tests/mtfw/test_arc_fs.py
+++ b/tests/mtfw/test_arc_fs.py
@@ -1,0 +1,125 @@
+import os
+import time
+import zlib
+
+import pytest
+
+from albam.engines.mtfw.arc_fs import MTFW_FS
+
+# TODO: hardcoded for now; parametrize / move to --arcdir-style pytest option
+# once this stops being a prototype.
+GAME_ROOT = os.environ.get("ALBAM_TEST_RE5_GAME_ROOT", "")
+
+pytestmark = pytest.mark.skipif(
+    not os.path.isdir(GAME_ROOT), reason=f"RE5 install not found at {GAME_ROOT}"
+)
+
+# Known-bad archives in this specific install: they use a container layout
+# arc.ksy doesn't model (see MTFW_FS.failed_arcs). Asserted by name so a
+# regression (more archives silently failing to parse) gets caught.
+EXPECTED_FAILED_ARCS = {
+    "s101.arc",
+    "uOmS103ScrAdj.arc",
+    "uOmf303.arc",
+}
+
+# A file known to live in multiple archives with the same relative path but
+# different content (see the duplicate-content report from the arc_fs
+# prototyping session) - useful as a stable point-lookup target.
+SAMPLE_PATH = "/sound/se/mt/se_mt0002.srq"
+
+PACKED_PATH = "pawn/pl/pl00/model/pl0000.mod"
+LOOSE_PATH = "re5dx9.exe"  # a real file sitting directly under GAME_ROOT
+
+
+@pytest.fixture(scope="module")
+def game_fs():
+    return MTFW_FS(GAME_ROOT)
+
+
+def test_construction_finds_arcs_and_skips_bad_ones(game_fs):
+    failed_names = {os.path.basename(p) for p, _e in game_fs.failed_arcs}
+    assert failed_names == EXPECTED_FAILED_ARCS
+    # +1 for the loose/"<loose>" OSFS layer added on top
+    assert len(list(game_fs.iterate_fs())) > 1000
+
+
+def test_index_is_not_built_by_point_lookups(game_fs):
+    assert game_fs._owner is None
+
+    assert game_fs.exists(SAMPLE_PATH)
+    assert game_fs._owner is None, "exists() should not trigger the lazy index"
+
+    game_fs.readbytes(SAMPLE_PATH)
+    assert game_fs._owner is None, "readbytes() should not trigger the lazy index"
+
+    game_fs.getinfo(SAMPLE_PATH, namespaces=["details"])
+    assert game_fs._owner is None, "getinfo() should not trigger the lazy index"
+
+
+def test_origin_of_before_index_built(game_fs):
+    assert game_fs._owner is None
+
+    origin = game_fs.origin_of(PACKED_PATH)
+    assert origin is not None and origin.endswith(".arc")
+    assert game_fs._owner is None, "origin_of() should not trigger the lazy index"
+
+    assert game_fs.origin_of(LOOSE_PATH) is None
+    assert game_fs.origin_of("nope/does/not/exist.foo") is None
+    assert game_fs._owner is None
+
+
+def test_listdir_builds_and_caches_the_index(game_fs):
+    game_fs.listdir("/sound/se/mt")
+    assert game_fs._owner is not None
+    owner_before = game_fs._owner
+    game_fs.listdir("/sound/se/mt")
+    assert game_fs._owner is owner_before, "index should be built once, then reused"
+
+
+def test_walk_matches_and_is_fast_after_first_call(game_fs):
+    t0 = time.time()
+    first = sorted(game_fs.walk.files())
+    first_duration = time.time() - t0
+
+    t0 = time.time()
+    second = sorted(game_fs.walk.files())
+    second_duration = time.time() - t0
+
+    assert first == second
+    assert len(first) > 40000  # sanity: this is a whole game install
+    # second call reuses the cached index; generously bounded to avoid
+    # flaking on slow CI, but should be an order of magnitude faster than
+    # the ~70s the unindexed MultiFS fan-out took for this same walk.
+    assert second_duration < max(first_duration / 3, 5)
+
+
+def test_point_lookup_matches_manual_decompression(game_fs):
+    owner_fs = game_fs._delegate(SAMPLE_PATH)
+    assert owner_fs is not None
+
+    # independent read path: raw seek/read on the arc file itself, bypassing
+    # ArcFS/openbin entirely, using only the offset/zsize kaitai already
+    # parsed for this entry.
+    file_entry = owner_fs._entries[SAMPLE_PATH]
+    with open(owner_fs.arc_path, "rb") as f:
+        f.seek(file_entry.offset)
+        raw = f.read(file_entry.zsize)
+    expected = zlib.decompress(raw)
+
+    assert game_fs.readbytes(SAMPLE_PATH) == expected
+
+
+def test_missing_path_raises(game_fs):
+    from fs.errors import ResourceNotFound
+
+    with pytest.raises(ResourceNotFound):
+        game_fs.readbytes("/this/does/not/exist.foo")
+
+
+def test_origin_of_after_index_built_matches_pre_index_result(game_fs):
+    assert game_fs._owner is not None  # built by earlier tests in this module
+
+    assert game_fs.origin_of(PACKED_PATH) == game_fs._owner[game_fs.validatepath(PACKED_PATH)].arc_path
+    assert game_fs.origin_of(LOOSE_PATH) is None
+    assert game_fs.origin_of("nope/does/not/exist.foo") is None

--- a/tests/mtfw/test_arc_fs_r2.py
+++ b/tests/mtfw/test_arc_fs_r2.py
@@ -1,0 +1,104 @@
+"""
+MTFW_FS.from_s3() against a real Cloudflare R2 bucket, using credentials
+from a local .env file (see arc_fs prototyping session / README for the
+expected keys: R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY,
+R2_BUCKET_NAME, optionally R2_PREFIX). Skipped entirely if that .env isn't
+present/complete, so this never runs (or needs credentials) on another
+machine or in CI.
+"""
+import os
+
+import pytest
+
+boto3 = pytest.importorskip("boto3")
+pytest.importorskip("dotenv")
+pytest.importorskip("smart_open")
+
+from dotenv import load_dotenv  # noqa: E402
+
+from albam.engines.mtfw.arc_fs import MTFW_FS  # noqa: E402
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+load_dotenv(os.path.join(REPO, ".env"))
+
+REQUIRED_ENV = ("R2_ACCOUNT_ID", "R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY", "R2_BUCKET_NAME")
+_missing = [k for k in REQUIRED_ENV if not os.environ.get(k)]
+
+pytestmark = pytest.mark.skipif(
+    bool(_missing), reason=f"real R2 .env not configured (missing: {_missing})"
+)
+
+# known to exist in this account's bucket as of the arc_fs prototyping
+# session - adjust here if the bucket's contents change.
+SAMPLE_PATH = "/effect/tex/0011/tx0011_BM.tex"
+SAMPLE_ARC_SUFFIX = "uPl02JillCos3.arc"
+
+
+def _r2_kwargs():
+    return dict(
+        bucket=os.environ["R2_BUCKET_NAME"],
+        prefix=os.environ.get("R2_PREFIX", ""),
+        endpoint_url=f"https://{os.environ['R2_ACCOUNT_ID']}.r2.cloudflarestorage.com",
+        aws_access_key_id=os.environ["R2_ACCESS_KEY_ID"],
+        aws_secret_access_key=os.environ["R2_SECRET_ACCESS_KEY"],
+    )
+
+
+@pytest.fixture(scope="module")
+def game_fs():
+    return MTFW_FS.from_s3(**_r2_kwargs())
+
+
+@pytest.fixture
+def get_object_calls(monkeypatch):
+    """Record (Range, ContentLength) for every get_object call made by any
+    S3 client built while this fixture is active, including the one
+    MTFW_FS.from_s3 constructs internally."""
+    calls = []
+    real_client_factory = boto3.client
+
+    def spying_client_factory(*args, **kwargs):
+        client = real_client_factory(*args, **kwargs)
+        original_get_object = client.get_object
+
+        def spy(**gkwargs):
+            result = original_get_object(**gkwargs)
+            calls.append((gkwargs.get("Range"), result["ContentLength"]))
+            return result
+
+        client.get_object = spy
+        return client
+
+    monkeypatch.setattr(boto3, "client", spying_client_factory)
+    return calls
+
+
+def test_real_r2_finds_arcs_without_errors(game_fs):
+    assert game_fs.failed_arcs == []
+    # at least one arc plus the default loose layer
+    assert len(list(game_fs.iterate_fs())) >= 2
+
+
+def test_real_r2_reads_real_content(game_fs):
+    data = game_fs.readbytes(SAMPLE_PATH)
+    assert data[:3] == b"TEX"
+
+    origin = game_fs.origin_of(SAMPLE_PATH)
+    assert origin is not None and origin.endswith(SAMPLE_ARC_SUFFIX)
+
+
+def test_real_r2_reads_are_bounded_not_full_downloads(get_object_calls):
+    game_fs = MTFW_FS.from_s3(**_r2_kwargs())
+
+    # every request so far (construction: one header+table fetch per arc)
+    # must be a bounded range, never open-ended to EOF
+    assert all(_range and not _range.endswith("-") for _range, _ in get_object_calls)
+
+    get_object_calls.clear()  # isolate the read below from construction's calls
+    data = game_fs.readbytes(SAMPLE_PATH)
+    assert data[:3] == b"TEX"
+
+    assert all(_range and not _range.endswith("-") for _range, _ in get_object_calls)
+    # sanity: total fetched shouldn't be wildly larger than what was read
+    total_fetched = sum(cl for _r, cl in get_object_calls)
+    assert total_fetched < 10 * len(data)

--- a/tests/mtfw/test_arc_fs_s3.py
+++ b/tests/mtfw/test_arc_fs_s3.py
@@ -1,0 +1,185 @@
+"""
+MTFW_FS.from_s3() against a mocked S3 (moto) - no real bucket/credentials
+needed to validate the mechanism. Real Cloudflare R2 usage differs only in
+which endpoint_url/credentials get passed to from_s3() (see its docstring).
+Everything else - listing, opening, ranged reads, decompression - is
+identical, since R2 speaks the S3 API.
+"""
+import os
+import zlib
+
+import pytest
+
+boto3 = pytest.importorskip("boto3")
+pytest.importorskip("moto")
+pytest.importorskip("smart_open")
+
+from moto import mock_aws  # noqa: E402
+
+from albam.engines.mtfw.arc_fs import MTFW_FS  # noqa: E402
+from albam.engines.mtfw.structs.arc import Arc  # noqa: E402
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+FIXTURE_ARCS = ("s400.arc", "uPl00ChrisNormal.arc")
+BUCKET = "re5-assets"
+# where arcs actually sit, nested a few levels down - realistic layout, but
+# NOT what gets passed as `prefix=` to from_s3(). `prefix` has to be the
+# common root covering *both* where arcs live (searched recursively beneath
+# it, like local find_arc_files()/os.walk) and where loose files' exposed
+# paths are rooted - narrowing it to ARC_DIR would silently break loose
+# resolution and the arc-itself-via-loose-layer parity below. Here that
+# common root is the bucket root itself, hence GAME_ROOT_PREFIX = "".
+ARC_DIR = "nativePC_MT/Image/Archive/"
+GAME_ROOT_PREFIX = ""
+SAMPLE_PATH = "pawn/pl/pl00/model/pl0000.mod"
+
+# from_s3() builds its own client internally now (no client= param), so
+# tests just need *some* credentials moto will accept - these never talk to
+# anything real.
+DUMMY_CREDS = dict(
+    aws_access_key_id="testing",
+    aws_secret_access_key="testing",
+    region_name="us-east-1",
+)
+
+
+def _local_fixture_path(name):
+    return os.path.join(REPO, "tests", "data", "re5", name)
+
+
+def _from_s3(**kwargs):
+    kwargs = {**DUMMY_CREDS, **kwargs}
+    return MTFW_FS.from_s3(bucket=BUCKET, prefix=GAME_ROOT_PREFIX, **kwargs)
+
+
+@pytest.fixture
+def s3_client():
+    with mock_aws():
+        client = boto3.client("s3", region_name="us-east-1")
+        client.create_bucket(Bucket=BUCKET)
+        for name in FIXTURE_ARCS:
+            with open(_local_fixture_path(name), "rb") as f:
+                client.put_object(Bucket=BUCKET, Key=ARC_DIR + name, Body=f.read())
+        yield client
+
+
+@pytest.fixture
+def get_object_calls(s3_client, monkeypatch):
+    """Record (Range, ContentLength) for every get_object call made by any
+    S3 client built while this fixture is active. Needed because from_s3()
+    builds its client internally now - tests have no direct handle on it to
+    spy on, so instead this wraps boto3.client() itself for the duration of
+    the test, spying on whatever client(s) get constructed through it
+    (both the setup client above and from_s3()'s own).
+    """
+    calls = []
+    real_client_factory = boto3.client
+
+    def spying_client_factory(*args, **kwargs):
+        client = real_client_factory(*args, **kwargs)
+        original_get_object = client.get_object
+
+        def spy(**gkwargs):
+            result = original_get_object(**gkwargs)
+            calls.append((gkwargs.get("Range"), result["ContentLength"]))
+            return result
+
+        client.get_object = spy
+        return client
+
+    monkeypatch.setattr(boto3, "client", spying_client_factory)
+    return calls
+
+
+def test_from_s3_loads_arcs(s3_client):
+    game_fs = _from_s3(include_loose=False)
+    assert game_fs.failed_arcs == []
+    assert len(list(game_fs.iterate_fs())) == len(FIXTURE_ARCS)
+
+
+def test_from_s3_includes_loose_layer_by_default(s3_client):
+    game_fs = _from_s3()
+    assert len(list(game_fs.iterate_fs())) == len(FIXTURE_ARCS) + 1
+
+
+def test_from_s3_include_loose_false_disables_loose_layer(s3_client):
+    loose_override = b"MOD\x00LOOSE-OVERRIDE-CONTENT"
+    s3_client.put_object(Bucket=BUCKET, Key=SAMPLE_PATH, Body=loose_override)
+
+    game_fs = _from_s3(include_loose=False)
+    # with no loose layer, the packed copy is all there is - loose_override
+    # sitting in the bucket at that key is simply invisible
+    assert game_fs.readbytes(SAMPLE_PATH) != loose_override
+    assert game_fs.readbytes(SAMPLE_PATH)[:3] == b"MOD"
+
+
+def test_from_s3_construction_does_not_download_whole_arcs(get_object_calls):
+    _from_s3()
+
+    total_fetched = sum(content_length for _range, content_length in get_object_calls)
+    total_arc_bytes = sum(
+        os.path.getsize(_local_fixture_path(name)) for name in FIXTURE_ARCS
+    )
+    # constructing only needs each archive's header+file-table, never the
+    # (here, 50+ MiB combined) compressed content - true even with the
+    # default loose layer, since S3LooseFS.__init__ makes no calls at all
+    assert total_fetched < total_arc_bytes / 10
+    # and every request must be a bounded range, never open-ended to EOF
+    assert all(_range and not _range.endswith("-") for _range, _ in get_object_calls)
+
+
+def test_from_s3_read_matches_local_reference(get_object_calls):
+    game_fs = _from_s3()
+
+    get_object_calls.clear()  # isolate the read below from construction's calls
+    data = game_fs.readbytes(SAMPLE_PATH)
+    assert data[:3] == b"MOD"
+
+    # bounded, and nowhere near the size of the archive it came from
+    assert all(_range and not _range.endswith("-") for _range, _ in get_object_calls)
+    fetched = sum(cl for _r, cl in get_object_calls)
+    assert fetched < os.path.getsize(_local_fixture_path("uPl00ChrisNormal.arc"))
+
+    local_arc = Arc.from_file(_local_fixture_path("uPl00ChrisNormal.arc"))
+    local_arc._read()
+    file_entry = next(fe for fe in local_arc.file_entries if fe.file_path == "pawn\\pl\\pl00\\model\\pl0000")
+    expected = zlib.decompress(file_entry.raw_data)
+    local_arc._io.close()
+
+    assert data == expected
+
+
+def test_from_s3_origin_of(s3_client):
+    game_fs = _from_s3()
+    assert game_fs.origin_of(SAMPLE_PATH) == ARC_DIR + "uPl00ChrisNormal.arc"
+
+
+def test_from_s3_loose_file_overrides_packed_content(s3_client):
+    # a loose override lives at the path itself, not under the arcs' prefix -
+    # same convention as a local unpacked/modded file under game_root.
+    loose_override = b"MOD\x00LOOSE-OVERRIDE-CONTENT"
+    s3_client.put_object(Bucket=BUCKET, Key=SAMPLE_PATH, Body=loose_override)
+
+    game_fs = _from_s3()
+
+    assert game_fs.readbytes(SAMPLE_PATH) == loose_override
+    # not from an arc, so origin_of should say so
+    assert game_fs.origin_of(SAMPLE_PATH) is None
+
+
+def test_from_s3_arc_file_itself_reachable_via_loose_layer(s3_client):
+    """Parity with local MTFW_FS: an .arc is not excluded from the loose
+    layer, so it remains readable as a raw whole blob at its own key,
+    independent of its unpacked content exposed at different paths."""
+    arc_key = ARC_DIR + "uPl00ChrisNormal.arc"
+    game_fs = _from_s3()
+
+    assert game_fs.exists(arc_key)
+    name, owner_fs = game_fs.which(arc_key)
+    assert name == "<loose>"
+
+    raw = game_fs.readbytes(arc_key)
+    with open(_local_fixture_path("uPl00ChrisNormal.arc"), "rb") as f:
+        assert raw == f.read()
+    # resolved via the loose layer, not the arc layer, so origin_of is None
+    assert game_fs.origin_of(arc_key) is None

--- a/tests/test_vfs_fs_backed.py
+++ b/tests/test_vfs_fs_backed.py
@@ -1,0 +1,133 @@
+"""
+Tests for the fs.base.FS-backed side of the VFS (albam/vfs.py's
+add_fs_root/add_export_root, and albam/lib/fs_registry.py) added as part of
+replacing VirtualFileSystem's Blender-property-only storage with a live FS
+instance as the source of truth. Uses MemoryFS throughout - the mechanism
+itself is engine-agnostic; MTFW_FS/ArcFS-specific integration is covered in
+tests/mtfw/test_origin_arc_path.py.
+"""
+import bpy
+import pytest
+from fs.memoryfs import MemoryFS
+
+from albam.lib import fs_registry
+from albam.vfs import VirtualFileData
+
+
+@pytest.fixture(autouse=True)
+def _clean_vfs_state():
+    # vfs/exported are session-scoped Blender state (register() runs once
+    # per pytest session), so without this, roots added by one test would
+    # collide by name with roots added by another - node ids are keyed by
+    # app_id::relative_path only, not by which root added them.
+    yield
+    bpy.context.scene.albam.vfs.file_list.clear()
+    bpy.context.scene.albam.exported.file_list.clear()
+    fs_registry.clear()
+
+
+def _sample_fs():
+    fs_instance = MemoryFS()
+    fs_instance.makedirs("model/pl/pl00")
+    fs_instance.writebytes("/model/pl/pl00/pl00.mod", b"mod-bytes")
+    fs_instance.writebytes("/model/pl/pl00/pl00.mrl", b"mrl-bytes")
+    return fs_instance
+
+
+def test_fs_registry_register_get_unregister():
+    fs_instance = MemoryFS()
+    key = fs_registry.register(fs_instance)
+
+    assert fs_registry.get(key) is fs_instance
+
+    fs_registry.unregister(key)
+    with pytest.raises(KeyError):
+        fs_registry.get(key)
+
+
+def test_fs_registry_clear():
+    key_a = fs_registry.register(MemoryFS())
+    key_b = fs_registry.register(MemoryFS())
+
+    fs_registry.clear()
+
+    with pytest.raises(KeyError):
+        fs_registry.get(key_a)
+    with pytest.raises(KeyError):
+        fs_registry.get(key_b)
+
+
+def test_add_fs_root_builds_tree_and_reads_bytes():
+    vfs = bpy.context.scene.albam.vfs
+    root = vfs.add_fs_root("re5", _sample_fs(), display_name="sample-root")
+
+    # add_fs_root must return a live, correctly-populated reference, not the
+    # pre-population one captured before file_list.add() calls that follow
+    # can invalidate it (see the fix in albam/vfs.py).
+    assert root.name == "re5::sample-root"
+    assert root.fs_key
+    assert root.is_root
+    assert root.is_archive is False
+
+    vfile_mod = vfs.select_vfile("re5", "model/pl/pl00/pl00.mod")
+    assert vfile_mod.get_bytes() == b"mod-bytes"
+
+    vfile_mrl = vfs.get_vfile("re5", "model/pl/pl00/pl00.mrl")
+    assert vfile_mrl.get_bytes() == b"mrl-bytes"
+
+    # intermediate directory nodes must exist too, for the tree UI - node ids
+    # are app_id::relative_path, not prefixed by the root's own display name.
+    dir_node = vfs.file_list["re5::model::pl::pl00"]
+    assert dir_node.is_expandable
+
+
+def test_add_fs_root_is_archive_flag():
+    vfs = bpy.context.scene.albam.vfs
+    root = vfs.add_fs_root("re5", MemoryFS(), display_name="an.arc", is_archive=True)
+    assert root.is_archive is True
+
+
+def test_add_export_root_writes_and_reads_bytes():
+    exported = bpy.context.scene.albam.exported
+    vfiles = [
+        VirtualFileData("re5", "model/pl/pl00/pl00.mod", data_bytes=b"exported-mod"),
+        VirtualFileData("re5", "model/pl/pl00/pl00.mrl", data_bytes=b"exported-mrl"),
+    ]
+
+    root = exported.add_export_root("re5", "export-root", vfiles)
+
+    assert root.name and root.fs_key
+
+    vfile_mod = exported.select_vfile("re5", "model/pl/pl00/pl00.mod")
+    assert vfile_mod.get_bytes() == b"exported-mod"
+
+    vfile_mrl = exported.get_vfile("re5", "model/pl/pl00/pl00.mrl")
+    assert vfile_mrl.get_bytes() == b"exported-mrl"
+
+
+def test_add_export_root_defaults_missing_bytes_to_empty():
+    exported = bpy.context.scene.albam.exported
+    exported.add_export_root(
+        "re5", "export-root-2", [VirtualFileData("re5", "empty.txt", data_bytes=None)]
+    )
+
+    vfile = exported.select_vfile("re5", "empty.txt")
+    assert vfile.get_bytes() == b""
+
+
+def test_remove_root_unregisters_fs():
+    from albam.vfs import ALBAM_OT_VirtualFileSystemRemoveRootVFile
+
+    vfs = bpy.context.scene.albam.vfs
+    root = vfs.add_fs_root("re5", _sample_fs(), display_name="removable-root")
+    key = root.fs_key
+    assert fs_registry.get(key) is not None
+
+    vfs.file_list_selected_index = vfs.file_list.find(root.name)
+    ALBAM_OT_VirtualFileSystemRemoveRootVFile.execute(
+        ALBAM_OT_VirtualFileSystemRemoveRootVFile, bpy.context
+    )
+
+    assert len(vfs.file_list) == 0
+    with pytest.raises(KeyError):
+        fs_registry.get(key)


### PR DESCRIPTION
## Summary

Migrates MT Framework's VFS reads off the old hand rolled `ArcWrapper` and tree building path onto a generic PyFilesystem2 (`fs.base.FS`) backend.

- `ArcFS`: a view of a single `.arc` that only supports reading.
- `MTFW_FS`: overlays every `.arc` under a game root plus loose or modded files into one `MultiFS`, with a `from_s3()` alternate constructor for installs backed by S3 or R2.
- `albam/vfs.py` now builds trees and reads bytes through `register_fs_root_loader` and `fs_registry` for both import (`scene.albam.vfs`) and export (`scene.albam.exported`, backed by a writable `MemoryFS`), replacing two separate hand rolled implementations.
- `ALBAM_OT_Pack` resolves its target `.arc` via `origin_arc_path()` instead of assuming one VFS root maps to one archive.
- FS backed roots are closed and evicted from `fs_registry` on removal and addon unregister, so repeated add and remove cycles don't leak open file handles.
- `fs` moves from an optional extra to a core dependency, pinned alongside `setuptools<81` (newer setuptools breaks `fs`'s import entirely).

This is PR 1 of a larger branch split (this, then a hash based test dataset and R2 migration, then RE Engine PakFS, then packaging infra); the following PRs build on this one.

## Deliberately out of scope here

- Removing the now unused `ArcWrapper` class. It's still imported by the legacy `--arcdir` test fixtures in `tests/mtfw/conftest.py`, which only go away once the dataset migration PR lands. Removing it here would break those fixtures.
- `tests/mtfw/test_origin_arc_path.py`. Its first version depended on a local `tests/data/re5` fixture that's gitignored and doesn't exist in a fresh checkout. It's reintroduced, backed by R2, in the dataset migration PR instead.