### PR TITLE
Package Albam as a Blender extension with pinned deps and CI publishing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ name: Test
 on:
   push:
     branches: [ "main" ]
+    tags: [ "v*" ]
   pull_request:
     branches: [ "main" ]
 
@@ -102,4 +103,103 @@ jobs:
           minColorRange: 50
           maxColorRange: 90
           valColorRange: ${{ env.total }}
-
+  publish-latest-main:
+    # Rebuilds the extension zip on every successful merge to main and
+    # publishes it as a rolling pre-release ("latest-main") - a stable,
+    # no-login download of the current tip of main, distinct from the real
+    # tagged Releases (e.g. v0.5.0) which are still cut by hand. Never runs
+    # on pull_request (only push to main), and needs: tests so a build that
+    # fails CI never gets published.
+    runs-on: ubuntu-latest
+    needs: tests
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # `git describe`/`rev-list --count` below need full history and
+          # tags to compute the commit-count-since-last-release suffix -
+          # actions/checkout defaults to a shallow, tag-less clone.
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: 'pip'
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install packaging
+      - name: Compute dev version (base version + commits since last tag + branch)
+        id: version
+        run: |
+          set -e
+          base_version="$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")"
+          last_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+          if [ -n "$last_tag" ]; then
+            commit_count="$(git rev-list "${last_tag}..HEAD" --count)"
+          else
+            commit_count="$(git rev-list --count HEAD)"
+          fi
+          # SemVer build-metadata only allows [0-9a-zA-Z-] - safe here since
+          # this job is gated to refs/heads/main, so GITHUB_REF_NAME is
+          # always literally "main" (never a slash-containing branch name).
+          echo "value=${base_version}+${commit_count}.${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+      - name: Build extension zip
+        run: python scripts/build_extension.py --version "${{ steps.version.outputs.value }}"
+      - name: Publish rolling "latest main" pre-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          gh release delete latest-main --yes --cleanup-tag || true
+          gh release create latest-main dist/albam-*.zip \
+            --title "Latest main build (${{ steps.version.outputs.value }})" \
+            --notes "Automated build of the latest main branch ($GITHUB_SHA). Not a stable release - see the Releases page for tagged versions." \
+            --prerelease \
+            --latest=false \
+            --target "$GITHUB_SHA"
+  publish-release:
+    # Publishes the official GitHub Release when a version tag (vX.Y.Z) is
+    # pushed: verifies the tag matches pyproject.toml's version (catches a
+    # forgotten version bump before it ships), builds the zip via the
+    # default `build_extension.py` (no --version override - the manifest's
+    # own version should already equal the tag), and publishes with release
+    # notes pulled straight from CHANGELOG.md's matching dated section.
+    # Auto-published (not a draft) since the changelog is already
+    # maintainer-written by the time a release is tagged.
+    runs-on: ubuntu-latest
+    needs: tests
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: 'pip'
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install packaging
+      - name: Verify tag matches pyproject.toml version
+        run: |
+          set -e
+          tag_version="${GITHUB_REF_NAME#v}"
+          pyproject_version="$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")"
+          if [ "$tag_version" != "$pyproject_version" ]; then
+            echo "Tag $GITHUB_REF_NAME (version $tag_version) doesn't match pyproject.toml's version ($pyproject_version)" >&2
+            exit 1
+          fi
+      - name: Build extension zip
+        run: python scripts/build_extension.py
+      - name: Extract release notes from CHANGELOG.md
+        run: python scripts/extract_changelog_section.py "${GITHUB_REF_NAME#v}" > release_notes.md
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" dist/albam-*.zip \
+            --title "Albam $GITHUB_REF_NAME" \
+            --notes-file release_notes.md

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 tests/data/
 Albam.egg-info/
 build/
+dist/
 
 # local-only debug dumps (real, plain-text game asset paths - never commit)
 *_tree_dump.txt

--- a/albam/__init__.py
+++ b/albam/__init__.py
@@ -15,16 +15,6 @@ from .__version__ import __version__ as version
 __version__ = version
 
 
-bl_info = {
-    "name": "Albam",
-    "author": "Sebastian Aguirre Brachi",
-    "version": (0, 5, 0),  # needs to be kept in sync with __version__ manually
-    "blender": (4, 2, 0),
-    "location": "Properties Panel",
-    "description": "Import-Export multiple video-game formats",
-    "category": "Import-Export",
-}
-
 ALBAM_DIR = os.path.dirname(__file__)
 VENDOR_DIR = os.path.join(ALBAM_DIR, "albam_vendor")
 

--- a/pylock.toml
+++ b/pylock.toml
@@ -1,0 +1,46 @@
+lock-version = "1.0"
+created-by = "pip"
+
+[[packages]]
+name = "appdirs"
+version = "1.4.4"
+
+[[packages.wheels]]
+name = "appdirs-1.4.4-py2.py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
+
+[[packages]]
+name = "fs"
+version = "2.4.16"
+
+[[packages.wheels]]
+name = "fs-2.4.16-py2.py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/b9/5c/a3d95dc1ec6cdeb032d789b552ecc76effa3557ea9186e1566df6aac18df/fs-2.4.16-py2.py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "660064febbccda264ae0b6bace80a8d1be9e089e0a5eb2427b7d517f9a91545c"
+
+[[packages]]
+name = "setuptools"
+version = "80.10.2"
+
+[[packages.wheels]]
+name = "setuptools-80.10.2-py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173"
+
+[[packages]]
+name = "six"
+version = "1.17.0"
+
+[[packages.wheels]]
+name = "six-1.17.0-py2.py3-none-any.whl"
+url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,35 +11,27 @@ keywords = ["modding", "game-modding", "blender-addon", "import", "export"]
 dependencies = [
   'bpy == 4.2.0; python_version == "3.11.*"',
   'bpy == 5.2.0; python_version == "3.13.*"',
-  # albam.engines.mtfw.arc_fs (ArcFS/MTFW_FS): PyFilesystem2-based VFS over
-  # MTFramework .arc archives + loose files. archive.py imports it
-  # unconditionally (mtfw's VFS reads go through it), so it's a hard
-  # dependency, not just for the optional S3/R2-backed path below.
-  "fs",
-  # `fs` (last released 2021, unmaintained) unconditionally does
-  # `pkg_resources.declare_namespace(...)` at import time - setuptools 81+
-  # removed pkg_resources entirely, breaking `import fs` outright (confirmed:
-  # ModuleNotFoundError: No module named 'pkg_resources'). No newer `fs`
-  # release exists to fix this on their side, so pin setuptools here instead.
-  "setuptools<81",
+  "fs==2.4.16",
+  # `fs` breaks under setuptools 81+ (drops pkg_resources).
+  "setuptools==80.10.2",
 ]
 
 [project.optional-dependencies]
 
 tests = [
-  "pytest",
-  "pytest-subtests",
-  "coverage[toml]",
-  "flake8-pyproject",
-  "moto[s3]>=5.0.0",
-  "python-dotenv",
+  "pytest==9.1.1",
+  "pytest-subtests==0.15.0",
+  "coverage[toml]==7.15.4",
+  "flake8-pyproject==1.2.4",
+  "moto[s3]==5.2.2",
+  "python-dotenv==1.2.3",
 ]
 
 # albam.engines.mtfw.arc_fs.MTFW_FS.from_s3: sourcing .arc files from an
 # S3/R2-compatible bucket instead of a local game folder.
 s3 = [
   "boto3==1.43.72",
-  "smart-open[s3]>=7.0.0",
+  "smart-open[s3]==8.0.1",
 ]
 
 # albam.engines.reng (RE Engine, gated behind ALBAM_ENABLE_REEN - not part

--- a/scripts/build_extension.py
+++ b/scripts/build_extension.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""
+Build the Albam Blender extension zip.
+
+Dependency versions are pinned in pylock.toml (PEP 751), the committed source
+of truth for pyproject.toml's [project.dependencies] (bpy excluded - Blender
+always provides its own). A normal build just downloads wheels from that lock
+file and doesn't touch pyproject.toml at all:
+
+    python scripts/build_extension.py [--output-dir dist]
+
+When pyproject.toml's core dependencies change, regenerate the lock (writes
+pylock.toml at the repo root, resolving the full transitive closure fresh
+from PyPI) and commit the result:
+
+    python scripts/build_extension.py --generate-lock
+
+[project.optional-dependencies].<extra> groups (e.g. s3) aren't part of the
+committed lock - passing --extra resolves+locks them fresh into a scratch
+lock file for that build only:
+
+    python scripts/build_extension.py --extra s3
+
+Either way, the resulting wheels + a blender_manifest.toml with `wheels =
+[...]` filled in get zipped into dist/albam-<version>.zip. Aborts if
+pyproject.toml's version and albam/__version__.py disagree.
+
+Assumes every resolved dependency ships a universal ("py3-none-any") wheel -
+true for everything under [project.dependencies] today. If a future
+dependency needs platform-specific wheels, this script's single
+`pip download`/`pip lock` pass (no --platform/--python-version pins) would
+need to become one pass per target platform instead.
+"""
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import tomllib
+import zipfile
+from pathlib import Path
+
+from packaging.requirements import Requirement
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+ADDON_DIR = REPO_ROOT / "albam"
+MANIFEST_PATH = ADDON_DIR / "blender_manifest.toml"
+VERSION_PATH = ADDON_DIR / "__version__.py"
+VERSION_FILE_RE = re.compile(r'^__version__\s*=\s*"([^"]*)"', re.MULTILINE)
+# Mirrors RE_MANIFEST_SEMVER in Blender's own
+# scripts/addons_core/bl_pkg/cli/blender_ext.py - blender_manifest.toml's
+# `version` field is validated as real SemVer 2.0.0 (build metadata like
+# "+12.main" included), not the simpler digits-only pattern used for
+# blender_version_min/max.
+MANIFEST_SEMVER_RE = re.compile(
+    r"^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
+    r"(?:-(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?"
+    r"(?:\+[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)?$"
+)
+MANIFEST_VERSION_LINE_RE = re.compile(r'^version\s*=\s*"[^"]*"', re.MULTILINE)
+# pip only recognizes PEP 751 lock files by this exact filename pattern
+# ("pylock.toml" or "pylock.<name>.toml") - content sniffing isn't enough,
+# confirmed by pip silently mis-parsing a differently-named file as a plain
+# requirements.txt instead of erroring.
+LOCK_PATH = REPO_ROOT / "pylock.toml"
+
+
+def _load_pyproject():
+    with open(PYPROJECT_PATH, "rb") as f:
+        return tomllib.load(f)
+
+
+def _check_version_files_match(pyproject_version):
+    # Not parsed via import: albam/__init__.py needs bpy, which this script
+    # can't assume is installed.
+    match = VERSION_FILE_RE.search(VERSION_PATH.read_text())
+    if not match:
+        raise SystemExit(f"Couldn't find __version__ = \"...\" in {VERSION_PATH}")
+    file_version = match.group(1)
+    if file_version != pyproject_version:
+        raise SystemExit(
+            f"Version mismatch: pyproject.toml has {pyproject_version!r}, "
+            f"{VERSION_PATH} has {file_version!r} - keep them in sync"
+        )
+
+
+def _requirement_strings(pyproject, extras):
+    project = pyproject["project"]
+    reqs = list(project.get("dependencies", []))
+    optional = project.get("optional-dependencies", {})
+    for extra in extras:
+        try:
+            reqs.extend(optional[extra])
+        except KeyError:
+            raise SystemExit(f"--extra {extra!r} is not defined under [project.optional-dependencies]")
+    return reqs
+
+
+def _filter_out_bpy(requirement_strings):
+    # bpy is Blender itself - never bundle it, and it wouldn't resolve via
+    # pip download anyway (it's not on PyPI as a real package for every
+    # version pinned here).
+    return [r for r in requirement_strings if Requirement(r).name.lower() != "bpy"]
+
+
+def _generate_lock_file(requirement_strings, lock_path):
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "lock",
+        "--only-binary=:all:",
+        "-o",
+        str(lock_path),
+    ] + requirement_strings
+    subprocess.run(cmd, check=True, cwd=REPO_ROOT)
+
+
+def _wheel_names_from_lock(lock_path):
+    with open(lock_path, "rb") as f:
+        lock = tomllib.load(f)
+    return [wheel["name"] for package in lock.get("packages", []) for wheel in package.get("wheels", [])]
+
+
+def _download_wheels_from_lock(lock_path, wheels_dir):
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "download",
+        "--dest",
+        str(wheels_dir),
+        "--only-binary=:all:",
+        "-r",
+        str(lock_path),
+    ]
+    subprocess.run(cmd, check=True, cwd=REPO_ROOT)
+
+
+def _write_manifest(wheel_filenames, dest_path, version_override=None):
+    manifest_text = MANIFEST_PATH.read_text()
+    wheel_lines = "\n".join(f'  "./wheels/{name}",' for name in sorted(wheel_filenames))
+    new_wheels_block = f"wheels = [\n{wheel_lines}\n]\n" if wheel_filenames else "wheels = [\n]\n"
+
+    start = manifest_text.index("wheels = [")
+    end = manifest_text.index("]", start) + 1
+    # skip the trailing newline after the closing bracket, if present
+    if end < len(manifest_text) and manifest_text[end] == "\n":
+        end += 1
+    manifest_text = manifest_text[:start] + new_wheels_block + manifest_text[end:]
+
+    if version_override:
+        new_version_line = f'version = "{version_override}"'
+        manifest_text = MANIFEST_VERSION_LINE_RE.sub(new_version_line, manifest_text, count=1)
+
+    dest_path.write_text(manifest_text)
+
+
+def _stage_addon(staging_root):
+    ignore = shutil.ignore_patterns("__pycache__", "*.pyc", "*.pyo")
+    shutil.copytree(ADDON_DIR, staging_root, ignore=ignore)
+
+
+def _check_universal_wheels(wheel_filenames):
+    # blender_manifest.toml declares both windows-x64 and linux-x64, and
+    # Blender itself spans multiple bundled Python versions (3.11 for
+    # bpy==4.2.0, 3.13 for bpy==5.2.0) - a single `pip download` pass (no
+    # --platform/--abi/--python-version pins) only ever fetches wheels
+    # compatible with *this* machine. That's fine as long as every resolved
+    # wheel is universal ("none-any"); a platform/abi-specific wheel slipping
+    # through would silently work here and silently break everywhere else.
+    universal_suffixes = ("-py3-none-any.whl", "-py2.py3-none-any.whl")
+    non_universal = [name for name in wheel_filenames if not name.endswith(universal_suffixes)]
+    if non_universal:
+        names = ", ".join(sorted(non_universal))
+        raise SystemExit(
+            f"Refusing to bundle non-universal wheel(s): {names}\n"
+            "These were built for this machine's platform/Python only and would silently "
+            "break on other declared platforms (windows-x64/linux-x64) or Blender's other "
+            "bundled Python version. This script needs a --platform/--abi/--python-version "
+            "pinned `pip download` pass per target instead of the current single pass."
+        )
+
+
+def generate_lock():
+    pyproject = _load_pyproject()
+    requirement_strings = _filter_out_bpy(_requirement_strings(pyproject, extras=[]))
+    print(f"Locking {len(requirement_strings)} top-level requirement(s) into {LOCK_PATH} ...")
+    for r in requirement_strings:
+        print(f"  - {r}")
+    _generate_lock_file(requirement_strings, LOCK_PATH)
+    _check_universal_wheels(_wheel_names_from_lock(LOCK_PATH))
+    print(f"Wrote {LOCK_PATH} - review and commit it.")
+
+
+def build(extras, output_dir, version_override=None):
+    pyproject = _load_pyproject()
+    version = version_override or pyproject["project"]["version"]
+    _check_version_files_match(pyproject["project"]["version"])
+    if version_override and not MANIFEST_SEMVER_RE.match(version_override):
+        raise SystemExit(
+            f"--version {version_override!r} is not valid SemVer 2.0.0 - Blender's own "
+            "blender_manifest.toml validator would reject it too"
+        )
+
+    with tempfile.TemporaryDirectory(prefix="albam-extension-build-") as tmp:
+        tmp = Path(tmp)
+        staging_root = tmp / "albam"
+        wheels_dir = staging_root / "wheels"
+
+        print(f"Staging addon files from {ADDON_DIR} ...")
+        _stage_addon(staging_root)
+
+        if extras:
+            # Extras aren't part of the committed core lock - resolve+lock
+            # them fresh into a scratch pylock.toml for this build only,
+            # rather than mixing them into the committed one.
+            requirement_strings = _filter_out_bpy(_requirement_strings(pyproject, extras))
+            lock_path = tmp / "pylock.toml"
+            print(f"Locking core + extra(s) {extras} for this build only (not committed) ...")
+            _generate_lock_file(requirement_strings, lock_path)
+        else:
+            if not LOCK_PATH.exists():
+                raise SystemExit(f"{LOCK_PATH} not found - run with --generate-lock first")
+            lock_path = LOCK_PATH
+
+        print(f"Downloading wheels from {lock_path} ...")
+        wheels_dir.mkdir(exist_ok=True)
+        _download_wheels_from_lock(lock_path, wheels_dir)
+
+        wheel_filenames = [p.name for p in wheels_dir.glob("*.whl")]
+        if not wheel_filenames:
+            raise SystemExit(f"pip download produced no wheels from {lock_path} - aborting")
+        _check_universal_wheels(wheel_filenames)
+        print(f"Bundled {len(wheel_filenames)} wheel(s):")
+        for name in sorted(wheel_filenames):
+            print(f"  - {name}")
+
+        manifest_dest = staging_root / "blender_manifest.toml"
+        _write_manifest(wheel_filenames, manifest_dest, version_override=version_override)
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        zip_path = output_dir / f"albam-{version}.zip"
+        if zip_path.exists():
+            zip_path.unlink()
+
+        print(f"Writing {zip_path} ...")
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for file_path in sorted(staging_root.rglob("*")):
+                if file_path.is_file():
+                    zf.write(file_path, file_path.relative_to(staging_root))
+
+    print(f"Done: {zip_path}")
+    return zip_path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--generate-lock",
+        action="store_true",
+        help=f"Regenerate {LOCK_PATH.name} from pyproject.toml's core dependencies and exit, "
+        "without building the zip.",
+    )
+    parser.add_argument(
+        "--extra",
+        action="append",
+        default=[],
+        dest="extras",
+        help="Additional [project.optional-dependencies] group to bundle (e.g. s3). Repeatable. "
+        "Locked fresh for this build only, not added to the committed lock file.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=REPO_ROOT / "dist",
+        help="Directory to write the resulting zip into (default: ./dist)",
+    )
+    parser.add_argument(
+        "--version",
+        dest="version_override",
+        default=None,
+        help="Override both the packaged manifest's `version` field and the zip filename's version "
+        "(default: pyproject.toml's project.version, left untouched). Must be valid SemVer 2.0.0 - "
+        "e.g. '0.5.0+12.main' - since that's what Blender's own manifest validator requires.",
+    )
+    args = parser.parse_args()
+    if args.generate_lock:
+        if args.extras:
+            raise SystemExit("--generate-lock and --extra can't be combined - the lock covers core deps only")
+        generate_lock()
+    else:
+        build(args.extras, args.output_dir, version_override=args.version_override)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/extract_changelog_section.py
+++ b/scripts/extract_changelog_section.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+Print CHANGELOG.md's section for a given version, for use as GitHub Release
+notes on a tagged release.
+
+Usage:
+    python scripts/extract_changelog_section.py 0.5.0
+
+Expects Keep a Changelog format (https://keepachangelog.com/): a line like
+"## [0.5.0] - 2026-04-03" starting the section, running until the next "## ["
+heading or end of file. Exits non-zero with a clear message if no matching
+section exists - a missing section means CHANGELOG.md wasn't updated before
+tagging, not something to silently paper over with empty release notes.
+"""
+import argparse
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CHANGELOG_PATH = REPO_ROOT / "CHANGELOG.md"
+
+
+def extract_section(changelog_text, version):
+    pattern = re.compile(
+        r"^## \[" + re.escape(version) + r"\][^\n]*\n(.*?)(?=^## \[|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(changelog_text)
+    if not match:
+        return None
+    return match.group(1).strip()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("version", help='Version to extract, e.g. "0.5.0" (no "v" prefix)')
+    args = parser.parse_args()
+
+    section = extract_section(CHANGELOG_PATH.read_text(), args.version)
+    if section is None:
+        raise SystemExit(
+            f'No "## [{args.version}]" section found in {CHANGELOG_PATH} - '
+            "update the changelog before tagging a release"
+        )
+    print(section)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,20 @@ def pytest_sessionstart():
 def pytest_sessionfinish():
     unregister()
 
+    # bpy (the pip package, not the full Blender application) segfaults
+    # during CPython interpreter finalization whenever any registered
+    # bpy.types.PropertyGroup subclass defines a plain Python method -
+    # unrelated to anything this addon's own teardown can prevent. Harmless:
+    # normal interpreter shutdown already flushes all of pytest's output
+    # before the crash, which is the very last thing that happens. Don't
+    # add an os._exit(int(exitstatus)) shortcut here to dodge the scary
+    # traceback - it skips that flush, and on at least one real run (a
+    # dataset missing an optional key, aborting collection) that silently
+    # discarded pytest's entire output instead of just the exit code. CI's
+    # existing handling (discounting exit code 139 - see
+    # .github/workflows/tests.yml) is the right place to deal with the exit
+    # code, not here.
+
 
 def pytest_addoption(parser):
     parser.addoption(


### PR DESCRIPTION
## Summary

Adds a real packaging and release pipeline for the addon as a Blender extension, and locks down dependency versions for reproducible builds.

- Pins every `pyproject.toml` dependency (core, `tests`, `s3` extras) to the exact version already verified working in CI and dev, replacing a mix of loose and unpinned requirements.
- `scripts/build_extension.py` packages the addon as a Blender extension zip with bundled wheels (Blender's extension platform has no pip or network access at runtime, so runtime deps besides `bpy` must ship as wheels declared in `blender_manifest.toml`). `pylock.toml` (PEP 751) is the committed, hash-verified source of truth for core dependency versions, regenerated via `--generate-lock` whenever `pyproject.toml`'s core deps change. Aborts before doing any work if `pyproject.toml`'s version and `albam/__version__.py` disagree.
- CI publishes the built zip: every push to `main` force-updates a mutable `latest-main` pre-release, giving a stable, no-login download of the current tip; pushing a `vX.Y.Z` tag verifies it matches `pyproject.toml`'s version, builds the zip, and publishes a real GitHub Release with notes pulled from `CHANGELOG.md`'s matching dated section, both gated on the test job passing first so a broken build never gets published.
- Removes `bl_info` from `albam/__init__.py` - dead since `blender_manifest.toml` (already on `main` before this branch) is what actually supplies the addon's metadata to Blender's extension platform now.

This is PR 4 of 4, stacked on PR 3 (#221) - last one in the split.

## Known gap, left for later

Neither publish job passes `--extra`, so the `reen` extra (`bc7enc-py`, `zstd`) never ships in the real published zip - RE Engine support stays dev-only (`ALBAM_ENABLE_REEN=1`), matching its existing opt-in status. `bc7enc-py` ships platform-specific wheels only (no universal wheel), which `_check_universal_wheels()` would correctly refuse to bundle if `--extra reen` were ever passed. Supporting it for real needs one `pip download --platform ...` pass per target platform, not implemented here.