### PR TITLE
Fix vertex colors being brightened on every import export round trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Import SBC for DMC4
 - Issue with SBC generation that broke high collision mesh (eff) and left holes in low collision mesh (scr)
 - Typo that set wrong name ("name") for the color attribute layer
+- Typo that brightened vertex colors on every import-export round trip
 
 ### Changed
 

--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -522,8 +522,8 @@ def _process_uvs(vertex, uvs_1_out, uvs_2_out, uvs_3_out, uvs_4_out):
 def _process_vertex_colors(mod_version, vertex, rgba_out):
     if not hasattr(vertex, "rgba"):
         return
-    b = vertex.rgba.x / 225
-    g = vertex.rgba.y / 225
+    b = vertex.rgba.x / 255
+    g = vertex.rgba.y / 255
     r = vertex.rgba.z / 255
     a = vertex.rgba.w / 255
     rgba_out.append((r, g, b, a))


### PR DESCRIPTION
## Summary

`_process_vertex_colors` divided the blue and green channels of a vertex's `rgba` by 225 instead
of 255, while red and alpha used 255. The `.ksy`'s `rgba.x/y/z/w` hold BGRA rather than RGBA, so
this scaled blue and green up by 255/225 (~13%) on import, and the export path faithfully wrote
the inflated values back out, clipping at 255. Every import export round trip compounded it.

- Measured before the fix: not a single blue or green byte survived a round trip, typically off
  by 24 of 255. After: both channels behave exactly like red.
- The channel order itself is correct, despite how it reads: import assigns `r <- z, g <- y,
  b <- x`, and the export side's `b, g, r, a = color` unpacking faithfully inverts that.
- Introduced in 7db8895 (#133).

No test covers this yet: no model in `mod_serialization_hashes.json` carries vertex colors, and
`test_vertex_buffer_bytes` doesn't compare `rgba`. Colors still don't round trip byte exact for a
second, unrelated reason (`BYTE_COLOR` is read and written through the scene linear `.color`
rather than `.color_srgb`, which 73 of 256 byte values cannot survive), so asserting on them only
becomes worthwhile once that one is fixed too. Follow up PR next, after which `rgba` can join
`position` and `uv` as a strict byte comparison.
