### PR TITLE
Fix vertex colors losing precision on every import export round trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Issue with SBC generation that broke high collision mesh (eff) and left holes in low collision mesh (scr)
 - Typo that set wrong name ("name") for the color attribute layer
 - Typo that brightened vertex colors on every import-export round trip
+- Vertex colors losing precision on every import-export round trip
 
 ### Changed
 

--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -667,9 +667,28 @@ def _build_uvs(bl_mesh, uvs, name="uv"):
 
 def _build_vertex_colors(bl_mesh, vertex_colors, name="imported_colors"):
     if len(vertex_colors) > 0:
-        # As import-export works with 1byte colors, no need to use full float for that
-        color_layer = bl_mesh.color_attributes.new(name=name, domain='CORNER', type='BYTE_COLOR')
-        # color_layer = bl_mesh.data.color_attributes[name]
+        # FLOAT_COLOR, not BYTE_COLOR, even though the file's colors are one
+        # byte per channel: Blender stores a BYTE_COLOR attribute as sRGB
+        # bytes and exposes it through `.color` in scene linear, converting
+        # each way, and 73 of 256 byte values do not survive that pair of
+        # conversions. A float attribute holds `byte / 255` exactly, so the
+        # round trip is lossless without reinterpreting what the byte means.
+        #
+        # TODO: verify what the engine actually does with these values. They
+        # are written here as scene linear (`byte / 255`), which is what
+        # Albam has always done, but that is an assumption, not a checked
+        # fact - MT Framework may well treat them as sRGB, in which case
+        # every imported model shades too bright in Blender by roughly the
+        # sRGB curve (byte 128 would be 0.216 linear rather than 0.502).
+        # Nothing here settles it: this is a round trip property, and both
+        # readings round trip exactly. To settle it, compare an in-game
+        # screenshot of stage geometry with strong vertex color variation
+        # against a Blender render of the same model with the attribute
+        # driving base color, or check what an independent MT Framework tool
+        # assumes. If it turns out to be sRGB, write via `.color_srgb` here
+        # and read via `.color_srgb` in _get_vertex_colors - both sides have
+        # to move together, since either alone shifts every color.
+        color_layer = bl_mesh.color_attributes.new(name=name, domain='CORNER', type='FLOAT_COLOR')
         for poly in bl_mesh.polygons:
             for loop_index in poly.loop_indices:
                 loop = bl_mesh.loops[loop_index]
@@ -854,7 +873,10 @@ def export_mod(bl_obj):
     dst_mod.index_buffer = index_buffer
 
     offset = dst_mod.size_top_level_
-    dst_mod.header.offset_bones_data = offset
+    # A model with no armature has no bones_data section at all (num_bones is
+    # what gates it, see the .ksy): real files signal that with a 0 offset
+    # rather than an offset pointing at an empty section
+    dst_mod.header.offset_bones_data = offset if dst_mod.header.num_bones else 0
     dst_mod.header.offset_groups = offset + dst_mod.bones_data_size_
     dst_mod.header.offset_materials_data = dst_mod.header.offset_groups + dst_mod.groups_size_
     dst_mod.header.offset_meshes_data = dst_mod.header.offset_materials_data + dst_mod.materials_data.size_
@@ -2053,7 +2075,9 @@ def _convert_vtx_col_layer(mesh, src_layer):
         return src_layer
     else:
         scr_col_layer_name = src_layer.name
-        dst_col_layer = mesh.color_attributes.new(name="_temp", domain='CORNER', type='BYTE_COLOR')
+        # FLOAT_COLOR to match _build_vertex_colors: routing colors through a
+        # byte layer here would re-introduce the precision loss it avoids
+        dst_col_layer = mesh.color_attributes.new(name="_temp", domain='CORNER', type='FLOAT_COLOR')
 
         src_data = src_layer.data
         dst_data = dst_col_layer.data
@@ -2146,7 +2170,7 @@ def _duplicate_vtx_by_attr(src_obj):
     # Set vertex colors
     for i, col_layer in enumerate(color_layers):
         col_layer_new = dst_mesh.color_attributes.new(
-            name=col_layer.name, domain='CORNER', type='BYTE_COLOR')
+            name=col_layer.name, domain='CORNER', type='FLOAT_COLOR')
         for poly in dst_mesh.polygons:
             for loop_idx in poly.loop_indices:
                 col_layer_new.data[loop_idx].color = new_col_layers[i][dst_mesh.loops[loop_idx].vertex_index]

--- a/tests/mtfw/datasets/mod_serialization_hashes.json
+++ b/tests/mtfw/datasets/mod_serialization_hashes.json
@@ -6,5 +6,9 @@
     {
         "app_id": "re5",
         "mod_path_hash": "2dc02b22175deb2f"
+    },
+    {
+        "app_id": "re5",
+        "mod_path_hash": "dd278c4da3cc1635"
     }
 ]

--- a/tests/mtfw/test_mod_serialization.py
+++ b/tests/mtfw/test_mod_serialization.py
@@ -1,3 +1,4 @@
+from collections import Counter
 import json
 import os
 
@@ -46,6 +47,16 @@ def test_dataset_hashes_are_in_catalog():
         )
 
 
+def _bones_data_error(src_mod, dst_mod):
+    """Difference in bones_data section size, or 0 for a model with no
+    armature at all (stage geometry), where neither side has the section.
+    """
+    if src_mod.bones_data is None or dst_mod.bones_data is None:
+        assert src_mod.bones_data is None and dst_mod.bones_data is None
+        return 0
+    return abs(src_mod.bones_data.size_ - dst_mod.bones_data.size_)
+
+
 @pytest.fixture(scope="session")
 def mod_export_local(game_fs_root, local_app_id, local_mod_path_hash):
     from albam.engines.mtfw.mesh import APPID_CLASS_MAPPER
@@ -89,7 +100,7 @@ def test_export_header(mod_imported_local, mod_exported_local):
     sheader = mod_imported_local.header
     dheader = mod_exported_local.header
 
-    bones_data_error = abs(mod_imported_local.bones_data.size_ - mod_exported_local.bones_data.size_)
+    bones_data_error = _bones_data_error(mod_imported_local, mod_exported_local)
     assert (sheader.version in (210, 211, 212) and not bones_data_error) or sheader.version == 156
 
     assert sheader.ident == dheader.ident == b"MOD\x00"
@@ -121,19 +132,21 @@ def test_export_top_level(mod_imported_local, mod_exported_local):
     assert mod_imported_local.bbox_min.x == pytest.approx(mod_exported_local.bbox_min.x, rel=0.001)
     assert mod_imported_local.bbox_min.y == pytest.approx(mod_exported_local.bbox_min.y, rel=0.001)
     assert mod_imported_local.bbox_min.z == pytest.approx(mod_exported_local.bbox_min.z, rel=0.001)
-    assert mod_imported_local.bbox_min.w == pytest.approx(mod_exported_local.bbox_min.w, rel=0.001)
+    # .w is padding, not a coordinate: real files carry uninitialized garbage
+    # there (seen on stage models), while export always writes 0.0
 
     assert mod_imported_local.bbox_max.x == pytest.approx(mod_exported_local.bbox_max.x, rel=0.001)
     assert mod_imported_local.bbox_max.y == pytest.approx(mod_exported_local.bbox_max.y, rel=0.001)
     assert mod_imported_local.bbox_max.z == pytest.approx(mod_exported_local.bbox_max.z, rel=0.001)
-    assert mod_imported_local.bbox_max.w == pytest.approx(mod_exported_local.bbox_max.w, rel=0.001)
 
 
 def test_export_bones_data(mod_imported_local, mod_exported_local, subtests):
     # TODO: matrices
+    if mod_imported_local.bones_data is None:
+        pytest.skip("model has no armature")
     sbd = mod_imported_local.bones_data
     dbd = mod_exported_local.bones_data
-    bones_data_error = abs(mod_imported_local.bones_data.size_ - mod_exported_local.bones_data.size_)
+    bones_data_error = _bones_data_error(mod_imported_local, mod_exported_local)
     assert ((mod_exported_local.header.version in (210, 211, 212) and not bones_data_error) or
             mod_exported_local.header.version == 156)
 
@@ -269,6 +282,50 @@ def test_vertices(mod_imported_local, mod_exported_local, subtests):
                         src_vertex.normal.x == (dst_vertex.normal.x + 2) or \
                         src_vertex.normal.x == (dst_vertex.normal.x - 2) or \
                         src_vertex.normal.x == dst_vertex.normal.x'''
+
+
+def test_vertex_colors(mod_imported_local, mod_exported_local, subtests):
+    """
+    Vertex colors must survive a round trip byte for byte, compared as a
+    multiset of (uv, rgba) per mesh rather than per vertex index: the
+    exporter is free to hand two vertices with identical attributes a
+    different pair of buffer slots than the original file used, which is
+    invisible to the GPU since only the index buffer says which slot a
+    triangle corner reads from.
+
+    uv rather than position identifies the vertex here because position is
+    not bit stable across a round trip: import scales cm to m and export
+    scales back, and that pair of float32 multiplications lands ~1 ULP away
+    for a small fraction of vertices (~3% of one mesh in this dataset).
+    That has nothing to do with colors, so it has no business failing this
+    test.
+
+    A mesh whose vertex count/format doesn't match the original is a
+    separate, already tracked gap (see test_meshes_data_xfail), so it's
+    skipped rather than failed.
+    """
+    def colored(mesh):
+        return Counter(
+            (getattr(v, "uv", None) and (v.uv.u, v.uv.v),
+             (v.rgba.x, v.rgba.y, v.rgba.z, v.rgba.w))
+            for v in mesh.vertices if hasattr(v, "rgba")
+        )
+
+    src_meshes = mod_imported_local.meshes_data.meshes
+    dst_meshes = mod_exported_local.meshes_data.meshes
+    checked = 0
+    for mi, (src_mesh, dst_mesh) in enumerate(zip(src_meshes, dst_meshes)):
+        if (src_mesh.num_vertices, src_mesh.vertex_stride) != (
+                dst_mesh.num_vertices, dst_mesh.vertex_stride):
+            continue
+        src_colors = colored(src_mesh)
+        if not src_colors:
+            continue
+        checked += 1
+        with subtests.test(mesh_index=mi):
+            assert src_colors == colored(dst_mesh)
+    if not checked:
+        pytest.skip("no mesh in this model carries vertex colors")
 
 
 @pytest.mark.xfail(reason="WIP")


### PR DESCRIPTION
## Summary

Vertex colors did not survive an import export round trip: Blender stores a `BYTE_COLOR`
attribute as sRGB bytes and exposes it through `.color` in scene linear, converting each way.
Import wrote a file byte through that as if it were linear and export read it back the same way,
so every round trip pushed the value through two conversions around an 8 bit store. 73 of 256
byte values cannot survive that; 36% of the bytes in a real model came back off by one.

Three things, in one commit:

- **The fix.** Imported colors are now a `FLOAT_COLOR` attribute, which holds `byte / 255`
  exactly. `_convert_vtx_col_layer` and `_duplicate_vtx_by_attr` move to `FLOAT_COLOR` too, since
  routing colors back through a byte layer re-introduces the loss (the autofix export path does
  exactly that).
- **Test coverage.** Adds the first model with no armature to `mod_serialization_hashes.json` and
  a `test_vertex_colors` asserting colors round trip byte for byte. Vertex colors live on static
  geometry in this engine, so nothing in the suite covered either path before. Verified the test
  is not vacuous: it fails on all 19 colored meshes without the fix, passes with it.
- **What that coverage exposed.** Three assertions had quietly grown to assume a character model
  (two dereferenced `bones_data` unconditionally; `test_export_top_level` compared `bbox_min/max.w`,
  a padding slot real files leave uninitialized). And one real export bug: `offset_bones_data`
  pointed at a section that isn't there instead of being 0.

## The interpretation question

`.color_srgb` would also round trip exactly, and was my first fix. `FLOAT_COLOR` is better because
it is *neutral*: it fixes the precision loss without changing what the byte is taken to mean.

| storage | property | bytes failing round trip | linear value seen for byte 128 |
|---|---|---|---|
| `BYTE_COLOR` | `.color` | 73/256 | 0.5029 (old behavior) |
| `BYTE_COLOR` | `.color_srgb` | 0/256 | 0.2159 |
| `FLOAT_COLOR` | `.color` | 0/256 | 0.5020 (this PR) |

Going the `.color_srgb` route would have made every imported model shade ~2.3x darker as a side
effect of a precision fix. Whether linear or sRGB is what the engine actually intends is still
unverified - there is a TODO in `_build_vertex_colors` saying so and how to settle it.

## Notes

- Positions are deliberately not part of `test_vertex_colors`'s key: the cm to m conversion is not
  bit stable in float32 and lands ~1 ULP away on a small fraction of vertices, which has nothing
  to do with colors.
- Full `test_mod_serialization.py` against real data: 16 passed, 850 subtests passed, 0 failed.
