### PR TITLE
Regenerate every Kaitai parser with the 0.11 release compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,15 +70,6 @@ one command rather than a per-file split that nothing in a `.ksy` records. It im
 `from_bytes()`) no longer parses anything on its own, so every call site follows it with an
 explicit `_read()`.
 
-`tests/test_generated_structs.py` keeps all of this honest: every `.ksy` has to compile, every
-parser has to be generated read-write, and the generated `Mesh` classes have to keep the lazy-write
-attributes `albam/engines/mtfw/mesh.py` assigns to by hand (`<field>__enabled`). Those were named
-`<field>__to_write` before the 0.11 release; since assigning an attribute a class doesn't define is
-legal Python, that rename would otherwise have left exporting running while silently writing the
-vertex and index buffers twice.
-
-The vendored runtime in `albam/albam_vendor/kaitaistruct.py` reports `0.11.dev1` and satisfies the
-`API_VERSION >= (0, 11)` check the generated code makes.
 
 ## Supported Engines
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,31 @@ PYTHONPATH="$VIRTUAL_ENV/lib/python3.13/site-packages" blender --python-use-syst
 ```
 
 
+### Regenerating the Kaitai Struct parsers
+
+Binary formats are described by `.ksy` files under each engine's `structs/` directory and compiled
+to the `*.py` next to them with [Kaitai Struct](https://kaitai.io/) (currently 0.11):
+
+```
+kaitai-struct-compiler --target python -w --outdir . <file>.ksy
+```
+
+`-w`/`--read-write` applies to every parser, including formats albam only reads today, so there is
+one command rather than a per-file split that nothing in a `.ksy` records. It implies
+`--no-auto-read`, which is the one thing callers have to know: constructing a parser (or calling
+`from_bytes()`) no longer parses anything on its own, so every call site follows it with an
+explicit `_read()`.
+
+`tests/test_generated_structs.py` keeps all of this honest: every `.ksy` has to compile, every
+parser has to be generated read-write, and the generated `Mesh` classes have to keep the lazy-write
+attributes `albam/engines/mtfw/mesh.py` assigns to by hand (`<field>__enabled`). Those were named
+`<field>__to_write` before the 0.11 release; since assigning an attribute a class doesn't define is
+legal Python, that rename would otherwise have left exporting running while silently writing the
+vertex and index buffers twice.
+
+The vendored runtime in `albam/albam_vendor/kaitaistruct.py` reports `0.11.dev1` and satisfies the
+`API_VERSION >= (0, 11)` check the generated code makes.
+
 ## Supported Engines
 
 * [MT Framework](https://en.wikipedia.org/wiki/MT_Framework)

--- a/albam/engines/hexn/structs/edgemodel.ksy
+++ b/albam/engines/hexn/structs/edgemodel.ksy
@@ -4,7 +4,7 @@ meta:
   title: Hexane Engine Model Format
   file-extension: edgemodel
   license: CC0-1.0
-  ks-version: 0.8
+  ks-version: '0.11'
 
 seq:
   - {id: header, type: edge_header}

--- a/albam/engines/hexn/structs/matb.ksy
+++ b/albam/engines/hexn/structs/matb.ksy
@@ -4,7 +4,7 @@ meta:
   title: Hexane Engine Material Format
   file-extension: matb
   license: CC0-1.0
-  ks-version: 0.8
+  ks-version: '0.11'
 
 
 seq:

--- a/albam/engines/hexn/structs/ssg.ksy
+++ b/albam/engines/hexn/structs/ssg.ksy
@@ -4,7 +4,7 @@ meta:
   title: Hexane Engine Archive format
   file-extension: ssg
   license: CC0-1.0
-  ks-version: 0.8
+  ks-version: '0.11'
 
 seq:
   - {id: id_magic, contents: [0x06, 0x00, 0x00, 0x00]}

--- a/albam/engines/mtfw/animation.py
+++ b/albam/engines/mtfw/animation.py
@@ -23,6 +23,7 @@ ROOT_BONE_NAME = '0'
 def load_lmt(file_item, context):
     lmt_bytes = file_item.get_bytes()
     lmt = Lmt(KaitaiStream(io.BytesIO(lmt_bytes)))
+    lmt._read()
     armature = context.scene.albam.import_options_lmt.armature
     mapping = _create_bone_mapping(armature)
 

--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -1362,9 +1362,9 @@ def _serialize_meshes_data(bl_obj, bl_meshes, src_mod, dst_mod, materials_map, b
     for mesh_index, bl_mesh in enumerate(bl_meshes):
         face_padding = 0 if app_id not in ["re5", "dd"] else 2
         mesh = dst_mod.Mesh(_parent=meshes_data, _root=meshes_data._root)
-        mesh.indices__to_write = False
-        mesh.vertices__to_write = False
-        mesh.vertices2__to_write = False
+        mesh.indices__enabled = False
+        mesh.vertices__enabled = False
+        mesh.vertices2__enabled = False
         mesh_bone_palette = None
         mesh_bone_palette_index = None
         if bone_palettes:

--- a/albam/engines/mtfw/scripts/dump_mfx.py
+++ b/albam/engines/mtfw/scripts/dump_mfx.py
@@ -19,6 +19,7 @@ def dump_mfx(app_id, mfx_filepath):
     from ..structs.mfx import Mfx
 
     mfx = Mfx.from_file(mfx_filepath)
+    mfx._read()
 
     try:
         with open(OUT) as f:

--- a/albam/engines/mtfw/structs/arc.ksy
+++ b/albam/engines/mtfw/structs/arc.ksy
@@ -3,7 +3,7 @@ meta:
   endian: le
   file-extension: arc
   id: arc
-  ks-version: 0.10
+  ks-version: '0.11'
   title: MTFramework archive format
 
 

--- a/albam/engines/mtfw/structs/arc.py
+++ b/albam/engines/mtfw/structs/arc.py
@@ -5,14 +5,14 @@ import kaitaistruct
 from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
 
 
-if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 11):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.11 or later is required, but you have %s" % (kaitaistruct.__version__))
 
 class Arc(ReadWriteKaitaiStruct):
     def __init__(self, _io=None, _parent=None, _root=None):
-        self._io = _io
+        super(Arc, self).__init__(_io)
         self._parent = _parent
-        self._root = _root if _root else self
+        self._root = _root or self
 
     def _read(self):
         self.header = Arc.ArcHeader(self._io, self, self._root)
@@ -20,10 +20,13 @@ class Arc(ReadWriteKaitaiStruct):
         self.file_entries = []
         for i in range(self._root.header.num_files):
             _t_file_entries = Arc.FileEntry(self._io, self, self._root)
-            _t_file_entries._read()
-            self.file_entries.append(_t_file_entries)
+            try:
+                _t_file_entries._read()
+            finally:
+                self.file_entries.append(_t_file_entries)
 
-        self.padding = self._io.read_bytes((32760 - ((self._root.header.num_files * 80) % 32768)))
+        self.padding = self._io.read_bytes(32760 - (self._root.header.num_files * 80) % 32768)
+        self._dirty = False
 
 
     def _fetch_instances(self):
@@ -46,35 +49,36 @@ class Arc(ReadWriteKaitaiStruct):
 
 
     def _check(self):
-        pass
         if self.header._root != self._root:
-            raise kaitaistruct.ConsistencyError(u"header", self.header._root, self._root)
+            raise kaitaistruct.ConsistencyError(u"header", self._root, self.header._root)
         if self.header._parent != self:
-            raise kaitaistruct.ConsistencyError(u"header", self.header._parent, self)
-        if (len(self.file_entries) != self._root.header.num_files):
-            raise kaitaistruct.ConsistencyError(u"file_entries", len(self.file_entries), self._root.header.num_files)
+            raise kaitaistruct.ConsistencyError(u"header", self, self.header._parent)
+        if len(self.file_entries) != self._root.header.num_files:
+            raise kaitaistruct.ConsistencyError(u"file_entries", self._root.header.num_files, len(self.file_entries))
         for i in range(len(self.file_entries)):
             pass
             if self.file_entries[i]._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"file_entries", self.file_entries[i]._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"file_entries", self._root, self.file_entries[i]._root)
             if self.file_entries[i]._parent != self:
-                raise kaitaistruct.ConsistencyError(u"file_entries", self.file_entries[i]._parent, self)
+                raise kaitaistruct.ConsistencyError(u"file_entries", self, self.file_entries[i]._parent)
 
-        if (len(self.padding) != (32760 - ((self._root.header.num_files * 80) % 32768))):
-            raise kaitaistruct.ConsistencyError(u"padding", len(self.padding), (32760 - ((self._root.header.num_files * 80) % 32768)))
+        if len(self.padding) != 32760 - (self._root.header.num_files * 80) % 32768:
+            raise kaitaistruct.ConsistencyError(u"padding", 32760 - (self._root.header.num_files * 80) % 32768, len(self.padding))
+        self._dirty = False
 
     class ArcHeader(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Arc.ArcHeader, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
             self.ident = self._io.read_bytes(4)
-            if not (self.ident == b"\x41\x52\x43\x00"):
+            if not self.ident == b"\x41\x52\x43\x00":
                 raise kaitaistruct.ValidationNotEqualError(b"\x41\x52\x43\x00", self.ident, self._io, u"/types/arc_header/seq/0")
             self.version = self._io.read_s2le()
             self.num_files = self._io.read_s2le()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -89,11 +93,11 @@ class Arc(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
-            if (len(self.ident) != 4):
-                raise kaitaistruct.ConsistencyError(u"ident", len(self.ident), 4)
-            if not (self.ident == b"\x41\x52\x43\x00"):
+            if len(self.ident) != 4:
+                raise kaitaistruct.ConsistencyError(u"ident", 4, len(self.ident))
+            if not self.ident == b"\x41\x52\x43\x00":
                 raise kaitaistruct.ValidationNotEqualError(b"\x41\x52\x43\x00", self.ident, None, u"/types/arc_header/seq/0")
+            self._dirty = False
 
         @property
         def size_(self):
@@ -108,29 +112,33 @@ class Arc(ReadWriteKaitaiStruct):
 
     class FileEntry(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Arc.FileEntry, self).__init__(_io)
             self._parent = _parent
             self._root = _root
             self._should_write_raw_data = False
-            self.raw_data__to_write = True
+            self.raw_data__enabled = True
 
         def _read(self):
-            self.file_path = (KaitaiStream.bytes_terminate(self._io.read_bytes(64), 0, False)).decode("ASCII")
+            self.file_path = (KaitaiStream.bytes_terminate(self._io.read_bytes(64), 0, False)).decode(u"ASCII")
             self.file_type = self._io.read_s4le()
             self.zsize = self._io.read_u4le()
             self.size = self._io.read_bits_int_le(29)
             self.flags = self._io.read_bits_int_le(3)
             self.offset = self._io.read_u4le()
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
             _ = self.raw_data
+            if hasattr(self, '_m_raw_data'):
+                pass
+
 
 
         def _write__seq(self, io=None):
             super(Arc.FileEntry, self)._write__seq(io)
-            self._should_write_raw_data = self.raw_data__to_write
+            self._should_write_raw_data = self.raw_data__enabled
             self._io.write_bytes_limit((self.file_path).encode(u"ASCII"), 64, 0, 0)
             self._io.write_s4le(self.file_type)
             self._io.write_u4le(self.zsize)
@@ -140,11 +148,16 @@ class Arc(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
-            if (len((self.file_path).encode(u"ASCII")) > 64):
-                raise kaitaistruct.ConsistencyError(u"file_path", len((self.file_path).encode(u"ASCII")), 64)
-            if (KaitaiStream.byte_array_index_of((self.file_path).encode(u"ASCII"), 0) != -1):
-                raise kaitaistruct.ConsistencyError(u"file_path", KaitaiStream.byte_array_index_of((self.file_path).encode(u"ASCII"), 0), -1)
+            if len((self.file_path).encode(u"ASCII")) > 64:
+                raise kaitaistruct.ConsistencyError(u"file_path", 64, len((self.file_path).encode(u"ASCII")))
+            if KaitaiStream.byte_array_index_of((self.file_path).encode(u"ASCII"), 0) != -1:
+                raise kaitaistruct.ConsistencyError(u"file_path", -1, KaitaiStream.byte_array_index_of((self.file_path).encode(u"ASCII"), 0))
+            if self.raw_data__enabled:
+                pass
+                if len(self._m_raw_data) != self.zsize:
+                    raise kaitaistruct.ConsistencyError(u"raw_data", self.zsize, len(self._m_raw_data))
+
+            self._dirty = False
 
         @property
         def raw_data(self):
@@ -152,6 +165,9 @@ class Arc(ReadWriteKaitaiStruct):
                 self._write_raw_data()
             if hasattr(self, '_m_raw_data'):
                 return self._m_raw_data
+
+            if not self.raw_data__enabled:
+                return None
 
             io = self._root._io
             _pos = io.pos()
@@ -162,6 +178,7 @@ class Arc(ReadWriteKaitaiStruct):
 
         @raw_data.setter
         def raw_data(self, v):
+            self._dirty = True
             self._m_raw_data = v
 
         def _write_raw_data(self):
@@ -169,14 +186,8 @@ class Arc(ReadWriteKaitaiStruct):
             io = self._root._io
             _pos = io.pos()
             io.seek(self.offset)
-            io.write_bytes(self.raw_data)
+            io.write_bytes(self._m_raw_data)
             io.seek(_pos)
-
-
-        def _check_raw_data(self):
-            pass
-            if (len(self.raw_data) != self.zsize):
-                raise kaitaistruct.ConsistencyError(u"raw_data", len(self.raw_data), self.zsize)
 
 
 

--- a/albam/engines/mtfw/structs/lmt.ksy
+++ b/albam/engines/mtfw/structs/lmt.ksy
@@ -2,7 +2,7 @@ meta:
   endian: le
   file-extension: lmt
   id: lmt
-  ks-version: 0.10
+  ks-version: '0.11'
   title: MTFramework animation format
 
 

--- a/albam/engines/mtfw/structs/lmt.py
+++ b/albam/engines/mtfw/structs/lmt.py
@@ -1,18 +1,18 @@
 # This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
+# type: ignore
 
 import kaitaistruct
-from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
+from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
 
 
-if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 11):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.11 or later is required, but you have %s" % (kaitaistruct.__version__))
 
-class Lmt(KaitaiStruct):
-    def __init__(self, _io, _parent=None, _root=None):
-        self._io = _io
+class Lmt(ReadWriteKaitaiStruct):
+    def __init__(self, _io=None, _parent=None, _root=None):
+        super(Lmt, self).__init__(_io)
         self._parent = _parent
-        self._root = _root if _root else self
-        self._read()
+        self._root = _root or self
 
     def _read(self):
         self.id_magic = self._io.read_bytes(4)
@@ -22,61 +22,113 @@ class Lmt(KaitaiStruct):
         self.num_block_offsets = self._io.read_u2le()
         self.block_offsets = []
         for i in range(self.num_block_offsets):
-            self.block_offsets.append(Lmt.BlockOffset(self._io, self, self._root))
+            _t_block_offsets = Lmt.BlockOffset(self._io, self, self._root)
+            try:
+                _t_block_offsets._read()
+            finally:
+                self.block_offsets.append(_t_block_offsets)
+
+        self._dirty = False
 
 
-    class Atk(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+    def _fetch_instances(self):
+        pass
+        for i in range(len(self.block_offsets)):
+            pass
+            self.block_offsets[i]._fetch_instances()
+
+
+
+    def _write__seq(self, io=None):
+        super(Lmt, self)._write__seq(io)
+        self._io.write_bytes(self.id_magic)
+        self._io.write_u2le(self.version)
+        self._io.write_u2le(self.num_block_offsets)
+        for i in range(len(self.block_offsets)):
+            pass
+            self.block_offsets[i]._write__seq(self._io)
+
+
+
+    def _check(self):
+        if len(self.id_magic) != 4:
+            raise kaitaistruct.ConsistencyError(u"id_magic", 4, len(self.id_magic))
+        if not self.id_magic == b"\x4C\x4D\x54\x00":
+            raise kaitaistruct.ValidationNotEqualError(b"\x4C\x4D\x54\x00", self.id_magic, None, u"/seq/0")
+        if len(self.block_offsets) != self.num_block_offsets:
+            raise kaitaistruct.ConsistencyError(u"block_offsets", self.num_block_offsets, len(self.block_offsets))
+        for i in range(len(self.block_offsets)):
+            pass
+            if self.block_offsets[i]._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"block_offsets", self._root, self.block_offsets[i]._root)
+            if self.block_offsets[i]._parent != self:
+                raise kaitaistruct.ConsistencyError(u"block_offsets", self, self.block_offsets[i]._parent)
+
+        self._dirty = False
+
+    class Atk(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Lmt.Atk, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
 
         def _read(self):
             self.unk_00 = self._io.read_u4le()
             self.duration = self._io.read_u4le()
+            self._dirty = False
 
 
-    class BlockOffset(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Lmt.Atk, self)._write__seq(io)
+            self._io.write_u4le(self.unk_00)
+            self._io.write_u4le(self.duration)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Atk2(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Lmt.Atk2, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
 
         def _read(self):
-            self.offset = self._io.read_u4le()
-
-        @property
-        def lmt_ver(self):
-            if hasattr(self, '_m_lmt_ver'):
-                return self._m_lmt_ver
-
-            self._m_lmt_ver = self._parent.version
-            return getattr(self, '_m_lmt_ver', None)
-
-        @property
-        def block_header(self):
-            if hasattr(self, '_m_block_header'):
-                return self._m_block_header
-
-            _pos = self._io.pos()
-            self._io.seek(self.offset)
-            _on = self.lmt_ver
-            if _on == 51:
-                self._m_block_header = Lmt.BlockHeader51(self._io, self, self._root)
-            elif _on == 67:
-                self._m_block_header = Lmt.BlockHeader67(self._io, self, self._root)
-            self._io.seek(_pos)
-            return getattr(self, '_m_block_header', None)
+            self.unk_00 = self._io.read_u4le()
+            self.unk_01 = self._io.read_u4le()
+            self._dirty = False
 
 
-    class BlockHeader51(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Lmt.Atk2, self)._write__seq(io)
+            self._io.write_u4le(self.unk_00)
+            self._io.write_u4le(self.unk_01)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class BlockHeader51(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Lmt.BlockHeader51, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
+            self._should_write_atk_buff = False
+            self.atk_buff__enabled = True
+            self._should_write_atk_buff2 = False
+            self.atk_buff2__enabled = True
+            self._should_write_tracks = False
+            self.tracks__enabled = True
 
         def _read(self):
             self.ofs_frame = self._io.read_u4le()
@@ -98,68 +150,592 @@ class Lmt(KaitaiStruct):
 
             self.count_02 = self._io.read_u4le()
             self.ofs_buffer_02 = self._io.read_u4le()
+            self._dirty = False
 
-        @property
-        def tracks(self):
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.unk_01)):
+                pass
+
+            for i in range(len(self.unk_02)):
+                pass
+
+            for i in range(len(self.sfx)):
+                pass
+
+            _ = self.atk_buff
+            if hasattr(self, '_m_atk_buff'):
+                pass
+                for i in range(len(self._m_atk_buff)):
+                    pass
+                    self._m_atk_buff[i]._fetch_instances()
+
+
+            _ = self.atk_buff2
+            if hasattr(self, '_m_atk_buff2'):
+                pass
+                for i in range(len(self._m_atk_buff2)):
+                    pass
+                    self._m_atk_buff2[i]._fetch_instances()
+
+
+            _ = self.tracks
             if hasattr(self, '_m_tracks'):
-                return self._m_tracks
+                pass
+                for i in range(len(self._m_tracks)):
+                    pass
+                    self._m_tracks[i]._fetch_instances()
 
-            _pos = self._io.pos()
-            self._io.seek(self.ofs_frame)
-            self._m_tracks = []
-            for i in range(self.num_tracks):
-                self._m_tracks.append(Lmt.Track51(self._io, self, self._root))
 
-            self._io.seek(_pos)
-            return getattr(self, '_m_tracks', None)
+
+
+        def _write__seq(self, io=None):
+            super(Lmt.BlockHeader51, self)._write__seq(io)
+            self._should_write_atk_buff = self.atk_buff__enabled
+            self._should_write_atk_buff2 = self.atk_buff2__enabled
+            self._should_write_tracks = self.tracks__enabled
+            self._io.write_u4le(self.ofs_frame)
+            self._io.write_u4le(self.num_tracks)
+            self._io.write_u4le(self.num_frames)
+            for i in range(len(self.unk_01)):
+                pass
+                self._io.write_f4le(self.unk_01[i])
+
+            for i in range(len(self.unk_02)):
+                pass
+                self._io.write_u4le(self.unk_02[i])
+
+            self._io.write_u4le(self.count_01)
+            self._io.write_u4le(self.ofs_buffer_01)
+            for i in range(len(self.sfx)):
+                pass
+                self._io.write_u2le(self.sfx[i])
+
+            self._io.write_u4le(self.count_02)
+            self._io.write_u4le(self.ofs_buffer_02)
+
+
+        def _check(self):
+            if len(self.unk_01) != 9:
+                raise kaitaistruct.ConsistencyError(u"unk_01", 9, len(self.unk_01))
+            for i in range(len(self.unk_01)):
+                pass
+
+            if len(self.unk_02) != 16:
+                raise kaitaistruct.ConsistencyError(u"unk_02", 16, len(self.unk_02))
+            for i in range(len(self.unk_02)):
+                pass
+
+            if len(self.sfx) != 32:
+                raise kaitaistruct.ConsistencyError(u"sfx", 32, len(self.sfx))
+            for i in range(len(self.sfx)):
+                pass
+
+            if self.atk_buff__enabled:
+                pass
+                if len(self._m_atk_buff) != self.count_01:
+                    raise kaitaistruct.ConsistencyError(u"atk_buff", self.count_01, len(self._m_atk_buff))
+                for i in range(len(self._m_atk_buff)):
+                    pass
+                    if self._m_atk_buff[i]._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"atk_buff", self._root, self._m_atk_buff[i]._root)
+                    if self._m_atk_buff[i]._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"atk_buff", self, self._m_atk_buff[i]._parent)
+
+
+            if self.atk_buff2__enabled:
+                pass
+                if len(self._m_atk_buff2) != self.count_02:
+                    raise kaitaistruct.ConsistencyError(u"atk_buff2", self.count_02, len(self._m_atk_buff2))
+                for i in range(len(self._m_atk_buff2)):
+                    pass
+                    if self._m_atk_buff2[i]._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"atk_buff2", self._root, self._m_atk_buff2[i]._root)
+                    if self._m_atk_buff2[i]._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"atk_buff2", self, self._m_atk_buff2[i]._parent)
+
+
+            if self.tracks__enabled:
+                pass
+                if len(self._m_tracks) != self.num_tracks:
+                    raise kaitaistruct.ConsistencyError(u"tracks", self.num_tracks, len(self._m_tracks))
+                for i in range(len(self._m_tracks)):
+                    pass
+                    if self._m_tracks[i]._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"tracks", self._root, self._m_tracks[i]._root)
+                    if self._m_tracks[i]._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"tracks", self, self._m_tracks[i]._parent)
+
+
+            self._dirty = False
 
         @property
         def atk_buff(self):
+            if self._should_write_atk_buff:
+                self._write_atk_buff()
             if hasattr(self, '_m_atk_buff'):
                 return self._m_atk_buff
+
+            if not self.atk_buff__enabled:
+                return None
 
             _pos = self._io.pos()
             self._io.seek(self.ofs_buffer_01)
             self._m_atk_buff = []
             for i in range(self.count_01):
-                self._m_atk_buff.append(Lmt.Atk(self._io, self, self._root))
+                _t__m_atk_buff = Lmt.Atk(self._io, self, self._root)
+                try:
+                    _t__m_atk_buff._read()
+                finally:
+                    self._m_atk_buff.append(_t__m_atk_buff)
 
             self._io.seek(_pos)
             return getattr(self, '_m_atk_buff', None)
 
+        @atk_buff.setter
+        def atk_buff(self, v):
+            self._dirty = True
+            self._m_atk_buff = v
+
+        def _write_atk_buff(self):
+            self._should_write_atk_buff = False
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_buffer_01)
+            for i in range(len(self._m_atk_buff)):
+                pass
+                self._m_atk_buff[i]._write__seq(self._io)
+
+            self._io.seek(_pos)
+
         @property
         def atk_buff2(self):
+            if self._should_write_atk_buff2:
+                self._write_atk_buff2()
             if hasattr(self, '_m_atk_buff2'):
                 return self._m_atk_buff2
+
+            if not self.atk_buff2__enabled:
+                return None
 
             _pos = self._io.pos()
             self._io.seek(self.ofs_buffer_02)
             self._m_atk_buff2 = []
             for i in range(self.count_02):
-                self._m_atk_buff2.append(Lmt.Atk2(self._io, self, self._root))
+                _t__m_atk_buff2 = Lmt.Atk2(self._io, self, self._root)
+                try:
+                    _t__m_atk_buff2._read()
+                finally:
+                    self._m_atk_buff2.append(_t__m_atk_buff2)
 
             self._io.seek(_pos)
             return getattr(self, '_m_atk_buff2', None)
 
+        @atk_buff2.setter
+        def atk_buff2(self, v):
+            self._dirty = True
+            self._m_atk_buff2 = v
 
-    class Atk2(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+        def _write_atk_buff2(self):
+            self._should_write_atk_buff2 = False
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_buffer_02)
+            for i in range(len(self._m_atk_buff2)):
+                pass
+                self._m_atk_buff2[i]._write__seq(self._io)
+
+            self._io.seek(_pos)
+
+        @property
+        def tracks(self):
+            if self._should_write_tracks:
+                self._write_tracks()
+            if hasattr(self, '_m_tracks'):
+                return self._m_tracks
+
+            if not self.tracks__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_frame)
+            self._m_tracks = []
+            for i in range(self.num_tracks):
+                _t__m_tracks = Lmt.Track51(self._io, self, self._root)
+                try:
+                    _t__m_tracks._read()
+                finally:
+                    self._m_tracks.append(_t__m_tracks)
+
+            self._io.seek(_pos)
+            return getattr(self, '_m_tracks', None)
+
+        @tracks.setter
+        def tracks(self, v):
+            self._dirty = True
+            self._m_tracks = v
+
+        def _write_tracks(self):
+            self._should_write_tracks = False
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_frame)
+            for i in range(len(self._m_tracks)):
+                pass
+                self._m_tracks[i]._write__seq(self._io)
+
+            self._io.seek(_pos)
+
+
+    class BlockHeader67(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Lmt.BlockHeader67, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
+            self._should_write_tracks = False
+            self.tracks__enabled = True
 
         def _read(self):
+            self.ofs_frame = self._io.read_u4le()
+            self.num_tracks = self._io.read_u4le()
+            self.num_frames = self._io.read_u4le()
+            self.loop_frame = self._io.read_u4le()
+            self.unk_floats = []
+            for i in range(8):
+                self.unk_floats.append(self._io.read_f4le())
+
             self.unk_00 = self._io.read_u4le()
-            self.unk_01 = self._io.read_u4le()
+            self.ofs_buffer_1 = self._io.read_u4le()
+            self.ofs_buffer_2 = self._io.read_u4le()
+            self._dirty = False
 
 
-    class Track51(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.unk_floats)):
+                pass
+
+            _ = self.tracks
+            if hasattr(self, '_m_tracks'):
+                pass
+                for i in range(len(self._m_tracks)):
+                    pass
+                    self._m_tracks[i]._fetch_instances()
+
+
+
+
+        def _write__seq(self, io=None):
+            super(Lmt.BlockHeader67, self)._write__seq(io)
+            self._should_write_tracks = self.tracks__enabled
+            self._io.write_u4le(self.ofs_frame)
+            self._io.write_u4le(self.num_tracks)
+            self._io.write_u4le(self.num_frames)
+            self._io.write_u4le(self.loop_frame)
+            for i in range(len(self.unk_floats)):
+                pass
+                self._io.write_f4le(self.unk_floats[i])
+
+            self._io.write_u4le(self.unk_00)
+            self._io.write_u4le(self.ofs_buffer_1)
+            self._io.write_u4le(self.ofs_buffer_2)
+
+
+        def _check(self):
+            if len(self.unk_floats) != 8:
+                raise kaitaistruct.ConsistencyError(u"unk_floats", 8, len(self.unk_floats))
+            for i in range(len(self.unk_floats)):
+                pass
+
+            if self.tracks__enabled:
+                pass
+                if len(self._m_tracks) != self.num_tracks:
+                    raise kaitaistruct.ConsistencyError(u"tracks", self.num_tracks, len(self._m_tracks))
+                for i in range(len(self._m_tracks)):
+                    pass
+                    if self._m_tracks[i]._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"tracks", self._root, self._m_tracks[i]._root)
+                    if self._m_tracks[i]._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"tracks", self, self._m_tracks[i]._parent)
+
+
+            self._dirty = False
+
+        @property
+        def tracks(self):
+            if self._should_write_tracks:
+                self._write_tracks()
+            if hasattr(self, '_m_tracks'):
+                return self._m_tracks
+
+            if not self.tracks__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_frame)
+            self._m_tracks = []
+            for i in range(self.num_tracks):
+                _t__m_tracks = Lmt.Track67(self._io, self, self._root)
+                try:
+                    _t__m_tracks._read()
+                finally:
+                    self._m_tracks.append(_t__m_tracks)
+
+            self._io.seek(_pos)
+            return getattr(self, '_m_tracks', None)
+
+        @tracks.setter
+        def tracks(self, v):
+            self._dirty = True
+            self._m_tracks = v
+
+        def _write_tracks(self):
+            self._should_write_tracks = False
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_frame)
+            for i in range(len(self._m_tracks)):
+                pass
+                self._m_tracks[i]._write__seq(self._io)
+
+            self._io.seek(_pos)
+
+
+    class BlockOffset(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Lmt.BlockOffset, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
+            self._should_write_block_header = False
+            self.block_header__enabled = True
+
+        def _read(self):
+            self.offset = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.block_header
+            if hasattr(self, '_m_block_header'):
+                pass
+                _on = self.lmt_ver
+                if _on == 51:
+                    pass
+                    self._m_block_header._fetch_instances()
+                elif _on == 67:
+                    pass
+                    self._m_block_header._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Lmt.BlockOffset, self)._write__seq(io)
+            self._should_write_block_header = self.block_header__enabled
+            self._io.write_u4le(self.offset)
+
+
+        def _check(self):
+            if self.block_header__enabled:
+                pass
+                _on = self.lmt_ver
+                if _on == 51:
+                    pass
+                    if self._m_block_header._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"block_header", self._root, self._m_block_header._root)
+                    if self._m_block_header._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"block_header", self, self._m_block_header._parent)
+                elif _on == 67:
+                    pass
+                    if self._m_block_header._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"block_header", self._root, self._m_block_header._root)
+                    if self._m_block_header._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"block_header", self, self._m_block_header._parent)
+
+            self._dirty = False
+
+        @property
+        def block_header(self):
+            if self._should_write_block_header:
+                self._write_block_header()
+            if hasattr(self, '_m_block_header'):
+                return self._m_block_header
+
+            if not self.block_header__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self.offset)
+            _on = self.lmt_ver
+            if _on == 51:
+                pass
+                self._m_block_header = Lmt.BlockHeader51(self._io, self, self._root)
+                self._m_block_header._read()
+            elif _on == 67:
+                pass
+                self._m_block_header = Lmt.BlockHeader67(self._io, self, self._root)
+                self._m_block_header._read()
+            self._io.seek(_pos)
+            return getattr(self, '_m_block_header', None)
+
+        @block_header.setter
+        def block_header(self, v):
+            self._dirty = True
+            self._m_block_header = v
+
+        def _write_block_header(self):
+            self._should_write_block_header = False
+            _pos = self._io.pos()
+            self._io.seek(self.offset)
+            _on = self.lmt_ver
+            if _on == 51:
+                pass
+                self._m_block_header._write__seq(self._io)
+            elif _on == 67:
+                pass
+                self._m_block_header._write__seq(self._io)
+            self._io.seek(_pos)
+
+        @property
+        def lmt_ver(self):
+            if hasattr(self, '_m_lmt_ver'):
+                return self._m_lmt_ver
+
+            self._m_lmt_ver = self._parent.version
+            return getattr(self, '_m_lmt_ver', None)
+
+        def _invalidate_lmt_ver(self):
+            del self._m_lmt_ver
+
+    class FloatBuffer(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Lmt.FloatBuffer, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.unk_00 = []
+            for i in range(8):
+                self.unk_00.append(self._io.read_f4le())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.unk_00)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Lmt.FloatBuffer, self)._write__seq(io)
+            for i in range(len(self.unk_00)):
+                pass
+                self._io.write_f4le(self.unk_00[i])
+
+
+
+        def _check(self):
+            if len(self.unk_00) != 8:
+                raise kaitaistruct.ConsistencyError(u"unk_00", 8, len(self.unk_00))
+            for i in range(len(self.unk_00)):
+                pass
+
+            self._dirty = False
+
+
+    class OfsFloatBuff(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Lmt.OfsFloatBuff, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_body = False
+            self.body__enabled = True
+
+        def _read(self):
+            self.ofs_buffer = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.body
+            if hasattr(self, '_m_body'):
+                pass
+                self._m_body._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Lmt.OfsFloatBuff, self)._write__seq(io)
+            self._should_write_body = self.body__enabled
+            self._io.write_u4le(self.ofs_buffer)
+
+
+        def _check(self):
+            if self.body__enabled:
+                pass
+                if self.is_exist != 0:
+                    pass
+                    if self._m_body._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"body", self._root, self._m_body._root)
+                    if self._m_body._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"body", self, self._m_body._parent)
+
+
+            self._dirty = False
+
+        @property
+        def body(self):
+            if self._should_write_body:
+                self._write_body()
+            if hasattr(self, '_m_body'):
+                return self._m_body
+
+            if not self.body__enabled:
+                return None
+
+            if self.is_exist != 0:
+                pass
+                _pos = self._io.pos()
+                self._io.seek(self.ofs_buffer)
+                self._m_body = Lmt.FloatBuffer(self._io, self, self._root)
+                self._m_body._read()
+                self._io.seek(_pos)
+
+            return getattr(self, '_m_body', None)
+
+        @body.setter
+        def body(self, v):
+            self._dirty = True
+            self._m_body = v
+
+        def _write_body(self):
+            self._should_write_body = False
+            if self.is_exist != 0:
+                pass
+                _pos = self._io.pos()
+                self._io.seek(self.ofs_buffer)
+                self._m_body._write__seq(self._io)
+                self._io.seek(_pos)
+
+
+        @property
+        def is_exist(self):
+            if hasattr(self, '_m_is_exist'):
+                return self._m_is_exist
+
+            self._m_is_exist = self.ofs_buffer
+            return getattr(self, '_m_is_exist', None)
+
+        def _invalidate_is_exist(self):
+            del self._m_is_exist
+
+    class Track51(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Lmt.Track51, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_data = False
+            self.data__enabled = True
 
         def _read(self):
             self.buffer_type = self._io.read_u1()
@@ -173,11 +749,58 @@ class Lmt(KaitaiStruct):
             for i in range(4):
                 self.unk_reference_data.append(self._io.read_f4le())
 
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.unk_reference_data)):
+                pass
+
+            _ = self.data
+            if hasattr(self, '_m_data'):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Lmt.Track51, self)._write__seq(io)
+            self._should_write_data = self.data__enabled
+            self._io.write_u1(self.buffer_type)
+            self._io.write_u1(self.usage)
+            self._io.write_u1(self.joint_type)
+            self._io.write_u1(self.bone_index)
+            self._io.write_f4le(self.unk_01)
+            self._io.write_u4le(self.len_data)
+            self._io.write_u4le(self.ofs_data)
+            for i in range(len(self.unk_reference_data)):
+                pass
+                self._io.write_f4le(self.unk_reference_data[i])
+
+
+
+        def _check(self):
+            if len(self.unk_reference_data) != 4:
+                raise kaitaistruct.ConsistencyError(u"unk_reference_data", 4, len(self.unk_reference_data))
+            for i in range(len(self.unk_reference_data)):
+                pass
+
+            if self.data__enabled:
+                pass
+                if len(self._m_data) != self.len_data:
+                    raise kaitaistruct.ConsistencyError(u"data", self.len_data, len(self._m_data))
+
+            self._dirty = False
 
         @property
         def data(self):
+            if self._should_write_data:
+                self._write_data()
             if hasattr(self, '_m_data'):
                 return self._m_data
+
+            if not self.data__enabled:
+                return None
 
             _pos = self._io.pos()
             self._io.seek(self.ofs_data)
@@ -185,59 +808,26 @@ class Lmt(KaitaiStruct):
             self._io.seek(_pos)
             return getattr(self, '_m_data', None)
 
+        @data.setter
+        def data(self, v):
+            self._dirty = True
+            self._m_data = v
 
-    class FloatBuffer(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+        def _write_data(self):
+            self._should_write_data = False
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_data)
+            self._io.write_bytes(self._m_data)
+            self._io.seek(_pos)
+
+
+    class Track67(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Lmt.Track67, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
-
-        def _read(self):
-            self.unk_00 = []
-            for i in range(8):
-                self.unk_00.append(self._io.read_f4le())
-
-
-
-    class OfsFloatBuff(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
-
-        def _read(self):
-            self.ofs_buffer = self._io.read_u4le()
-
-        @property
-        def is_exist(self):
-            if hasattr(self, '_m_is_exist'):
-                return self._m_is_exist
-
-            self._m_is_exist = self.ofs_buffer
-            return getattr(self, '_m_is_exist', None)
-
-        @property
-        def body(self):
-            if hasattr(self, '_m_body'):
-                return self._m_body
-
-            if self.is_exist != 0:
-                _pos = self._io.pos()
-                self._io.seek(self.ofs_buffer)
-                self._m_body = Lmt.FloatBuffer(self._io, self, self._root)
-                self._io.seek(_pos)
-
-            return getattr(self, '_m_body', None)
-
-
-    class Track67(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
+            self._should_write_data = False
+            self.data__enabled = True
 
         def _read(self):
             self.buffer_type = self._io.read_u1()
@@ -252,11 +842,65 @@ class Lmt(KaitaiStruct):
                 self.unk_reference_data.append(self._io.read_f4le())
 
             self.ofs_floats = Lmt.OfsFloatBuff(self._io, self, self._root)
+            self.ofs_floats._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.unk_reference_data)):
+                pass
+
+            self.ofs_floats._fetch_instances()
+            _ = self.data
+            if hasattr(self, '_m_data'):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Lmt.Track67, self)._write__seq(io)
+            self._should_write_data = self.data__enabled
+            self._io.write_u1(self.buffer_type)
+            self._io.write_u1(self.usage)
+            self._io.write_u1(self.joint_type)
+            self._io.write_u1(self.bone_index)
+            self._io.write_f4le(self.weight)
+            self._io.write_u4le(self.len_data)
+            self._io.write_u4le(self.ofs_data)
+            for i in range(len(self.unk_reference_data)):
+                pass
+                self._io.write_f4le(self.unk_reference_data[i])
+
+            self.ofs_floats._write__seq(self._io)
+
+
+        def _check(self):
+            if len(self.unk_reference_data) != 4:
+                raise kaitaistruct.ConsistencyError(u"unk_reference_data", 4, len(self.unk_reference_data))
+            for i in range(len(self.unk_reference_data)):
+                pass
+
+            if self.ofs_floats._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"ofs_floats", self._root, self.ofs_floats._root)
+            if self.ofs_floats._parent != self:
+                raise kaitaistruct.ConsistencyError(u"ofs_floats", self, self.ofs_floats._parent)
+            if self.data__enabled:
+                pass
+                if len(self._m_data) != self.len_data:
+                    raise kaitaistruct.ConsistencyError(u"data", self.len_data, len(self._m_data))
+
+            self._dirty = False
 
         @property
         def data(self):
+            if self._should_write_data:
+                self._write_data()
             if hasattr(self, '_m_data'):
                 return self._m_data
+
+            if not self.data__enabled:
+                return None
 
             _pos = self._io.pos()
             self._io.seek(self.ofs_data)
@@ -264,40 +908,17 @@ class Lmt(KaitaiStruct):
             self._io.seek(_pos)
             return getattr(self, '_m_data', None)
 
+        @data.setter
+        def data(self, v):
+            self._dirty = True
+            self._m_data = v
 
-    class BlockHeader67(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
-
-        def _read(self):
-            self.ofs_frame = self._io.read_u4le()
-            self.num_tracks = self._io.read_u4le()
-            self.num_frames = self._io.read_u4le()
-            self.loop_frame = self._io.read_u4le()
-            self.unk_floats = []
-            for i in range(8):
-                self.unk_floats.append(self._io.read_f4le())
-
-            self.unk_00 = self._io.read_u4le()
-            self.ofs_buffer_1 = self._io.read_u4le()
-            self.ofs_buffer_2 = self._io.read_u4le()
-
-        @property
-        def tracks(self):
-            if hasattr(self, '_m_tracks'):
-                return self._m_tracks
-
+        def _write_data(self):
+            self._should_write_data = False
             _pos = self._io.pos()
-            self._io.seek(self.ofs_frame)
-            self._m_tracks = []
-            for i in range(self.num_tracks):
-                self._m_tracks.append(Lmt.Track67(self._io, self, self._root))
-
+            self._io.seek(self.ofs_data)
+            self._io.write_bytes(self._m_data)
             self._io.seek(_pos)
-            return getattr(self, '_m_tracks', None)
 
 
 

--- a/albam/engines/mtfw/structs/mfx.ksy
+++ b/albam/engines/mtfw/structs/mfx.ksy
@@ -3,7 +3,7 @@ meta:
   bit-endian: le
   file-extension: mfx
   id: mfx
-  ks-version: 0.10
+  ks-version: '0.11'
   title: MTFramework Shader List format
 seq:
   - {id: id_magic, contents: [77, 70, 88, 0]}

--- a/albam/engines/mtfw/structs/mfx.py
+++ b/albam/engines/mtfw/structs/mfx.py
@@ -1,18 +1,18 @@
 # This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
+# type: ignore
 
 import kaitaistruct
-from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
+from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
 
 
-if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 11):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.11 or later is required, but you have %s" % (kaitaistruct.__version__))
 
-class Mfx(KaitaiStruct):
-    def __init__(self, _io, _parent=None, _root=None):
-        self._io = _io
+class Mfx(ReadWriteKaitaiStruct):
+    def __init__(self, _io=None, _parent=None, _root=None):
+        super(Mfx, self).__init__(_io)
         self._parent = _parent
-        self._root = _root if _root else self
-        self._read()
+        self._root = _root or self
 
     def _read(self):
         self.id_magic = self._io.read_bytes(4)
@@ -26,15 +26,59 @@ class Mfx(KaitaiStruct):
         self.unk_04 = self._io.read_u4le()
         self.entry_pointers = []
         for i in range(self.num_entries):
-            self.entry_pointers.append(Mfx.MfxEntryPointer(self._io, self, self._root))
+            _t_entry_pointers = Mfx.MfxEntryPointer(self._io, self, self._root)
+            try:
+                _t_entry_pointers._read()
+            finally:
+                self.entry_pointers.append(_t_entry_pointers)
+
+        self._dirty = False
 
 
-    class Attr0(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+    def _fetch_instances(self):
+        pass
+        for i in range(len(self.entry_pointers)):
+            pass
+            self.entry_pointers[i]._fetch_instances()
+
+
+
+    def _write__seq(self, io=None):
+        super(Mfx, self)._write__seq(io)
+        self._io.write_bytes(self.id_magic)
+        self._io.write_u2le(self.unk_01)
+        self._io.write_u2le(self.unk_02)
+        self._io.write_u4le(self.unk_03)
+        self._io.write_u4le(self.num_entries)
+        self._io.write_u4le(self.offset_string_table)
+        self._io.write_u4le(self.unk_04)
+        for i in range(len(self.entry_pointers)):
+            pass
+            self.entry_pointers[i]._write__seq(self._io)
+
+
+
+    def _check(self):
+        if len(self.id_magic) != 4:
+            raise kaitaistruct.ConsistencyError(u"id_magic", 4, len(self.id_magic))
+        if not self.id_magic == b"\x4D\x46\x58\x00":
+            raise kaitaistruct.ValidationNotEqualError(b"\x4D\x46\x58\x00", self.id_magic, None, u"/seq/0")
+        if len(self.entry_pointers) != self.num_entries:
+            raise kaitaistruct.ConsistencyError(u"entry_pointers", self.num_entries, len(self.entry_pointers))
+        for i in range(len(self.entry_pointers)):
+            pass
+            if self.entry_pointers[i]._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"entry_pointers", self._root, self.entry_pointers[i]._root)
+            if self.entry_pointers[i]._parent != self:
+                raise kaitaistruct.ConsistencyError(u"entry_pointers", self, self.entry_pointers[i]._parent)
+
+        self._dirty = False
+
+    class Attr0(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mfx.Attr0, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
 
         def _read(self):
             self.unk_ofs = self._io.read_u4le()
@@ -42,97 +86,152 @@ class Mfx(KaitaiStruct):
             self.ofs_floats = self._io.read_u4le()
             self.body = []
             for i in range(self._parent.num_attributes0):
-                self.body.append(Mfx.MfxAttribute0(self._io, self, self._root))
+                _t_body = Mfx.MfxAttribute0(self._io, self, self._root)
+                try:
+                    _t_body._read()
+                finally:
+                    self.body.append(_t_body)
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.body)):
+                pass
+                self.body[i]._fetch_instances()
 
 
 
-    class SubAttr0(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+        def _write__seq(self, io=None):
+            super(Mfx.Attr0, self)._write__seq(io)
+            self._io.write_u4le(self.unk_ofs)
+            self._io.write_u4le(self.ofs_attr)
+            self._io.write_u4le(self.ofs_floats)
+            for i in range(len(self.body)):
+                pass
+                self.body[i]._write__seq(self._io)
+
+
+
+        def _check(self):
+            if len(self.body) != self._parent.num_attributes0:
+                raise kaitaistruct.ConsistencyError(u"body", self._parent.num_attributes0, len(self.body))
+            for i in range(len(self.body)):
+                pass
+                if self.body[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"body", self._root, self.body[i]._root)
+                if self.body[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"body", self, self.body[i]._parent)
+
+            self._dirty = False
+
+
+    class Attr8(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mfx.Attr8, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
-
-        def _read(self):
-            self.offset_name = self._io.read_u4le()
-            self.unk_00 = self._io.read_u4le()
-            self.base_off = self._io.read_bits_int_le(4)
-            self.instancing = self._io.read_bits_int_le(4)
-            self.unk = self._io.read_bits_int_le(8)
-            self.count = self._io.read_bits_int_le(8)
-            self.comp_count = self._io.read_bits_int_le(8)
-            self._io.align_to_byte()
-            self.unk_01 = self._io.read_u2le()
-            self.unk_02 = self._io.read_u2le()
-            self.unk_03 = self._io.read_u4le()
-            self.unk_ofs_00 = self._io.read_u4le()
-            self.unk_ofs_01 = self._io.read_u4le()
-
-        @property
-        def name(self):
-            if hasattr(self, '_m_name'):
-                return self._m_name
-
-            _pos = self._io.pos()
-            self._io.seek((self._root.offset_string_table + self.offset_name))
-            self._m_name = (self._io.read_bytes_term(0, False, True, True)).decode(u"ASCII")
-            self._io.seek(_pos)
-            return getattr(self, '_m_name', None)
-
-
-    class Attr8(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
 
         def _read(self):
             self.header = self._io.read_u4le()
             self.body = []
             for i in range(self._parent.num_attributes):
-                self.body.append(Mfx.MfxAttribute8(self._io, self, self._root))
+                _t_body = Mfx.MfxAttribute8(self._io, self, self._root)
+                try:
+                    _t_body._read()
+                finally:
+                    self.body.append(_t_body)
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.body)):
+                pass
+                self.body[i]._fetch_instances()
 
 
 
-    class MfxAttribute8(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+        def _write__seq(self, io=None):
+            super(Mfx.Attr8, self)._write__seq(io)
+            self._io.write_u4le(self.header)
+            for i in range(len(self.body)):
+                pass
+                self.body[i]._write__seq(self._io)
+
+
+
+        def _check(self):
+            if len(self.body) != self._parent.num_attributes:
+                raise kaitaistruct.ConsistencyError(u"body", self._parent.num_attributes, len(self.body))
+            for i in range(len(self.body)):
+                pass
+                if self.body[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"body", self._root, self.body[i]._root)
+                if self.body[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"body", self, self.body[i]._parent)
+
+            self._dirty = False
+
+
+    class Attr9(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mfx.Attr9, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
 
         def _read(self):
-            self.offset_name = self._io.read_u4le()
-            self.unk_01 = self._io.read_bits_int_le(6)
-            self.comp_type = self._io.read_bits_int_le(5)
-            self.comp_count = self._io.read_bits_int_le(11)
-            self.base_off = self._io.read_bits_int_le(9)
-            self.instancing = self._io.read_bits_int_le(1) != 0
-            self._io.align_to_byte()
-            self.unk_02 = []
-            for i in range(5):
-                self.unk_02.append(self._io.read_u4le())
+            self.header = self._io.read_u4le()
+            self.body = []
+            for i in range(self._parent.num_attributes):
+                _t_body = Mfx.MfxAttribute9(self._io, self, self._root)
+                try:
+                    _t_body._read()
+                finally:
+                    self.body.append(_t_body)
+
+            self._dirty = False
 
 
-        @property
-        def name(self):
-            if hasattr(self, '_m_name'):
-                return self._m_name
-
-            _pos = self._io.pos()
-            self._io.seek((self._root.offset_string_table + self.offset_name))
-            self._m_name = (self._io.read_bytes_term(0, False, True, True)).decode(u"ASCII")
-            self._io.seek(_pos)
-            return getattr(self, '_m_name', None)
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.body)):
+                pass
+                self.body[i]._fetch_instances()
 
 
-    class MfxAttribute0(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+
+        def _write__seq(self, io=None):
+            super(Mfx.Attr9, self)._write__seq(io)
+            self._io.write_u4le(self.header)
+            for i in range(len(self.body)):
+                pass
+                self.body[i]._write__seq(self._io)
+
+
+
+        def _check(self):
+            if len(self.body) != self._parent.num_attributes:
+                raise kaitaistruct.ConsistencyError(u"body", self._parent.num_attributes, len(self.body))
+            for i in range(len(self.body)):
+                pass
+                if self.body[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"body", self._root, self.body[i]._root)
+                if self.body[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"body", self, self.body[i]._parent)
+
+            self._dirty = False
+
+
+    class MfxAttribute0(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mfx.MfxAttribute0, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
+            self._should_write_name = False
+            self.name__enabled = True
 
         def _read(self):
             self.offset_name = self._io.read_u4le()
@@ -145,7 +244,6 @@ class Mfx(KaitaiStruct):
             self.instancing = self._io.read_bits_int_le(8)
             self.unk_bit = self._io.read_bits_int_le(8)
             self.comp_count = self._io.read_bits_int_le(8)
-            self._io.align_to_byte()
             self.unk_01 = self._io.read_u2le()
             self.unk_02 = self._io.read_u2le()
             self.unk_b00 = self._io.read_u1()
@@ -154,40 +252,93 @@ class Mfx(KaitaiStruct):
             self.sub_attr_num = self._io.read_u1()
             self.sub_attr_ofs = self._io.read_u4le()
             self.unk_ofs = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.unk_00)):
+                pass
+
+            _ = self.name
+            if hasattr(self, '_m_name'):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mfx.MfxAttribute0, self)._write__seq(io)
+            self._should_write_name = self.name__enabled
+            self._io.write_u4le(self.offset_name)
+            for i in range(len(self.unk_00)):
+                pass
+                self._io.write_u2le(self.unk_00[i])
+
+            self._io.write_bits_int_le(4, self.base_off)
+            self._io.write_bits_int_le(4, self.count)
+            self._io.write_bits_int_le(8, self.instancing)
+            self._io.write_bits_int_le(8, self.unk_bit)
+            self._io.write_bits_int_le(8, self.comp_count)
+            self._io.write_u2le(self.unk_01)
+            self._io.write_u2le(self.unk_02)
+            self._io.write_u1(self.unk_b00)
+            self._io.write_u1(self.float_buff_ofs)
+            self._io.write_u1(self.unk_b01)
+            self._io.write_u1(self.sub_attr_num)
+            self._io.write_u4le(self.sub_attr_ofs)
+            self._io.write_u4le(self.unk_ofs)
+
+
+        def _check(self):
+            if len(self.unk_00) != 2:
+                raise kaitaistruct.ConsistencyError(u"unk_00", 2, len(self.unk_00))
+            for i in range(len(self.unk_00)):
+                pass
+
+            if self.name__enabled:
+                pass
+                if KaitaiStream.byte_array_index_of((self._m_name).encode(u"ASCII"), 0) != -1:
+                    raise kaitaistruct.ConsistencyError(u"name", -1, KaitaiStream.byte_array_index_of((self._m_name).encode(u"ASCII"), 0))
+
+            self._dirty = False
 
         @property
         def name(self):
+            if self._should_write_name:
+                self._write_name()
             if hasattr(self, '_m_name'):
                 return self._m_name
 
+            if not self.name__enabled:
+                return None
+
             _pos = self._io.pos()
-            self._io.seek((self._root.offset_string_table + self.offset_name))
+            self._io.seek(self._root.offset_string_table + self.offset_name)
             self._m_name = (self._io.read_bytes_term(0, False, True, True)).decode(u"ASCII")
             self._io.seek(_pos)
             return getattr(self, '_m_name', None)
 
+        @name.setter
+        def name(self, v):
+            self._dirty = True
+            self._m_name = v
 
-    class Attr9(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+        def _write_name(self):
+            self._should_write_name = False
+            _pos = self._io.pos()
+            self._io.seek(self._root.offset_string_table + self.offset_name)
+            self._io.write_bytes((self._m_name).encode(u"ASCII"))
+            self._io.write_u1(0)
+            self._io.seek(_pos)
+
+
+    class MfxAttribute8(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mfx.MfxAttribute8, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
-
-        def _read(self):
-            self.header = self._io.read_u4le()
-            self.body = []
-            for i in range(self._parent.num_attributes):
-                self.body.append(Mfx.MfxAttribute9(self._io, self, self._root))
-
-
-
-    class MfxAttribute9(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
+            self._should_write_name = False
+            self.name__enabled = True
 
         def _read(self):
             self.offset_name = self._io.read_u4le()
@@ -196,25 +347,166 @@ class Mfx(KaitaiStruct):
             self.comp_count = self._io.read_bits_int_le(11)
             self.base_off = self._io.read_bits_int_le(9)
             self.instancing = self._io.read_bits_int_le(1) != 0
+            self.unk_02 = []
+            for i in range(5):
+                self.unk_02.append(self._io.read_u4le())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.unk_02)):
+                pass
+
+            _ = self.name
+            if hasattr(self, '_m_name'):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mfx.MfxAttribute8, self)._write__seq(io)
+            self._should_write_name = self.name__enabled
+            self._io.write_u4le(self.offset_name)
+            self._io.write_bits_int_le(6, self.unk_01)
+            self._io.write_bits_int_le(5, self.comp_type)
+            self._io.write_bits_int_le(11, self.comp_count)
+            self._io.write_bits_int_le(9, self.base_off)
+            self._io.write_bits_int_le(1, int(self.instancing))
+            for i in range(len(self.unk_02)):
+                pass
+                self._io.write_u4le(self.unk_02[i])
+
+
+
+        def _check(self):
+            if len(self.unk_02) != 5:
+                raise kaitaistruct.ConsistencyError(u"unk_02", 5, len(self.unk_02))
+            for i in range(len(self.unk_02)):
+                pass
+
+            if self.name__enabled:
+                pass
+                if KaitaiStream.byte_array_index_of((self._m_name).encode(u"ASCII"), 0) != -1:
+                    raise kaitaistruct.ConsistencyError(u"name", -1, KaitaiStream.byte_array_index_of((self._m_name).encode(u"ASCII"), 0))
+
+            self._dirty = False
 
         @property
         def name(self):
+            if self._should_write_name:
+                self._write_name()
             if hasattr(self, '_m_name'):
                 return self._m_name
 
+            if not self.name__enabled:
+                return None
+
             _pos = self._io.pos()
-            self._io.seek((self._root.offset_string_table + self.offset_name))
+            self._io.seek(self._root.offset_string_table + self.offset_name)
             self._m_name = (self._io.read_bytes_term(0, False, True, True)).decode(u"ASCII")
             self._io.seek(_pos)
             return getattr(self, '_m_name', None)
 
+        @name.setter
+        def name(self, v):
+            self._dirty = True
+            self._m_name = v
 
-    class MfxEntry(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+        def _write_name(self):
+            self._should_write_name = False
+            _pos = self._io.pos()
+            self._io.seek(self._root.offset_string_table + self.offset_name)
+            self._io.write_bytes((self._m_name).encode(u"ASCII"))
+            self._io.write_u1(0)
+            self._io.seek(_pos)
+
+
+    class MfxAttribute9(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mfx.MfxAttribute9, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
+            self._should_write_name = False
+            self.name__enabled = True
+
+        def _read(self):
+            self.offset_name = self._io.read_u4le()
+            self.unk_01 = self._io.read_bits_int_le(6)
+            self.comp_type = self._io.read_bits_int_le(5)
+            self.comp_count = self._io.read_bits_int_le(11)
+            self.base_off = self._io.read_bits_int_le(9)
+            self.instancing = self._io.read_bits_int_le(1) != 0
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.name
+            if hasattr(self, '_m_name'):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mfx.MfxAttribute9, self)._write__seq(io)
+            self._should_write_name = self.name__enabled
+            self._io.write_u4le(self.offset_name)
+            self._io.write_bits_int_le(6, self.unk_01)
+            self._io.write_bits_int_le(5, self.comp_type)
+            self._io.write_bits_int_le(11, self.comp_count)
+            self._io.write_bits_int_le(9, self.base_off)
+            self._io.write_bits_int_le(1, int(self.instancing))
+
+
+        def _check(self):
+            if self.name__enabled:
+                pass
+                if KaitaiStream.byte_array_index_of((self._m_name).encode(u"ASCII"), 0) != -1:
+                    raise kaitaistruct.ConsistencyError(u"name", -1, KaitaiStream.byte_array_index_of((self._m_name).encode(u"ASCII"), 0))
+
+            self._dirty = False
+
+        @property
+        def name(self):
+            if self._should_write_name:
+                self._write_name()
+            if hasattr(self, '_m_name'):
+                return self._m_name
+
+            if not self.name__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self._root.offset_string_table + self.offset_name)
+            self._m_name = (self._io.read_bytes_term(0, False, True, True)).decode(u"ASCII")
+            self._io.seek(_pos)
+            return getattr(self, '_m_name', None)
+
+        @name.setter
+        def name(self, v):
+            self._dirty = True
+            self._m_name = v
+
+        def _write_name(self):
+            self._should_write_name = False
+            _pos = self._io.pos()
+            self._io.seek(self._root.offset_string_table + self.offset_name)
+            self._io.write_bytes((self._m_name).encode(u"ASCII"))
+            self._io.write_u1(0)
+            self._io.seek(_pos)
+
+
+    class MfxEntry(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mfx.MfxEntry, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_friendly_name = False
+            self.friendly_name__enabled = True
+            self._should_write_name = False
+            self.name__enabled = True
 
         def _read(self):
             self.offset_string_1 = self._io.read_u4le()
@@ -222,7 +514,6 @@ class Mfx(KaitaiStruct):
             self.field_8_a = self._io.read_bits_int_le(6)
             self.field_8_b = self._io.read_bits_int_le(16)
             self.fill = self._io.read_bits_int_le(10)
-            self._io.align_to_byte()
             self.unk_01 = self._io.read_u2le()
             self.index = self._io.read_u2le()
             self.field_c = self._io.read_u4le()
@@ -231,56 +522,315 @@ class Mfx(KaitaiStruct):
             self.unk_02 = self._io.read_u1()
             self.num_attributes0 = self._io.read_u2le()
             _on = self.field_8_a
-            if _on == 8:
-                self.attributes = Mfx.Attr8(self._io, self, self._root)
-            elif _on == 9:
-                self.attributes = Mfx.Attr9(self._io, self, self._root)
-            elif _on == 0:
+            if _on == 0:
+                pass
                 self.attributes = Mfx.Attr0(self._io, self, self._root)
+                self.attributes._read()
+            elif _on == 8:
+                pass
+                self.attributes = Mfx.Attr8(self._io, self, self._root)
+                self.attributes._read()
+            elif _on == 9:
+                pass
+                self.attributes = Mfx.Attr9(self._io, self, self._root)
+                self.attributes._read()
+            self._dirty = False
 
-        @property
-        def name(self):
+
+        def _fetch_instances(self):
+            pass
+            _on = self.field_8_a
+            if _on == 0:
+                pass
+                self.attributes._fetch_instances()
+            elif _on == 8:
+                pass
+                self.attributes._fetch_instances()
+            elif _on == 9:
+                pass
+                self.attributes._fetch_instances()
+            _ = self.friendly_name
+            if hasattr(self, '_m_friendly_name'):
+                pass
+
+            _ = self.name
             if hasattr(self, '_m_name'):
-                return self._m_name
+                pass
 
-            _pos = self._io.pos()
-            self._io.seek((self._root.offset_string_table + self.offset_string_1))
-            self._m_name = (self._io.read_bytes_term(0, False, True, True)).decode(u"ASCII")
-            self._io.seek(_pos)
-            return getattr(self, '_m_name', None)
+
+
+        def _write__seq(self, io=None):
+            super(Mfx.MfxEntry, self)._write__seq(io)
+            self._should_write_friendly_name = self.friendly_name__enabled
+            self._should_write_name = self.name__enabled
+            self._io.write_u4le(self.offset_string_1)
+            self._io.write_u4le(self.offset_string_2)
+            self._io.write_bits_int_le(6, self.field_8_a)
+            self._io.write_bits_int_le(16, self.field_8_b)
+            self._io.write_bits_int_le(10, self.fill)
+            self._io.write_u2le(self.unk_01)
+            self._io.write_u2le(self.index)
+            self._io.write_u4le(self.field_c)
+            self._io.write_u4le(self.field_10)
+            self._io.write_u1(self.num_attributes)
+            self._io.write_u1(self.unk_02)
+            self._io.write_u2le(self.num_attributes0)
+            _on = self.field_8_a
+            if _on == 0:
+                pass
+                self.attributes._write__seq(self._io)
+            elif _on == 8:
+                pass
+                self.attributes._write__seq(self._io)
+            elif _on == 9:
+                pass
+                self.attributes._write__seq(self._io)
+
+
+        def _check(self):
+            _on = self.field_8_a
+            if _on == 0:
+                pass
+                if self.attributes._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"attributes", self._root, self.attributes._root)
+                if self.attributes._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"attributes", self, self.attributes._parent)
+            elif _on == 8:
+                pass
+                if self.attributes._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"attributes", self._root, self.attributes._root)
+                if self.attributes._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"attributes", self, self.attributes._parent)
+            elif _on == 9:
+                pass
+                if self.attributes._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"attributes", self._root, self.attributes._root)
+                if self.attributes._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"attributes", self, self.attributes._parent)
+            if self.friendly_name__enabled:
+                pass
+                if KaitaiStream.byte_array_index_of((self._m_friendly_name).encode(u"ASCII"), 0) != -1:
+                    raise kaitaistruct.ConsistencyError(u"friendly_name", -1, KaitaiStream.byte_array_index_of((self._m_friendly_name).encode(u"ASCII"), 0))
+
+            if self.name__enabled:
+                pass
+                if KaitaiStream.byte_array_index_of((self._m_name).encode(u"ASCII"), 0) != -1:
+                    raise kaitaistruct.ConsistencyError(u"name", -1, KaitaiStream.byte_array_index_of((self._m_name).encode(u"ASCII"), 0))
+
+            self._dirty = False
 
         @property
         def friendly_name(self):
+            if self._should_write_friendly_name:
+                self._write_friendly_name()
             if hasattr(self, '_m_friendly_name'):
                 return self._m_friendly_name
 
+            if not self.friendly_name__enabled:
+                return None
+
             _pos = self._io.pos()
-            self._io.seek((self._root.offset_string_table + self.offset_string_2))
+            self._io.seek(self._root.offset_string_table + self.offset_string_2)
             self._m_friendly_name = (self._io.read_bytes_term(0, False, True, True)).decode(u"ASCII")
             self._io.seek(_pos)
             return getattr(self, '_m_friendly_name', None)
 
+        @friendly_name.setter
+        def friendly_name(self, v):
+            self._dirty = True
+            self._m_friendly_name = v
 
-    class MfxEntryPointer(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+        def _write_friendly_name(self):
+            self._should_write_friendly_name = False
+            _pos = self._io.pos()
+            self._io.seek(self._root.offset_string_table + self.offset_string_2)
+            self._io.write_bytes((self._m_friendly_name).encode(u"ASCII"))
+            self._io.write_u1(0)
+            self._io.seek(_pos)
+
+        @property
+        def name(self):
+            if self._should_write_name:
+                self._write_name()
+            if hasattr(self, '_m_name'):
+                return self._m_name
+
+            if not self.name__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self._root.offset_string_table + self.offset_string_1)
+            self._m_name = (self._io.read_bytes_term(0, False, True, True)).decode(u"ASCII")
+            self._io.seek(_pos)
+            return getattr(self, '_m_name', None)
+
+        @name.setter
+        def name(self, v):
+            self._dirty = True
+            self._m_name = v
+
+        def _write_name(self):
+            self._should_write_name = False
+            _pos = self._io.pos()
+            self._io.seek(self._root.offset_string_table + self.offset_string_1)
+            self._io.write_bytes((self._m_name).encode(u"ASCII"))
+            self._io.write_u1(0)
+            self._io.seek(_pos)
+
+
+    class MfxEntryPointer(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mfx.MfxEntryPointer, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
+            self._should_write_mfx_entry = False
+            self.mfx_entry__enabled = True
 
         def _read(self):
             self.offset = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.mfx_entry
+            if hasattr(self, '_m_mfx_entry'):
+                pass
+                self._m_mfx_entry._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Mfx.MfxEntryPointer, self)._write__seq(io)
+            self._should_write_mfx_entry = self.mfx_entry__enabled
+            self._io.write_u4le(self.offset)
+
+
+        def _check(self):
+            if self.mfx_entry__enabled:
+                pass
+                if self._m_mfx_entry._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"mfx_entry", self._root, self._m_mfx_entry._root)
+                if self._m_mfx_entry._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"mfx_entry", self, self._m_mfx_entry._parent)
+
+            self._dirty = False
 
         @property
         def mfx_entry(self):
+            if self._should_write_mfx_entry:
+                self._write_mfx_entry()
             if hasattr(self, '_m_mfx_entry'):
                 return self._m_mfx_entry
+
+            if not self.mfx_entry__enabled:
+                return None
 
             _pos = self._io.pos()
             self._io.seek(self.offset)
             self._m_mfx_entry = Mfx.MfxEntry(self._io, self, self._root)
+            self._m_mfx_entry._read()
             self._io.seek(_pos)
             return getattr(self, '_m_mfx_entry', None)
+
+        @mfx_entry.setter
+        def mfx_entry(self, v):
+            self._dirty = True
+            self._m_mfx_entry = v
+
+        def _write_mfx_entry(self):
+            self._should_write_mfx_entry = False
+            _pos = self._io.pos()
+            self._io.seek(self.offset)
+            self._m_mfx_entry._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    class SubAttr0(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mfx.SubAttr0, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_name = False
+            self.name__enabled = True
+
+        def _read(self):
+            self.offset_name = self._io.read_u4le()
+            self.unk_00 = self._io.read_u4le()
+            self.base_off = self._io.read_bits_int_le(4)
+            self.instancing = self._io.read_bits_int_le(4)
+            self.unk = self._io.read_bits_int_le(8)
+            self.count = self._io.read_bits_int_le(8)
+            self.comp_count = self._io.read_bits_int_le(8)
+            self.unk_01 = self._io.read_u2le()
+            self.unk_02 = self._io.read_u2le()
+            self.unk_03 = self._io.read_u4le()
+            self.unk_ofs_00 = self._io.read_u4le()
+            self.unk_ofs_01 = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.name
+            if hasattr(self, '_m_name'):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mfx.SubAttr0, self)._write__seq(io)
+            self._should_write_name = self.name__enabled
+            self._io.write_u4le(self.offset_name)
+            self._io.write_u4le(self.unk_00)
+            self._io.write_bits_int_le(4, self.base_off)
+            self._io.write_bits_int_le(4, self.instancing)
+            self._io.write_bits_int_le(8, self.unk)
+            self._io.write_bits_int_le(8, self.count)
+            self._io.write_bits_int_le(8, self.comp_count)
+            self._io.write_u2le(self.unk_01)
+            self._io.write_u2le(self.unk_02)
+            self._io.write_u4le(self.unk_03)
+            self._io.write_u4le(self.unk_ofs_00)
+            self._io.write_u4le(self.unk_ofs_01)
+
+
+        def _check(self):
+            if self.name__enabled:
+                pass
+                if KaitaiStream.byte_array_index_of((self._m_name).encode(u"ASCII"), 0) != -1:
+                    raise kaitaistruct.ConsistencyError(u"name", -1, KaitaiStream.byte_array_index_of((self._m_name).encode(u"ASCII"), 0))
+
+            self._dirty = False
+
+        @property
+        def name(self):
+            if self._should_write_name:
+                self._write_name()
+            if hasattr(self, '_m_name'):
+                return self._m_name
+
+            if not self.name__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self._root.offset_string_table + self.offset_name)
+            self._m_name = (self._io.read_bytes_term(0, False, True, True)).decode(u"ASCII")
+            self._io.seek(_pos)
+            return getattr(self, '_m_name', None)
+
+        @name.setter
+        def name(self, v):
+            self._dirty = True
+            self._m_name = v
+
+        def _write_name(self):
+            self._should_write_name = False
+            _pos = self._io.pos()
+            self._io.seek(self._root.offset_string_table + self.offset_name)
+            self._io.write_bytes((self._m_name).encode(u"ASCII"))
+            self._io.write_u1(0)
+            self._io.seek(_pos)
 
 
 

--- a/albam/engines/mtfw/structs/mod-153.ksy
+++ b/albam/engines/mtfw/structs/mod-153.ksy
@@ -3,7 +3,7 @@ meta:
   bit-endian: le
   file-extension: mod
   id: mod_153
-  ks-version: 0.10
+  ks-version: '0.11'
   title: MTFramework model format 153
 
 seq:

--- a/albam/engines/mtfw/structs/mod-156.ksy
+++ b/albam/engines/mtfw/structs/mod-156.ksy
@@ -3,7 +3,7 @@ meta:
   bit-endian: le
   file-extension: mod
   id: mod_156
-  ks-version: 0.11
+  ks-version: '0.11'
   title: MTFramework model format 156
 
 seq:

--- a/albam/engines/mtfw/structs/mod-21.ksy
+++ b/albam/engines/mtfw/structs/mod-21.ksy
@@ -3,7 +3,7 @@ meta:
   bit-endian: le
   file-extension: mod
   id: mod_21
-  ks-version: 0.11
+  ks-version: '0.11'
   title: MTFramework model format 210 and 211
 
 seq:

--- a/albam/engines/mtfw/structs/mod_153.py
+++ b/albam/engines/mtfw/structs/mod_153.py
@@ -5,28 +5,28 @@ import kaitaistruct
 from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
 
 
-if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 11):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.11 or later is required, but you have %s" % (kaitaistruct.__version__))
 
 class Mod153(ReadWriteKaitaiStruct):
     def __init__(self, _io=None, _parent=None, _root=None):
-        self._io = _io
+        super(Mod153, self).__init__(_io)
         self._parent = _parent
-        self._root = _root if _root else self
-        self._should_write_vertex_buffer = False
-        self.vertex_buffer__to_write = True
-        self._should_write_materials_data = False
-        self.materials_data__to_write = True
-        self._should_write_vertex_buffer_2 = False
-        self.vertex_buffer_2__to_write = True
-        self._should_write_meshes_data = False
-        self.meshes_data__to_write = True
-        self._should_write_index_buffer = False
-        self.index_buffer__to_write = True
+        self._root = _root or self
         self._should_write_bones_data = False
-        self.bones_data__to_write = True
+        self.bones_data__enabled = True
         self._should_write_groups = False
-        self.groups__to_write = True
+        self.groups__enabled = True
+        self._should_write_index_buffer = False
+        self.index_buffer__enabled = True
+        self._should_write_materials_data = False
+        self.materials_data__enabled = True
+        self._should_write_meshes_data = False
+        self.meshes_data__enabled = True
+        self._should_write_vertex_buffer = False
+        self.vertex_buffer__enabled = True
+        self._should_write_vertex_buffer_2 = False
+        self.vertex_buffer_2__enabled = True
 
     def _read(self):
         self.header = Mod153.ModHeader(self._io, self, self._root)
@@ -41,6 +41,7 @@ class Mod153(ReadWriteKaitaiStruct):
         self.bbox_max._read()
         self.model_info = Mod153.ModelInfo(self._io, self, self._root)
         self.model_info._read()
+        self._dirty = False
 
 
     def _fetch_instances(self):
@@ -50,49 +51,52 @@ class Mod153(ReadWriteKaitaiStruct):
         self.bbox_min._fetch_instances()
         self.bbox_max._fetch_instances()
         self.model_info._fetch_instances()
-        if (self.header.offset_vertex_buffer > 0):
+        _ = self.bones_data
+        if hasattr(self, '_m_bones_data'):
             pass
-            _ = self.vertex_buffer
-
-        if (self.header.offset_materials_data > 0):
-            pass
-            _ = self.materials_data
-            self.materials_data._fetch_instances()
-
-        if (self.header.offset_vertex_buffer_2 > 0):
-            pass
-            _ = self.vertex_buffer_2
-
-        if (self.header.offset_meshes_data > 0):
-            pass
-            _ = self.meshes_data
-            self.meshes_data._fetch_instances()
-
-        if (self.header.offset_index_buffer > 0):
-            pass
-            _ = self.index_buffer
-
-        if (self.header.num_bones != 0):
-            pass
-            _ = self.bones_data
-            self.bones_data._fetch_instances()
+            self._m_bones_data._fetch_instances()
 
         _ = self.groups
-        for i in range(len(self._m_groups)):
+        if hasattr(self, '_m_groups'):
             pass
-            self.groups[i]._fetch_instances()
+            for i in range(len(self._m_groups)):
+                pass
+                self._m_groups[i]._fetch_instances()
+
+
+        _ = self.index_buffer
+        if hasattr(self, '_m_index_buffer'):
+            pass
+
+        _ = self.materials_data
+        if hasattr(self, '_m_materials_data'):
+            pass
+            self._m_materials_data._fetch_instances()
+
+        _ = self.meshes_data
+        if hasattr(self, '_m_meshes_data'):
+            pass
+            self._m_meshes_data._fetch_instances()
+
+        _ = self.vertex_buffer
+        if hasattr(self, '_m_vertex_buffer'):
+            pass
+
+        _ = self.vertex_buffer_2
+        if hasattr(self, '_m_vertex_buffer_2'):
+            pass
 
 
 
     def _write__seq(self, io=None):
         super(Mod153, self)._write__seq(io)
-        self._should_write_vertex_buffer = self.vertex_buffer__to_write
-        self._should_write_materials_data = self.materials_data__to_write
-        self._should_write_vertex_buffer_2 = self.vertex_buffer_2__to_write
-        self._should_write_meshes_data = self.meshes_data__to_write
-        self._should_write_index_buffer = self.index_buffer__to_write
-        self._should_write_bones_data = self.bones_data__to_write
-        self._should_write_groups = self.groups__to_write
+        self._should_write_bones_data = self.bones_data__enabled
+        self._should_write_groups = self.groups__enabled
+        self._should_write_index_buffer = self.index_buffer__enabled
+        self._should_write_materials_data = self.materials_data__enabled
+        self._should_write_meshes_data = self.meshes_data__enabled
+        self._should_write_vertex_buffer = self.vertex_buffer__enabled
+        self._should_write_vertex_buffer_2 = self.vertex_buffer_2__enabled
         self.header._write__seq(self._io)
         self._io.write_u4le(self.reserved_01)
         self._io.write_u4le(self.reserved_02)
@@ -103,554 +107,97 @@ class Mod153(ReadWriteKaitaiStruct):
 
 
     def _check(self):
-        pass
         if self.header._root != self._root:
-            raise kaitaistruct.ConsistencyError(u"header", self.header._root, self._root)
+            raise kaitaistruct.ConsistencyError(u"header", self._root, self.header._root)
         if self.header._parent != self:
-            raise kaitaistruct.ConsistencyError(u"header", self.header._parent, self)
+            raise kaitaistruct.ConsistencyError(u"header", self, self.header._parent)
         if self.bsphere._root != self._root:
-            raise kaitaistruct.ConsistencyError(u"bsphere", self.bsphere._root, self._root)
+            raise kaitaistruct.ConsistencyError(u"bsphere", self._root, self.bsphere._root)
         if self.bsphere._parent != self:
-            raise kaitaistruct.ConsistencyError(u"bsphere", self.bsphere._parent, self)
+            raise kaitaistruct.ConsistencyError(u"bsphere", self, self.bsphere._parent)
         if self.bbox_min._root != self._root:
-            raise kaitaistruct.ConsistencyError(u"bbox_min", self.bbox_min._root, self._root)
+            raise kaitaistruct.ConsistencyError(u"bbox_min", self._root, self.bbox_min._root)
         if self.bbox_min._parent != self:
-            raise kaitaistruct.ConsistencyError(u"bbox_min", self.bbox_min._parent, self)
+            raise kaitaistruct.ConsistencyError(u"bbox_min", self, self.bbox_min._parent)
         if self.bbox_max._root != self._root:
-            raise kaitaistruct.ConsistencyError(u"bbox_max", self.bbox_max._root, self._root)
+            raise kaitaistruct.ConsistencyError(u"bbox_max", self._root, self.bbox_max._root)
         if self.bbox_max._parent != self:
-            raise kaitaistruct.ConsistencyError(u"bbox_max", self.bbox_max._parent, self)
+            raise kaitaistruct.ConsistencyError(u"bbox_max", self, self.bbox_max._parent)
         if self.model_info._root != self._root:
-            raise kaitaistruct.ConsistencyError(u"model_info", self.model_info._root, self._root)
+            raise kaitaistruct.ConsistencyError(u"model_info", self._root, self.model_info._root)
         if self.model_info._parent != self:
-            raise kaitaistruct.ConsistencyError(u"model_info", self.model_info._parent, self)
-
-    class Vec4(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.x = self._io.read_f4le()
-            self.y = self._io.read_f4le()
-            self.z = self._io.read_f4le()
-            self.w = self._io.read_f4le()
-
-
-        def _fetch_instances(self):
+            raise kaitaistruct.ConsistencyError(u"model_info", self, self.model_info._parent)
+        if self.bones_data__enabled:
             pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod153.Vec4, self)._write__seq(io)
-            self._io.write_f4le(self.x)
-            self._io.write_f4le(self.y)
-            self._io.write_f4le(self.z)
-            self._io.write_f4le(self.w)
-
-
-        def _check(self):
-            pass
-
-
-    class BonePalette(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.unk_01 = self._io.read_u4le()
-            self.indices = []
-            for i in range(32):
-                self.indices.append(self._io.read_u1())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.indices)):
+            if self.header.num_bones != 0:
                 pass
+                if self._m_bones_data._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"bones_data", self._root, self._m_bones_data._root)
+                if self._m_bones_data._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"bones_data", self, self._m_bones_data._parent)
 
 
-
-        def _write__seq(self, io=None):
-            super(Mod153.BonePalette, self)._write__seq(io)
-            self._io.write_u4le(self.unk_01)
-            for i in range(len(self.indices)):
+        if self.groups__enabled:
+            pass
+            if len(self._m_groups) != self.header.num_groups:
+                raise kaitaistruct.ConsistencyError(u"groups", self.header.num_groups, len(self._m_groups))
+            for i in range(len(self._m_groups)):
                 pass
-                self._io.write_u1(self.indices[i])
+                if self._m_groups[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"groups", self._root, self._m_groups[i]._root)
+                if self._m_groups[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"groups", self, self._m_groups[i]._parent)
 
 
-
-        def _check(self):
+        if self.index_buffer__enabled:
             pass
-            if (len(self.indices) != 32):
-                raise kaitaistruct.ConsistencyError(u"indices", len(self.indices), 32)
-            for i in range(len(self.indices)):
+            if self.header.offset_index_buffer > 0:
                 pass
+                if len(self._m_index_buffer) != self.header.num_faces * 2 - 2:
+                    raise kaitaistruct.ConsistencyError(u"index_buffer", self.header.num_faces * 2 - 2, len(self._m_index_buffer))
 
 
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 36
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class ModHeader(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.ident = self._io.read_bytes(4)
-            if not (self.ident == b"\x4D\x4F\x44\x00"):
-                raise kaitaistruct.ValidationNotEqualError(b"\x4D\x4F\x44\x00", self.ident, self._io, u"/types/mod_header/seq/0")
-            self.version = self._io.read_u1()
-            self.revision = self._io.read_u1()
-            self.num_bones = self._io.read_u2le()
-            self.num_meshes = self._io.read_u2le()
-            self.num_materials = self._io.read_u2le()
-            self.num_vertices = self._io.read_u4le()
-            self.num_faces = self._io.read_u4le()
-            self.num_edges = self._io.read_u4le()
-            self.size_vertex_buffer = self._io.read_u4le()
-            self.size_vertex_buffer_2 = self._io.read_u4le()
-            self.num_textures = self._io.read_u4le()
-            self.num_groups = self._io.read_u4le()
-            self.num_bone_palettes = self._io.read_u4le()
-            self.offset_bones_data = self._io.read_u4le()
-            self.offset_groups = self._io.read_u4le()
-            self.offset_materials_data = self._io.read_u4le()
-            self.offset_meshes_data = self._io.read_u4le()
-            self.offset_vertex_buffer = self._io.read_u4le()
-            self.offset_vertex_buffer_2 = self._io.read_u4le()
-            self.offset_index_buffer = self._io.read_u4le()
-
-
-        def _fetch_instances(self):
+        if self.materials_data__enabled:
             pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod153.ModHeader, self)._write__seq(io)
-            self._io.write_bytes(self.ident)
-            self._io.write_u1(self.version)
-            self._io.write_u1(self.revision)
-            self._io.write_u2le(self.num_bones)
-            self._io.write_u2le(self.num_meshes)
-            self._io.write_u2le(self.num_materials)
-            self._io.write_u4le(self.num_vertices)
-            self._io.write_u4le(self.num_faces)
-            self._io.write_u4le(self.num_edges)
-            self._io.write_u4le(self.size_vertex_buffer)
-            self._io.write_u4le(self.size_vertex_buffer_2)
-            self._io.write_u4le(self.num_textures)
-            self._io.write_u4le(self.num_groups)
-            self._io.write_u4le(self.num_bone_palettes)
-            self._io.write_u4le(self.offset_bones_data)
-            self._io.write_u4le(self.offset_groups)
-            self._io.write_u4le(self.offset_materials_data)
-            self._io.write_u4le(self.offset_meshes_data)
-            self._io.write_u4le(self.offset_vertex_buffer)
-            self._io.write_u4le(self.offset_vertex_buffer_2)
-            self._io.write_u4le(self.offset_index_buffer)
-
-
-        def _check(self):
-            pass
-            if (len(self.ident) != 4):
-                raise kaitaistruct.ConsistencyError(u"ident", len(self.ident), 4)
-            if not (self.ident == b"\x4D\x4F\x44\x00"):
-                raise kaitaistruct.ValidationNotEqualError(b"\x4D\x4F\x44\x00", self.ident, None, u"/types/mod_header/seq/0")
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 72
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Vertex(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod153.Vec4S2(self._io, self, self._root)
-            self.position._read()
-            self.bone_indices = []
-            for i in range(4):
-                self.bone_indices.append(self._io.read_u1())
-
-            self.weight_values = []
-            for i in range(4):
-                self.weight_values.append(self._io.read_u1())
-
-            self.normal = Mod153.Vec4U1(self._io, self, self._root)
-            self.normal._read()
-            self.tangent = Mod153.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.uv = Mod153.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod153.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            for i in range(len(self.bone_indices)):
+            if self.header.offset_materials_data > 0:
                 pass
-
-            for i in range(len(self.weight_values)):
-                pass
-
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
+                if self._m_materials_data._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"materials_data", self._root, self._m_materials_data._root)
+                if self._m_materials_data._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"materials_data", self, self._m_materials_data._parent)
 
 
-        def _write__seq(self, io=None):
-            super(Mod153.Vertex, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            for i in range(len(self.bone_indices)):
-                pass
-                self._io.write_u1(self.bone_indices[i])
-
-            for i in range(len(self.weight_values)):
-                pass
-                self._io.write_u1(self.weight_values[i])
-
-            self.normal._write__seq(self._io)
-            self.tangent._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
-
-
-        def _check(self):
+        if self.meshes_data__enabled:
             pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if (len(self.bone_indices) != 4):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 4)
-            for i in range(len(self.bone_indices)):
+            if self.header.offset_meshes_data > 0:
                 pass
+                if self._m_meshes_data._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"meshes_data", self._root, self._m_meshes_data._root)
+                if self._m_meshes_data._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"meshes_data", self, self._m_meshes_data._parent)
 
-            if (len(self.weight_values) != 4):
-                raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values), 4)
-            for i in range(len(self.weight_values)):
+
+        if self.vertex_buffer__enabled:
+            pass
+            if self.header.offset_vertex_buffer > 0:
                 pass
-
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
+                if len(self._m_vertex_buffer) != self.header.size_vertex_buffer:
+                    raise kaitaistruct.ConsistencyError(u"vertex_buffer", self.header.size_vertex_buffer, len(self._m_vertex_buffer))
 
 
-    class Vec2HalfFloat(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.u = self._io.read_bytes(2)
-            self.v = self._io.read_bytes(2)
-
-
-        def _fetch_instances(self):
+        if self.vertex_buffer_2__enabled:
             pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod153.Vec2HalfFloat, self)._write__seq(io)
-            self._io.write_bytes(self.u)
-            self._io.write_bytes(self.v)
-
-
-        def _check(self):
-            pass
-            if (len(self.u) != 2):
-                raise kaitaistruct.ConsistencyError(u"u", len(self.u), 2)
-            if (len(self.v) != 2):
-                raise kaitaistruct.ConsistencyError(u"v", len(self.v), 2)
-
-
-    class VfSkin(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod153.Vec4S2(self._io, self, self._root)
-            self.position._read()
-            self.bone_indices = []
-            for i in range(4):
-                self.bone_indices.append(self._io.read_u1())
-
-            self.weight_values = []
-            for i in range(4):
-                self.weight_values.append(self._io.read_u1())
-
-            self.normal = Mod153.Vec4U1(self._io, self, self._root)
-            self.normal._read()
-            self.tangent = Mod153.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.uv = Mod153.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod153.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            for i in range(len(self.bone_indices)):
+            if self.header.offset_vertex_buffer_2 > 0:
                 pass
-
-            for i in range(len(self.weight_values)):
-                pass
-
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
+                if len(self._m_vertex_buffer_2) != self.header.size_vertex_buffer_2:
+                    raise kaitaistruct.ConsistencyError(u"vertex_buffer_2", self.header.size_vertex_buffer_2, len(self._m_vertex_buffer_2))
 
 
-        def _write__seq(self, io=None):
-            super(Mod153.VfSkin, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            for i in range(len(self.bone_indices)):
-                pass
-                self._io.write_u1(self.bone_indices[i])
-
-            for i in range(len(self.weight_values)):
-                pass
-                self._io.write_u1(self.weight_values[i])
-
-            self.normal._write__seq(self._io)
-            self.tangent._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if (len(self.bone_indices) != 4):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 4)
-            for i in range(len(self.bone_indices)):
-                pass
-
-            if (len(self.weight_values) != 4):
-                raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values), 4)
-            for i in range(len(self.weight_values)):
-                pass
-
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-
-
-    class RcnTriangle(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.v0 = self._io.read_bits_int_le(21)
-            self.v1 = self._io.read_bits_int_le(21)
-            self.v2 = self._io.read_bits_int_le(21)
-            self.reserved = self._io.read_bits_int_le(1) != 0
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod153.RcnTriangle, self)._write__seq(io)
-            self._io.write_bits_int_le(21, self.v0)
-            self._io.write_bits_int_le(21, self.v1)
-            self._io.write_bits_int_le(21, self.v2)
-            self._io.write_bits_int_le(1, int(self.reserved))
-
-
-        def _check(self):
-            pass
-
-
-    class Matrix4x4(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.row_1 = Mod153.Vec4(self._io, self, self._root)
-            self.row_1._read()
-            self.row_2 = Mod153.Vec4(self._io, self, self._root)
-            self.row_2._read()
-            self.row_3 = Mod153.Vec4(self._io, self, self._root)
-            self.row_3._read()
-            self.row_4 = Mod153.Vec4(self._io, self, self._root)
-            self.row_4._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.row_1._fetch_instances()
-            self.row_2._fetch_instances()
-            self.row_3._fetch_instances()
-            self.row_4._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod153.Matrix4x4, self)._write__seq(io)
-            self.row_1._write__seq(self._io)
-            self.row_2._write__seq(self._io)
-            self.row_3._write__seq(self._io)
-            self.row_4._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.row_1._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"row_1", self.row_1._root, self._root)
-            if self.row_1._parent != self:
-                raise kaitaistruct.ConsistencyError(u"row_1", self.row_1._parent, self)
-            if self.row_2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"row_2", self.row_2._root, self._root)
-            if self.row_2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"row_2", self.row_2._parent, self)
-            if self.row_3._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"row_3", self.row_3._root, self._root)
-            if self.row_3._parent != self:
-                raise kaitaistruct.ConsistencyError(u"row_3", self.row_3._parent, self)
-            if self.row_4._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"row_4", self.row_4._root, self._root)
-            if self.row_4._parent != self:
-                raise kaitaistruct.ConsistencyError(u"row_4", self.row_4._parent, self)
-
-
-    class VfNonSkinCol(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod153.Vec3(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod153.Vec4U1(self._io, self, self._root)
-            self.normal._read()
-            self.tangent = Mod153.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.uv = Mod153.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod153.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-            self.rgba = Mod153.Vec4U1(self._io, self, self._root)
-            self.rgba._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
-            self.rgba._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod153.VfNonSkinCol, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self.tangent._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
-            self.rgba._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-            if self.rgba._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._root, self._root)
-            if self.rgba._parent != self:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._parent, self)
-
+        self._dirty = False
 
     class Bone(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod153.Bone, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -663,6 +210,7 @@ class Mod153(ReadWriteKaitaiStruct):
             self.parent_distance = self._io.read_f4le()
             self.location = Mod153.Vec3(self._io, self, self._root)
             self.location._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -682,11 +230,11 @@ class Mod153(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
             if self.location._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"location", self.location._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"location", self._root, self.location._root)
             if self.location._parent != self:
-                raise kaitaistruct.ConsistencyError(u"location", self.location._parent, self)
+                raise kaitaistruct.ConsistencyError(u"location", self, self.location._parent)
+            self._dirty = False
 
         @property
         def size_(self):
@@ -699,717 +247,267 @@ class Mod153(ReadWriteKaitaiStruct):
         def _invalidate_size_(self):
             del self._m_size_
 
-    class Vertex0(ReadWriteKaitaiStruct):
+    class BonePalette(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod153.BonePalette, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
-            self.position = Mod153.Vec3(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod153.Vec4U1(self._io, self, self._root)
-            self.normal._read()
-            self.tangent = Mod153.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.uv = Mod153.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod153.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-            self.uv3 = Mod153.Vec2HalfFloat(self._io, self, self._root)
-            self.uv3._read()
+            self.unk_01 = self._io.read_u4le()
+            self.indices = []
+            for i in range(32):
+                self.indices.append(self._io.read_u1())
+
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
-            self.uv3._fetch_instances()
+            for i in range(len(self.indices)):
+                pass
+
 
 
         def _write__seq(self, io=None):
-            super(Mod153.Vertex0, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self.tangent._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
-            self.uv3._write__seq(self._io)
+            super(Mod153.BonePalette, self)._write__seq(io)
+            self._io.write_u4le(self.unk_01)
+            for i in range(len(self.indices)):
+                pass
+                self._io.write_u1(self.indices[i])
 
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-            if self.uv3._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._root, self._root)
-            if self.uv3._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._parent, self)
-
-
-    class ModelInfo(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.middist = self._io.read_s4le()
-            self.lowdist = self._io.read_s4le()
-            self.light_group = self._io.read_u4le()
-            self.strip_type = self._io.read_u1()
-            self.memory = self._io.read_u1()
-            self.reserved = self._io.read_u2le()
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod153.ModelInfo, self)._write__seq(io)
-            self._io.write_s4le(self.middist)
-            self._io.write_s4le(self.lowdist)
-            self._io.write_u4le(self.light_group)
-            self._io.write_u1(self.strip_type)
-            self._io.write_u1(self.memory)
-            self._io.write_u2le(self.reserved)
 
 
         def _check(self):
-            pass
+            if len(self.indices) != 32:
+                raise kaitaistruct.ConsistencyError(u"indices", 32, len(self.indices))
+            for i in range(len(self.indices)):
+                pass
+
+            self._dirty = False
 
         @property
         def size_(self):
             if hasattr(self, '_m_size_'):
                 return self._m_size_
 
-            self._m_size_ = 16
+            self._m_size_ = 36
             return getattr(self, '_m_size_', None)
 
         def _invalidate_size_(self):
             del self._m_size_
 
-    class Vec2(ReadWriteKaitaiStruct):
+    class BonesData(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod153.BonesData, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
-            self.x = self._io.read_f4le()
-            self.y = self._io.read_f4le()
+            self.bones_hierarchy = []
+            for i in range(self._root.header.num_bones):
+                _t_bones_hierarchy = Mod153.Bone(self._io, self, self._root)
+                try:
+                    _t_bones_hierarchy._read()
+                finally:
+                    self.bones_hierarchy.append(_t_bones_hierarchy)
+
+            self.parent_space_matrices = []
+            for i in range(self._root.header.num_bones):
+                _t_parent_space_matrices = Mod153.Matrix4x4(self._io, self, self._root)
+                try:
+                    _t_parent_space_matrices._read()
+                finally:
+                    self.parent_space_matrices.append(_t_parent_space_matrices)
+
+            self.inverse_bind_matrices = []
+            for i in range(self._root.header.num_bones):
+                _t_inverse_bind_matrices = Mod153.Matrix4x4(self._io, self, self._root)
+                try:
+                    _t_inverse_bind_matrices._read()
+                finally:
+                    self.inverse_bind_matrices.append(_t_inverse_bind_matrices)
+
+            if self._root.header.num_bones != 0:
+                pass
+                self.bone_map = self._io.read_bytes(256)
+
+            self.bone_palettes = []
+            for i in range(self._root.header.num_bone_palettes):
+                _t_bone_palettes = Mod153.BonePalette(self._io, self, self._root)
+                try:
+                    _t_bone_palettes._read()
+                finally:
+                    self.bone_palettes.append(_t_bone_palettes)
+
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod153.Vec2, self)._write__seq(io)
-            self._io.write_f4le(self.x)
-            self._io.write_f4le(self.y)
-
-
-        def _check(self):
-            pass
-
-
-    class Vec4U1(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.x = self._io.read_u1()
-            self.y = self._io.read_u1()
-            self.z = self._io.read_u1()
-            self.w = self._io.read_u1()
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod153.Vec4U1, self)._write__seq(io)
-            self._io.write_u1(self.x)
-            self._io.write_u1(self.y)
-            self._io.write_u1(self.z)
-            self._io.write_u1(self.w)
-
-
-        def _check(self):
-            pass
-
-
-    class MeshesData(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.meshes = []
-            for i in range(self._root.header.num_meshes):
-                _t_meshes = Mod153.Mesh(self._io, self, self._root)
-                _t_meshes._read()
-                self.meshes.append(_t_meshes)
-
-            self.num_weight_bounds = self._io.read_u4le()
-            self.weight_bounds = []
-            for i in range(self.num_weight_bounds):
-                _t_weight_bounds = Mod153.WeightBound(self._io, self, self._root)
-                _t_weight_bounds._read()
-                self.weight_bounds.append(_t_weight_bounds)
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.meshes)):
+            for i in range(len(self.bones_hierarchy)):
                 pass
-                self.meshes[i]._fetch_instances()
+                self.bones_hierarchy[i]._fetch_instances()
 
-            for i in range(len(self.weight_bounds)):
+            for i in range(len(self.parent_space_matrices)):
                 pass
-                self.weight_bounds[i]._fetch_instances()
+                self.parent_space_matrices[i]._fetch_instances()
+
+            for i in range(len(self.inverse_bind_matrices)):
+                pass
+                self.inverse_bind_matrices[i]._fetch_instances()
+
+            if self._root.header.num_bones != 0:
+                pass
+
+            for i in range(len(self.bone_palettes)):
+                pass
+                self.bone_palettes[i]._fetch_instances()
 
 
 
         def _write__seq(self, io=None):
-            super(Mod153.MeshesData, self)._write__seq(io)
-            for i in range(len(self.meshes)):
+            super(Mod153.BonesData, self)._write__seq(io)
+            for i in range(len(self.bones_hierarchy)):
                 pass
-                self.meshes[i]._write__seq(self._io)
+                self.bones_hierarchy[i]._write__seq(self._io)
 
-            self._io.write_u4le(self.num_weight_bounds)
-            for i in range(len(self.weight_bounds)):
+            for i in range(len(self.parent_space_matrices)):
                 pass
-                self.weight_bounds[i]._write__seq(self._io)
+                self.parent_space_matrices[i]._write__seq(self._io)
+
+            for i in range(len(self.inverse_bind_matrices)):
+                pass
+                self.inverse_bind_matrices[i]._write__seq(self._io)
+
+            if self._root.header.num_bones != 0:
+                pass
+                self._io.write_bytes(self.bone_map)
+
+            for i in range(len(self.bone_palettes)):
+                pass
+                self.bone_palettes[i]._write__seq(self._io)
 
 
 
         def _check(self):
-            pass
-            if (len(self.meshes) != self._root.header.num_meshes):
-                raise kaitaistruct.ConsistencyError(u"meshes", len(self.meshes), self._root.header.num_meshes)
-            for i in range(len(self.meshes)):
+            if len(self.bones_hierarchy) != self._root.header.num_bones:
+                raise kaitaistruct.ConsistencyError(u"bones_hierarchy", self._root.header.num_bones, len(self.bones_hierarchy))
+            for i in range(len(self.bones_hierarchy)):
                 pass
-                if self.meshes[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"meshes", self.meshes[i]._root, self._root)
-                if self.meshes[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"meshes", self.meshes[i]._parent, self)
+                if self.bones_hierarchy[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"bones_hierarchy", self._root, self.bones_hierarchy[i]._root)
+                if self.bones_hierarchy[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"bones_hierarchy", self, self.bones_hierarchy[i]._parent)
 
-            if (len(self.weight_bounds) != self.num_weight_bounds):
-                raise kaitaistruct.ConsistencyError(u"weight_bounds", len(self.weight_bounds), self.num_weight_bounds)
-            for i in range(len(self.weight_bounds)):
+            if len(self.parent_space_matrices) != self._root.header.num_bones:
+                raise kaitaistruct.ConsistencyError(u"parent_space_matrices", self._root.header.num_bones, len(self.parent_space_matrices))
+            for i in range(len(self.parent_space_matrices)):
                 pass
-                if self.weight_bounds[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"weight_bounds", self.weight_bounds[i]._root, self._root)
-                if self.weight_bounds[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"weight_bounds", self.weight_bounds[i]._parent, self)
+                if self.parent_space_matrices[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"parent_space_matrices", self._root, self.parent_space_matrices[i]._root)
+                if self.parent_space_matrices[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"parent_space_matrices", self, self.parent_space_matrices[i]._parent)
 
+            if len(self.inverse_bind_matrices) != self._root.header.num_bones:
+                raise kaitaistruct.ConsistencyError(u"inverse_bind_matrices", self._root.header.num_bones, len(self.inverse_bind_matrices))
+            for i in range(len(self.inverse_bind_matrices)):
+                pass
+                if self.inverse_bind_matrices[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"inverse_bind_matrices", self._root, self.inverse_bind_matrices[i]._root)
+                if self.inverse_bind_matrices[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"inverse_bind_matrices", self, self.inverse_bind_matrices[i]._parent)
+
+            if self._root.header.num_bones != 0:
+                pass
+                if len(self.bone_map) != 256:
+                    raise kaitaistruct.ConsistencyError(u"bone_map", 256, len(self.bone_map))
+
+            if len(self.bone_palettes) != self._root.header.num_bone_palettes:
+                raise kaitaistruct.ConsistencyError(u"bone_palettes", self._root.header.num_bone_palettes, len(self.bone_palettes))
+            for i in range(len(self.bone_palettes)):
+                pass
+                if self.bone_palettes[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"bone_palettes", self._root, self.bone_palettes[i]._root)
+                if self.bone_palettes[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"bone_palettes", self, self.bone_palettes[i]._parent)
+
+            self._dirty = False
 
         @property
         def size_(self):
             if hasattr(self, '_m_size_'):
                 return self._m_size_
 
-            self._m_size_ = (((self._root.header.num_meshes * self.meshes[0].size_) + 4) + (self.num_weight_bounds * self.weight_bounds[0].size_))
+            self._m_size_ = ((((self._root.header.num_bones * self.bones_hierarchy[0].size_ + self._root.header.num_bones * 64) + self._root.header.num_bones * 64) + 256) + self._root.header.num_bone_palettes * self.bone_palettes[0].size_ if self._root.header.num_bones > 0 else 0)
             return getattr(self, '_m_size_', None)
 
         def _invalidate_size_(self):
             del self._m_size_
 
-    class Mesh(ReadWriteKaitaiStruct):
+    class Group(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod153.Group, self).__init__(_io)
             self._parent = _parent
             self._root = _root
-            self._should_write_indices = False
-            self.indices__to_write = True
-            self._should_write_vertices = False
-            self.vertices__to_write = True
-            self._should_write_vertices2 = False
-            self.vertices2__to_write = True
 
         def _read(self):
-            self.idx_group = self._io.read_u2le()
-            self.idx_material = self._io.read_u2le()
-            self.disp = self._io.read_u1()
-            self.level_of_detail = self._io.read_u1()
-            self.alpha_priority = self._io.read_u1()
-            self.vertex_format = self._io.read_u1()
-            self.vertex_stride = self._io.read_u1()
-            self.vertex_stride_2 = self._io.read_u1()
-            self.connective = self._io.read_u1()
-            self.shape = self._io.read_bits_int_le(1) != 0
-            self.env = self._io.read_bits_int_le(1) != 0
-            self.refrect = self._io.read_bits_int_le(1) != 0
-            self.reserved2_flag_1 = self._io.read_bits_int_le(1) != 0
-            self.reserved2_flag_2 = self._io.read_bits_int_le(1) != 0
-            self.shadow_cast = self._io.read_bits_int_le(1) != 0
-            self.shadow_receive = self._io.read_bits_int_le(1) != 0
-            self.sort = self._io.read_bits_int_le(1) != 0
-            self.num_vertices = self._io.read_u2le()
-            self.max_index = self._io.read_u2le()
-            self.vertex_position_2 = self._io.read_u4le()
-            self.vertex_offset = self._io.read_u4le()
-            self.vertex_offset_2 = self._io.read_u4le()
-            self.face_position = self._io.read_u4le()
-            self.num_indices = self._io.read_u4le()
-            self.face_offset = self._io.read_u4le()
-            self.vdeclbase = self._io.read_u1()
-            self.vdecl = self._io.read_u1()
-            self.min_index = self._io.read_u2le()
-            self.num_weight_bounds = self._io.read_u1()
-            self.idx_bone_palette = self._io.read_u1()
-            self.rcn_base = self._io.read_u2le()
-            self.boundary = self._io.read_u4le()
+            self.group_index = self._io.read_u4le()
+            self.reserved = []
+            for i in range(3):
+                self.reserved.append(self._io.read_u4le())
+
+            self.pos = Mod153.Vec3(self._io, self, self._root)
+            self.pos._read()
+            self.radius = self._io.read_f4le()
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
-            _ = self.indices
-            for i in range(len(self._m_indices)):
+            for i in range(len(self.reserved)):
                 pass
 
-            _ = self.vertices
-            for i in range(len(self._m_vertices)):
-                pass
-                _on = self._root.materials_data.materials[self.idx_material].vtype
-                if _on == 0:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 4:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 6:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 7:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 1:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 3:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 5:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 8:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 2:
-                    pass
-                    self.vertices[i]._fetch_instances()
-
-            if (self.vertex_stride_2 > 0):
-                pass
-                _ = self.vertices2
-                for i in range(len(self._m_vertices2)):
-                    pass
-                    _on = self.vertex_stride_2
-                    if _on == 4:
-                        pass
-                        self.vertices2[i]._fetch_instances()
-                    elif _on == 8:
-                        pass
-                        self.vertices2[i]._fetch_instances()
-
-
+            self.pos._fetch_instances()
 
 
         def _write__seq(self, io=None):
-            super(Mod153.Mesh, self)._write__seq(io)
-            self._should_write_indices = self.indices__to_write
-            self._should_write_vertices = self.vertices__to_write
-            self._should_write_vertices2 = self.vertices2__to_write
-            self._io.write_u2le(self.idx_group)
-            self._io.write_u2le(self.idx_material)
-            self._io.write_u1(self.disp)
-            self._io.write_u1(self.level_of_detail)
-            self._io.write_u1(self.alpha_priority)
-            self._io.write_u1(self.vertex_format)
-            self._io.write_u1(self.vertex_stride)
-            self._io.write_u1(self.vertex_stride_2)
-            self._io.write_u1(self.connective)
-            self._io.write_bits_int_le(1, int(self.shape))
-            self._io.write_bits_int_le(1, int(self.env))
-            self._io.write_bits_int_le(1, int(self.refrect))
-            self._io.write_bits_int_le(1, int(self.reserved2_flag_1))
-            self._io.write_bits_int_le(1, int(self.reserved2_flag_2))
-            self._io.write_bits_int_le(1, int(self.shadow_cast))
-            self._io.write_bits_int_le(1, int(self.shadow_receive))
-            self._io.write_bits_int_le(1, int(self.sort))
-            self._io.write_u2le(self.num_vertices)
-            self._io.write_u2le(self.max_index)
-            self._io.write_u4le(self.vertex_position_2)
-            self._io.write_u4le(self.vertex_offset)
-            self._io.write_u4le(self.vertex_offset_2)
-            self._io.write_u4le(self.face_position)
-            self._io.write_u4le(self.num_indices)
-            self._io.write_u4le(self.face_offset)
-            self._io.write_u1(self.vdeclbase)
-            self._io.write_u1(self.vdecl)
-            self._io.write_u2le(self.min_index)
-            self._io.write_u1(self.num_weight_bounds)
-            self._io.write_u1(self.idx_bone_palette)
-            self._io.write_u2le(self.rcn_base)
-            self._io.write_u4le(self.boundary)
+            super(Mod153.Group, self)._write__seq(io)
+            self._io.write_u4le(self.group_index)
+            for i in range(len(self.reserved)):
+                pass
+                self._io.write_u4le(self.reserved[i])
+
+            self.pos._write__seq(self._io)
+            self._io.write_f4le(self.radius)
 
 
         def _check(self):
-            pass
+            if len(self.reserved) != 3:
+                raise kaitaistruct.ConsistencyError(u"reserved", 3, len(self.reserved))
+            for i in range(len(self.reserved)):
+                pass
+
+            if self.pos._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"pos", self._root, self.pos._root)
+            if self.pos._parent != self:
+                raise kaitaistruct.ConsistencyError(u"pos", self, self.pos._parent)
+            self._dirty = False
 
         @property
         def size_(self):
             if hasattr(self, '_m_size_'):
                 return self._m_size_
 
-            self._m_size_ = 52
+            self._m_size_ = 32
             return getattr(self, '_m_size_', None)
 
         def _invalidate_size_(self):
             del self._m_size_
-        @property
-        def indices(self):
-            if self._should_write_indices:
-                self._write_indices()
-            if hasattr(self, '_m_indices'):
-                return self._m_indices
-
-            _pos = self._io.pos()
-            self._io.seek(((self._root.header.offset_index_buffer + (self.face_offset * 2)) + (self.face_position * 2)))
-            self._m_indices = []
-            for i in range(self.num_indices):
-                self._m_indices.append(self._io.read_u2le())
-
-            self._io.seek(_pos)
-            return getattr(self, '_m_indices', None)
-
-        @indices.setter
-        def indices(self, v):
-            self._m_indices = v
-
-        def _write_indices(self):
-            self._should_write_indices = False
-            _pos = self._io.pos()
-            self._io.seek(((self._root.header.offset_index_buffer + (self.face_offset * 2)) + (self.face_position * 2)))
-            for i in range(len(self._m_indices)):
-                pass
-                self._io.write_u2le(self.indices[i])
-
-            self._io.seek(_pos)
-
-
-        def _check_indices(self):
-            pass
-            if (len(self.indices) != self.num_indices):
-                raise kaitaistruct.ConsistencyError(u"indices", len(self.indices), self.num_indices)
-            for i in range(len(self._m_indices)):
-                pass
-
-
-        @property
-        def vertices(self):
-            if self._should_write_vertices:
-                self._write_vertices()
-            if hasattr(self, '_m_vertices'):
-                return self._m_vertices
-
-            _pos = self._io.pos()
-            self._io.seek((((self._root.header.offset_vertex_buffer + (self.min_index * self.vertex_stride)) + self.vertex_offset) if (self.min_index > self.vertex_position_2) else ((self._root.header.offset_vertex_buffer + (self.min_index * self.vertex_stride)) + self.vertex_offset)))
-            self._m_vertices = []
-            for i in range((((self.max_index - self.min_index) + 1) if (self.min_index > self.vertex_position_2) else self.num_vertices)):
-                _on = self._root.materials_data.materials[self.idx_material].vtype
-                if _on == 0:
-                    pass
-                    _t__m_vertices = Mod153.VfSkin(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 4:
-                    pass
-                    _t__m_vertices = Mod153.VfSkin(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 6:
-                    pass
-                    _t__m_vertices = Mod153.VfNonSkin(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 7:
-                    pass
-                    _t__m_vertices = Mod153.VfSkinEx(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 1:
-                    pass
-                    _t__m_vertices = Mod153.VfSkinEx(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 3:
-                    pass
-                    _t__m_vertices = Mod153.VfNonSkinCol(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 5:
-                    pass
-                    _t__m_vertices = Mod153.VfSkin(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 8:
-                    pass
-                    _t__m_vertices = Mod153.VfNonSkinCol(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 2:
-                    pass
-                    _t__m_vertices = Mod153.VfNonSkin(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-
-            self._io.seek(_pos)
-            return getattr(self, '_m_vertices', None)
-
-        @vertices.setter
-        def vertices(self, v):
-            self._m_vertices = v
-
-        def _write_vertices(self):
-            self._should_write_vertices = False
-            _pos = self._io.pos()
-            self._io.seek((((self._root.header.offset_vertex_buffer + (self.min_index * self.vertex_stride)) + self.vertex_offset) if (self.min_index > self.vertex_position_2) else ((self._root.header.offset_vertex_buffer + (self.min_index * self.vertex_stride)) + self.vertex_offset)))
-            for i in range(len(self._m_vertices)):
-                pass
-                _on = self._root.materials_data.materials[self.idx_material].vtype
-                if _on == 0:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 4:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 6:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 7:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 1:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 3:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 5:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 8:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 2:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-
-            self._io.seek(_pos)
-
-
-        def _check_vertices(self):
-            pass
-            if (len(self.vertices) != (((self.max_index - self.min_index) + 1) if (self.min_index > self.vertex_position_2) else self.num_vertices)):
-                raise kaitaistruct.ConsistencyError(u"vertices", len(self.vertices), (((self.max_index - self.min_index) + 1) if (self.min_index > self.vertex_position_2) else self.num_vertices))
-            for i in range(len(self._m_vertices)):
-                pass
-                _on = self._root.materials_data.materials[self.idx_material].vtype
-                if _on == 0:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 4:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 6:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 7:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 1:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 3:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 5:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 8:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 2:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-
-
-        @property
-        def vertices2(self):
-            if self._should_write_vertices2:
-                self._write_vertices2()
-            if hasattr(self, '_m_vertices2'):
-                return self._m_vertices2
-
-            if (self.vertex_stride_2 > 0):
-                pass
-                _pos = self._io.pos()
-                self._io.seek(((self._root.header.offset_vertex_buffer_2 + (self.vertex_position_2 * self.vertex_stride_2)) + self.vertex_offset_2))
-                self._m_vertices2 = []
-                for i in range(self.num_vertices):
-                    _on = self.vertex_stride_2
-                    if _on == 4:
-                        pass
-                        _t__m_vertices2 = Mod153.Vertex24(self._io, self, self._root)
-                        _t__m_vertices2._read()
-                        self._m_vertices2.append(_t__m_vertices2)
-                    elif _on == 8:
-                        pass
-                        _t__m_vertices2 = Mod153.Vertex28(self._io, self, self._root)
-                        _t__m_vertices2._read()
-                        self._m_vertices2.append(_t__m_vertices2)
-
-                self._io.seek(_pos)
-
-            return getattr(self, '_m_vertices2', None)
-
-        @vertices2.setter
-        def vertices2(self, v):
-            self._m_vertices2 = v
-
-        def _write_vertices2(self):
-            self._should_write_vertices2 = False
-            if (self.vertex_stride_2 > 0):
-                pass
-                _pos = self._io.pos()
-                self._io.seek(((self._root.header.offset_vertex_buffer_2 + (self.vertex_position_2 * self.vertex_stride_2)) + self.vertex_offset_2))
-                for i in range(len(self._m_vertices2)):
-                    pass
-                    _on = self.vertex_stride_2
-                    if _on == 4:
-                        pass
-                        self.vertices2[i]._write__seq(self._io)
-                    elif _on == 8:
-                        pass
-                        self.vertices2[i]._write__seq(self._io)
-
-                self._io.seek(_pos)
-
-
-
-        def _check_vertices2(self):
-            pass
-            if (self.vertex_stride_2 > 0):
-                pass
-                if (len(self.vertices2) != self.num_vertices):
-                    raise kaitaistruct.ConsistencyError(u"vertices2", len(self.vertices2), self.num_vertices)
-                for i in range(len(self._m_vertices2)):
-                    pass
-                    _on = self.vertex_stride_2
-                    if _on == 4:
-                        pass
-                        if self.vertices2[i]._root != self._root:
-                            raise kaitaistruct.ConsistencyError(u"vertices2", self.vertices2[i]._root, self._root)
-                        if self.vertices2[i]._parent != self:
-                            raise kaitaistruct.ConsistencyError(u"vertices2", self.vertices2[i]._parent, self)
-                    elif _on == 8:
-                        pass
-                        if self.vertices2[i]._root != self._root:
-                            raise kaitaistruct.ConsistencyError(u"vertices2", self.vertices2[i]._root, self._root)
-                        if self.vertices2[i]._parent != self:
-                            raise kaitaistruct.ConsistencyError(u"vertices2", self.vertices2[i]._parent, self)
-
-
-
-
-    class RcnTable(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.vindex = self._io.read_bits_int_le(21)
-            self.noffset = self._io.read_bits_int_le(10)
-            self.edge = self._io.read_bits_int_le(1) != 0
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod153.RcnTable, self)._write__seq(io)
-            self._io.write_bits_int_le(21, self.vindex)
-            self._io.write_bits_int_le(10, self.noffset)
-            self._io.write_bits_int_le(1, int(self.edge))
-
-
-        def _check(self):
-            pass
-
 
     class Material(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod153.Material, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -1468,6 +566,7 @@ class Mod153(ReadWriteKaitaiStruct):
             self.alpha_ref = self._io.read_u4le()
             self.reserved1 = self._io.read_u4le()
             self.reserved2 = self._io.read_u4le()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -1548,32 +647,32 @@ class Mod153(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
-            if (len(self.fresnel_factor) != 4):
-                raise kaitaistruct.ConsistencyError(u"fresnel_factor", len(self.fresnel_factor), 4)
+            if len(self.fresnel_factor) != 4:
+                raise kaitaistruct.ConsistencyError(u"fresnel_factor", 4, len(self.fresnel_factor))
             for i in range(len(self.fresnel_factor)):
                 pass
 
-            if (len(self.lightmap_factor) != 4):
-                raise kaitaistruct.ConsistencyError(u"lightmap_factor", len(self.lightmap_factor), 4)
+            if len(self.lightmap_factor) != 4:
+                raise kaitaistruct.ConsistencyError(u"lightmap_factor", 4, len(self.lightmap_factor))
             for i in range(len(self.lightmap_factor)):
                 pass
 
-            if (len(self.detail_factor) != 4):
-                raise kaitaistruct.ConsistencyError(u"detail_factor", len(self.detail_factor), 4)
+            if len(self.detail_factor) != 4:
+                raise kaitaistruct.ConsistencyError(u"detail_factor", 4, len(self.detail_factor))
             for i in range(len(self.detail_factor)):
                 pass
 
-            if (len(self.transmit_factor) != 4):
-                raise kaitaistruct.ConsistencyError(u"transmit_factor", len(self.transmit_factor), 4)
+            if len(self.transmit_factor) != 4:
+                raise kaitaistruct.ConsistencyError(u"transmit_factor", 4, len(self.transmit_factor))
             for i in range(len(self.transmit_factor)):
                 pass
 
-            if (len(self.parallax_factor) != 4):
-                raise kaitaistruct.ConsistencyError(u"parallax_factor", len(self.parallax_factor), 4)
+            if len(self.parallax_factor) != 4:
+                raise kaitaistruct.ConsistencyError(u"parallax_factor", 4, len(self.parallax_factor))
             for i in range(len(self.parallax_factor)):
                 pass
 
+            self._dirty = False
 
         @property
         def size_(self):
@@ -1586,245 +685,26 @@ class Mod153(ReadWriteKaitaiStruct):
         def _invalidate_size_(self):
             del self._m_size_
 
-    class WeightBound(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.bone_id = self._io.read_u4le()
-            self.unk_01 = Mod153.Vec3(self._io, self, self._root)
-            self.unk_01._read()
-            self.bsphere = Mod153.Vec4(self._io, self, self._root)
-            self.bsphere._read()
-            self.bbox_min = Mod153.Vec4(self._io, self, self._root)
-            self.bbox_min._read()
-            self.bbox_max = Mod153.Vec4(self._io, self, self._root)
-            self.bbox_max._read()
-            self.oabb = Mod153.Matrix4x4(self._io, self, self._root)
-            self.oabb._read()
-            self.oabb_dimension = Mod153.Vec4(self._io, self, self._root)
-            self.oabb_dimension._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.unk_01._fetch_instances()
-            self.bsphere._fetch_instances()
-            self.bbox_min._fetch_instances()
-            self.bbox_max._fetch_instances()
-            self.oabb._fetch_instances()
-            self.oabb_dimension._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod153.WeightBound, self)._write__seq(io)
-            self._io.write_u4le(self.bone_id)
-            self.unk_01._write__seq(self._io)
-            self.bsphere._write__seq(self._io)
-            self.bbox_min._write__seq(self._io)
-            self.bbox_max._write__seq(self._io)
-            self.oabb._write__seq(self._io)
-            self.oabb_dimension._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.unk_01._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"unk_01", self.unk_01._root, self._root)
-            if self.unk_01._parent != self:
-                raise kaitaistruct.ConsistencyError(u"unk_01", self.unk_01._parent, self)
-            if self.bsphere._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"bsphere", self.bsphere._root, self._root)
-            if self.bsphere._parent != self:
-                raise kaitaistruct.ConsistencyError(u"bsphere", self.bsphere._parent, self)
-            if self.bbox_min._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"bbox_min", self.bbox_min._root, self._root)
-            if self.bbox_min._parent != self:
-                raise kaitaistruct.ConsistencyError(u"bbox_min", self.bbox_min._parent, self)
-            if self.bbox_max._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"bbox_max", self.bbox_max._root, self._root)
-            if self.bbox_max._parent != self:
-                raise kaitaistruct.ConsistencyError(u"bbox_max", self.bbox_max._parent, self)
-            if self.oabb._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"oabb", self.oabb._root, self._root)
-            if self.oabb._parent != self:
-                raise kaitaistruct.ConsistencyError(u"oabb", self.oabb._parent, self)
-            if self.oabb_dimension._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"oabb_dimension", self.oabb_dimension._root, self._root)
-            if self.oabb_dimension._parent != self:
-                raise kaitaistruct.ConsistencyError(u"oabb_dimension", self.oabb_dimension._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 144
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Vec3(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.x = self._io.read_f4le()
-            self.y = self._io.read_f4le()
-            self.z = self._io.read_f4le()
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod153.Vec3, self)._write__seq(io)
-            self._io.write_f4le(self.x)
-            self._io.write_f4le(self.y)
-            self._io.write_f4le(self.z)
-
-
-        def _check(self):
-            pass
-
-
-    class VfNonSkin(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod153.Vec3(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod153.Vec4U1(self._io, self, self._root)
-            self.normal._read()
-            self.tangent = Mod153.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.uv = Mod153.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod153.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-            self.uv3 = Mod153.Vec2HalfFloat(self._io, self, self._root)
-            self.uv3._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
-            self.uv3._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod153.VfNonSkin, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self.tangent._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
-            self.uv3._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-            if self.uv3._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._root, self._root)
-            if self.uv3._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._parent, self)
-
-
-    class RcnVertex(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.x = self._io.read_u2le()
-            self.y = self._io.read_u2le()
-            self.z = self._io.read_u2le()
-            self.w = self._io.read_u2le()
-            self.w0 = self._io.read_u1()
-            self.w1 = self._io.read_u1()
-            self.w2 = self._io.read_u1()
-            self.w3 = self._io.read_u1()
-            self.j0 = self._io.read_u1()
-            self.j1 = self._io.read_u1()
-            self.j2 = self._io.read_u1()
-            self.j3 = self._io.read_u1()
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod153.RcnVertex, self)._write__seq(io)
-            self._io.write_u2le(self.x)
-            self._io.write_u2le(self.y)
-            self._io.write_u2le(self.z)
-            self._io.write_u2le(self.w)
-            self._io.write_u1(self.w0)
-            self._io.write_u1(self.w1)
-            self._io.write_u1(self.w2)
-            self._io.write_u1(self.w3)
-            self._io.write_u1(self.j0)
-            self._io.write_u1(self.j1)
-            self._io.write_u1(self.j2)
-            self._io.write_u1(self.j3)
-
-
-        def _check(self):
-            pass
-
-
     class MaterialsData(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod153.MaterialsData, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
             self.textures = []
             for i in range(self._root.header.num_textures):
-                self.textures.append((KaitaiStream.bytes_terminate(self._io.read_bytes(64), 0, False)).decode("ASCII"))
+                self.textures.append((KaitaiStream.bytes_terminate(self._io.read_bytes(64), 0, False)).decode(u"ASCII"))
 
             self.materials = []
             for i in range(self._root.header.num_materials):
                 _t_materials = Mod153.Material(self._io, self, self._root)
-                _t_materials._read()
-                self.materials.append(_t_materials)
+                try:
+                    _t_materials._read()
+                finally:
+                    self.materials.append(_t_materials)
 
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -1851,322 +731,776 @@ class Mod153(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
-            if (len(self.textures) != self._root.header.num_textures):
-                raise kaitaistruct.ConsistencyError(u"textures", len(self.textures), self._root.header.num_textures)
+            if len(self.textures) != self._root.header.num_textures:
+                raise kaitaistruct.ConsistencyError(u"textures", self._root.header.num_textures, len(self.textures))
             for i in range(len(self.textures)):
                 pass
-                if (len((self.textures[i]).encode(u"ASCII")) > 64):
-                    raise kaitaistruct.ConsistencyError(u"textures", len((self.textures[i]).encode(u"ASCII")), 64)
-                if (KaitaiStream.byte_array_index_of((self.textures[i]).encode(u"ASCII"), 0) != -1):
-                    raise kaitaistruct.ConsistencyError(u"textures", KaitaiStream.byte_array_index_of((self.textures[i]).encode(u"ASCII"), 0), -1)
+                if len((self.textures[i]).encode(u"ASCII")) > 64:
+                    raise kaitaistruct.ConsistencyError(u"textures", 64, len((self.textures[i]).encode(u"ASCII")))
+                if KaitaiStream.byte_array_index_of((self.textures[i]).encode(u"ASCII"), 0) != -1:
+                    raise kaitaistruct.ConsistencyError(u"textures", -1, KaitaiStream.byte_array_index_of((self.textures[i]).encode(u"ASCII"), 0))
 
-            if (len(self.materials) != self._root.header.num_materials):
-                raise kaitaistruct.ConsistencyError(u"materials", len(self.materials), self._root.header.num_materials)
+            if len(self.materials) != self._root.header.num_materials:
+                raise kaitaistruct.ConsistencyError(u"materials", self._root.header.num_materials, len(self.materials))
             for i in range(len(self.materials)):
                 pass
                 if self.materials[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"materials", self.materials[i]._root, self._root)
+                    raise kaitaistruct.ConsistencyError(u"materials", self._root, self.materials[i]._root)
                 if self.materials[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"materials", self.materials[i]._parent, self)
+                    raise kaitaistruct.ConsistencyError(u"materials", self, self.materials[i]._parent)
 
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = ((64 * self._root.header.num_textures) + (self._root.header.num_materials * self.materials[0].size_))
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Vertex24(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.occlusion = Mod153.Vec4U1(self._io, self, self._root)
-            self.occlusion._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.occlusion._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod153.Vertex24, self)._write__seq(io)
-            self.occlusion._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.occlusion._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"occlusion", self.occlusion._root, self._root)
-            if self.occlusion._parent != self:
-                raise kaitaistruct.ConsistencyError(u"occlusion", self.occlusion._parent, self)
-
-
-    class VfSkinEx(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod153.Vec4S2(self._io, self, self._root)
-            self.position._read()
-            self.bone_indices = []
-            for i in range(8):
-                self.bone_indices.append(self._io.read_u1())
-
-            self.weight_values = []
-            for i in range(8):
-                self.weight_values.append(self._io.read_u1())
-
-            self.normal = Mod153.Vec4U1(self._io, self, self._root)
-            self.normal._read()
-            self.uv = Mod153.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            for i in range(len(self.bone_indices)):
-                pass
-
-            for i in range(len(self.weight_values)):
-                pass
-
-            self.normal._fetch_instances()
-            self.uv._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod153.VfSkinEx, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            for i in range(len(self.bone_indices)):
-                pass
-                self._io.write_u1(self.bone_indices[i])
-
-            for i in range(len(self.weight_values)):
-                pass
-                self._io.write_u1(self.weight_values[i])
-
-            self.normal._write__seq(self._io)
-            self.uv._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if (len(self.bone_indices) != 8):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 8)
-            for i in range(len(self.bone_indices)):
-                pass
-
-            if (len(self.weight_values) != 8):
-                raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values), 8)
-            for i in range(len(self.weight_values)):
-                pass
-
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-
-
-    class BonesData(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.bones_hierarchy = []
-            for i in range(self._root.header.num_bones):
-                _t_bones_hierarchy = Mod153.Bone(self._io, self, self._root)
-                _t_bones_hierarchy._read()
-                self.bones_hierarchy.append(_t_bones_hierarchy)
-
-            self.parent_space_matrices = []
-            for i in range(self._root.header.num_bones):
-                _t_parent_space_matrices = Mod153.Matrix4x4(self._io, self, self._root)
-                _t_parent_space_matrices._read()
-                self.parent_space_matrices.append(_t_parent_space_matrices)
-
-            self.inverse_bind_matrices = []
-            for i in range(self._root.header.num_bones):
-                _t_inverse_bind_matrices = Mod153.Matrix4x4(self._io, self, self._root)
-                _t_inverse_bind_matrices._read()
-                self.inverse_bind_matrices.append(_t_inverse_bind_matrices)
-
-            if (self._root.header.num_bones != 0):
-                pass
-                self.bone_map = self._io.read_bytes(256)
-
-            self.bone_palettes = []
-            for i in range(self._root.header.num_bone_palettes):
-                _t_bone_palettes = Mod153.BonePalette(self._io, self, self._root)
-                _t_bone_palettes._read()
-                self.bone_palettes.append(_t_bone_palettes)
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.bones_hierarchy)):
-                pass
-                self.bones_hierarchy[i]._fetch_instances()
-
-            for i in range(len(self.parent_space_matrices)):
-                pass
-                self.parent_space_matrices[i]._fetch_instances()
-
-            for i in range(len(self.inverse_bind_matrices)):
-                pass
-                self.inverse_bind_matrices[i]._fetch_instances()
-
-            if (self._root.header.num_bones != 0):
-                pass
-
-            for i in range(len(self.bone_palettes)):
-                pass
-                self.bone_palettes[i]._fetch_instances()
-
-
-
-        def _write__seq(self, io=None):
-            super(Mod153.BonesData, self)._write__seq(io)
-            for i in range(len(self.bones_hierarchy)):
-                pass
-                self.bones_hierarchy[i]._write__seq(self._io)
-
-            for i in range(len(self.parent_space_matrices)):
-                pass
-                self.parent_space_matrices[i]._write__seq(self._io)
-
-            for i in range(len(self.inverse_bind_matrices)):
-                pass
-                self.inverse_bind_matrices[i]._write__seq(self._io)
-
-            if (self._root.header.num_bones != 0):
-                pass
-                self._io.write_bytes(self.bone_map)
-
-            for i in range(len(self.bone_palettes)):
-                pass
-                self.bone_palettes[i]._write__seq(self._io)
-
-
-
-        def _check(self):
-            pass
-            if (len(self.bones_hierarchy) != self._root.header.num_bones):
-                raise kaitaistruct.ConsistencyError(u"bones_hierarchy", len(self.bones_hierarchy), self._root.header.num_bones)
-            for i in range(len(self.bones_hierarchy)):
-                pass
-                if self.bones_hierarchy[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"bones_hierarchy", self.bones_hierarchy[i]._root, self._root)
-                if self.bones_hierarchy[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"bones_hierarchy", self.bones_hierarchy[i]._parent, self)
-
-            if (len(self.parent_space_matrices) != self._root.header.num_bones):
-                raise kaitaistruct.ConsistencyError(u"parent_space_matrices", len(self.parent_space_matrices), self._root.header.num_bones)
-            for i in range(len(self.parent_space_matrices)):
-                pass
-                if self.parent_space_matrices[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"parent_space_matrices", self.parent_space_matrices[i]._root, self._root)
-                if self.parent_space_matrices[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"parent_space_matrices", self.parent_space_matrices[i]._parent, self)
-
-            if (len(self.inverse_bind_matrices) != self._root.header.num_bones):
-                raise kaitaistruct.ConsistencyError(u"inverse_bind_matrices", len(self.inverse_bind_matrices), self._root.header.num_bones)
-            for i in range(len(self.inverse_bind_matrices)):
-                pass
-                if self.inverse_bind_matrices[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"inverse_bind_matrices", self.inverse_bind_matrices[i]._root, self._root)
-                if self.inverse_bind_matrices[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"inverse_bind_matrices", self.inverse_bind_matrices[i]._parent, self)
-
-            if (self._root.header.num_bones != 0):
-                pass
-                if (len(self.bone_map) != 256):
-                    raise kaitaistruct.ConsistencyError(u"bone_map", len(self.bone_map), 256)
-
-            if (len(self.bone_palettes) != self._root.header.num_bone_palettes):
-                raise kaitaistruct.ConsistencyError(u"bone_palettes", len(self.bone_palettes), self._root.header.num_bone_palettes)
-            for i in range(len(self.bone_palettes)):
-                pass
-                if self.bone_palettes[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"bone_palettes", self.bone_palettes[i]._root, self._root)
-                if self.bone_palettes[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"bone_palettes", self.bone_palettes[i]._parent, self)
-
+            self._dirty = False
 
         @property
         def size_(self):
             if hasattr(self, '_m_size_'):
                 return self._m_size_
 
-            self._m_size_ = ((((((self._root.header.num_bones * self.bones_hierarchy[0].size_) + (self._root.header.num_bones * 64)) + (self._root.header.num_bones * 64)) + 256) + (self._root.header.num_bone_palettes * self.bone_palettes[0].size_)) if (self._root.header.num_bones > 0) else 0)
+            self._m_size_ = 64 * self._root.header.num_textures + self._root.header.num_materials * self.materials[0].size_
             return getattr(self, '_m_size_', None)
 
         def _invalidate_size_(self):
             del self._m_size_
 
-    class Vertex28(ReadWriteKaitaiStruct):
+    class Matrix4x4(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod153.Matrix4x4, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
-            self.occlusion = Mod153.Vec4U1(self._io, self, self._root)
-            self.occlusion._read()
-            self.tangent = Mod153.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
+            self.row_1 = Mod153.Vec4(self._io, self, self._root)
+            self.row_1._read()
+            self.row_2 = Mod153.Vec4(self._io, self, self._root)
+            self.row_2._read()
+            self.row_3 = Mod153.Vec4(self._io, self, self._root)
+            self.row_3._read()
+            self.row_4 = Mod153.Vec4(self._io, self, self._root)
+            self.row_4._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
-            self.occlusion._fetch_instances()
-            self.tangent._fetch_instances()
+            self.row_1._fetch_instances()
+            self.row_2._fetch_instances()
+            self.row_3._fetch_instances()
+            self.row_4._fetch_instances()
 
 
         def _write__seq(self, io=None):
-            super(Mod153.Vertex28, self)._write__seq(io)
-            self.occlusion._write__seq(self._io)
-            self.tangent._write__seq(self._io)
+            super(Mod153.Matrix4x4, self)._write__seq(io)
+            self.row_1._write__seq(self._io)
+            self.row_2._write__seq(self._io)
+            self.row_3._write__seq(self._io)
+            self.row_4._write__seq(self._io)
 
 
         def _check(self):
-            pass
-            if self.occlusion._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"occlusion", self.occlusion._root, self._root)
-            if self.occlusion._parent != self:
-                raise kaitaistruct.ConsistencyError(u"occlusion", self.occlusion._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
+            if self.row_1._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"row_1", self._root, self.row_1._root)
+            if self.row_1._parent != self:
+                raise kaitaistruct.ConsistencyError(u"row_1", self, self.row_1._parent)
+            if self.row_2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"row_2", self._root, self.row_2._root)
+            if self.row_2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"row_2", self, self.row_2._parent)
+            if self.row_3._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"row_3", self._root, self.row_3._root)
+            if self.row_3._parent != self:
+                raise kaitaistruct.ConsistencyError(u"row_3", self, self.row_3._parent)
+            if self.row_4._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"row_4", self._root, self.row_4._root)
+            if self.row_4._parent != self:
+                raise kaitaistruct.ConsistencyError(u"row_4", self, self.row_4._parent)
+            self._dirty = False
 
+
+    class Mesh(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod153.Mesh, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_indices = False
+            self.indices__enabled = True
+            self._should_write_vertices = False
+            self.vertices__enabled = True
+            self._should_write_vertices2 = False
+            self.vertices2__enabled = True
+
+        def _read(self):
+            self.idx_group = self._io.read_u2le()
+            self.idx_material = self._io.read_u2le()
+            self.disp = self._io.read_u1()
+            self.level_of_detail = self._io.read_u1()
+            self.alpha_priority = self._io.read_u1()
+            self.vertex_format = self._io.read_u1()
+            self.vertex_stride = self._io.read_u1()
+            self.vertex_stride_2 = self._io.read_u1()
+            self.connective = self._io.read_u1()
+            self.shape = self._io.read_bits_int_le(1) != 0
+            self.env = self._io.read_bits_int_le(1) != 0
+            self.refrect = self._io.read_bits_int_le(1) != 0
+            self.reserved2_flag_1 = self._io.read_bits_int_le(1) != 0
+            self.reserved2_flag_2 = self._io.read_bits_int_le(1) != 0
+            self.shadow_cast = self._io.read_bits_int_le(1) != 0
+            self.shadow_receive = self._io.read_bits_int_le(1) != 0
+            self.sort = self._io.read_bits_int_le(1) != 0
+            self.num_vertices = self._io.read_u2le()
+            self.max_index = self._io.read_u2le()
+            self.vertex_position_2 = self._io.read_u4le()
+            self.vertex_offset = self._io.read_u4le()
+            self.vertex_offset_2 = self._io.read_u4le()
+            self.face_position = self._io.read_u4le()
+            self.num_indices = self._io.read_u4le()
+            self.face_offset = self._io.read_u4le()
+            self.vdeclbase = self._io.read_u1()
+            self.vdecl = self._io.read_u1()
+            self.min_index = self._io.read_u2le()
+            self.num_weight_bounds = self._io.read_u1()
+            self.idx_bone_palette = self._io.read_u1()
+            self.rcn_base = self._io.read_u2le()
+            self.boundary = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.indices
+            if hasattr(self, '_m_indices'):
+                pass
+                for i in range(len(self._m_indices)):
+                    pass
+
+
+            _ = self.vertices
+            if hasattr(self, '_m_vertices'):
+                pass
+                for i in range(len(self._m_vertices)):
+                    pass
+                    _on = self._root.materials_data.materials[self.idx_material].vtype
+                    if _on == 0:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 1:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 2:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 3:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 4:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 5:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 6:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 7:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 8:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+
+
+            _ = self.vertices2
+            if hasattr(self, '_m_vertices2'):
+                pass
+                for i in range(len(self._m_vertices2)):
+                    pass
+                    _on = self.vertex_stride_2
+                    if _on == 4:
+                        pass
+                        self._m_vertices2[i]._fetch_instances()
+                    elif _on == 8:
+                        pass
+                        self._m_vertices2[i]._fetch_instances()
+
+
+
+
+        def _write__seq(self, io=None):
+            super(Mod153.Mesh, self)._write__seq(io)
+            self._should_write_indices = self.indices__enabled
+            self._should_write_vertices = self.vertices__enabled
+            self._should_write_vertices2 = self.vertices2__enabled
+            self._io.write_u2le(self.idx_group)
+            self._io.write_u2le(self.idx_material)
+            self._io.write_u1(self.disp)
+            self._io.write_u1(self.level_of_detail)
+            self._io.write_u1(self.alpha_priority)
+            self._io.write_u1(self.vertex_format)
+            self._io.write_u1(self.vertex_stride)
+            self._io.write_u1(self.vertex_stride_2)
+            self._io.write_u1(self.connective)
+            self._io.write_bits_int_le(1, int(self.shape))
+            self._io.write_bits_int_le(1, int(self.env))
+            self._io.write_bits_int_le(1, int(self.refrect))
+            self._io.write_bits_int_le(1, int(self.reserved2_flag_1))
+            self._io.write_bits_int_le(1, int(self.reserved2_flag_2))
+            self._io.write_bits_int_le(1, int(self.shadow_cast))
+            self._io.write_bits_int_le(1, int(self.shadow_receive))
+            self._io.write_bits_int_le(1, int(self.sort))
+            self._io.write_u2le(self.num_vertices)
+            self._io.write_u2le(self.max_index)
+            self._io.write_u4le(self.vertex_position_2)
+            self._io.write_u4le(self.vertex_offset)
+            self._io.write_u4le(self.vertex_offset_2)
+            self._io.write_u4le(self.face_position)
+            self._io.write_u4le(self.num_indices)
+            self._io.write_u4le(self.face_offset)
+            self._io.write_u1(self.vdeclbase)
+            self._io.write_u1(self.vdecl)
+            self._io.write_u2le(self.min_index)
+            self._io.write_u1(self.num_weight_bounds)
+            self._io.write_u1(self.idx_bone_palette)
+            self._io.write_u2le(self.rcn_base)
+            self._io.write_u4le(self.boundary)
+
+
+        def _check(self):
+            if self.indices__enabled:
+                pass
+                if len(self._m_indices) != self.num_indices:
+                    raise kaitaistruct.ConsistencyError(u"indices", self.num_indices, len(self._m_indices))
+                for i in range(len(self._m_indices)):
+                    pass
+
+
+            if self.vertices__enabled:
+                pass
+                if len(self._m_vertices) != ((self.max_index - self.min_index) + 1 if self.min_index > self.vertex_position_2 else self.num_vertices):
+                    raise kaitaistruct.ConsistencyError(u"vertices", ((self.max_index - self.min_index) + 1 if self.min_index > self.vertex_position_2 else self.num_vertices), len(self._m_vertices))
+                for i in range(len(self._m_vertices)):
+                    pass
+                    _on = self._root.materials_data.materials[self.idx_material].vtype
+                    if _on == 0:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 1:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 2:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 3:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 4:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 5:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 6:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 7:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 8:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+
+
+            if self.vertices2__enabled:
+                pass
+                if self.vertex_stride_2 > 0:
+                    pass
+                    if len(self._m_vertices2) != self.num_vertices:
+                        raise kaitaistruct.ConsistencyError(u"vertices2", self.num_vertices, len(self._m_vertices2))
+                    for i in range(len(self._m_vertices2)):
+                        pass
+                        _on = self.vertex_stride_2
+                        if _on == 4:
+                            pass
+                            if self._m_vertices2[i]._root != self._root:
+                                raise kaitaistruct.ConsistencyError(u"vertices2", self._root, self._m_vertices2[i]._root)
+                            if self._m_vertices2[i]._parent != self:
+                                raise kaitaistruct.ConsistencyError(u"vertices2", self, self._m_vertices2[i]._parent)
+                        elif _on == 8:
+                            pass
+                            if self._m_vertices2[i]._root != self._root:
+                                raise kaitaistruct.ConsistencyError(u"vertices2", self._root, self._m_vertices2[i]._root)
+                            if self._m_vertices2[i]._parent != self:
+                                raise kaitaistruct.ConsistencyError(u"vertices2", self, self._m_vertices2[i]._parent)
+
+
+
+            self._dirty = False
+
+        @property
+        def indices(self):
+            if self._should_write_indices:
+                self._write_indices()
+            if hasattr(self, '_m_indices'):
+                return self._m_indices
+
+            if not self.indices__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek((self._root.header.offset_index_buffer + self.face_offset * 2) + self.face_position * 2)
+            self._m_indices = []
+            for i in range(self.num_indices):
+                self._m_indices.append(self._io.read_u2le())
+
+            self._io.seek(_pos)
+            return getattr(self, '_m_indices', None)
+
+        @indices.setter
+        def indices(self, v):
+            self._dirty = True
+            self._m_indices = v
+
+        def _write_indices(self):
+            self._should_write_indices = False
+            _pos = self._io.pos()
+            self._io.seek((self._root.header.offset_index_buffer + self.face_offset * 2) + self.face_position * 2)
+            for i in range(len(self._m_indices)):
+                pass
+                self._io.write_u2le(self._m_indices[i])
+
+            self._io.seek(_pos)
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 52
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+        @property
+        def vertices(self):
+            if self._should_write_vertices:
+                self._write_vertices()
+            if hasattr(self, '_m_vertices'):
+                return self._m_vertices
+
+            if not self.vertices__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(((self._root.header.offset_vertex_buffer + self.min_index * self.vertex_stride) + self.vertex_offset if self.min_index > self.vertex_position_2 else (self._root.header.offset_vertex_buffer + self.min_index * self.vertex_stride) + self.vertex_offset))
+            self._m_vertices = []
+            for i in range(((self.max_index - self.min_index) + 1 if self.min_index > self.vertex_position_2 else self.num_vertices)):
+                _on = self._root.materials_data.materials[self.idx_material].vtype
+                if _on == 0:
+                    pass
+                    _t__m_vertices = Mod153.VfSkin(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 1:
+                    pass
+                    _t__m_vertices = Mod153.VfSkinEx(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 2:
+                    pass
+                    _t__m_vertices = Mod153.VfNonSkin(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 3:
+                    pass
+                    _t__m_vertices = Mod153.VfNonSkinCol(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 4:
+                    pass
+                    _t__m_vertices = Mod153.VfSkin(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 5:
+                    pass
+                    _t__m_vertices = Mod153.VfSkin(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 6:
+                    pass
+                    _t__m_vertices = Mod153.VfNonSkin(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 7:
+                    pass
+                    _t__m_vertices = Mod153.VfSkinEx(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 8:
+                    pass
+                    _t__m_vertices = Mod153.VfNonSkinCol(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+
+            self._io.seek(_pos)
+            return getattr(self, '_m_vertices', None)
+
+        @vertices.setter
+        def vertices(self, v):
+            self._dirty = True
+            self._m_vertices = v
+
+        def _write_vertices(self):
+            self._should_write_vertices = False
+            _pos = self._io.pos()
+            self._io.seek(((self._root.header.offset_vertex_buffer + self.min_index * self.vertex_stride) + self.vertex_offset if self.min_index > self.vertex_position_2 else (self._root.header.offset_vertex_buffer + self.min_index * self.vertex_stride) + self.vertex_offset))
+            for i in range(len(self._m_vertices)):
+                pass
+                _on = self._root.materials_data.materials[self.idx_material].vtype
+                if _on == 0:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 1:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 2:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 3:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 4:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 5:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 6:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 7:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 8:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+
+            self._io.seek(_pos)
+
+        @property
+        def vertices2(self):
+            if self._should_write_vertices2:
+                self._write_vertices2()
+            if hasattr(self, '_m_vertices2'):
+                return self._m_vertices2
+
+            if not self.vertices2__enabled:
+                return None
+
+            if self.vertex_stride_2 > 0:
+                pass
+                _pos = self._io.pos()
+                self._io.seek((self._root.header.offset_vertex_buffer_2 + self.vertex_position_2 * self.vertex_stride_2) + self.vertex_offset_2)
+                self._m_vertices2 = []
+                for i in range(self.num_vertices):
+                    _on = self.vertex_stride_2
+                    if _on == 4:
+                        pass
+                        _t__m_vertices2 = Mod153.Vertex24(self._io, self, self._root)
+                        try:
+                            _t__m_vertices2._read()
+                        finally:
+                            self._m_vertices2.append(_t__m_vertices2)
+                    elif _on == 8:
+                        pass
+                        _t__m_vertices2 = Mod153.Vertex28(self._io, self, self._root)
+                        try:
+                            _t__m_vertices2._read()
+                        finally:
+                            self._m_vertices2.append(_t__m_vertices2)
+
+                self._io.seek(_pos)
+
+            return getattr(self, '_m_vertices2', None)
+
+        @vertices2.setter
+        def vertices2(self, v):
+            self._dirty = True
+            self._m_vertices2 = v
+
+        def _write_vertices2(self):
+            self._should_write_vertices2 = False
+            if self.vertex_stride_2 > 0:
+                pass
+                _pos = self._io.pos()
+                self._io.seek((self._root.header.offset_vertex_buffer_2 + self.vertex_position_2 * self.vertex_stride_2) + self.vertex_offset_2)
+                for i in range(len(self._m_vertices2)):
+                    pass
+                    _on = self.vertex_stride_2
+                    if _on == 4:
+                        pass
+                        self._m_vertices2[i]._write__seq(self._io)
+                    elif _on == 8:
+                        pass
+                        self._m_vertices2[i]._write__seq(self._io)
+
+                self._io.seek(_pos)
+
+
+
+    class MeshesData(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod153.MeshesData, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.meshes = []
+            for i in range(self._root.header.num_meshes):
+                _t_meshes = Mod153.Mesh(self._io, self, self._root)
+                try:
+                    _t_meshes._read()
+                finally:
+                    self.meshes.append(_t_meshes)
+
+            self.num_weight_bounds = self._io.read_u4le()
+            self.weight_bounds = []
+            for i in range(self.num_weight_bounds):
+                _t_weight_bounds = Mod153.WeightBound(self._io, self, self._root)
+                try:
+                    _t_weight_bounds._read()
+                finally:
+                    self.weight_bounds.append(_t_weight_bounds)
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.meshes)):
+                pass
+                self.meshes[i]._fetch_instances()
+
+            for i in range(len(self.weight_bounds)):
+                pass
+                self.weight_bounds[i]._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Mod153.MeshesData, self)._write__seq(io)
+            for i in range(len(self.meshes)):
+                pass
+                self.meshes[i]._write__seq(self._io)
+
+            self._io.write_u4le(self.num_weight_bounds)
+            for i in range(len(self.weight_bounds)):
+                pass
+                self.weight_bounds[i]._write__seq(self._io)
+
+
+
+        def _check(self):
+            if len(self.meshes) != self._root.header.num_meshes:
+                raise kaitaistruct.ConsistencyError(u"meshes", self._root.header.num_meshes, len(self.meshes))
+            for i in range(len(self.meshes)):
+                pass
+                if self.meshes[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"meshes", self._root, self.meshes[i]._root)
+                if self.meshes[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"meshes", self, self.meshes[i]._parent)
+
+            if len(self.weight_bounds) != self.num_weight_bounds:
+                raise kaitaistruct.ConsistencyError(u"weight_bounds", self.num_weight_bounds, len(self.weight_bounds))
+            for i in range(len(self.weight_bounds)):
+                pass
+                if self.weight_bounds[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"weight_bounds", self._root, self.weight_bounds[i]._root)
+                if self.weight_bounds[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"weight_bounds", self, self.weight_bounds[i]._parent)
+
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = (self._root.header.num_meshes * self.meshes[0].size_ + 4) + self.num_weight_bounds * self.weight_bounds[0].size_
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class ModHeader(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod153.ModHeader, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.ident = self._io.read_bytes(4)
+            if not self.ident == b"\x4D\x4F\x44\x00":
+                raise kaitaistruct.ValidationNotEqualError(b"\x4D\x4F\x44\x00", self.ident, self._io, u"/types/mod_header/seq/0")
+            self.version = self._io.read_u1()
+            self.revision = self._io.read_u1()
+            self.num_bones = self._io.read_u2le()
+            self.num_meshes = self._io.read_u2le()
+            self.num_materials = self._io.read_u2le()
+            self.num_vertices = self._io.read_u4le()
+            self.num_faces = self._io.read_u4le()
+            self.num_edges = self._io.read_u4le()
+            self.size_vertex_buffer = self._io.read_u4le()
+            self.size_vertex_buffer_2 = self._io.read_u4le()
+            self.num_textures = self._io.read_u4le()
+            self.num_groups = self._io.read_u4le()
+            self.num_bone_palettes = self._io.read_u4le()
+            self.offset_bones_data = self._io.read_u4le()
+            self.offset_groups = self._io.read_u4le()
+            self.offset_materials_data = self._io.read_u4le()
+            self.offset_meshes_data = self._io.read_u4le()
+            self.offset_vertex_buffer = self._io.read_u4le()
+            self.offset_vertex_buffer_2 = self._io.read_u4le()
+            self.offset_index_buffer = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod153.ModHeader, self)._write__seq(io)
+            self._io.write_bytes(self.ident)
+            self._io.write_u1(self.version)
+            self._io.write_u1(self.revision)
+            self._io.write_u2le(self.num_bones)
+            self._io.write_u2le(self.num_meshes)
+            self._io.write_u2le(self.num_materials)
+            self._io.write_u4le(self.num_vertices)
+            self._io.write_u4le(self.num_faces)
+            self._io.write_u4le(self.num_edges)
+            self._io.write_u4le(self.size_vertex_buffer)
+            self._io.write_u4le(self.size_vertex_buffer_2)
+            self._io.write_u4le(self.num_textures)
+            self._io.write_u4le(self.num_groups)
+            self._io.write_u4le(self.num_bone_palettes)
+            self._io.write_u4le(self.offset_bones_data)
+            self._io.write_u4le(self.offset_groups)
+            self._io.write_u4le(self.offset_materials_data)
+            self._io.write_u4le(self.offset_meshes_data)
+            self._io.write_u4le(self.offset_vertex_buffer)
+            self._io.write_u4le(self.offset_vertex_buffer_2)
+            self._io.write_u4le(self.offset_index_buffer)
+
+
+        def _check(self):
+            if len(self.ident) != 4:
+                raise kaitaistruct.ConsistencyError(u"ident", 4, len(self.ident))
+            if not self.ident == b"\x4D\x4F\x44\x00":
+                raise kaitaistruct.ValidationNotEqualError(b"\x4D\x4F\x44\x00", self.ident, None, u"/types/mod_header/seq/0")
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 72
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class ModelInfo(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod153.ModelInfo, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.middist = self._io.read_s4le()
+            self.lowdist = self._io.read_s4le()
+            self.light_group = self._io.read_u4le()
+            self.strip_type = self._io.read_u1()
+            self.memory = self._io.read_u1()
+            self.reserved = self._io.read_u2le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod153.ModelInfo, self)._write__seq(io)
+            self._io.write_s4le(self.middist)
+            self._io.write_s4le(self.lowdist)
+            self._io.write_u4le(self.light_group)
+            self._io.write_u1(self.strip_type)
+            self._io.write_u1(self.memory)
+            self._io.write_u2le(self.reserved)
+
+
+        def _check(self):
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 16
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
 
     class RcnHeader(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod153.RcnHeader, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -2179,6 +1513,7 @@ class Mod153(ReadWriteKaitaiStruct):
             self.num_tbl = self._io.read_u4le()
             self.parts = self._io.read_u4le()
             self.reserved = self._io.read_u4le()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -2198,7 +1533,7 @@ class Mod153(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
+            self._dirty = False
 
         @property
         def size_(self):
@@ -2211,9 +1546,227 @@ class Mod153(ReadWriteKaitaiStruct):
         def _invalidate_size_(self):
             del self._m_size_
 
+    class RcnTable(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod153.RcnTable, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.vindex = self._io.read_bits_int_le(21)
+            self.noffset = self._io.read_bits_int_le(10)
+            self.edge = self._io.read_bits_int_le(1) != 0
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod153.RcnTable, self)._write__seq(io)
+            self._io.write_bits_int_le(21, self.vindex)
+            self._io.write_bits_int_le(10, self.noffset)
+            self._io.write_bits_int_le(1, int(self.edge))
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class RcnTriangle(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod153.RcnTriangle, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.v0 = self._io.read_bits_int_le(21)
+            self.v1 = self._io.read_bits_int_le(21)
+            self.v2 = self._io.read_bits_int_le(21)
+            self.reserved = self._io.read_bits_int_le(1) != 0
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod153.RcnTriangle, self)._write__seq(io)
+            self._io.write_bits_int_le(21, self.v0)
+            self._io.write_bits_int_le(21, self.v1)
+            self._io.write_bits_int_le(21, self.v2)
+            self._io.write_bits_int_le(1, int(self.reserved))
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class RcnVertex(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod153.RcnVertex, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.x = self._io.read_u2le()
+            self.y = self._io.read_u2le()
+            self.z = self._io.read_u2le()
+            self.w = self._io.read_u2le()
+            self.w0 = self._io.read_u1()
+            self.w1 = self._io.read_u1()
+            self.w2 = self._io.read_u1()
+            self.w3 = self._io.read_u1()
+            self.j0 = self._io.read_u1()
+            self.j1 = self._io.read_u1()
+            self.j2 = self._io.read_u1()
+            self.j3 = self._io.read_u1()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod153.RcnVertex, self)._write__seq(io)
+            self._io.write_u2le(self.x)
+            self._io.write_u2le(self.y)
+            self._io.write_u2le(self.z)
+            self._io.write_u2le(self.w)
+            self._io.write_u1(self.w0)
+            self._io.write_u1(self.w1)
+            self._io.write_u1(self.w2)
+            self._io.write_u1(self.w3)
+            self._io.write_u1(self.j0)
+            self._io.write_u1(self.j1)
+            self._io.write_u1(self.j2)
+            self._io.write_u1(self.j3)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Vec2(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod153.Vec2, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.x = self._io.read_f4le()
+            self.y = self._io.read_f4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod153.Vec2, self)._write__seq(io)
+            self._io.write_f4le(self.x)
+            self._io.write_f4le(self.y)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Vec2HalfFloat(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod153.Vec2HalfFloat, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.u = self._io.read_bytes(2)
+            self.v = self._io.read_bytes(2)
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod153.Vec2HalfFloat, self)._write__seq(io)
+            self._io.write_bytes(self.u)
+            self._io.write_bytes(self.v)
+
+
+        def _check(self):
+            if len(self.u) != 2:
+                raise kaitaistruct.ConsistencyError(u"u", 2, len(self.u))
+            if len(self.v) != 2:
+                raise kaitaistruct.ConsistencyError(u"v", 2, len(self.v))
+            self._dirty = False
+
+
+    class Vec3(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod153.Vec3, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.x = self._io.read_f4le()
+            self.y = self._io.read_f4le()
+            self.z = self._io.read_f4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod153.Vec3, self)._write__seq(io)
+            self._io.write_f4le(self.x)
+            self._io.write_f4le(self.y)
+            self._io.write_f4le(self.z)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Vec4(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod153.Vec4, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.x = self._io.read_f4le()
+            self.y = self._io.read_f4le()
+            self.z = self._io.read_f4le()
+            self.w = self._io.read_f4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod153.Vec4, self)._write__seq(io)
+            self._io.write_f4le(self.x)
+            self._io.write_f4le(self.y)
+            self._io.write_f4le(self.z)
+            self._io.write_f4le(self.w)
+
+
+        def _check(self):
+            self._dirty = False
+
+
     class Vec4S2(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod153.Vec4S2, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -2222,6 +1775,7 @@ class Mod153(ReadWriteKaitaiStruct):
             self.y = self._io.read_s2le()
             self.z = self._io.read_s2le()
             self.w = self._io.read_s2le()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -2237,71 +1791,274 @@ class Mod153(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
+            self._dirty = False
 
 
-    class Group(ReadWriteKaitaiStruct):
+    class Vec4U1(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod153.Vec4U1, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
-            self.group_index = self._io.read_u4le()
-            self.reserved = []
-            for i in range(3):
-                self.reserved.append(self._io.read_u4le())
-
-            self.pos = Mod153.Vec3(self._io, self, self._root)
-            self.pos._read()
-            self.radius = self._io.read_f4le()
+            self.x = self._io.read_u1()
+            self.y = self._io.read_u1()
+            self.z = self._io.read_u1()
+            self.w = self._io.read_u1()
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
-            for i in range(len(self.reserved)):
-                pass
-
-            self.pos._fetch_instances()
 
 
         def _write__seq(self, io=None):
-            super(Mod153.Group, self)._write__seq(io)
-            self._io.write_u4le(self.group_index)
-            for i in range(len(self.reserved)):
-                pass
-                self._io.write_u4le(self.reserved[i])
-
-            self.pos._write__seq(self._io)
-            self._io.write_f4le(self.radius)
+            super(Mod153.Vec4U1, self)._write__seq(io)
+            self._io.write_u1(self.x)
+            self._io.write_u1(self.y)
+            self._io.write_u1(self.z)
+            self._io.write_u1(self.w)
 
 
         def _check(self):
+            self._dirty = False
+
+
+    class Vertex(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod153.Vertex, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod153.Vec4S2(self._io, self, self._root)
+            self.position._read()
+            self.bone_indices = []
+            for i in range(4):
+                self.bone_indices.append(self._io.read_u1())
+
+            self.weight_values = []
+            for i in range(4):
+                self.weight_values.append(self._io.read_u1())
+
+            self.normal = Mod153.Vec4U1(self._io, self, self._root)
+            self.normal._read()
+            self.tangent = Mod153.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod153.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod153.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
             pass
-            if (len(self.reserved) != 3):
-                raise kaitaistruct.ConsistencyError(u"reserved", len(self.reserved), 3)
-            for i in range(len(self.reserved)):
+            self.position._fetch_instances()
+            for i in range(len(self.bone_indices)):
                 pass
 
-            if self.pos._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"pos", self.pos._root, self._root)
-            if self.pos._parent != self:
-                raise kaitaistruct.ConsistencyError(u"pos", self.pos._parent, self)
+            for i in range(len(self.weight_values)):
+                pass
 
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
 
-            self._m_size_ = 32
-            return getattr(self, '_m_size_', None)
 
-        def _invalidate_size_(self):
-            del self._m_size_
+        def _write__seq(self, io=None):
+            super(Mod153.Vertex, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            for i in range(len(self.bone_indices)):
+                pass
+                self._io.write_u1(self.bone_indices[i])
+
+            for i in range(len(self.weight_values)):
+                pass
+                self._io.write_u1(self.weight_values[i])
+
+            self.normal._write__seq(self._io)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if len(self.bone_indices) != 4:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 4, len(self.bone_indices))
+            for i in range(len(self.bone_indices)):
+                pass
+
+            if len(self.weight_values) != 4:
+                raise kaitaistruct.ConsistencyError(u"weight_values", 4, len(self.weight_values))
+            for i in range(len(self.weight_values)):
+                pass
+
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            self._dirty = False
+
+
+    class Vertex24(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod153.Vertex24, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.occlusion = Mod153.Vec4U1(self._io, self, self._root)
+            self.occlusion._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.occlusion._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod153.Vertex24, self)._write__seq(io)
+            self.occlusion._write__seq(self._io)
+
+
+        def _check(self):
+            if self.occlusion._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"occlusion", self._root, self.occlusion._root)
+            if self.occlusion._parent != self:
+                raise kaitaistruct.ConsistencyError(u"occlusion", self, self.occlusion._parent)
+            self._dirty = False
+
+
+    class Vertex28(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod153.Vertex28, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.occlusion = Mod153.Vec4U1(self._io, self, self._root)
+            self.occlusion._read()
+            self.tangent = Mod153.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.occlusion._fetch_instances()
+            self.tangent._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod153.Vertex28, self)._write__seq(io)
+            self.occlusion._write__seq(self._io)
+            self.tangent._write__seq(self._io)
+
+
+        def _check(self):
+            if self.occlusion._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"occlusion", self._root, self.occlusion._root)
+            if self.occlusion._parent != self:
+                raise kaitaistruct.ConsistencyError(u"occlusion", self, self.occlusion._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            self._dirty = False
+
+
+    class Vertex0(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod153.Vertex0, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod153.Vec3(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod153.Vec4U1(self._io, self, self._root)
+            self.normal._read()
+            self.tangent = Mod153.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod153.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod153.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self.uv3 = Mod153.Vec2HalfFloat(self._io, self, self._root)
+            self.uv3._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
+            self.uv3._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod153.Vertex0, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+            self.uv3._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            if self.uv3._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv3", self._root, self.uv3._root)
+            if self.uv3._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv3", self, self.uv3._parent)
+            self._dirty = False
+
 
     class Vertex5(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod153.Vertex5, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -2320,6 +2077,7 @@ class Mod153(ReadWriteKaitaiStruct):
             self.normal._read()
             self.uv = Mod153.Vec2HalfFloat(self._io, self, self._root)
             self.uv._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -2351,252 +2109,425 @@ class Mod153(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
             if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
             if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if (len(self.bone_indices) != 8):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 8)
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if len(self.bone_indices) != 8:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 8, len(self.bone_indices))
             for i in range(len(self.bone_indices)):
                 pass
 
-            if (len(self.weight_values) != 8):
-                raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values), 8)
+            if len(self.weight_values) != 8:
+                raise kaitaistruct.ConsistencyError(u"weight_values", 8, len(self.weight_values))
             for i in range(len(self.weight_values)):
                 pass
 
             if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
             if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
             if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
             if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            self._dirty = False
 
 
-    @property
-    def vertex_buffer(self):
-        if self._should_write_vertex_buffer:
-            self._write_vertex_buffer()
-        if hasattr(self, '_m_vertex_buffer'):
-            return self._m_vertex_buffer
+    class VfNonSkin(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod153.VfNonSkin, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
 
-        if (self.header.offset_vertex_buffer > 0):
+        def _read(self):
+            self.position = Mod153.Vec3(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod153.Vec4U1(self._io, self, self._root)
+            self.normal._read()
+            self.tangent = Mod153.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod153.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod153.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self.uv3 = Mod153.Vec2HalfFloat(self._io, self, self._root)
+            self.uv3._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
             pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_vertex_buffer)
-            self._m_vertex_buffer = self._io.read_bytes(self.header.size_vertex_buffer)
-            self._io.seek(_pos)
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
+            self.uv3._fetch_instances()
 
-        return getattr(self, '_m_vertex_buffer', None)
 
-    @vertex_buffer.setter
-    def vertex_buffer(self, v):
-        self._m_vertex_buffer = v
+        def _write__seq(self, io=None):
+            super(Mod153.VfNonSkin, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+            self.uv3._write__seq(self._io)
 
-    def _write_vertex_buffer(self):
-        self._should_write_vertex_buffer = False
-        if (self.header.offset_vertex_buffer > 0):
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            if self.uv3._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv3", self._root, self.uv3._root)
+            if self.uv3._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv3", self, self.uv3._parent)
+            self._dirty = False
+
+
+    class VfNonSkinCol(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod153.VfNonSkinCol, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod153.Vec3(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod153.Vec4U1(self._io, self, self._root)
+            self.normal._read()
+            self.tangent = Mod153.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod153.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod153.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self.rgba = Mod153.Vec4U1(self._io, self, self._root)
+            self.rgba._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
             pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_vertex_buffer)
-            self._io.write_bytes(self.vertex_buffer)
-            self._io.seek(_pos)
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
+            self.rgba._fetch_instances()
 
 
+        def _write__seq(self, io=None):
+            super(Mod153.VfNonSkinCol, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+            self.rgba._write__seq(self._io)
 
-    def _check_vertex_buffer(self):
-        pass
-        if (self.header.offset_vertex_buffer > 0):
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            if self.rgba._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"rgba", self._root, self.rgba._root)
+            if self.rgba._parent != self:
+                raise kaitaistruct.ConsistencyError(u"rgba", self, self.rgba._parent)
+            self._dirty = False
+
+
+    class VfSkin(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod153.VfSkin, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod153.Vec4S2(self._io, self, self._root)
+            self.position._read()
+            self.bone_indices = []
+            for i in range(4):
+                self.bone_indices.append(self._io.read_u1())
+
+            self.weight_values = []
+            for i in range(4):
+                self.weight_values.append(self._io.read_u1())
+
+            self.normal = Mod153.Vec4U1(self._io, self, self._root)
+            self.normal._read()
+            self.tangent = Mod153.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod153.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod153.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
             pass
-            if (len(self.vertex_buffer) != self.header.size_vertex_buffer):
-                raise kaitaistruct.ConsistencyError(u"vertex_buffer", len(self.vertex_buffer), self.header.size_vertex_buffer)
+            self.position._fetch_instances()
+            for i in range(len(self.bone_indices)):
+                pass
+
+            for i in range(len(self.weight_values)):
+                pass
+
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
 
 
-    @property
-    def materials_data(self):
-        if self._should_write_materials_data:
-            self._write_materials_data()
-        if hasattr(self, '_m_materials_data'):
-            return self._m_materials_data
+        def _write__seq(self, io=None):
+            super(Mod153.VfSkin, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            for i in range(len(self.bone_indices)):
+                pass
+                self._io.write_u1(self.bone_indices[i])
 
-        if (self.header.offset_materials_data > 0):
+            for i in range(len(self.weight_values)):
+                pass
+                self._io.write_u1(self.weight_values[i])
+
+            self.normal._write__seq(self._io)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if len(self.bone_indices) != 4:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 4, len(self.bone_indices))
+            for i in range(len(self.bone_indices)):
+                pass
+
+            if len(self.weight_values) != 4:
+                raise kaitaistruct.ConsistencyError(u"weight_values", 4, len(self.weight_values))
+            for i in range(len(self.weight_values)):
+                pass
+
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            self._dirty = False
+
+
+    class VfSkinEx(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod153.VfSkinEx, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod153.Vec4S2(self._io, self, self._root)
+            self.position._read()
+            self.bone_indices = []
+            for i in range(8):
+                self.bone_indices.append(self._io.read_u1())
+
+            self.weight_values = []
+            for i in range(8):
+                self.weight_values.append(self._io.read_u1())
+
+            self.normal = Mod153.Vec4U1(self._io, self, self._root)
+            self.normal._read()
+            self.uv = Mod153.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
             pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_materials_data)
-            self._m_materials_data = Mod153.MaterialsData(self._io, self, self._root)
-            self._m_materials_data._read()
-            self._io.seek(_pos)
+            self.position._fetch_instances()
+            for i in range(len(self.bone_indices)):
+                pass
 
-        return getattr(self, '_m_materials_data', None)
+            for i in range(len(self.weight_values)):
+                pass
 
-    @materials_data.setter
-    def materials_data(self, v):
-        self._m_materials_data = v
+            self.normal._fetch_instances()
+            self.uv._fetch_instances()
 
-    def _write_materials_data(self):
-        self._should_write_materials_data = False
-        if (self.header.offset_materials_data > 0):
+
+        def _write__seq(self, io=None):
+            super(Mod153.VfSkinEx, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            for i in range(len(self.bone_indices)):
+                pass
+                self._io.write_u1(self.bone_indices[i])
+
+            for i in range(len(self.weight_values)):
+                pass
+                self._io.write_u1(self.weight_values[i])
+
+            self.normal._write__seq(self._io)
+            self.uv._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if len(self.bone_indices) != 8:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 8, len(self.bone_indices))
+            for i in range(len(self.bone_indices)):
+                pass
+
+            if len(self.weight_values) != 8:
+                raise kaitaistruct.ConsistencyError(u"weight_values", 8, len(self.weight_values))
+            for i in range(len(self.weight_values)):
+                pass
+
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            self._dirty = False
+
+
+    class WeightBound(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod153.WeightBound, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.bone_id = self._io.read_u4le()
+            self.unk_01 = Mod153.Vec3(self._io, self, self._root)
+            self.unk_01._read()
+            self.bsphere = Mod153.Vec4(self._io, self, self._root)
+            self.bsphere._read()
+            self.bbox_min = Mod153.Vec4(self._io, self, self._root)
+            self.bbox_min._read()
+            self.bbox_max = Mod153.Vec4(self._io, self, self._root)
+            self.bbox_max._read()
+            self.oabb = Mod153.Matrix4x4(self._io, self, self._root)
+            self.oabb._read()
+            self.oabb_dimension = Mod153.Vec4(self._io, self, self._root)
+            self.oabb_dimension._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
             pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_materials_data)
-            self.materials_data._write__seq(self._io)
-            self._io.seek(_pos)
+            self.unk_01._fetch_instances()
+            self.bsphere._fetch_instances()
+            self.bbox_min._fetch_instances()
+            self.bbox_max._fetch_instances()
+            self.oabb._fetch_instances()
+            self.oabb_dimension._fetch_instances()
 
 
-
-    def _check_materials_data(self):
-        pass
-        if (self.header.offset_materials_data > 0):
-            pass
-            if self.materials_data._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"materials_data", self.materials_data._root, self._root)
-            if self.materials_data._parent != self:
-                raise kaitaistruct.ConsistencyError(u"materials_data", self.materials_data._parent, self)
-
-
-    @property
-    def bones_data_size_(self):
-        if hasattr(self, '_m_bones_data_size_'):
-            return self._m_bones_data_size_
-
-        self._m_bones_data_size_ = (0 if (self.header.num_bones == 0) else self.bones_data.size_)
-        return getattr(self, '_m_bones_data_size_', None)
-
-    def _invalidate_bones_data_size_(self):
-        del self._m_bones_data_size_
-    @property
-    def vertex_buffer_2(self):
-        if self._should_write_vertex_buffer_2:
-            self._write_vertex_buffer_2()
-        if hasattr(self, '_m_vertex_buffer_2'):
-            return self._m_vertex_buffer_2
-
-        if (self.header.offset_vertex_buffer_2 > 0):
-            pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_vertex_buffer_2)
-            self._m_vertex_buffer_2 = self._io.read_bytes(self.header.size_vertex_buffer_2)
-            self._io.seek(_pos)
-
-        return getattr(self, '_m_vertex_buffer_2', None)
-
-    @vertex_buffer_2.setter
-    def vertex_buffer_2(self, v):
-        self._m_vertex_buffer_2 = v
-
-    def _write_vertex_buffer_2(self):
-        self._should_write_vertex_buffer_2 = False
-        if (self.header.offset_vertex_buffer_2 > 0):
-            pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_vertex_buffer_2)
-            self._io.write_bytes(self.vertex_buffer_2)
-            self._io.seek(_pos)
+        def _write__seq(self, io=None):
+            super(Mod153.WeightBound, self)._write__seq(io)
+            self._io.write_u4le(self.bone_id)
+            self.unk_01._write__seq(self._io)
+            self.bsphere._write__seq(self._io)
+            self.bbox_min._write__seq(self._io)
+            self.bbox_max._write__seq(self._io)
+            self.oabb._write__seq(self._io)
+            self.oabb_dimension._write__seq(self._io)
 
 
+        def _check(self):
+            if self.unk_01._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"unk_01", self._root, self.unk_01._root)
+            if self.unk_01._parent != self:
+                raise kaitaistruct.ConsistencyError(u"unk_01", self, self.unk_01._parent)
+            if self.bsphere._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"bsphere", self._root, self.bsphere._root)
+            if self.bsphere._parent != self:
+                raise kaitaistruct.ConsistencyError(u"bsphere", self, self.bsphere._parent)
+            if self.bbox_min._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"bbox_min", self._root, self.bbox_min._root)
+            if self.bbox_min._parent != self:
+                raise kaitaistruct.ConsistencyError(u"bbox_min", self, self.bbox_min._parent)
+            if self.bbox_max._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"bbox_max", self._root, self.bbox_max._root)
+            if self.bbox_max._parent != self:
+                raise kaitaistruct.ConsistencyError(u"bbox_max", self, self.bbox_max._parent)
+            if self.oabb._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"oabb", self._root, self.oabb._root)
+            if self.oabb._parent != self:
+                raise kaitaistruct.ConsistencyError(u"oabb", self, self.oabb._parent)
+            if self.oabb_dimension._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"oabb_dimension", self._root, self.oabb_dimension._root)
+            if self.oabb_dimension._parent != self:
+                raise kaitaistruct.ConsistencyError(u"oabb_dimension", self, self.oabb_dimension._parent)
+            self._dirty = False
 
-    def _check_vertex_buffer_2(self):
-        pass
-        if (self.header.offset_vertex_buffer_2 > 0):
-            pass
-            if (len(self.vertex_buffer_2) != self.header.size_vertex_buffer_2):
-                raise kaitaistruct.ConsistencyError(u"vertex_buffer_2", len(self.vertex_buffer_2), self.header.size_vertex_buffer_2)
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
 
+            self._m_size_ = 144
+            return getattr(self, '_m_size_', None)
 
-    @property
-    def meshes_data(self):
-        if self._should_write_meshes_data:
-            self._write_meshes_data()
-        if hasattr(self, '_m_meshes_data'):
-            return self._m_meshes_data
+        def _invalidate_size_(self):
+            del self._m_size_
 
-        if (self.header.offset_meshes_data > 0):
-            pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_meshes_data)
-            self._m_meshes_data = Mod153.MeshesData(self._io, self, self._root)
-            self._m_meshes_data._read()
-            self._io.seek(_pos)
-
-        return getattr(self, '_m_meshes_data', None)
-
-    @meshes_data.setter
-    def meshes_data(self, v):
-        self._m_meshes_data = v
-
-    def _write_meshes_data(self):
-        self._should_write_meshes_data = False
-        if (self.header.offset_meshes_data > 0):
-            pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_meshes_data)
-            self.meshes_data._write__seq(self._io)
-            self._io.seek(_pos)
-
-
-
-    def _check_meshes_data(self):
-        pass
-        if (self.header.offset_meshes_data > 0):
-            pass
-            if self.meshes_data._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"meshes_data", self.meshes_data._root, self._root)
-            if self.meshes_data._parent != self:
-                raise kaitaistruct.ConsistencyError(u"meshes_data", self.meshes_data._parent, self)
-
-
-    @property
-    def index_buffer(self):
-        if self._should_write_index_buffer:
-            self._write_index_buffer()
-        if hasattr(self, '_m_index_buffer'):
-            return self._m_index_buffer
-
-        if (self.header.offset_index_buffer > 0):
-            pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_index_buffer)
-            self._m_index_buffer = self._io.read_bytes(((self.header.num_faces * 2) - 2))
-            self._io.seek(_pos)
-
-        return getattr(self, '_m_index_buffer', None)
-
-    @index_buffer.setter
-    def index_buffer(self, v):
-        self._m_index_buffer = v
-
-    def _write_index_buffer(self):
-        self._should_write_index_buffer = False
-        if (self.header.offset_index_buffer > 0):
-            pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_index_buffer)
-            self._io.write_bytes(self.index_buffer)
-            self._io.seek(_pos)
-
-
-
-    def _check_index_buffer(self):
-        pass
-        if (self.header.offset_index_buffer > 0):
-            pass
-            if (len(self.index_buffer) != ((self.header.num_faces * 2) - 2)):
-                raise kaitaistruct.ConsistencyError(u"index_buffer", len(self.index_buffer), ((self.header.num_faces * 2) - 2))
-
-
-    @property
-    def size_top_level_(self):
-        if hasattr(self, '_m_size_top_level_'):
-            return self._m_size_top_level_
-
-        self._m_size_top_level_ = (self._root.header.size_ + 72)
-        return getattr(self, '_m_size_top_level_', None)
-
-    def _invalidate_size_top_level_(self):
-        del self._m_size_top_level_
     @property
     def bones_data(self):
         if self._should_write_bones_data:
@@ -2604,7 +2535,10 @@ class Mod153(ReadWriteKaitaiStruct):
         if hasattr(self, '_m_bones_data'):
             return self._m_bones_data
 
-        if (self.header.num_bones != 0):
+        if not self.bones_data__enabled:
+            return None
+
+        if self.header.num_bones != 0:
             pass
             _pos = self._io.pos()
             self._io.seek(self.header.offset_bones_data)
@@ -2616,29 +2550,29 @@ class Mod153(ReadWriteKaitaiStruct):
 
     @bones_data.setter
     def bones_data(self, v):
+        self._dirty = True
         self._m_bones_data = v
 
     def _write_bones_data(self):
         self._should_write_bones_data = False
-        if (self.header.num_bones != 0):
+        if self.header.num_bones != 0:
             pass
             _pos = self._io.pos()
             self._io.seek(self.header.offset_bones_data)
-            self.bones_data._write__seq(self._io)
+            self._m_bones_data._write__seq(self._io)
             self._io.seek(_pos)
 
 
+    @property
+    def bones_data_size_(self):
+        if hasattr(self, '_m_bones_data_size_'):
+            return self._m_bones_data_size_
 
-    def _check_bones_data(self):
-        pass
-        if (self.header.num_bones != 0):
-            pass
-            if self.bones_data._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"bones_data", self.bones_data._root, self._root)
-            if self.bones_data._parent != self:
-                raise kaitaistruct.ConsistencyError(u"bones_data", self.bones_data._parent, self)
+        self._m_bones_data_size_ = (0 if self.header.num_bones == 0 else self.bones_data.size_)
+        return getattr(self, '_m_bones_data_size_', None)
 
-
+    def _invalidate_bones_data_size_(self):
+        del self._m_bones_data_size_
     @property
     def groups(self):
         if self._should_write_groups:
@@ -2646,19 +2580,25 @@ class Mod153(ReadWriteKaitaiStruct):
         if hasattr(self, '_m_groups'):
             return self._m_groups
 
+        if not self.groups__enabled:
+            return None
+
         _pos = self._io.pos()
         self._io.seek(self.header.offset_groups)
         self._m_groups = []
         for i in range(self.header.num_groups):
             _t__m_groups = Mod153.Group(self._io, self, self._root)
-            _t__m_groups._read()
-            self._m_groups.append(_t__m_groups)
+            try:
+                _t__m_groups._read()
+            finally:
+                self._m_groups.append(_t__m_groups)
 
         self._io.seek(_pos)
         return getattr(self, '_m_groups', None)
 
     @groups.setter
     def groups(self, v):
+        self._dirty = True
         self._m_groups = v
 
     def _write_groups(self):
@@ -2667,31 +2607,200 @@ class Mod153(ReadWriteKaitaiStruct):
         self._io.seek(self.header.offset_groups)
         for i in range(len(self._m_groups)):
             pass
-            self.groups[i]._write__seq(self._io)
+            self._m_groups[i]._write__seq(self._io)
 
         self._io.seek(_pos)
-
-
-    def _check_groups(self):
-        pass
-        if (len(self.groups) != self.header.num_groups):
-            raise kaitaistruct.ConsistencyError(u"groups", len(self.groups), self.header.num_groups)
-        for i in range(len(self._m_groups)):
-            pass
-            if self.groups[i]._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"groups", self.groups[i]._root, self._root)
-            if self.groups[i]._parent != self:
-                raise kaitaistruct.ConsistencyError(u"groups", self.groups[i]._parent, self)
-
 
     @property
     def groups_size_(self):
         if hasattr(self, '_m_groups_size_'):
             return self._m_groups_size_
 
-        self._m_groups_size_ = (self.groups[0].size_ * self.header.num_groups)
+        self._m_groups_size_ = self.groups[0].size_ * self.header.num_groups
         return getattr(self, '_m_groups_size_', None)
 
     def _invalidate_groups_size_(self):
         del self._m_groups_size_
+    @property
+    def index_buffer(self):
+        if self._should_write_index_buffer:
+            self._write_index_buffer()
+        if hasattr(self, '_m_index_buffer'):
+            return self._m_index_buffer
+
+        if not self.index_buffer__enabled:
+            return None
+
+        if self.header.offset_index_buffer > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_index_buffer)
+            self._m_index_buffer = self._io.read_bytes(self.header.num_faces * 2 - 2)
+            self._io.seek(_pos)
+
+        return getattr(self, '_m_index_buffer', None)
+
+    @index_buffer.setter
+    def index_buffer(self, v):
+        self._dirty = True
+        self._m_index_buffer = v
+
+    def _write_index_buffer(self):
+        self._should_write_index_buffer = False
+        if self.header.offset_index_buffer > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_index_buffer)
+            self._io.write_bytes(self._m_index_buffer)
+            self._io.seek(_pos)
+
+
+    @property
+    def materials_data(self):
+        if self._should_write_materials_data:
+            self._write_materials_data()
+        if hasattr(self, '_m_materials_data'):
+            return self._m_materials_data
+
+        if not self.materials_data__enabled:
+            return None
+
+        if self.header.offset_materials_data > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_materials_data)
+            self._m_materials_data = Mod153.MaterialsData(self._io, self, self._root)
+            self._m_materials_data._read()
+            self._io.seek(_pos)
+
+        return getattr(self, '_m_materials_data', None)
+
+    @materials_data.setter
+    def materials_data(self, v):
+        self._dirty = True
+        self._m_materials_data = v
+
+    def _write_materials_data(self):
+        self._should_write_materials_data = False
+        if self.header.offset_materials_data > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_materials_data)
+            self._m_materials_data._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    @property
+    def meshes_data(self):
+        if self._should_write_meshes_data:
+            self._write_meshes_data()
+        if hasattr(self, '_m_meshes_data'):
+            return self._m_meshes_data
+
+        if not self.meshes_data__enabled:
+            return None
+
+        if self.header.offset_meshes_data > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_meshes_data)
+            self._m_meshes_data = Mod153.MeshesData(self._io, self, self._root)
+            self._m_meshes_data._read()
+            self._io.seek(_pos)
+
+        return getattr(self, '_m_meshes_data', None)
+
+    @meshes_data.setter
+    def meshes_data(self, v):
+        self._dirty = True
+        self._m_meshes_data = v
+
+    def _write_meshes_data(self):
+        self._should_write_meshes_data = False
+        if self.header.offset_meshes_data > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_meshes_data)
+            self._m_meshes_data._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    @property
+    def size_top_level_(self):
+        if hasattr(self, '_m_size_top_level_'):
+            return self._m_size_top_level_
+
+        self._m_size_top_level_ = self._root.header.size_ + 72
+        return getattr(self, '_m_size_top_level_', None)
+
+    def _invalidate_size_top_level_(self):
+        del self._m_size_top_level_
+    @property
+    def vertex_buffer(self):
+        if self._should_write_vertex_buffer:
+            self._write_vertex_buffer()
+        if hasattr(self, '_m_vertex_buffer'):
+            return self._m_vertex_buffer
+
+        if not self.vertex_buffer__enabled:
+            return None
+
+        if self.header.offset_vertex_buffer > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_vertex_buffer)
+            self._m_vertex_buffer = self._io.read_bytes(self.header.size_vertex_buffer)
+            self._io.seek(_pos)
+
+        return getattr(self, '_m_vertex_buffer', None)
+
+    @vertex_buffer.setter
+    def vertex_buffer(self, v):
+        self._dirty = True
+        self._m_vertex_buffer = v
+
+    def _write_vertex_buffer(self):
+        self._should_write_vertex_buffer = False
+        if self.header.offset_vertex_buffer > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_vertex_buffer)
+            self._io.write_bytes(self._m_vertex_buffer)
+            self._io.seek(_pos)
+
+
+    @property
+    def vertex_buffer_2(self):
+        if self._should_write_vertex_buffer_2:
+            self._write_vertex_buffer_2()
+        if hasattr(self, '_m_vertex_buffer_2'):
+            return self._m_vertex_buffer_2
+
+        if not self.vertex_buffer_2__enabled:
+            return None
+
+        if self.header.offset_vertex_buffer_2 > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_vertex_buffer_2)
+            self._m_vertex_buffer_2 = self._io.read_bytes(self.header.size_vertex_buffer_2)
+            self._io.seek(_pos)
+
+        return getattr(self, '_m_vertex_buffer_2', None)
+
+    @vertex_buffer_2.setter
+    def vertex_buffer_2(self, v):
+        self._dirty = True
+        self._m_vertex_buffer_2 = v
+
+    def _write_vertex_buffer_2(self):
+        self._should_write_vertex_buffer_2 = False
+        if self.header.offset_vertex_buffer_2 > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_vertex_buffer_2)
+            self._io.write_bytes(self._m_vertex_buffer_2)
+            self._io.seek(_pos)
+
+
 

--- a/albam/engines/mtfw/structs/mod_156.py
+++ b/albam/engines/mtfw/structs/mod_156.py
@@ -5,28 +5,28 @@ import kaitaistruct
 from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
 
 
-if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 11):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.11 or later is required, but you have %s" % (kaitaistruct.__version__))
 
 class Mod156(ReadWriteKaitaiStruct):
     def __init__(self, _io=None, _parent=None, _root=None):
-        self._io = _io
+        super(Mod156, self).__init__(_io)
         self._parent = _parent
-        self._root = _root if _root else self
-        self._should_write_vertex_buffer = False
-        self.vertex_buffer__to_write = True
-        self._should_write_materials_data = False
-        self.materials_data__to_write = True
-        self._should_write_vertex_buffer_2 = False
-        self.vertex_buffer_2__to_write = True
-        self._should_write_meshes_data = False
-        self.meshes_data__to_write = True
-        self._should_write_index_buffer = False
-        self.index_buffer__to_write = True
+        self._root = _root or self
         self._should_write_bones_data = False
-        self.bones_data__to_write = True
+        self.bones_data__enabled = True
         self._should_write_groups = False
-        self.groups__to_write = True
+        self.groups__enabled = True
+        self._should_write_index_buffer = False
+        self.index_buffer__enabled = True
+        self._should_write_materials_data = False
+        self.materials_data__enabled = True
+        self._should_write_meshes_data = False
+        self.meshes_data__enabled = True
+        self._should_write_vertex_buffer = False
+        self.vertex_buffer__enabled = True
+        self._should_write_vertex_buffer_2 = False
+        self.vertex_buffer_2__enabled = True
 
     def _read(self):
         self.header = Mod156.ModHeader(self._io, self, self._root)
@@ -46,21 +46,28 @@ class Mod156(ReadWriteKaitaiStruct):
         self.rcn_tables = []
         for i in range(self.rcn_header.num_tbl):
             _t_rcn_tables = Mod156.RcnTable(self._io, self, self._root)
-            _t_rcn_tables._read()
-            self.rcn_tables.append(_t_rcn_tables)
+            try:
+                _t_rcn_tables._read()
+            finally:
+                self.rcn_tables.append(_t_rcn_tables)
 
         self.rcn_vertices = []
         for i in range(self.rcn_header.num_vtx):
             _t_rcn_vertices = Mod156.RcnVertex(self._io, self, self._root)
-            _t_rcn_vertices._read()
-            self.rcn_vertices.append(_t_rcn_vertices)
+            try:
+                _t_rcn_vertices._read()
+            finally:
+                self.rcn_vertices.append(_t_rcn_vertices)
 
         self.rcn_trianlges = []
         for i in range(self.rcn_header.num_tri):
             _t_rcn_trianlges = Mod156.RcnTriangle(self._io, self, self._root)
-            _t_rcn_trianlges._read()
-            self.rcn_trianlges.append(_t_rcn_trianlges)
+            try:
+                _t_rcn_trianlges._read()
+            finally:
+                self.rcn_trianlges.append(_t_rcn_trianlges)
 
+        self._dirty = False
 
 
     def _fetch_instances(self):
@@ -83,49 +90,52 @@ class Mod156(ReadWriteKaitaiStruct):
             pass
             self.rcn_trianlges[i]._fetch_instances()
 
-        if (self.header.offset_vertex_buffer > 0):
+        _ = self.bones_data
+        if hasattr(self, '_m_bones_data'):
             pass
-            _ = self.vertex_buffer
-
-        if (self.header.offset_materials_data > 0):
-            pass
-            _ = self.materials_data
-            self.materials_data._fetch_instances()
-
-        if (self.header.offset_vertex_buffer_2 > 0):
-            pass
-            _ = self.vertex_buffer_2
-
-        if (self.header.offset_meshes_data > 0):
-            pass
-            _ = self.meshes_data
-            self.meshes_data._fetch_instances()
-
-        if (self.header.offset_index_buffer > 0):
-            pass
-            _ = self.index_buffer
-
-        if (self.header.num_bones != 0):
-            pass
-            _ = self.bones_data
-            self.bones_data._fetch_instances()
+            self._m_bones_data._fetch_instances()
 
         _ = self.groups
-        for i in range(len(self._m_groups)):
+        if hasattr(self, '_m_groups'):
             pass
-            self.groups[i]._fetch_instances()
+            for i in range(len(self._m_groups)):
+                pass
+                self._m_groups[i]._fetch_instances()
+
+
+        _ = self.index_buffer
+        if hasattr(self, '_m_index_buffer'):
+            pass
+
+        _ = self.materials_data
+        if hasattr(self, '_m_materials_data'):
+            pass
+            self._m_materials_data._fetch_instances()
+
+        _ = self.meshes_data
+        if hasattr(self, '_m_meshes_data'):
+            pass
+            self._m_meshes_data._fetch_instances()
+
+        _ = self.vertex_buffer
+        if hasattr(self, '_m_vertex_buffer'):
+            pass
+
+        _ = self.vertex_buffer_2
+        if hasattr(self, '_m_vertex_buffer_2'):
+            pass
 
 
 
     def _write__seq(self, io=None):
         super(Mod156, self)._write__seq(io)
-        self._should_write_vertex_buffer = self.vertex_buffer__to_write
-        self._should_write_materials_data = self.materials_data__to_write
-        self._should_write_vertex_buffer_2 = self.vertex_buffer_2__to_write
-        self._should_write_meshes_data = self.meshes_data__to_write
-        self._should_write_index_buffer = self.index_buffer__to_write
-        self._should_write_bones_data = self.bones_data__to_write
-        self._should_write_groups = self.groups__to_write
+        self._should_write_bones_data = self.bones_data__enabled
+        self._should_write_groups = self.groups__enabled
+        self._should_write_index_buffer = self.index_buffer__enabled
+        self._should_write_materials_data = self.materials_data__enabled
+        self._should_write_meshes_data = self.meshes_data__enabled
+        self._should_write_vertex_buffer = self.vertex_buffer__enabled
+        self._should_write_vertex_buffer_2 = self.vertex_buffer_2__enabled
         self.header._write__seq(self._io)
         self._io.write_u4le(self.reserved_01)
         self._io.write_u4le(self.reserved_02)
@@ -149,492 +159,128 @@ class Mod156(ReadWriteKaitaiStruct):
 
 
     def _check(self):
-        pass
         if self.header._root != self._root:
-            raise kaitaistruct.ConsistencyError(u"header", self.header._root, self._root)
+            raise kaitaistruct.ConsistencyError(u"header", self._root, self.header._root)
         if self.header._parent != self:
-            raise kaitaistruct.ConsistencyError(u"header", self.header._parent, self)
+            raise kaitaistruct.ConsistencyError(u"header", self, self.header._parent)
         if self.bsphere._root != self._root:
-            raise kaitaistruct.ConsistencyError(u"bsphere", self.bsphere._root, self._root)
+            raise kaitaistruct.ConsistencyError(u"bsphere", self._root, self.bsphere._root)
         if self.bsphere._parent != self:
-            raise kaitaistruct.ConsistencyError(u"bsphere", self.bsphere._parent, self)
+            raise kaitaistruct.ConsistencyError(u"bsphere", self, self.bsphere._parent)
         if self.bbox_min._root != self._root:
-            raise kaitaistruct.ConsistencyError(u"bbox_min", self.bbox_min._root, self._root)
+            raise kaitaistruct.ConsistencyError(u"bbox_min", self._root, self.bbox_min._root)
         if self.bbox_min._parent != self:
-            raise kaitaistruct.ConsistencyError(u"bbox_min", self.bbox_min._parent, self)
+            raise kaitaistruct.ConsistencyError(u"bbox_min", self, self.bbox_min._parent)
         if self.bbox_max._root != self._root:
-            raise kaitaistruct.ConsistencyError(u"bbox_max", self.bbox_max._root, self._root)
+            raise kaitaistruct.ConsistencyError(u"bbox_max", self._root, self.bbox_max._root)
         if self.bbox_max._parent != self:
-            raise kaitaistruct.ConsistencyError(u"bbox_max", self.bbox_max._parent, self)
+            raise kaitaistruct.ConsistencyError(u"bbox_max", self, self.bbox_max._parent)
         if self.model_info._root != self._root:
-            raise kaitaistruct.ConsistencyError(u"model_info", self.model_info._root, self._root)
+            raise kaitaistruct.ConsistencyError(u"model_info", self._root, self.model_info._root)
         if self.model_info._parent != self:
-            raise kaitaistruct.ConsistencyError(u"model_info", self.model_info._parent, self)
+            raise kaitaistruct.ConsistencyError(u"model_info", self, self.model_info._parent)
         if self.rcn_header._root != self._root:
-            raise kaitaistruct.ConsistencyError(u"rcn_header", self.rcn_header._root, self._root)
+            raise kaitaistruct.ConsistencyError(u"rcn_header", self._root, self.rcn_header._root)
         if self.rcn_header._parent != self:
-            raise kaitaistruct.ConsistencyError(u"rcn_header", self.rcn_header._parent, self)
-        if (len(self.rcn_tables) != self.rcn_header.num_tbl):
-            raise kaitaistruct.ConsistencyError(u"rcn_tables", len(self.rcn_tables), self.rcn_header.num_tbl)
+            raise kaitaistruct.ConsistencyError(u"rcn_header", self, self.rcn_header._parent)
+        if len(self.rcn_tables) != self.rcn_header.num_tbl:
+            raise kaitaistruct.ConsistencyError(u"rcn_tables", self.rcn_header.num_tbl, len(self.rcn_tables))
         for i in range(len(self.rcn_tables)):
             pass
             if self.rcn_tables[i]._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"rcn_tables", self.rcn_tables[i]._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"rcn_tables", self._root, self.rcn_tables[i]._root)
             if self.rcn_tables[i]._parent != self:
-                raise kaitaistruct.ConsistencyError(u"rcn_tables", self.rcn_tables[i]._parent, self)
+                raise kaitaistruct.ConsistencyError(u"rcn_tables", self, self.rcn_tables[i]._parent)
 
-        if (len(self.rcn_vertices) != self.rcn_header.num_vtx):
-            raise kaitaistruct.ConsistencyError(u"rcn_vertices", len(self.rcn_vertices), self.rcn_header.num_vtx)
+        if len(self.rcn_vertices) != self.rcn_header.num_vtx:
+            raise kaitaistruct.ConsistencyError(u"rcn_vertices", self.rcn_header.num_vtx, len(self.rcn_vertices))
         for i in range(len(self.rcn_vertices)):
             pass
             if self.rcn_vertices[i]._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"rcn_vertices", self.rcn_vertices[i]._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"rcn_vertices", self._root, self.rcn_vertices[i]._root)
             if self.rcn_vertices[i]._parent != self:
-                raise kaitaistruct.ConsistencyError(u"rcn_vertices", self.rcn_vertices[i]._parent, self)
+                raise kaitaistruct.ConsistencyError(u"rcn_vertices", self, self.rcn_vertices[i]._parent)
 
-        if (len(self.rcn_trianlges) != self.rcn_header.num_tri):
-            raise kaitaistruct.ConsistencyError(u"rcn_trianlges", len(self.rcn_trianlges), self.rcn_header.num_tri)
+        if len(self.rcn_trianlges) != self.rcn_header.num_tri:
+            raise kaitaistruct.ConsistencyError(u"rcn_trianlges", self.rcn_header.num_tri, len(self.rcn_trianlges))
         for i in range(len(self.rcn_trianlges)):
             pass
             if self.rcn_trianlges[i]._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"rcn_trianlges", self.rcn_trianlges[i]._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"rcn_trianlges", self._root, self.rcn_trianlges[i]._root)
             if self.rcn_trianlges[i]._parent != self:
-                raise kaitaistruct.ConsistencyError(u"rcn_trianlges", self.rcn_trianlges[i]._parent, self)
+                raise kaitaistruct.ConsistencyError(u"rcn_trianlges", self, self.rcn_trianlges[i]._parent)
 
-
-    class Vec4(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.x = self._io.read_f4le()
-            self.y = self._io.read_f4le()
-            self.z = self._io.read_f4le()
-            self.w = self._io.read_f4le()
-
-
-        def _fetch_instances(self):
+        if self.bones_data__enabled:
             pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod156.Vec4, self)._write__seq(io)
-            self._io.write_f4le(self.x)
-            self._io.write_f4le(self.y)
-            self._io.write_f4le(self.z)
-            self._io.write_f4le(self.w)
-
-
-        def _check(self):
-            pass
-
-
-    class BonePalette(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.unk_01 = self._io.read_u4le()
-            self.indices = []
-            for i in range(32):
-                self.indices.append(self._io.read_u1())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.indices)):
+            if self.header.num_bones != 0:
                 pass
+                if self._m_bones_data._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"bones_data", self._root, self._m_bones_data._root)
+                if self._m_bones_data._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"bones_data", self, self._m_bones_data._parent)
 
 
-
-        def _write__seq(self, io=None):
-            super(Mod156.BonePalette, self)._write__seq(io)
-            self._io.write_u4le(self.unk_01)
-            for i in range(len(self.indices)):
+        if self.groups__enabled:
+            pass
+            if len(self._m_groups) != self.header.num_groups:
+                raise kaitaistruct.ConsistencyError(u"groups", self.header.num_groups, len(self._m_groups))
+            for i in range(len(self._m_groups)):
                 pass
-                self._io.write_u1(self.indices[i])
+                if self._m_groups[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"groups", self._root, self._m_groups[i]._root)
+                if self._m_groups[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"groups", self, self._m_groups[i]._parent)
 
 
-
-        def _check(self):
+        if self.index_buffer__enabled:
             pass
-            if (len(self.indices) != 32):
-                raise kaitaistruct.ConsistencyError(u"indices", len(self.indices), 32)
-            for i in range(len(self.indices)):
+            if self.header.offset_index_buffer > 0:
                 pass
+                if len(self._m_index_buffer) != self.header.num_faces * 2 - 2:
+                    raise kaitaistruct.ConsistencyError(u"index_buffer", self.header.num_faces * 2 - 2, len(self._m_index_buffer))
 
 
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 36
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class ModHeader(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.ident = self._io.read_bytes(4)
-            if not (self.ident == b"\x4D\x4F\x44\x00"):
-                raise kaitaistruct.ValidationNotEqualError(b"\x4D\x4F\x44\x00", self.ident, self._io, u"/types/mod_header/seq/0")
-            self.version = self._io.read_u1()
-            self.revision = self._io.read_u1()
-            self.num_bones = self._io.read_u2le()
-            self.num_meshes = self._io.read_u2le()
-            self.num_materials = self._io.read_u2le()
-            self.num_vertices = self._io.read_u4le()
-            self.num_faces = self._io.read_u4le()
-            self.num_edges = self._io.read_u4le()
-            self.size_vertex_buffer = self._io.read_u4le()
-            self.size_vertex_buffer_2 = self._io.read_u4le()
-            self.num_textures = self._io.read_u4le()
-            self.num_groups = self._io.read_u4le()
-            self.num_bone_palettes = self._io.read_u4le()
-            self.offset_bones_data = self._io.read_u4le()
-            self.offset_groups = self._io.read_u4le()
-            self.offset_materials_data = self._io.read_u4le()
-            self.offset_meshes_data = self._io.read_u4le()
-            self.offset_vertex_buffer = self._io.read_u4le()
-            self.offset_vertex_buffer_2 = self._io.read_u4le()
-            self.offset_index_buffer = self._io.read_u4le()
-
-
-        def _fetch_instances(self):
+        if self.materials_data__enabled:
             pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod156.ModHeader, self)._write__seq(io)
-            self._io.write_bytes(self.ident)
-            self._io.write_u1(self.version)
-            self._io.write_u1(self.revision)
-            self._io.write_u2le(self.num_bones)
-            self._io.write_u2le(self.num_meshes)
-            self._io.write_u2le(self.num_materials)
-            self._io.write_u4le(self.num_vertices)
-            self._io.write_u4le(self.num_faces)
-            self._io.write_u4le(self.num_edges)
-            self._io.write_u4le(self.size_vertex_buffer)
-            self._io.write_u4le(self.size_vertex_buffer_2)
-            self._io.write_u4le(self.num_textures)
-            self._io.write_u4le(self.num_groups)
-            self._io.write_u4le(self.num_bone_palettes)
-            self._io.write_u4le(self.offset_bones_data)
-            self._io.write_u4le(self.offset_groups)
-            self._io.write_u4le(self.offset_materials_data)
-            self._io.write_u4le(self.offset_meshes_data)
-            self._io.write_u4le(self.offset_vertex_buffer)
-            self._io.write_u4le(self.offset_vertex_buffer_2)
-            self._io.write_u4le(self.offset_index_buffer)
-
-
-        def _check(self):
-            pass
-            if (len(self.ident) != 4):
-                raise kaitaistruct.ConsistencyError(u"ident", len(self.ident), 4)
-            if not (self.ident == b"\x4D\x4F\x44\x00"):
-                raise kaitaistruct.ValidationNotEqualError(b"\x4D\x4F\x44\x00", self.ident, None, u"/types/mod_header/seq/0")
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 72
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Vec2HalfFloat(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.u = self._io.read_bytes(2)
-            self.v = self._io.read_bytes(2)
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod156.Vec2HalfFloat, self)._write__seq(io)
-            self._io.write_bytes(self.u)
-            self._io.write_bytes(self.v)
-
-
-        def _check(self):
-            pass
-            if (len(self.u) != 2):
-                raise kaitaistruct.ConsistencyError(u"u", len(self.u), 2)
-            if (len(self.v) != 2):
-                raise kaitaistruct.ConsistencyError(u"v", len(self.v), 2)
-
-
-    class VfSkin(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod156.Vec4S2(self._io, self, self._root)
-            self.position._read()
-            self.bone_indices = []
-            for i in range(4):
-                self.bone_indices.append(self._io.read_u1())
-
-            self.weight_values = []
-            for i in range(4):
-                self.weight_values.append(self._io.read_u1())
-
-            self.normal = Mod156.Vec4U1(self._io, self, self._root)
-            self.normal._read()
-            self.tangent = Mod156.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.uv = Mod156.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod156.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            for i in range(len(self.bone_indices)):
+            if self.header.offset_materials_data > 0:
                 pass
+                if self._m_materials_data._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"materials_data", self._root, self._m_materials_data._root)
+                if self._m_materials_data._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"materials_data", self, self._m_materials_data._parent)
 
-            for i in range(len(self.weight_values)):
+
+        if self.meshes_data__enabled:
+            pass
+            if self.header.offset_meshes_data > 0:
                 pass
+                if self._m_meshes_data._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"meshes_data", self._root, self._m_meshes_data._root)
+                if self._m_meshes_data._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"meshes_data", self, self._m_meshes_data._parent)
 
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
 
-
-        def _write__seq(self, io=None):
-            super(Mod156.VfSkin, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            for i in range(len(self.bone_indices)):
+        if self.vertex_buffer__enabled:
+            pass
+            if self.header.offset_vertex_buffer > 0:
                 pass
-                self._io.write_u1(self.bone_indices[i])
+                if len(self._m_vertex_buffer) != self.header.size_vertex_buffer:
+                    raise kaitaistruct.ConsistencyError(u"vertex_buffer", self.header.size_vertex_buffer, len(self._m_vertex_buffer))
 
-            for i in range(len(self.weight_values)):
+
+        if self.vertex_buffer_2__enabled:
+            pass
+            if self.header.offset_vertex_buffer_2 > 0:
                 pass
-                self._io.write_u1(self.weight_values[i])
-
-            self.normal._write__seq(self._io)
-            self.tangent._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
+                if len(self._m_vertex_buffer_2) != self.header.size_vertex_buffer_2:
+                    raise kaitaistruct.ConsistencyError(u"vertex_buffer_2", self.header.size_vertex_buffer_2, len(self._m_vertex_buffer_2))
 
 
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if (len(self.bone_indices) != 4):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 4)
-            for i in range(len(self.bone_indices)):
-                pass
-
-            if (len(self.weight_values) != 4):
-                raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values), 4)
-            for i in range(len(self.weight_values)):
-                pass
-
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-
-
-    class RcnTriangle(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.v0 = self._io.read_bits_int_le(21)
-            self.v1 = self._io.read_bits_int_le(21)
-            self.v2 = self._io.read_bits_int_le(21)
-            self.reserved = self._io.read_bits_int_le(1) != 0
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod156.RcnTriangle, self)._write__seq(io)
-            self._io.write_bits_int_le(21, self.v0)
-            self._io.write_bits_int_le(21, self.v1)
-            self._io.write_bits_int_le(21, self.v2)
-            self._io.write_bits_int_le(1, int(self.reserved))
-
-
-        def _check(self):
-            pass
-
-
-    class Matrix4x4(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.row_1 = Mod156.Vec4(self._io, self, self._root)
-            self.row_1._read()
-            self.row_2 = Mod156.Vec4(self._io, self, self._root)
-            self.row_2._read()
-            self.row_3 = Mod156.Vec4(self._io, self, self._root)
-            self.row_3._read()
-            self.row_4 = Mod156.Vec4(self._io, self, self._root)
-            self.row_4._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.row_1._fetch_instances()
-            self.row_2._fetch_instances()
-            self.row_3._fetch_instances()
-            self.row_4._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod156.Matrix4x4, self)._write__seq(io)
-            self.row_1._write__seq(self._io)
-            self.row_2._write__seq(self._io)
-            self.row_3._write__seq(self._io)
-            self.row_4._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.row_1._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"row_1", self.row_1._root, self._root)
-            if self.row_1._parent != self:
-                raise kaitaistruct.ConsistencyError(u"row_1", self.row_1._parent, self)
-            if self.row_2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"row_2", self.row_2._root, self._root)
-            if self.row_2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"row_2", self.row_2._parent, self)
-            if self.row_3._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"row_3", self.row_3._root, self._root)
-            if self.row_3._parent != self:
-                raise kaitaistruct.ConsistencyError(u"row_3", self.row_3._parent, self)
-            if self.row_4._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"row_4", self.row_4._root, self._root)
-            if self.row_4._parent != self:
-                raise kaitaistruct.ConsistencyError(u"row_4", self.row_4._parent, self)
-
-
-    class VfNonSkinCol(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod156.Vec3(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod156.Vec4U1(self._io, self, self._root)
-            self.normal._read()
-            self.tangent = Mod156.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.uv = Mod156.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod156.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-            self.rgba = Mod156.Vec4U1(self._io, self, self._root)
-            self.rgba._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
-            self.rgba._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod156.VfNonSkinCol, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self.tangent._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
-            self.rgba._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-            if self.rgba._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._root, self._root)
-            if self.rgba._parent != self:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._parent, self)
-
+        self._dirty = False
 
     class Bone(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod156.Bone, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -647,6 +293,7 @@ class Mod156(ReadWriteKaitaiStruct):
             self.parent_distance = self._io.read_f4le()
             self.location = Mod156.Vec3(self._io, self, self._root)
             self.location._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -666,11 +313,11 @@ class Mod156(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
             if self.location._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"location", self.location._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"location", self._root, self.location._root)
             if self.location._parent != self:
-                raise kaitaistruct.ConsistencyError(u"location", self.location._parent, self)
+                raise kaitaistruct.ConsistencyError(u"location", self, self.location._parent)
+            self._dirty = False
 
         @property
         def size_(self):
@@ -683,597 +330,267 @@ class Mod156(ReadWriteKaitaiStruct):
         def _invalidate_size_(self):
             del self._m_size_
 
-    class ModelInfo(ReadWriteKaitaiStruct):
+    class BonePalette(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod156.BonePalette, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
-            self.middist = self._io.read_s4le()
-            self.lowdist = self._io.read_s4le()
-            self.light_group = self._io.read_u4le()
-            self.strip_type = self._io.read_u1()
-            self.memory = self._io.read_u1()
-            self.reserved = self._io.read_u2le()
+            self.unk_01 = self._io.read_u4le()
+            self.indices = []
+            for i in range(32):
+                self.indices.append(self._io.read_u1())
+
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
+            for i in range(len(self.indices)):
+                pass
+
 
 
         def _write__seq(self, io=None):
-            super(Mod156.ModelInfo, self)._write__seq(io)
-            self._io.write_s4le(self.middist)
-            self._io.write_s4le(self.lowdist)
-            self._io.write_u4le(self.light_group)
-            self._io.write_u1(self.strip_type)
-            self._io.write_u1(self.memory)
-            self._io.write_u2le(self.reserved)
+            super(Mod156.BonePalette, self)._write__seq(io)
+            self._io.write_u4le(self.unk_01)
+            for i in range(len(self.indices)):
+                pass
+                self._io.write_u1(self.indices[i])
+
 
 
         def _check(self):
-            pass
+            if len(self.indices) != 32:
+                raise kaitaistruct.ConsistencyError(u"indices", 32, len(self.indices))
+            for i in range(len(self.indices)):
+                pass
+
+            self._dirty = False
 
         @property
         def size_(self):
             if hasattr(self, '_m_size_'):
                 return self._m_size_
 
-            self._m_size_ = 16
+            self._m_size_ = 36
             return getattr(self, '_m_size_', None)
 
         def _invalidate_size_(self):
             del self._m_size_
 
-    class Vec2(ReadWriteKaitaiStruct):
+    class BonesData(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod156.BonesData, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
-            self.x = self._io.read_f4le()
-            self.y = self._io.read_f4le()
+            self.bones_hierarchy = []
+            for i in range(self._root.header.num_bones):
+                _t_bones_hierarchy = Mod156.Bone(self._io, self, self._root)
+                try:
+                    _t_bones_hierarchy._read()
+                finally:
+                    self.bones_hierarchy.append(_t_bones_hierarchy)
+
+            self.parent_space_matrices = []
+            for i in range(self._root.header.num_bones):
+                _t_parent_space_matrices = Mod156.Matrix4x4(self._io, self, self._root)
+                try:
+                    _t_parent_space_matrices._read()
+                finally:
+                    self.parent_space_matrices.append(_t_parent_space_matrices)
+
+            self.inverse_bind_matrices = []
+            for i in range(self._root.header.num_bones):
+                _t_inverse_bind_matrices = Mod156.Matrix4x4(self._io, self, self._root)
+                try:
+                    _t_inverse_bind_matrices._read()
+                finally:
+                    self.inverse_bind_matrices.append(_t_inverse_bind_matrices)
+
+            if self._root.header.num_bones != 0:
+                pass
+                self.bone_map = self._io.read_bytes(256)
+
+            self.bone_palettes = []
+            for i in range(self._root.header.num_bone_palettes):
+                _t_bone_palettes = Mod156.BonePalette(self._io, self, self._root)
+                try:
+                    _t_bone_palettes._read()
+                finally:
+                    self.bone_palettes.append(_t_bone_palettes)
+
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod156.Vec2, self)._write__seq(io)
-            self._io.write_f4le(self.x)
-            self._io.write_f4le(self.y)
-
-
-        def _check(self):
-            pass
-
-
-    class Vec4U1(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.x = self._io.read_u1()
-            self.y = self._io.read_u1()
-            self.z = self._io.read_u1()
-            self.w = self._io.read_u1()
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod156.Vec4U1, self)._write__seq(io)
-            self._io.write_u1(self.x)
-            self._io.write_u1(self.y)
-            self._io.write_u1(self.z)
-            self._io.write_u1(self.w)
-
-
-        def _check(self):
-            pass
-
-
-    class MeshesData(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.meshes = []
-            for i in range(self._root.header.num_meshes):
-                _t_meshes = Mod156.Mesh(self._io, self, self._root)
-                _t_meshes._read()
-                self.meshes.append(_t_meshes)
-
-            self.num_weight_bounds = self._io.read_u4le()
-            self.weight_bounds = []
-            for i in range(self.num_weight_bounds):
-                _t_weight_bounds = Mod156.WeightBound(self._io, self, self._root)
-                _t_weight_bounds._read()
-                self.weight_bounds.append(_t_weight_bounds)
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.meshes)):
+            for i in range(len(self.bones_hierarchy)):
                 pass
-                self.meshes[i]._fetch_instances()
+                self.bones_hierarchy[i]._fetch_instances()
 
-            for i in range(len(self.weight_bounds)):
+            for i in range(len(self.parent_space_matrices)):
                 pass
-                self.weight_bounds[i]._fetch_instances()
+                self.parent_space_matrices[i]._fetch_instances()
+
+            for i in range(len(self.inverse_bind_matrices)):
+                pass
+                self.inverse_bind_matrices[i]._fetch_instances()
+
+            if self._root.header.num_bones != 0:
+                pass
+
+            for i in range(len(self.bone_palettes)):
+                pass
+                self.bone_palettes[i]._fetch_instances()
 
 
 
         def _write__seq(self, io=None):
-            super(Mod156.MeshesData, self)._write__seq(io)
-            for i in range(len(self.meshes)):
+            super(Mod156.BonesData, self)._write__seq(io)
+            for i in range(len(self.bones_hierarchy)):
                 pass
-                self.meshes[i]._write__seq(self._io)
+                self.bones_hierarchy[i]._write__seq(self._io)
 
-            self._io.write_u4le(self.num_weight_bounds)
-            for i in range(len(self.weight_bounds)):
+            for i in range(len(self.parent_space_matrices)):
                 pass
-                self.weight_bounds[i]._write__seq(self._io)
+                self.parent_space_matrices[i]._write__seq(self._io)
+
+            for i in range(len(self.inverse_bind_matrices)):
+                pass
+                self.inverse_bind_matrices[i]._write__seq(self._io)
+
+            if self._root.header.num_bones != 0:
+                pass
+                self._io.write_bytes(self.bone_map)
+
+            for i in range(len(self.bone_palettes)):
+                pass
+                self.bone_palettes[i]._write__seq(self._io)
 
 
 
         def _check(self):
-            pass
-            if (len(self.meshes) != self._root.header.num_meshes):
-                raise kaitaistruct.ConsistencyError(u"meshes", len(self.meshes), self._root.header.num_meshes)
-            for i in range(len(self.meshes)):
+            if len(self.bones_hierarchy) != self._root.header.num_bones:
+                raise kaitaistruct.ConsistencyError(u"bones_hierarchy", self._root.header.num_bones, len(self.bones_hierarchy))
+            for i in range(len(self.bones_hierarchy)):
                 pass
-                if self.meshes[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"meshes", self.meshes[i]._root, self._root)
-                if self.meshes[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"meshes", self.meshes[i]._parent, self)
+                if self.bones_hierarchy[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"bones_hierarchy", self._root, self.bones_hierarchy[i]._root)
+                if self.bones_hierarchy[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"bones_hierarchy", self, self.bones_hierarchy[i]._parent)
 
-            if (len(self.weight_bounds) != self.num_weight_bounds):
-                raise kaitaistruct.ConsistencyError(u"weight_bounds", len(self.weight_bounds), self.num_weight_bounds)
-            for i in range(len(self.weight_bounds)):
+            if len(self.parent_space_matrices) != self._root.header.num_bones:
+                raise kaitaistruct.ConsistencyError(u"parent_space_matrices", self._root.header.num_bones, len(self.parent_space_matrices))
+            for i in range(len(self.parent_space_matrices)):
                 pass
-                if self.weight_bounds[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"weight_bounds", self.weight_bounds[i]._root, self._root)
-                if self.weight_bounds[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"weight_bounds", self.weight_bounds[i]._parent, self)
+                if self.parent_space_matrices[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"parent_space_matrices", self._root, self.parent_space_matrices[i]._root)
+                if self.parent_space_matrices[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"parent_space_matrices", self, self.parent_space_matrices[i]._parent)
 
+            if len(self.inverse_bind_matrices) != self._root.header.num_bones:
+                raise kaitaistruct.ConsistencyError(u"inverse_bind_matrices", self._root.header.num_bones, len(self.inverse_bind_matrices))
+            for i in range(len(self.inverse_bind_matrices)):
+                pass
+                if self.inverse_bind_matrices[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"inverse_bind_matrices", self._root, self.inverse_bind_matrices[i]._root)
+                if self.inverse_bind_matrices[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"inverse_bind_matrices", self, self.inverse_bind_matrices[i]._parent)
+
+            if self._root.header.num_bones != 0:
+                pass
+                if len(self.bone_map) != 256:
+                    raise kaitaistruct.ConsistencyError(u"bone_map", 256, len(self.bone_map))
+
+            if len(self.bone_palettes) != self._root.header.num_bone_palettes:
+                raise kaitaistruct.ConsistencyError(u"bone_palettes", self._root.header.num_bone_palettes, len(self.bone_palettes))
+            for i in range(len(self.bone_palettes)):
+                pass
+                if self.bone_palettes[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"bone_palettes", self._root, self.bone_palettes[i]._root)
+                if self.bone_palettes[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"bone_palettes", self, self.bone_palettes[i]._parent)
+
+            self._dirty = False
 
         @property
         def size_(self):
             if hasattr(self, '_m_size_'):
                 return self._m_size_
 
-            self._m_size_ = (((self._root.header.num_meshes * self.meshes[0].size_) + 4) + (self.num_weight_bounds * self.weight_bounds[0].size_))
+            self._m_size_ = ((((self._root.header.num_bones * self.bones_hierarchy[0].size_ + self._root.header.num_bones * 64) + self._root.header.num_bones * 64) + 256) + self._root.header.num_bone_palettes * self.bone_palettes[0].size_ if self._root.header.num_bones > 0 else 0)
             return getattr(self, '_m_size_', None)
 
         def _invalidate_size_(self):
             del self._m_size_
 
-    class Mesh(ReadWriteKaitaiStruct):
+    class Group(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod156.Group, self).__init__(_io)
             self._parent = _parent
             self._root = _root
-            self._should_write_indices = False
-            self.indices__to_write = True
-            self._should_write_vertices = False
-            self.vertices__to_write = True
-            self._should_write_vertices2 = False
-            self.vertices2__to_write = True
 
         def _read(self):
-            self.idx_group = self._io.read_u2le()
-            self.idx_material = self._io.read_u2le()
-            self.disp = self._io.read_u1()
-            self.level_of_detail = self._io.read_u1()
-            self.alpha_priority = self._io.read_u1()
-            self.max_bones_per_vertex = self._io.read_u1()
-            self.vertex_stride = self._io.read_u1()
-            self.vertex_stride_2 = self._io.read_u1()
-            self.connective = self._io.read_u1()
-            self.shape = self._io.read_bits_int_le(1) != 0
-            self.env = self._io.read_bits_int_le(1) != 0
-            self.refrect = self._io.read_bits_int_le(1) != 0
-            self.reserved2_flag_1 = self._io.read_bits_int_le(1) != 0
-            self.reserved2_flag_2 = self._io.read_bits_int_le(1) != 0
-            self.shadow_cast = self._io.read_bits_int_le(1) != 0
-            self.shadow_receive = self._io.read_bits_int_le(1) != 0
-            self.sort = self._io.read_bits_int_le(1) != 0
-            self.num_vertices = self._io.read_u2le()
-            self.max_index = self._io.read_u2le()
-            self.vertex_position_2 = self._io.read_u4le()
-            self.vertex_offset = self._io.read_u4le()
-            self.vertex_offset_2 = self._io.read_u4le()
-            self.face_position = self._io.read_u4le()
-            self.num_indices = self._io.read_u4le()
-            self.face_offset = self._io.read_u4le()
-            self.vdeclbase = self._io.read_u1()
-            self.vdecl = self._io.read_u1()
-            self.min_index = self._io.read_u2le()
-            self.num_weight_bounds = self._io.read_u1()
-            self.idx_bone_palette = self._io.read_u1()
-            self.rcn_base = self._io.read_u2le()
-            self.boundary = self._io.read_u4le()
+            self.group_index = self._io.read_u4le()
+            self.reserved = []
+            for i in range(3):
+                self.reserved.append(self._io.read_u4le())
+
+            self.pos = Mod156.Vec3(self._io, self, self._root)
+            self.pos._read()
+            self.radius = self._io.read_f4le()
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
-            _ = self.indices
-            for i in range(len(self._m_indices)):
+            for i in range(len(self.reserved)):
                 pass
 
-            _ = self.vertices
-            for i in range(len(self._m_vertices)):
-                pass
-                _on = self._root.materials_data.materials[self.idx_material].vtype
-                if _on == 0:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 4:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 1:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 3:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 5:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 2:
-                    pass
-                    self.vertices[i]._fetch_instances()
-
-            if (self.vertex_stride_2 > 0):
-                pass
-                _ = self.vertices2
-                for i in range(len(self._m_vertices2)):
-                    pass
-                    _on = self.vertex_stride_2
-                    if _on == 4:
-                        pass
-                        self.vertices2[i]._fetch_instances()
-                    elif _on == 8:
-                        pass
-                        self.vertices2[i]._fetch_instances()
-
-
+            self.pos._fetch_instances()
 
 
         def _write__seq(self, io=None):
-            super(Mod156.Mesh, self)._write__seq(io)
-            self._should_write_indices = self.indices__to_write
-            self._should_write_vertices = self.vertices__to_write
-            self._should_write_vertices2 = self.vertices2__to_write
-            self._io.write_u2le(self.idx_group)
-            self._io.write_u2le(self.idx_material)
-            self._io.write_u1(self.disp)
-            self._io.write_u1(self.level_of_detail)
-            self._io.write_u1(self.alpha_priority)
-            self._io.write_u1(self.max_bones_per_vertex)
-            self._io.write_u1(self.vertex_stride)
-            self._io.write_u1(self.vertex_stride_2)
-            self._io.write_u1(self.connective)
-            self._io.write_bits_int_le(1, int(self.shape))
-            self._io.write_bits_int_le(1, int(self.env))
-            self._io.write_bits_int_le(1, int(self.refrect))
-            self._io.write_bits_int_le(1, int(self.reserved2_flag_1))
-            self._io.write_bits_int_le(1, int(self.reserved2_flag_2))
-            self._io.write_bits_int_le(1, int(self.shadow_cast))
-            self._io.write_bits_int_le(1, int(self.shadow_receive))
-            self._io.write_bits_int_le(1, int(self.sort))
-            self._io.write_u2le(self.num_vertices)
-            self._io.write_u2le(self.max_index)
-            self._io.write_u4le(self.vertex_position_2)
-            self._io.write_u4le(self.vertex_offset)
-            self._io.write_u4le(self.vertex_offset_2)
-            self._io.write_u4le(self.face_position)
-            self._io.write_u4le(self.num_indices)
-            self._io.write_u4le(self.face_offset)
-            self._io.write_u1(self.vdeclbase)
-            self._io.write_u1(self.vdecl)
-            self._io.write_u2le(self.min_index)
-            self._io.write_u1(self.num_weight_bounds)
-            self._io.write_u1(self.idx_bone_palette)
-            self._io.write_u2le(self.rcn_base)
-            self._io.write_u4le(self.boundary)
+            super(Mod156.Group, self)._write__seq(io)
+            self._io.write_u4le(self.group_index)
+            for i in range(len(self.reserved)):
+                pass
+                self._io.write_u4le(self.reserved[i])
+
+            self.pos._write__seq(self._io)
+            self._io.write_f4le(self.radius)
 
 
         def _check(self):
-            pass
+            if len(self.reserved) != 3:
+                raise kaitaistruct.ConsistencyError(u"reserved", 3, len(self.reserved))
+            for i in range(len(self.reserved)):
+                pass
+
+            if self.pos._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"pos", self._root, self.pos._root)
+            if self.pos._parent != self:
+                raise kaitaistruct.ConsistencyError(u"pos", self, self.pos._parent)
+            self._dirty = False
 
         @property
         def size_(self):
             if hasattr(self, '_m_size_'):
                 return self._m_size_
 
-            self._m_size_ = 52
+            self._m_size_ = 32
             return getattr(self, '_m_size_', None)
 
         def _invalidate_size_(self):
             del self._m_size_
-        @property
-        def indices(self):
-            if self._should_write_indices:
-                self._write_indices()
-            if hasattr(self, '_m_indices'):
-                return self._m_indices
-
-            _pos = self._io.pos()
-            self._io.seek(((self._root.header.offset_index_buffer + (self.face_offset * 2)) + (self.face_position * 2)))
-            self._m_indices = []
-            for i in range(self.num_indices):
-                self._m_indices.append(self._io.read_u2le())
-
-            self._io.seek(_pos)
-            return getattr(self, '_m_indices', None)
-
-        @indices.setter
-        def indices(self, v):
-            self._m_indices = v
-
-        def _write_indices(self):
-            self._should_write_indices = False
-            _pos = self._io.pos()
-            self._io.seek(((self._root.header.offset_index_buffer + (self.face_offset * 2)) + (self.face_position * 2)))
-            for i in range(len(self._m_indices)):
-                pass
-                self._io.write_u2le(self.indices[i])
-
-            self._io.seek(_pos)
-
-
-        def _check_indices(self):
-            pass
-            if (len(self.indices) != self.num_indices):
-                raise kaitaistruct.ConsistencyError(u"indices", len(self.indices), self.num_indices)
-            for i in range(len(self._m_indices)):
-                pass
-
-
-        @property
-        def vertices(self):
-            if self._should_write_vertices:
-                self._write_vertices()
-            if hasattr(self, '_m_vertices'):
-                return self._m_vertices
-
-            _pos = self._io.pos()
-            self._io.seek((((self._root.header.offset_vertex_buffer + (self.min_index * self.vertex_stride)) + self.vertex_offset) if (self.min_index > self.vertex_position_2) else ((self._root.header.offset_vertex_buffer + (self.min_index * self.vertex_stride)) + self.vertex_offset)))
-            self._m_vertices = []
-            for i in range((((self.max_index - self.min_index) + 1) if (self.min_index > self.vertex_position_2) else self.num_vertices)):
-                _on = self._root.materials_data.materials[self.idx_material].vtype
-                if _on == 0:
-                    pass
-                    _t__m_vertices = Mod156.VfSkin(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 4:
-                    pass
-                    _t__m_vertices = Mod156.VfSkin(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 1:
-                    pass
-                    _t__m_vertices = Mod156.VfSkinEx(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 3:
-                    pass
-                    _t__m_vertices = Mod156.VfNonSkinCol(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 5:
-                    pass
-                    _t__m_vertices = Mod156.VfSkin(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 2:
-                    pass
-                    _t__m_vertices = Mod156.VfNonSkin(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-
-            self._io.seek(_pos)
-            return getattr(self, '_m_vertices', None)
-
-        @vertices.setter
-        def vertices(self, v):
-            self._m_vertices = v
-
-        def _write_vertices(self):
-            self._should_write_vertices = False
-            _pos = self._io.pos()
-            self._io.seek((((self._root.header.offset_vertex_buffer + (self.min_index * self.vertex_stride)) + self.vertex_offset) if (self.min_index > self.vertex_position_2) else ((self._root.header.offset_vertex_buffer + (self.min_index * self.vertex_stride)) + self.vertex_offset)))
-            for i in range(len(self._m_vertices)):
-                pass
-                _on = self._root.materials_data.materials[self.idx_material].vtype
-                if _on == 0:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 4:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 1:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 3:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 5:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 2:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-
-            self._io.seek(_pos)
-
-
-        def _check_vertices(self):
-            pass
-            if (len(self.vertices) != (((self.max_index - self.min_index) + 1) if (self.min_index > self.vertex_position_2) else self.num_vertices)):
-                raise kaitaistruct.ConsistencyError(u"vertices", len(self.vertices), (((self.max_index - self.min_index) + 1) if (self.min_index > self.vertex_position_2) else self.num_vertices))
-            for i in range(len(self._m_vertices)):
-                pass
-                _on = self._root.materials_data.materials[self.idx_material].vtype
-                if _on == 0:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 4:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 1:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 3:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 5:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 2:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-
-
-        @property
-        def vertices2(self):
-            if self._should_write_vertices2:
-                self._write_vertices2()
-            if hasattr(self, '_m_vertices2'):
-                return self._m_vertices2
-
-            if (self.vertex_stride_2 > 0):
-                pass
-                _pos = self._io.pos()
-                self._io.seek(((self._root.header.offset_vertex_buffer_2 + (self.vertex_position_2 * self.vertex_stride_2)) + self.vertex_offset_2))
-                self._m_vertices2 = []
-                for i in range(self.num_vertices):
-                    _on = self.vertex_stride_2
-                    if _on == 4:
-                        pass
-                        _t__m_vertices2 = Mod156.Vertex24(self._io, self, self._root)
-                        _t__m_vertices2._read()
-                        self._m_vertices2.append(_t__m_vertices2)
-                    elif _on == 8:
-                        pass
-                        _t__m_vertices2 = Mod156.Vertex28(self._io, self, self._root)
-                        _t__m_vertices2._read()
-                        self._m_vertices2.append(_t__m_vertices2)
-
-                self._io.seek(_pos)
-
-            return getattr(self, '_m_vertices2', None)
-
-        @vertices2.setter
-        def vertices2(self, v):
-            self._m_vertices2 = v
-
-        def _write_vertices2(self):
-            self._should_write_vertices2 = False
-            if (self.vertex_stride_2 > 0):
-                pass
-                _pos = self._io.pos()
-                self._io.seek(((self._root.header.offset_vertex_buffer_2 + (self.vertex_position_2 * self.vertex_stride_2)) + self.vertex_offset_2))
-                for i in range(len(self._m_vertices2)):
-                    pass
-                    _on = self.vertex_stride_2
-                    if _on == 4:
-                        pass
-                        self.vertices2[i]._write__seq(self._io)
-                    elif _on == 8:
-                        pass
-                        self.vertices2[i]._write__seq(self._io)
-
-                self._io.seek(_pos)
-
-
-
-        def _check_vertices2(self):
-            pass
-            if (self.vertex_stride_2 > 0):
-                pass
-                if (len(self.vertices2) != self.num_vertices):
-                    raise kaitaistruct.ConsistencyError(u"vertices2", len(self.vertices2), self.num_vertices)
-                for i in range(len(self._m_vertices2)):
-                    pass
-                    _on = self.vertex_stride_2
-                    if _on == 4:
-                        pass
-                        if self.vertices2[i]._root != self._root:
-                            raise kaitaistruct.ConsistencyError(u"vertices2", self.vertices2[i]._root, self._root)
-                        if self.vertices2[i]._parent != self:
-                            raise kaitaistruct.ConsistencyError(u"vertices2", self.vertices2[i]._parent, self)
-                    elif _on == 8:
-                        pass
-                        if self.vertices2[i]._root != self._root:
-                            raise kaitaistruct.ConsistencyError(u"vertices2", self.vertices2[i]._root, self._root)
-                        if self.vertices2[i]._parent != self:
-                            raise kaitaistruct.ConsistencyError(u"vertices2", self.vertices2[i]._parent, self)
-
-
-
-
-    class RcnTable(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.vindex = self._io.read_bits_int_le(21)
-            self.noffset = self._io.read_bits_int_le(10)
-            self.edge = self._io.read_bits_int_le(1) != 0
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod156.RcnTable, self)._write__seq(io)
-            self._io.write_bits_int_le(21, self.vindex)
-            self._io.write_bits_int_le(10, self.noffset)
-            self._io.write_bits_int_le(1, int(self.edge))
-
-
-        def _check(self):
-            pass
-
 
     class Material(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod156.Material, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -1334,6 +651,7 @@ class Mod156(ReadWriteKaitaiStruct):
             self.alpha_ref = self._io.read_u4le()
             self.heightmap = self._io.read_u4le()
             self.glossmap = self._io.read_u4le()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -1413,27 +731,27 @@ class Mod156(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
-            if (len(self.fresnel_factor) != 4):
-                raise kaitaistruct.ConsistencyError(u"fresnel_factor", len(self.fresnel_factor), 4)
+            if len(self.fresnel_factor) != 4:
+                raise kaitaistruct.ConsistencyError(u"fresnel_factor", 4, len(self.fresnel_factor))
             for i in range(len(self.fresnel_factor)):
                 pass
 
-            if (len(self.lightmap_factor) != 4):
-                raise kaitaistruct.ConsistencyError(u"lightmap_factor", len(self.lightmap_factor), 4)
+            if len(self.lightmap_factor) != 4:
+                raise kaitaistruct.ConsistencyError(u"lightmap_factor", 4, len(self.lightmap_factor))
             for i in range(len(self.lightmap_factor)):
                 pass
 
-            if (len(self.detail_factor) != 4):
-                raise kaitaistruct.ConsistencyError(u"detail_factor", len(self.detail_factor), 4)
+            if len(self.detail_factor) != 4:
+                raise kaitaistruct.ConsistencyError(u"detail_factor", 4, len(self.detail_factor))
             for i in range(len(self.detail_factor)):
                 pass
 
-            if (len(self.parallax_factor) != 2):
-                raise kaitaistruct.ConsistencyError(u"parallax_factor", len(self.parallax_factor), 2)
+            if len(self.parallax_factor) != 2:
+                raise kaitaistruct.ConsistencyError(u"parallax_factor", 2, len(self.parallax_factor))
             for i in range(len(self.parallax_factor)):
                 pass
 
+            self._dirty = False
 
         @property
         def size_(self):
@@ -1446,245 +764,26 @@ class Mod156(ReadWriteKaitaiStruct):
         def _invalidate_size_(self):
             del self._m_size_
 
-    class WeightBound(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.bone_id = self._io.read_u4le()
-            self.unk_01 = Mod156.Vec3(self._io, self, self._root)
-            self.unk_01._read()
-            self.bsphere = Mod156.Vec4(self._io, self, self._root)
-            self.bsphere._read()
-            self.bbox_min = Mod156.Vec4(self._io, self, self._root)
-            self.bbox_min._read()
-            self.bbox_max = Mod156.Vec4(self._io, self, self._root)
-            self.bbox_max._read()
-            self.oabb = Mod156.Matrix4x4(self._io, self, self._root)
-            self.oabb._read()
-            self.oabb_dimension = Mod156.Vec4(self._io, self, self._root)
-            self.oabb_dimension._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.unk_01._fetch_instances()
-            self.bsphere._fetch_instances()
-            self.bbox_min._fetch_instances()
-            self.bbox_max._fetch_instances()
-            self.oabb._fetch_instances()
-            self.oabb_dimension._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod156.WeightBound, self)._write__seq(io)
-            self._io.write_u4le(self.bone_id)
-            self.unk_01._write__seq(self._io)
-            self.bsphere._write__seq(self._io)
-            self.bbox_min._write__seq(self._io)
-            self.bbox_max._write__seq(self._io)
-            self.oabb._write__seq(self._io)
-            self.oabb_dimension._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.unk_01._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"unk_01", self.unk_01._root, self._root)
-            if self.unk_01._parent != self:
-                raise kaitaistruct.ConsistencyError(u"unk_01", self.unk_01._parent, self)
-            if self.bsphere._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"bsphere", self.bsphere._root, self._root)
-            if self.bsphere._parent != self:
-                raise kaitaistruct.ConsistencyError(u"bsphere", self.bsphere._parent, self)
-            if self.bbox_min._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"bbox_min", self.bbox_min._root, self._root)
-            if self.bbox_min._parent != self:
-                raise kaitaistruct.ConsistencyError(u"bbox_min", self.bbox_min._parent, self)
-            if self.bbox_max._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"bbox_max", self.bbox_max._root, self._root)
-            if self.bbox_max._parent != self:
-                raise kaitaistruct.ConsistencyError(u"bbox_max", self.bbox_max._parent, self)
-            if self.oabb._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"oabb", self.oabb._root, self._root)
-            if self.oabb._parent != self:
-                raise kaitaistruct.ConsistencyError(u"oabb", self.oabb._parent, self)
-            if self.oabb_dimension._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"oabb_dimension", self.oabb_dimension._root, self._root)
-            if self.oabb_dimension._parent != self:
-                raise kaitaistruct.ConsistencyError(u"oabb_dimension", self.oabb_dimension._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 144
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Vec3(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.x = self._io.read_f4le()
-            self.y = self._io.read_f4le()
-            self.z = self._io.read_f4le()
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod156.Vec3, self)._write__seq(io)
-            self._io.write_f4le(self.x)
-            self._io.write_f4le(self.y)
-            self._io.write_f4le(self.z)
-
-
-        def _check(self):
-            pass
-
-
-    class VfNonSkin(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod156.Vec3(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod156.Vec4U1(self._io, self, self._root)
-            self.normal._read()
-            self.tangent = Mod156.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.uv = Mod156.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod156.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-            self.uv3 = Mod156.Vec2HalfFloat(self._io, self, self._root)
-            self.uv3._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
-            self.uv3._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod156.VfNonSkin, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self.tangent._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
-            self.uv3._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-            if self.uv3._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._root, self._root)
-            if self.uv3._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._parent, self)
-
-
-    class RcnVertex(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.x = self._io.read_u2le()
-            self.y = self._io.read_u2le()
-            self.z = self._io.read_u2le()
-            self.w = self._io.read_u2le()
-            self.w0 = self._io.read_u1()
-            self.w1 = self._io.read_u1()
-            self.w2 = self._io.read_u1()
-            self.w3 = self._io.read_u1()
-            self.j0 = self._io.read_u1()
-            self.j1 = self._io.read_u1()
-            self.j2 = self._io.read_u1()
-            self.j3 = self._io.read_u1()
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod156.RcnVertex, self)._write__seq(io)
-            self._io.write_u2le(self.x)
-            self._io.write_u2le(self.y)
-            self._io.write_u2le(self.z)
-            self._io.write_u2le(self.w)
-            self._io.write_u1(self.w0)
-            self._io.write_u1(self.w1)
-            self._io.write_u1(self.w2)
-            self._io.write_u1(self.w3)
-            self._io.write_u1(self.j0)
-            self._io.write_u1(self.j1)
-            self._io.write_u1(self.j2)
-            self._io.write_u1(self.j3)
-
-
-        def _check(self):
-            pass
-
-
     class MaterialsData(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod156.MaterialsData, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
             self.textures = []
             for i in range(self._root.header.num_textures):
-                self.textures.append((KaitaiStream.bytes_terminate(self._io.read_bytes(64), 0, False)).decode("ASCII"))
+                self.textures.append((KaitaiStream.bytes_terminate(self._io.read_bytes(64), 0, False)).decode(u"ASCII"))
 
             self.materials = []
             for i in range(self._root.header.num_materials):
                 _t_materials = Mod156.Material(self._io, self, self._root)
-                _t_materials._read()
-                self.materials.append(_t_materials)
+                try:
+                    _t_materials._read()
+                finally:
+                    self.materials.append(_t_materials)
 
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -1711,46 +810,1052 @@ class Mod156(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
-            if (len(self.textures) != self._root.header.num_textures):
-                raise kaitaistruct.ConsistencyError(u"textures", len(self.textures), self._root.header.num_textures)
+            if len(self.textures) != self._root.header.num_textures:
+                raise kaitaistruct.ConsistencyError(u"textures", self._root.header.num_textures, len(self.textures))
             for i in range(len(self.textures)):
                 pass
-                if (len((self.textures[i]).encode(u"ASCII")) > 64):
-                    raise kaitaistruct.ConsistencyError(u"textures", len((self.textures[i]).encode(u"ASCII")), 64)
-                if (KaitaiStream.byte_array_index_of((self.textures[i]).encode(u"ASCII"), 0) != -1):
-                    raise kaitaistruct.ConsistencyError(u"textures", KaitaiStream.byte_array_index_of((self.textures[i]).encode(u"ASCII"), 0), -1)
+                if len((self.textures[i]).encode(u"ASCII")) > 64:
+                    raise kaitaistruct.ConsistencyError(u"textures", 64, len((self.textures[i]).encode(u"ASCII")))
+                if KaitaiStream.byte_array_index_of((self.textures[i]).encode(u"ASCII"), 0) != -1:
+                    raise kaitaistruct.ConsistencyError(u"textures", -1, KaitaiStream.byte_array_index_of((self.textures[i]).encode(u"ASCII"), 0))
 
-            if (len(self.materials) != self._root.header.num_materials):
-                raise kaitaistruct.ConsistencyError(u"materials", len(self.materials), self._root.header.num_materials)
+            if len(self.materials) != self._root.header.num_materials:
+                raise kaitaistruct.ConsistencyError(u"materials", self._root.header.num_materials, len(self.materials))
             for i in range(len(self.materials)):
                 pass
                 if self.materials[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"materials", self.materials[i]._root, self._root)
+                    raise kaitaistruct.ConsistencyError(u"materials", self._root, self.materials[i]._root)
                 if self.materials[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"materials", self.materials[i]._parent, self)
+                    raise kaitaistruct.ConsistencyError(u"materials", self, self.materials[i]._parent)
 
+            self._dirty = False
 
         @property
         def size_(self):
             if hasattr(self, '_m_size_'):
                 return self._m_size_
 
-            self._m_size_ = ((64 * self._root.header.num_textures) + (self._root.header.num_materials * self.materials[0].size_))
+            self._m_size_ = 64 * self._root.header.num_textures + self._root.header.num_materials * self.materials[0].size_
             return getattr(self, '_m_size_', None)
 
         def _invalidate_size_(self):
             del self._m_size_
 
+    class Matrix4x4(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod156.Matrix4x4, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.row_1 = Mod156.Vec4(self._io, self, self._root)
+            self.row_1._read()
+            self.row_2 = Mod156.Vec4(self._io, self, self._root)
+            self.row_2._read()
+            self.row_3 = Mod156.Vec4(self._io, self, self._root)
+            self.row_3._read()
+            self.row_4 = Mod156.Vec4(self._io, self, self._root)
+            self.row_4._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.row_1._fetch_instances()
+            self.row_2._fetch_instances()
+            self.row_3._fetch_instances()
+            self.row_4._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod156.Matrix4x4, self)._write__seq(io)
+            self.row_1._write__seq(self._io)
+            self.row_2._write__seq(self._io)
+            self.row_3._write__seq(self._io)
+            self.row_4._write__seq(self._io)
+
+
+        def _check(self):
+            if self.row_1._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"row_1", self._root, self.row_1._root)
+            if self.row_1._parent != self:
+                raise kaitaistruct.ConsistencyError(u"row_1", self, self.row_1._parent)
+            if self.row_2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"row_2", self._root, self.row_2._root)
+            if self.row_2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"row_2", self, self.row_2._parent)
+            if self.row_3._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"row_3", self._root, self.row_3._root)
+            if self.row_3._parent != self:
+                raise kaitaistruct.ConsistencyError(u"row_3", self, self.row_3._parent)
+            if self.row_4._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"row_4", self._root, self.row_4._root)
+            if self.row_4._parent != self:
+                raise kaitaistruct.ConsistencyError(u"row_4", self, self.row_4._parent)
+            self._dirty = False
+
+
+    class Mesh(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod156.Mesh, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_indices = False
+            self.indices__enabled = True
+            self._should_write_vertices = False
+            self.vertices__enabled = True
+            self._should_write_vertices2 = False
+            self.vertices2__enabled = True
+
+        def _read(self):
+            self.idx_group = self._io.read_u2le()
+            self.idx_material = self._io.read_u2le()
+            self.disp = self._io.read_u1()
+            self.level_of_detail = self._io.read_u1()
+            self.alpha_priority = self._io.read_u1()
+            self.max_bones_per_vertex = self._io.read_u1()
+            self.vertex_stride = self._io.read_u1()
+            self.vertex_stride_2 = self._io.read_u1()
+            self.connective = self._io.read_u1()
+            self.shape = self._io.read_bits_int_le(1) != 0
+            self.env = self._io.read_bits_int_le(1) != 0
+            self.refrect = self._io.read_bits_int_le(1) != 0
+            self.reserved2_flag_1 = self._io.read_bits_int_le(1) != 0
+            self.reserved2_flag_2 = self._io.read_bits_int_le(1) != 0
+            self.shadow_cast = self._io.read_bits_int_le(1) != 0
+            self.shadow_receive = self._io.read_bits_int_le(1) != 0
+            self.sort = self._io.read_bits_int_le(1) != 0
+            self.num_vertices = self._io.read_u2le()
+            self.max_index = self._io.read_u2le()
+            self.vertex_position_2 = self._io.read_u4le()
+            self.vertex_offset = self._io.read_u4le()
+            self.vertex_offset_2 = self._io.read_u4le()
+            self.face_position = self._io.read_u4le()
+            self.num_indices = self._io.read_u4le()
+            self.face_offset = self._io.read_u4le()
+            self.vdeclbase = self._io.read_u1()
+            self.vdecl = self._io.read_u1()
+            self.min_index = self._io.read_u2le()
+            self.num_weight_bounds = self._io.read_u1()
+            self.idx_bone_palette = self._io.read_u1()
+            self.rcn_base = self._io.read_u2le()
+            self.boundary = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.indices
+            if hasattr(self, '_m_indices'):
+                pass
+                for i in range(len(self._m_indices)):
+                    pass
+
+
+            _ = self.vertices
+            if hasattr(self, '_m_vertices'):
+                pass
+                for i in range(len(self._m_vertices)):
+                    pass
+                    _on = self._root.materials_data.materials[self.idx_material].vtype
+                    if _on == 0:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 1:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 2:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 3:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 4:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 5:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+
+
+            _ = self.vertices2
+            if hasattr(self, '_m_vertices2'):
+                pass
+                for i in range(len(self._m_vertices2)):
+                    pass
+                    _on = self.vertex_stride_2
+                    if _on == 4:
+                        pass
+                        self._m_vertices2[i]._fetch_instances()
+                    elif _on == 8:
+                        pass
+                        self._m_vertices2[i]._fetch_instances()
+
+
+
+
+        def _write__seq(self, io=None):
+            super(Mod156.Mesh, self)._write__seq(io)
+            self._should_write_indices = self.indices__enabled
+            self._should_write_vertices = self.vertices__enabled
+            self._should_write_vertices2 = self.vertices2__enabled
+            self._io.write_u2le(self.idx_group)
+            self._io.write_u2le(self.idx_material)
+            self._io.write_u1(self.disp)
+            self._io.write_u1(self.level_of_detail)
+            self._io.write_u1(self.alpha_priority)
+            self._io.write_u1(self.max_bones_per_vertex)
+            self._io.write_u1(self.vertex_stride)
+            self._io.write_u1(self.vertex_stride_2)
+            self._io.write_u1(self.connective)
+            self._io.write_bits_int_le(1, int(self.shape))
+            self._io.write_bits_int_le(1, int(self.env))
+            self._io.write_bits_int_le(1, int(self.refrect))
+            self._io.write_bits_int_le(1, int(self.reserved2_flag_1))
+            self._io.write_bits_int_le(1, int(self.reserved2_flag_2))
+            self._io.write_bits_int_le(1, int(self.shadow_cast))
+            self._io.write_bits_int_le(1, int(self.shadow_receive))
+            self._io.write_bits_int_le(1, int(self.sort))
+            self._io.write_u2le(self.num_vertices)
+            self._io.write_u2le(self.max_index)
+            self._io.write_u4le(self.vertex_position_2)
+            self._io.write_u4le(self.vertex_offset)
+            self._io.write_u4le(self.vertex_offset_2)
+            self._io.write_u4le(self.face_position)
+            self._io.write_u4le(self.num_indices)
+            self._io.write_u4le(self.face_offset)
+            self._io.write_u1(self.vdeclbase)
+            self._io.write_u1(self.vdecl)
+            self._io.write_u2le(self.min_index)
+            self._io.write_u1(self.num_weight_bounds)
+            self._io.write_u1(self.idx_bone_palette)
+            self._io.write_u2le(self.rcn_base)
+            self._io.write_u4le(self.boundary)
+
+
+        def _check(self):
+            if self.indices__enabled:
+                pass
+                if len(self._m_indices) != self.num_indices:
+                    raise kaitaistruct.ConsistencyError(u"indices", self.num_indices, len(self._m_indices))
+                for i in range(len(self._m_indices)):
+                    pass
+
+
+            if self.vertices__enabled:
+                pass
+                if len(self._m_vertices) != ((self.max_index - self.min_index) + 1 if self.min_index > self.vertex_position_2 else self.num_vertices):
+                    raise kaitaistruct.ConsistencyError(u"vertices", ((self.max_index - self.min_index) + 1 if self.min_index > self.vertex_position_2 else self.num_vertices), len(self._m_vertices))
+                for i in range(len(self._m_vertices)):
+                    pass
+                    _on = self._root.materials_data.materials[self.idx_material].vtype
+                    if _on == 0:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 1:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 2:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 3:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 4:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 5:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+
+
+            if self.vertices2__enabled:
+                pass
+                if self.vertex_stride_2 > 0:
+                    pass
+                    if len(self._m_vertices2) != self.num_vertices:
+                        raise kaitaistruct.ConsistencyError(u"vertices2", self.num_vertices, len(self._m_vertices2))
+                    for i in range(len(self._m_vertices2)):
+                        pass
+                        _on = self.vertex_stride_2
+                        if _on == 4:
+                            pass
+                            if self._m_vertices2[i]._root != self._root:
+                                raise kaitaistruct.ConsistencyError(u"vertices2", self._root, self._m_vertices2[i]._root)
+                            if self._m_vertices2[i]._parent != self:
+                                raise kaitaistruct.ConsistencyError(u"vertices2", self, self._m_vertices2[i]._parent)
+                        elif _on == 8:
+                            pass
+                            if self._m_vertices2[i]._root != self._root:
+                                raise kaitaistruct.ConsistencyError(u"vertices2", self._root, self._m_vertices2[i]._root)
+                            if self._m_vertices2[i]._parent != self:
+                                raise kaitaistruct.ConsistencyError(u"vertices2", self, self._m_vertices2[i]._parent)
+
+
+
+            self._dirty = False
+
+        @property
+        def indices(self):
+            if self._should_write_indices:
+                self._write_indices()
+            if hasattr(self, '_m_indices'):
+                return self._m_indices
+
+            if not self.indices__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek((self._root.header.offset_index_buffer + self.face_offset * 2) + self.face_position * 2)
+            self._m_indices = []
+            for i in range(self.num_indices):
+                self._m_indices.append(self._io.read_u2le())
+
+            self._io.seek(_pos)
+            return getattr(self, '_m_indices', None)
+
+        @indices.setter
+        def indices(self, v):
+            self._dirty = True
+            self._m_indices = v
+
+        def _write_indices(self):
+            self._should_write_indices = False
+            _pos = self._io.pos()
+            self._io.seek((self._root.header.offset_index_buffer + self.face_offset * 2) + self.face_position * 2)
+            for i in range(len(self._m_indices)):
+                pass
+                self._io.write_u2le(self._m_indices[i])
+
+            self._io.seek(_pos)
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 52
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+        @property
+        def vertices(self):
+            if self._should_write_vertices:
+                self._write_vertices()
+            if hasattr(self, '_m_vertices'):
+                return self._m_vertices
+
+            if not self.vertices__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(((self._root.header.offset_vertex_buffer + self.min_index * self.vertex_stride) + self.vertex_offset if self.min_index > self.vertex_position_2 else (self._root.header.offset_vertex_buffer + self.min_index * self.vertex_stride) + self.vertex_offset))
+            self._m_vertices = []
+            for i in range(((self.max_index - self.min_index) + 1 if self.min_index > self.vertex_position_2 else self.num_vertices)):
+                _on = self._root.materials_data.materials[self.idx_material].vtype
+                if _on == 0:
+                    pass
+                    _t__m_vertices = Mod156.VfSkin(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 1:
+                    pass
+                    _t__m_vertices = Mod156.VfSkinEx(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 2:
+                    pass
+                    _t__m_vertices = Mod156.VfNonSkin(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 3:
+                    pass
+                    _t__m_vertices = Mod156.VfNonSkinCol(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 4:
+                    pass
+                    _t__m_vertices = Mod156.VfSkin(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 5:
+                    pass
+                    _t__m_vertices = Mod156.VfSkin(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+
+            self._io.seek(_pos)
+            return getattr(self, '_m_vertices', None)
+
+        @vertices.setter
+        def vertices(self, v):
+            self._dirty = True
+            self._m_vertices = v
+
+        def _write_vertices(self):
+            self._should_write_vertices = False
+            _pos = self._io.pos()
+            self._io.seek(((self._root.header.offset_vertex_buffer + self.min_index * self.vertex_stride) + self.vertex_offset if self.min_index > self.vertex_position_2 else (self._root.header.offset_vertex_buffer + self.min_index * self.vertex_stride) + self.vertex_offset))
+            for i in range(len(self._m_vertices)):
+                pass
+                _on = self._root.materials_data.materials[self.idx_material].vtype
+                if _on == 0:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 1:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 2:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 3:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 4:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 5:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+
+            self._io.seek(_pos)
+
+        @property
+        def vertices2(self):
+            if self._should_write_vertices2:
+                self._write_vertices2()
+            if hasattr(self, '_m_vertices2'):
+                return self._m_vertices2
+
+            if not self.vertices2__enabled:
+                return None
+
+            if self.vertex_stride_2 > 0:
+                pass
+                _pos = self._io.pos()
+                self._io.seek((self._root.header.offset_vertex_buffer_2 + self.vertex_position_2 * self.vertex_stride_2) + self.vertex_offset_2)
+                self._m_vertices2 = []
+                for i in range(self.num_vertices):
+                    _on = self.vertex_stride_2
+                    if _on == 4:
+                        pass
+                        _t__m_vertices2 = Mod156.Vertex24(self._io, self, self._root)
+                        try:
+                            _t__m_vertices2._read()
+                        finally:
+                            self._m_vertices2.append(_t__m_vertices2)
+                    elif _on == 8:
+                        pass
+                        _t__m_vertices2 = Mod156.Vertex28(self._io, self, self._root)
+                        try:
+                            _t__m_vertices2._read()
+                        finally:
+                            self._m_vertices2.append(_t__m_vertices2)
+
+                self._io.seek(_pos)
+
+            return getattr(self, '_m_vertices2', None)
+
+        @vertices2.setter
+        def vertices2(self, v):
+            self._dirty = True
+            self._m_vertices2 = v
+
+        def _write_vertices2(self):
+            self._should_write_vertices2 = False
+            if self.vertex_stride_2 > 0:
+                pass
+                _pos = self._io.pos()
+                self._io.seek((self._root.header.offset_vertex_buffer_2 + self.vertex_position_2 * self.vertex_stride_2) + self.vertex_offset_2)
+                for i in range(len(self._m_vertices2)):
+                    pass
+                    _on = self.vertex_stride_2
+                    if _on == 4:
+                        pass
+                        self._m_vertices2[i]._write__seq(self._io)
+                    elif _on == 8:
+                        pass
+                        self._m_vertices2[i]._write__seq(self._io)
+
+                self._io.seek(_pos)
+
+
+
+    class MeshesData(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod156.MeshesData, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.meshes = []
+            for i in range(self._root.header.num_meshes):
+                _t_meshes = Mod156.Mesh(self._io, self, self._root)
+                try:
+                    _t_meshes._read()
+                finally:
+                    self.meshes.append(_t_meshes)
+
+            self.num_weight_bounds = self._io.read_u4le()
+            self.weight_bounds = []
+            for i in range(self.num_weight_bounds):
+                _t_weight_bounds = Mod156.WeightBound(self._io, self, self._root)
+                try:
+                    _t_weight_bounds._read()
+                finally:
+                    self.weight_bounds.append(_t_weight_bounds)
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.meshes)):
+                pass
+                self.meshes[i]._fetch_instances()
+
+            for i in range(len(self.weight_bounds)):
+                pass
+                self.weight_bounds[i]._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Mod156.MeshesData, self)._write__seq(io)
+            for i in range(len(self.meshes)):
+                pass
+                self.meshes[i]._write__seq(self._io)
+
+            self._io.write_u4le(self.num_weight_bounds)
+            for i in range(len(self.weight_bounds)):
+                pass
+                self.weight_bounds[i]._write__seq(self._io)
+
+
+
+        def _check(self):
+            if len(self.meshes) != self._root.header.num_meshes:
+                raise kaitaistruct.ConsistencyError(u"meshes", self._root.header.num_meshes, len(self.meshes))
+            for i in range(len(self.meshes)):
+                pass
+                if self.meshes[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"meshes", self._root, self.meshes[i]._root)
+                if self.meshes[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"meshes", self, self.meshes[i]._parent)
+
+            if len(self.weight_bounds) != self.num_weight_bounds:
+                raise kaitaistruct.ConsistencyError(u"weight_bounds", self.num_weight_bounds, len(self.weight_bounds))
+            for i in range(len(self.weight_bounds)):
+                pass
+                if self.weight_bounds[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"weight_bounds", self._root, self.weight_bounds[i]._root)
+                if self.weight_bounds[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"weight_bounds", self, self.weight_bounds[i]._parent)
+
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = (self._root.header.num_meshes * self.meshes[0].size_ + 4) + self.num_weight_bounds * self.weight_bounds[0].size_
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class ModHeader(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod156.ModHeader, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.ident = self._io.read_bytes(4)
+            if not self.ident == b"\x4D\x4F\x44\x00":
+                raise kaitaistruct.ValidationNotEqualError(b"\x4D\x4F\x44\x00", self.ident, self._io, u"/types/mod_header/seq/0")
+            self.version = self._io.read_u1()
+            self.revision = self._io.read_u1()
+            self.num_bones = self._io.read_u2le()
+            self.num_meshes = self._io.read_u2le()
+            self.num_materials = self._io.read_u2le()
+            self.num_vertices = self._io.read_u4le()
+            self.num_faces = self._io.read_u4le()
+            self.num_edges = self._io.read_u4le()
+            self.size_vertex_buffer = self._io.read_u4le()
+            self.size_vertex_buffer_2 = self._io.read_u4le()
+            self.num_textures = self._io.read_u4le()
+            self.num_groups = self._io.read_u4le()
+            self.num_bone_palettes = self._io.read_u4le()
+            self.offset_bones_data = self._io.read_u4le()
+            self.offset_groups = self._io.read_u4le()
+            self.offset_materials_data = self._io.read_u4le()
+            self.offset_meshes_data = self._io.read_u4le()
+            self.offset_vertex_buffer = self._io.read_u4le()
+            self.offset_vertex_buffer_2 = self._io.read_u4le()
+            self.offset_index_buffer = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod156.ModHeader, self)._write__seq(io)
+            self._io.write_bytes(self.ident)
+            self._io.write_u1(self.version)
+            self._io.write_u1(self.revision)
+            self._io.write_u2le(self.num_bones)
+            self._io.write_u2le(self.num_meshes)
+            self._io.write_u2le(self.num_materials)
+            self._io.write_u4le(self.num_vertices)
+            self._io.write_u4le(self.num_faces)
+            self._io.write_u4le(self.num_edges)
+            self._io.write_u4le(self.size_vertex_buffer)
+            self._io.write_u4le(self.size_vertex_buffer_2)
+            self._io.write_u4le(self.num_textures)
+            self._io.write_u4le(self.num_groups)
+            self._io.write_u4le(self.num_bone_palettes)
+            self._io.write_u4le(self.offset_bones_data)
+            self._io.write_u4le(self.offset_groups)
+            self._io.write_u4le(self.offset_materials_data)
+            self._io.write_u4le(self.offset_meshes_data)
+            self._io.write_u4le(self.offset_vertex_buffer)
+            self._io.write_u4le(self.offset_vertex_buffer_2)
+            self._io.write_u4le(self.offset_index_buffer)
+
+
+        def _check(self):
+            if len(self.ident) != 4:
+                raise kaitaistruct.ConsistencyError(u"ident", 4, len(self.ident))
+            if not self.ident == b"\x4D\x4F\x44\x00":
+                raise kaitaistruct.ValidationNotEqualError(b"\x4D\x4F\x44\x00", self.ident, None, u"/types/mod_header/seq/0")
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 72
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class ModelInfo(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod156.ModelInfo, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.middist = self._io.read_s4le()
+            self.lowdist = self._io.read_s4le()
+            self.light_group = self._io.read_u4le()
+            self.strip_type = self._io.read_u1()
+            self.memory = self._io.read_u1()
+            self.reserved = self._io.read_u2le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod156.ModelInfo, self)._write__seq(io)
+            self._io.write_s4le(self.middist)
+            self._io.write_s4le(self.lowdist)
+            self._io.write_u4le(self.light_group)
+            self._io.write_u1(self.strip_type)
+            self._io.write_u1(self.memory)
+            self._io.write_u2le(self.reserved)
+
+
+        def _check(self):
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 16
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class RcnHeader(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod156.RcnHeader, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.ptri = self._io.read_u4le()
+            self.pvtx = self._io.read_u4le()
+            self.ptb = self._io.read_u4le()
+            self.num_tri = self._io.read_u4le()
+            self.num_vtx = self._io.read_u4le()
+            self.num_tbl = self._io.read_u4le()
+            self.parts = self._io.read_u4le()
+            self.reserved = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod156.RcnHeader, self)._write__seq(io)
+            self._io.write_u4le(self.ptri)
+            self._io.write_u4le(self.pvtx)
+            self._io.write_u4le(self.ptb)
+            self._io.write_u4le(self.num_tri)
+            self._io.write_u4le(self.num_vtx)
+            self._io.write_u4le(self.num_tbl)
+            self._io.write_u4le(self.parts)
+            self._io.write_u4le(self.reserved)
+
+
+        def _check(self):
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 32
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class RcnTable(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod156.RcnTable, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.vindex = self._io.read_bits_int_le(21)
+            self.noffset = self._io.read_bits_int_le(10)
+            self.edge = self._io.read_bits_int_le(1) != 0
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod156.RcnTable, self)._write__seq(io)
+            self._io.write_bits_int_le(21, self.vindex)
+            self._io.write_bits_int_le(10, self.noffset)
+            self._io.write_bits_int_le(1, int(self.edge))
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class RcnTriangle(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod156.RcnTriangle, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.v0 = self._io.read_bits_int_le(21)
+            self.v1 = self._io.read_bits_int_le(21)
+            self.v2 = self._io.read_bits_int_le(21)
+            self.reserved = self._io.read_bits_int_le(1) != 0
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod156.RcnTriangle, self)._write__seq(io)
+            self._io.write_bits_int_le(21, self.v0)
+            self._io.write_bits_int_le(21, self.v1)
+            self._io.write_bits_int_le(21, self.v2)
+            self._io.write_bits_int_le(1, int(self.reserved))
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class RcnVertex(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod156.RcnVertex, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.x = self._io.read_u2le()
+            self.y = self._io.read_u2le()
+            self.z = self._io.read_u2le()
+            self.w = self._io.read_u2le()
+            self.w0 = self._io.read_u1()
+            self.w1 = self._io.read_u1()
+            self.w2 = self._io.read_u1()
+            self.w3 = self._io.read_u1()
+            self.j0 = self._io.read_u1()
+            self.j1 = self._io.read_u1()
+            self.j2 = self._io.read_u1()
+            self.j3 = self._io.read_u1()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod156.RcnVertex, self)._write__seq(io)
+            self._io.write_u2le(self.x)
+            self._io.write_u2le(self.y)
+            self._io.write_u2le(self.z)
+            self._io.write_u2le(self.w)
+            self._io.write_u1(self.w0)
+            self._io.write_u1(self.w1)
+            self._io.write_u1(self.w2)
+            self._io.write_u1(self.w3)
+            self._io.write_u1(self.j0)
+            self._io.write_u1(self.j1)
+            self._io.write_u1(self.j2)
+            self._io.write_u1(self.j3)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Vec2(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod156.Vec2, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.x = self._io.read_f4le()
+            self.y = self._io.read_f4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod156.Vec2, self)._write__seq(io)
+            self._io.write_f4le(self.x)
+            self._io.write_f4le(self.y)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Vec2HalfFloat(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod156.Vec2HalfFloat, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.u = self._io.read_bytes(2)
+            self.v = self._io.read_bytes(2)
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod156.Vec2HalfFloat, self)._write__seq(io)
+            self._io.write_bytes(self.u)
+            self._io.write_bytes(self.v)
+
+
+        def _check(self):
+            if len(self.u) != 2:
+                raise kaitaistruct.ConsistencyError(u"u", 2, len(self.u))
+            if len(self.v) != 2:
+                raise kaitaistruct.ConsistencyError(u"v", 2, len(self.v))
+            self._dirty = False
+
+
+    class Vec3(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod156.Vec3, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.x = self._io.read_f4le()
+            self.y = self._io.read_f4le()
+            self.z = self._io.read_f4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod156.Vec3, self)._write__seq(io)
+            self._io.write_f4le(self.x)
+            self._io.write_f4le(self.y)
+            self._io.write_f4le(self.z)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Vec4(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod156.Vec4, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.x = self._io.read_f4le()
+            self.y = self._io.read_f4le()
+            self.z = self._io.read_f4le()
+            self.w = self._io.read_f4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod156.Vec4, self)._write__seq(io)
+            self._io.write_f4le(self.x)
+            self._io.write_f4le(self.y)
+            self._io.write_f4le(self.z)
+            self._io.write_f4le(self.w)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Vec4S2(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod156.Vec4S2, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.x = self._io.read_s2le()
+            self.y = self._io.read_s2le()
+            self.z = self._io.read_s2le()
+            self.w = self._io.read_s2le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod156.Vec4S2, self)._write__seq(io)
+            self._io.write_s2le(self.x)
+            self._io.write_s2le(self.y)
+            self._io.write_s2le(self.z)
+            self._io.write_s2le(self.w)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Vec4U1(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod156.Vec4U1, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.x = self._io.read_u1()
+            self.y = self._io.read_u1()
+            self.z = self._io.read_u1()
+            self.w = self._io.read_u1()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod156.Vec4U1, self)._write__seq(io)
+            self._io.write_u1(self.x)
+            self._io.write_u1(self.y)
+            self._io.write_u1(self.z)
+            self._io.write_u1(self.w)
+
+
+        def _check(self):
+            self._dirty = False
+
+
     class Vertex24(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod156.Vertex24, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
             self.occlusion = Mod156.Vec4U1(self._io, self, self._root)
             self.occlusion._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -1764,16 +1869,288 @@ class Mod156(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
             if self.occlusion._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"occlusion", self.occlusion._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"occlusion", self._root, self.occlusion._root)
             if self.occlusion._parent != self:
-                raise kaitaistruct.ConsistencyError(u"occlusion", self.occlusion._parent, self)
+                raise kaitaistruct.ConsistencyError(u"occlusion", self, self.occlusion._parent)
+            self._dirty = False
+
+
+    class Vertex28(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod156.Vertex28, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.occlusion = Mod156.Vec4U1(self._io, self, self._root)
+            self.occlusion._read()
+            self.tangent = Mod156.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.occlusion._fetch_instances()
+            self.tangent._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod156.Vertex28, self)._write__seq(io)
+            self.occlusion._write__seq(self._io)
+            self.tangent._write__seq(self._io)
+
+
+        def _check(self):
+            if self.occlusion._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"occlusion", self._root, self.occlusion._root)
+            if self.occlusion._parent != self:
+                raise kaitaistruct.ConsistencyError(u"occlusion", self, self.occlusion._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            self._dirty = False
+
+
+    class VfNonSkin(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod156.VfNonSkin, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod156.Vec3(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod156.Vec4U1(self._io, self, self._root)
+            self.normal._read()
+            self.tangent = Mod156.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod156.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod156.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self.uv3 = Mod156.Vec2HalfFloat(self._io, self, self._root)
+            self.uv3._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
+            self.uv3._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod156.VfNonSkin, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+            self.uv3._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            if self.uv3._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv3", self._root, self.uv3._root)
+            if self.uv3._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv3", self, self.uv3._parent)
+            self._dirty = False
+
+
+    class VfNonSkinCol(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod156.VfNonSkinCol, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod156.Vec3(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod156.Vec4U1(self._io, self, self._root)
+            self.normal._read()
+            self.tangent = Mod156.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod156.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod156.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self.rgba = Mod156.Vec4U1(self._io, self, self._root)
+            self.rgba._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
+            self.rgba._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod156.VfNonSkinCol, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+            self.rgba._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            if self.rgba._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"rgba", self._root, self.rgba._root)
+            if self.rgba._parent != self:
+                raise kaitaistruct.ConsistencyError(u"rgba", self, self.rgba._parent)
+            self._dirty = False
+
+
+    class VfSkin(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod156.VfSkin, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod156.Vec4S2(self._io, self, self._root)
+            self.position._read()
+            self.bone_indices = []
+            for i in range(4):
+                self.bone_indices.append(self._io.read_u1())
+
+            self.weight_values = []
+            for i in range(4):
+                self.weight_values.append(self._io.read_u1())
+
+            self.normal = Mod156.Vec4U1(self._io, self, self._root)
+            self.normal._read()
+            self.tangent = Mod156.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod156.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod156.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            for i in range(len(self.bone_indices)):
+                pass
+
+            for i in range(len(self.weight_values)):
+                pass
+
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod156.VfSkin, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            for i in range(len(self.bone_indices)):
+                pass
+                self._io.write_u1(self.bone_indices[i])
+
+            for i in range(len(self.weight_values)):
+                pass
+                self._io.write_u1(self.weight_values[i])
+
+            self.normal._write__seq(self._io)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if len(self.bone_indices) != 4:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 4, len(self.bone_indices))
+            for i in range(len(self.bone_indices)):
+                pass
+
+            if len(self.weight_values) != 4:
+                raise kaitaistruct.ConsistencyError(u"weight_values", 4, len(self.weight_values))
+            for i in range(len(self.weight_values)):
+                pass
+
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            self._dirty = False
 
 
     class VfSkinEx(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod156.VfSkinEx, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -1792,6 +2169,7 @@ class Mod156(ReadWriteKaitaiStruct):
             self.normal._read()
             self.uv = Mod156.Vec2HalfFloat(self._io, self, self._root)
             self.uv._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -1823,563 +2201,113 @@ class Mod156(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
             if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
             if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if (len(self.bone_indices) != 8):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 8)
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if len(self.bone_indices) != 8:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 8, len(self.bone_indices))
             for i in range(len(self.bone_indices)):
                 pass
 
-            if (len(self.weight_values) != 8):
-                raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values), 8)
+            if len(self.weight_values) != 8:
+                raise kaitaistruct.ConsistencyError(u"weight_values", 8, len(self.weight_values))
             for i in range(len(self.weight_values)):
                 pass
 
             if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
             if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
             if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
             if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            self._dirty = False
 
 
-    class BonesData(ReadWriteKaitaiStruct):
+    class WeightBound(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod156.WeightBound, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
-            self.bones_hierarchy = []
-            for i in range(self._root.header.num_bones):
-                _t_bones_hierarchy = Mod156.Bone(self._io, self, self._root)
-                _t_bones_hierarchy._read()
-                self.bones_hierarchy.append(_t_bones_hierarchy)
-
-            self.parent_space_matrices = []
-            for i in range(self._root.header.num_bones):
-                _t_parent_space_matrices = Mod156.Matrix4x4(self._io, self, self._root)
-                _t_parent_space_matrices._read()
-                self.parent_space_matrices.append(_t_parent_space_matrices)
-
-            self.inverse_bind_matrices = []
-            for i in range(self._root.header.num_bones):
-                _t_inverse_bind_matrices = Mod156.Matrix4x4(self._io, self, self._root)
-                _t_inverse_bind_matrices._read()
-                self.inverse_bind_matrices.append(_t_inverse_bind_matrices)
-
-            if (self._root.header.num_bones != 0):
-                pass
-                self.bone_map = self._io.read_bytes(256)
-
-            self.bone_palettes = []
-            for i in range(self._root.header.num_bone_palettes):
-                _t_bone_palettes = Mod156.BonePalette(self._io, self, self._root)
-                _t_bone_palettes._read()
-                self.bone_palettes.append(_t_bone_palettes)
-
+            self.bone_id = self._io.read_u4le()
+            self.unk_01 = Mod156.Vec3(self._io, self, self._root)
+            self.unk_01._read()
+            self.bsphere = Mod156.Vec4(self._io, self, self._root)
+            self.bsphere._read()
+            self.bbox_min = Mod156.Vec4(self._io, self, self._root)
+            self.bbox_min._read()
+            self.bbox_max = Mod156.Vec4(self._io, self, self._root)
+            self.bbox_max._read()
+            self.oabb = Mod156.Matrix4x4(self._io, self, self._root)
+            self.oabb._read()
+            self.oabb_dimension = Mod156.Vec4(self._io, self, self._root)
+            self.oabb_dimension._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
-            for i in range(len(self.bones_hierarchy)):
-                pass
-                self.bones_hierarchy[i]._fetch_instances()
-
-            for i in range(len(self.parent_space_matrices)):
-                pass
-                self.parent_space_matrices[i]._fetch_instances()
-
-            for i in range(len(self.inverse_bind_matrices)):
-                pass
-                self.inverse_bind_matrices[i]._fetch_instances()
-
-            if (self._root.header.num_bones != 0):
-                pass
-
-            for i in range(len(self.bone_palettes)):
-                pass
-                self.bone_palettes[i]._fetch_instances()
-
+            self.unk_01._fetch_instances()
+            self.bsphere._fetch_instances()
+            self.bbox_min._fetch_instances()
+            self.bbox_max._fetch_instances()
+            self.oabb._fetch_instances()
+            self.oabb_dimension._fetch_instances()
 
 
         def _write__seq(self, io=None):
-            super(Mod156.BonesData, self)._write__seq(io)
-            for i in range(len(self.bones_hierarchy)):
-                pass
-                self.bones_hierarchy[i]._write__seq(self._io)
-
-            for i in range(len(self.parent_space_matrices)):
-                pass
-                self.parent_space_matrices[i]._write__seq(self._io)
-
-            for i in range(len(self.inverse_bind_matrices)):
-                pass
-                self.inverse_bind_matrices[i]._write__seq(self._io)
-
-            if (self._root.header.num_bones != 0):
-                pass
-                self._io.write_bytes(self.bone_map)
-
-            for i in range(len(self.bone_palettes)):
-                pass
-                self.bone_palettes[i]._write__seq(self._io)
-
+            super(Mod156.WeightBound, self)._write__seq(io)
+            self._io.write_u4le(self.bone_id)
+            self.unk_01._write__seq(self._io)
+            self.bsphere._write__seq(self._io)
+            self.bbox_min._write__seq(self._io)
+            self.bbox_max._write__seq(self._io)
+            self.oabb._write__seq(self._io)
+            self.oabb_dimension._write__seq(self._io)
 
 
         def _check(self):
-            pass
-            if (len(self.bones_hierarchy) != self._root.header.num_bones):
-                raise kaitaistruct.ConsistencyError(u"bones_hierarchy", len(self.bones_hierarchy), self._root.header.num_bones)
-            for i in range(len(self.bones_hierarchy)):
-                pass
-                if self.bones_hierarchy[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"bones_hierarchy", self.bones_hierarchy[i]._root, self._root)
-                if self.bones_hierarchy[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"bones_hierarchy", self.bones_hierarchy[i]._parent, self)
-
-            if (len(self.parent_space_matrices) != self._root.header.num_bones):
-                raise kaitaistruct.ConsistencyError(u"parent_space_matrices", len(self.parent_space_matrices), self._root.header.num_bones)
-            for i in range(len(self.parent_space_matrices)):
-                pass
-                if self.parent_space_matrices[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"parent_space_matrices", self.parent_space_matrices[i]._root, self._root)
-                if self.parent_space_matrices[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"parent_space_matrices", self.parent_space_matrices[i]._parent, self)
-
-            if (len(self.inverse_bind_matrices) != self._root.header.num_bones):
-                raise kaitaistruct.ConsistencyError(u"inverse_bind_matrices", len(self.inverse_bind_matrices), self._root.header.num_bones)
-            for i in range(len(self.inverse_bind_matrices)):
-                pass
-                if self.inverse_bind_matrices[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"inverse_bind_matrices", self.inverse_bind_matrices[i]._root, self._root)
-                if self.inverse_bind_matrices[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"inverse_bind_matrices", self.inverse_bind_matrices[i]._parent, self)
-
-            if (self._root.header.num_bones != 0):
-                pass
-                if (len(self.bone_map) != 256):
-                    raise kaitaistruct.ConsistencyError(u"bone_map", len(self.bone_map), 256)
-
-            if (len(self.bone_palettes) != self._root.header.num_bone_palettes):
-                raise kaitaistruct.ConsistencyError(u"bone_palettes", len(self.bone_palettes), self._root.header.num_bone_palettes)
-            for i in range(len(self.bone_palettes)):
-                pass
-                if self.bone_palettes[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"bone_palettes", self.bone_palettes[i]._root, self._root)
-                if self.bone_palettes[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"bone_palettes", self.bone_palettes[i]._parent, self)
-
+            if self.unk_01._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"unk_01", self._root, self.unk_01._root)
+            if self.unk_01._parent != self:
+                raise kaitaistruct.ConsistencyError(u"unk_01", self, self.unk_01._parent)
+            if self.bsphere._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"bsphere", self._root, self.bsphere._root)
+            if self.bsphere._parent != self:
+                raise kaitaistruct.ConsistencyError(u"bsphere", self, self.bsphere._parent)
+            if self.bbox_min._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"bbox_min", self._root, self.bbox_min._root)
+            if self.bbox_min._parent != self:
+                raise kaitaistruct.ConsistencyError(u"bbox_min", self, self.bbox_min._parent)
+            if self.bbox_max._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"bbox_max", self._root, self.bbox_max._root)
+            if self.bbox_max._parent != self:
+                raise kaitaistruct.ConsistencyError(u"bbox_max", self, self.bbox_max._parent)
+            if self.oabb._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"oabb", self._root, self.oabb._root)
+            if self.oabb._parent != self:
+                raise kaitaistruct.ConsistencyError(u"oabb", self, self.oabb._parent)
+            if self.oabb_dimension._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"oabb_dimension", self._root, self.oabb_dimension._root)
+            if self.oabb_dimension._parent != self:
+                raise kaitaistruct.ConsistencyError(u"oabb_dimension", self, self.oabb_dimension._parent)
+            self._dirty = False
 
         @property
         def size_(self):
             if hasattr(self, '_m_size_'):
                 return self._m_size_
 
-            self._m_size_ = ((((((self._root.header.num_bones * self.bones_hierarchy[0].size_) + (self._root.header.num_bones * 64)) + (self._root.header.num_bones * 64)) + 256) + (self._root.header.num_bone_palettes * self.bone_palettes[0].size_)) if (self._root.header.num_bones > 0) else 0)
+            self._m_size_ = 144
             return getattr(self, '_m_size_', None)
 
         def _invalidate_size_(self):
             del self._m_size_
 
-    class Vertex28(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.occlusion = Mod156.Vec4U1(self._io, self, self._root)
-            self.occlusion._read()
-            self.tangent = Mod156.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.occlusion._fetch_instances()
-            self.tangent._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod156.Vertex28, self)._write__seq(io)
-            self.occlusion._write__seq(self._io)
-            self.tangent._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.occlusion._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"occlusion", self.occlusion._root, self._root)
-            if self.occlusion._parent != self:
-                raise kaitaistruct.ConsistencyError(u"occlusion", self.occlusion._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-
-
-    class RcnHeader(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.ptri = self._io.read_u4le()
-            self.pvtx = self._io.read_u4le()
-            self.ptb = self._io.read_u4le()
-            self.num_tri = self._io.read_u4le()
-            self.num_vtx = self._io.read_u4le()
-            self.num_tbl = self._io.read_u4le()
-            self.parts = self._io.read_u4le()
-            self.reserved = self._io.read_u4le()
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod156.RcnHeader, self)._write__seq(io)
-            self._io.write_u4le(self.ptri)
-            self._io.write_u4le(self.pvtx)
-            self._io.write_u4le(self.ptb)
-            self._io.write_u4le(self.num_tri)
-            self._io.write_u4le(self.num_vtx)
-            self._io.write_u4le(self.num_tbl)
-            self._io.write_u4le(self.parts)
-            self._io.write_u4le(self.reserved)
-
-
-        def _check(self):
-            pass
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 32
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Vec4S2(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.x = self._io.read_s2le()
-            self.y = self._io.read_s2le()
-            self.z = self._io.read_s2le()
-            self.w = self._io.read_s2le()
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod156.Vec4S2, self)._write__seq(io)
-            self._io.write_s2le(self.x)
-            self._io.write_s2le(self.y)
-            self._io.write_s2le(self.z)
-            self._io.write_s2le(self.w)
-
-
-        def _check(self):
-            pass
-
-
-    class Group(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.group_index = self._io.read_u4le()
-            self.reserved = []
-            for i in range(3):
-                self.reserved.append(self._io.read_u4le())
-
-            self.pos = Mod156.Vec3(self._io, self, self._root)
-            self.pos._read()
-            self.radius = self._io.read_f4le()
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.reserved)):
-                pass
-
-            self.pos._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod156.Group, self)._write__seq(io)
-            self._io.write_u4le(self.group_index)
-            for i in range(len(self.reserved)):
-                pass
-                self._io.write_u4le(self.reserved[i])
-
-            self.pos._write__seq(self._io)
-            self._io.write_f4le(self.radius)
-
-
-        def _check(self):
-            pass
-            if (len(self.reserved) != 3):
-                raise kaitaistruct.ConsistencyError(u"reserved", len(self.reserved), 3)
-            for i in range(len(self.reserved)):
-                pass
-
-            if self.pos._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"pos", self.pos._root, self._root)
-            if self.pos._parent != self:
-                raise kaitaistruct.ConsistencyError(u"pos", self.pos._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 32
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    @property
-    def vertex_buffer(self):
-        if self._should_write_vertex_buffer:
-            self._write_vertex_buffer()
-        if hasattr(self, '_m_vertex_buffer'):
-            return self._m_vertex_buffer
-
-        if (self.header.offset_vertex_buffer > 0):
-            pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_vertex_buffer)
-            self._m_vertex_buffer = self._io.read_bytes(self.header.size_vertex_buffer)
-            self._io.seek(_pos)
-
-        return getattr(self, '_m_vertex_buffer', None)
-
-    @vertex_buffer.setter
-    def vertex_buffer(self, v):
-        self._m_vertex_buffer = v
-
-    def _write_vertex_buffer(self):
-        self._should_write_vertex_buffer = False
-        if (self.header.offset_vertex_buffer > 0):
-            pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_vertex_buffer)
-            self._io.write_bytes(self.vertex_buffer)
-            self._io.seek(_pos)
-
-
-
-    def _check_vertex_buffer(self):
-        pass
-        if (self.header.offset_vertex_buffer > 0):
-            pass
-            if (len(self.vertex_buffer) != self.header.size_vertex_buffer):
-                raise kaitaistruct.ConsistencyError(u"vertex_buffer", len(self.vertex_buffer), self.header.size_vertex_buffer)
-
-
-    @property
-    def materials_data(self):
-        if self._should_write_materials_data:
-            self._write_materials_data()
-        if hasattr(self, '_m_materials_data'):
-            return self._m_materials_data
-
-        if (self.header.offset_materials_data > 0):
-            pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_materials_data)
-            self._m_materials_data = Mod156.MaterialsData(self._io, self, self._root)
-            self._m_materials_data._read()
-            self._io.seek(_pos)
-
-        return getattr(self, '_m_materials_data', None)
-
-    @materials_data.setter
-    def materials_data(self, v):
-        self._m_materials_data = v
-
-    def _write_materials_data(self):
-        self._should_write_materials_data = False
-        if (self.header.offset_materials_data > 0):
-            pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_materials_data)
-            self.materials_data._write__seq(self._io)
-            self._io.seek(_pos)
-
-
-
-    def _check_materials_data(self):
-        pass
-        if (self.header.offset_materials_data > 0):
-            pass
-            if self.materials_data._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"materials_data", self.materials_data._root, self._root)
-            if self.materials_data._parent != self:
-                raise kaitaistruct.ConsistencyError(u"materials_data", self.materials_data._parent, self)
-
-
-    @property
-    def bones_data_size_(self):
-        if hasattr(self, '_m_bones_data_size_'):
-            return self._m_bones_data_size_
-
-        self._m_bones_data_size_ = (0 if (self.header.num_bones == 0) else self.bones_data.size_)
-        return getattr(self, '_m_bones_data_size_', None)
-
-    def _invalidate_bones_data_size_(self):
-        del self._m_bones_data_size_
-    @property
-    def vertex_buffer_2(self):
-        if self._should_write_vertex_buffer_2:
-            self._write_vertex_buffer_2()
-        if hasattr(self, '_m_vertex_buffer_2'):
-            return self._m_vertex_buffer_2
-
-        if (self.header.offset_vertex_buffer_2 > 0):
-            pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_vertex_buffer_2)
-            self._m_vertex_buffer_2 = self._io.read_bytes(self.header.size_vertex_buffer_2)
-            self._io.seek(_pos)
-
-        return getattr(self, '_m_vertex_buffer_2', None)
-
-    @vertex_buffer_2.setter
-    def vertex_buffer_2(self, v):
-        self._m_vertex_buffer_2 = v
-
-    def _write_vertex_buffer_2(self):
-        self._should_write_vertex_buffer_2 = False
-        if (self.header.offset_vertex_buffer_2 > 0):
-            pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_vertex_buffer_2)
-            self._io.write_bytes(self.vertex_buffer_2)
-            self._io.seek(_pos)
-
-
-
-    def _check_vertex_buffer_2(self):
-        pass
-        if (self.header.offset_vertex_buffer_2 > 0):
-            pass
-            if (len(self.vertex_buffer_2) != self.header.size_vertex_buffer_2):
-                raise kaitaistruct.ConsistencyError(u"vertex_buffer_2", len(self.vertex_buffer_2), self.header.size_vertex_buffer_2)
-
-
-    @property
-    def meshes_data(self):
-        if self._should_write_meshes_data:
-            self._write_meshes_data()
-        if hasattr(self, '_m_meshes_data'):
-            return self._m_meshes_data
-
-        if (self.header.offset_meshes_data > 0):
-            pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_meshes_data)
-            self._m_meshes_data = Mod156.MeshesData(self._io, self, self._root)
-            self._m_meshes_data._read()
-            self._io.seek(_pos)
-
-        return getattr(self, '_m_meshes_data', None)
-
-    @meshes_data.setter
-    def meshes_data(self, v):
-        self._m_meshes_data = v
-
-    def _write_meshes_data(self):
-        self._should_write_meshes_data = False
-        if (self.header.offset_meshes_data > 0):
-            pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_meshes_data)
-            self.meshes_data._write__seq(self._io)
-            self._io.seek(_pos)
-
-
-
-    def _check_meshes_data(self):
-        pass
-        if (self.header.offset_meshes_data > 0):
-            pass
-            if self.meshes_data._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"meshes_data", self.meshes_data._root, self._root)
-            if self.meshes_data._parent != self:
-                raise kaitaistruct.ConsistencyError(u"meshes_data", self.meshes_data._parent, self)
-
-
-    @property
-    def index_buffer(self):
-        if self._should_write_index_buffer:
-            self._write_index_buffer()
-        if hasattr(self, '_m_index_buffer'):
-            return self._m_index_buffer
-
-        if (self.header.offset_index_buffer > 0):
-            pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_index_buffer)
-            self._m_index_buffer = self._io.read_bytes(((self.header.num_faces * 2) - 2))
-            self._io.seek(_pos)
-
-        return getattr(self, '_m_index_buffer', None)
-
-    @index_buffer.setter
-    def index_buffer(self, v):
-        self._m_index_buffer = v
-
-    def _write_index_buffer(self):
-        self._should_write_index_buffer = False
-        if (self.header.offset_index_buffer > 0):
-            pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_index_buffer)
-            self._io.write_bytes(self.index_buffer)
-            self._io.seek(_pos)
-
-
-
-    def _check_index_buffer(self):
-        pass
-        if (self.header.offset_index_buffer > 0):
-            pass
-            if (len(self.index_buffer) != ((self.header.num_faces * 2) - 2)):
-                raise kaitaistruct.ConsistencyError(u"index_buffer", len(self.index_buffer), ((self.header.num_faces * 2) - 2))
-
-
-    @property
-    def size_top_level_(self):
-        if hasattr(self, '_m_size_top_level_'):
-            return self._m_size_top_level_
-
-        self._m_size_top_level_ = (self._root.header.size_ + 104)
-        return getattr(self, '_m_size_top_level_', None)
-
-    def _invalidate_size_top_level_(self):
-        del self._m_size_top_level_
     @property
     def bones_data(self):
         if self._should_write_bones_data:
@@ -2387,7 +2315,10 @@ class Mod156(ReadWriteKaitaiStruct):
         if hasattr(self, '_m_bones_data'):
             return self._m_bones_data
 
-        if (self.header.num_bones != 0):
+        if not self.bones_data__enabled:
+            return None
+
+        if self.header.num_bones != 0:
             pass
             _pos = self._io.pos()
             self._io.seek(self.header.offset_bones_data)
@@ -2399,29 +2330,29 @@ class Mod156(ReadWriteKaitaiStruct):
 
     @bones_data.setter
     def bones_data(self, v):
+        self._dirty = True
         self._m_bones_data = v
 
     def _write_bones_data(self):
         self._should_write_bones_data = False
-        if (self.header.num_bones != 0):
+        if self.header.num_bones != 0:
             pass
             _pos = self._io.pos()
             self._io.seek(self.header.offset_bones_data)
-            self.bones_data._write__seq(self._io)
+            self._m_bones_data._write__seq(self._io)
             self._io.seek(_pos)
 
 
+    @property
+    def bones_data_size_(self):
+        if hasattr(self, '_m_bones_data_size_'):
+            return self._m_bones_data_size_
 
-    def _check_bones_data(self):
-        pass
-        if (self.header.num_bones != 0):
-            pass
-            if self.bones_data._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"bones_data", self.bones_data._root, self._root)
-            if self.bones_data._parent != self:
-                raise kaitaistruct.ConsistencyError(u"bones_data", self.bones_data._parent, self)
+        self._m_bones_data_size_ = (0 if self.header.num_bones == 0 else self.bones_data.size_)
+        return getattr(self, '_m_bones_data_size_', None)
 
-
+    def _invalidate_bones_data_size_(self):
+        del self._m_bones_data_size_
     @property
     def groups(self):
         if self._should_write_groups:
@@ -2429,19 +2360,25 @@ class Mod156(ReadWriteKaitaiStruct):
         if hasattr(self, '_m_groups'):
             return self._m_groups
 
+        if not self.groups__enabled:
+            return None
+
         _pos = self._io.pos()
         self._io.seek(self.header.offset_groups)
         self._m_groups = []
         for i in range(self.header.num_groups):
             _t__m_groups = Mod156.Group(self._io, self, self._root)
-            _t__m_groups._read()
-            self._m_groups.append(_t__m_groups)
+            try:
+                _t__m_groups._read()
+            finally:
+                self._m_groups.append(_t__m_groups)
 
         self._io.seek(_pos)
         return getattr(self, '_m_groups', None)
 
     @groups.setter
     def groups(self, v):
+        self._dirty = True
         self._m_groups = v
 
     def _write_groups(self):
@@ -2450,31 +2387,200 @@ class Mod156(ReadWriteKaitaiStruct):
         self._io.seek(self.header.offset_groups)
         for i in range(len(self._m_groups)):
             pass
-            self.groups[i]._write__seq(self._io)
+            self._m_groups[i]._write__seq(self._io)
 
         self._io.seek(_pos)
-
-
-    def _check_groups(self):
-        pass
-        if (len(self.groups) != self.header.num_groups):
-            raise kaitaistruct.ConsistencyError(u"groups", len(self.groups), self.header.num_groups)
-        for i in range(len(self._m_groups)):
-            pass
-            if self.groups[i]._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"groups", self.groups[i]._root, self._root)
-            if self.groups[i]._parent != self:
-                raise kaitaistruct.ConsistencyError(u"groups", self.groups[i]._parent, self)
-
 
     @property
     def groups_size_(self):
         if hasattr(self, '_m_groups_size_'):
             return self._m_groups_size_
 
-        self._m_groups_size_ = (self.groups[0].size_ * self.header.num_groups)
+        self._m_groups_size_ = self.groups[0].size_ * self.header.num_groups
         return getattr(self, '_m_groups_size_', None)
 
     def _invalidate_groups_size_(self):
         del self._m_groups_size_
+    @property
+    def index_buffer(self):
+        if self._should_write_index_buffer:
+            self._write_index_buffer()
+        if hasattr(self, '_m_index_buffer'):
+            return self._m_index_buffer
+
+        if not self.index_buffer__enabled:
+            return None
+
+        if self.header.offset_index_buffer > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_index_buffer)
+            self._m_index_buffer = self._io.read_bytes(self.header.num_faces * 2 - 2)
+            self._io.seek(_pos)
+
+        return getattr(self, '_m_index_buffer', None)
+
+    @index_buffer.setter
+    def index_buffer(self, v):
+        self._dirty = True
+        self._m_index_buffer = v
+
+    def _write_index_buffer(self):
+        self._should_write_index_buffer = False
+        if self.header.offset_index_buffer > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_index_buffer)
+            self._io.write_bytes(self._m_index_buffer)
+            self._io.seek(_pos)
+
+
+    @property
+    def materials_data(self):
+        if self._should_write_materials_data:
+            self._write_materials_data()
+        if hasattr(self, '_m_materials_data'):
+            return self._m_materials_data
+
+        if not self.materials_data__enabled:
+            return None
+
+        if self.header.offset_materials_data > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_materials_data)
+            self._m_materials_data = Mod156.MaterialsData(self._io, self, self._root)
+            self._m_materials_data._read()
+            self._io.seek(_pos)
+
+        return getattr(self, '_m_materials_data', None)
+
+    @materials_data.setter
+    def materials_data(self, v):
+        self._dirty = True
+        self._m_materials_data = v
+
+    def _write_materials_data(self):
+        self._should_write_materials_data = False
+        if self.header.offset_materials_data > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_materials_data)
+            self._m_materials_data._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    @property
+    def meshes_data(self):
+        if self._should_write_meshes_data:
+            self._write_meshes_data()
+        if hasattr(self, '_m_meshes_data'):
+            return self._m_meshes_data
+
+        if not self.meshes_data__enabled:
+            return None
+
+        if self.header.offset_meshes_data > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_meshes_data)
+            self._m_meshes_data = Mod156.MeshesData(self._io, self, self._root)
+            self._m_meshes_data._read()
+            self._io.seek(_pos)
+
+        return getattr(self, '_m_meshes_data', None)
+
+    @meshes_data.setter
+    def meshes_data(self, v):
+        self._dirty = True
+        self._m_meshes_data = v
+
+    def _write_meshes_data(self):
+        self._should_write_meshes_data = False
+        if self.header.offset_meshes_data > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_meshes_data)
+            self._m_meshes_data._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    @property
+    def size_top_level_(self):
+        if hasattr(self, '_m_size_top_level_'):
+            return self._m_size_top_level_
+
+        self._m_size_top_level_ = self._root.header.size_ + 104
+        return getattr(self, '_m_size_top_level_', None)
+
+    def _invalidate_size_top_level_(self):
+        del self._m_size_top_level_
+    @property
+    def vertex_buffer(self):
+        if self._should_write_vertex_buffer:
+            self._write_vertex_buffer()
+        if hasattr(self, '_m_vertex_buffer'):
+            return self._m_vertex_buffer
+
+        if not self.vertex_buffer__enabled:
+            return None
+
+        if self.header.offset_vertex_buffer > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_vertex_buffer)
+            self._m_vertex_buffer = self._io.read_bytes(self.header.size_vertex_buffer)
+            self._io.seek(_pos)
+
+        return getattr(self, '_m_vertex_buffer', None)
+
+    @vertex_buffer.setter
+    def vertex_buffer(self, v):
+        self._dirty = True
+        self._m_vertex_buffer = v
+
+    def _write_vertex_buffer(self):
+        self._should_write_vertex_buffer = False
+        if self.header.offset_vertex_buffer > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_vertex_buffer)
+            self._io.write_bytes(self._m_vertex_buffer)
+            self._io.seek(_pos)
+
+
+    @property
+    def vertex_buffer_2(self):
+        if self._should_write_vertex_buffer_2:
+            self._write_vertex_buffer_2()
+        if hasattr(self, '_m_vertex_buffer_2'):
+            return self._m_vertex_buffer_2
+
+        if not self.vertex_buffer_2__enabled:
+            return None
+
+        if self.header.offset_vertex_buffer_2 > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_vertex_buffer_2)
+            self._m_vertex_buffer_2 = self._io.read_bytes(self.header.size_vertex_buffer_2)
+            self._io.seek(_pos)
+
+        return getattr(self, '_m_vertex_buffer_2', None)
+
+    @vertex_buffer_2.setter
+    def vertex_buffer_2(self, v):
+        self._dirty = True
+        self._m_vertex_buffer_2 = v
+
+    def _write_vertex_buffer_2(self):
+        self._should_write_vertex_buffer_2 = False
+        if self.header.offset_vertex_buffer_2 > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_vertex_buffer_2)
+            self._io.write_bytes(self._m_vertex_buffer_2)
+            self._io.seek(_pos)
+
+
 

--- a/albam/engines/mtfw/structs/mod_21.py
+++ b/albam/engines/mtfw/structs/mod_21.py
@@ -5,26 +5,26 @@ import kaitaistruct
 from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
 
 
-if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 11):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.11 or later is required, but you have %s" % (kaitaistruct.__version__))
 
 class Mod21(ReadWriteKaitaiStruct):
     def __init__(self, _io=None, _parent=None, _root=None):
-        self._io = _io
+        super(Mod21, self).__init__(_io)
         self._parent = _parent
-        self._root = _root if _root else self
-        self._should_write_vertex_buffer = False
-        self.vertex_buffer__to_write = True
-        self._should_write_materials_data = False
-        self.materials_data__to_write = True
-        self._should_write_meshes_data = False
-        self.meshes_data__to_write = True
-        self._should_write_index_buffer = False
-        self.index_buffer__to_write = True
+        self._root = _root or self
         self._should_write_bones_data = False
-        self.bones_data__to_write = True
+        self.bones_data__enabled = True
         self._should_write_groups = False
-        self.groups__to_write = True
+        self.groups__enabled = True
+        self._should_write_index_buffer = False
+        self.index_buffer__enabled = True
+        self._should_write_materials_data = False
+        self.materials_data__enabled = True
+        self._should_write_meshes_data = False
+        self.meshes_data__enabled = True
+        self._should_write_vertex_buffer = False
+        self.vertex_buffer__enabled = True
 
     def _read(self):
         self.header = Mod21.ModHeader(self._io, self, self._root)
@@ -37,10 +37,11 @@ class Mod21(ReadWriteKaitaiStruct):
         self.bbox_max._read()
         self.model_info = Mod21.ModelInfo(self._io, self, self._root)
         self.model_info._read()
-        if  (((self._root.header.version == 210)) or ((self._root.header.version == 212))) :
+        if  ((self._root.header.version == 210) or (self._root.header.version == 212)) :
             pass
             self.num_weight_bounds = self._io.read_u4le()
 
+        self._dirty = False
 
 
     def _fetch_instances(self):
@@ -50,116 +51,1617 @@ class Mod21(ReadWriteKaitaiStruct):
         self.bbox_min._fetch_instances()
         self.bbox_max._fetch_instances()
         self.model_info._fetch_instances()
-        if  (((self._root.header.version == 210)) or ((self._root.header.version == 212))) :
+        if  ((self._root.header.version == 210) or (self._root.header.version == 212)) :
             pass
 
-        _ = self.vertex_buffer
-        if (self.header.offset_materials_data > 0):
+        _ = self.bones_data
+        if hasattr(self, '_m_bones_data'):
             pass
-            _ = self.materials_data
-            self.materials_data._fetch_instances()
-
-        if (self.header.offset_meshes_data > 0):
-            pass
-            _ = self.meshes_data
-            self.meshes_data._fetch_instances()
-
-        _ = self.index_buffer
-        if (self.header.num_bones != 0):
-            pass
-            _ = self.bones_data
-            self.bones_data._fetch_instances()
+            self._m_bones_data._fetch_instances()
 
         _ = self.groups
-        for i in range(len(self._m_groups)):
+        if hasattr(self, '_m_groups'):
             pass
-            self.groups[i]._fetch_instances()
+            for i in range(len(self._m_groups)):
+                pass
+                self._m_groups[i]._fetch_instances()
+
+
+        _ = self.index_buffer
+        if hasattr(self, '_m_index_buffer'):
+            pass
+
+        _ = self.materials_data
+        if hasattr(self, '_m_materials_data'):
+            pass
+            self._m_materials_data._fetch_instances()
+
+        _ = self.meshes_data
+        if hasattr(self, '_m_meshes_data'):
+            pass
+            self._m_meshes_data._fetch_instances()
+
+        _ = self.vertex_buffer
+        if hasattr(self, '_m_vertex_buffer'):
+            pass
 
 
 
     def _write__seq(self, io=None):
         super(Mod21, self)._write__seq(io)
-        self._should_write_vertex_buffer = self.vertex_buffer__to_write
-        self._should_write_materials_data = self.materials_data__to_write
-        self._should_write_meshes_data = self.meshes_data__to_write
-        self._should_write_index_buffer = self.index_buffer__to_write
-        self._should_write_bones_data = self.bones_data__to_write
-        self._should_write_groups = self.groups__to_write
+        self._should_write_bones_data = self.bones_data__enabled
+        self._should_write_groups = self.groups__enabled
+        self._should_write_index_buffer = self.index_buffer__enabled
+        self._should_write_materials_data = self.materials_data__enabled
+        self._should_write_meshes_data = self.meshes_data__enabled
+        self._should_write_vertex_buffer = self.vertex_buffer__enabled
         self.header._write__seq(self._io)
         self.bsphere._write__seq(self._io)
         self.bbox_min._write__seq(self._io)
         self.bbox_max._write__seq(self._io)
         self.model_info._write__seq(self._io)
-        if  (((self._root.header.version == 210)) or ((self._root.header.version == 212))) :
+        if  ((self._root.header.version == 210) or (self._root.header.version == 212)) :
             pass
             self._io.write_u4le(self.num_weight_bounds)
 
 
 
     def _check(self):
-        pass
         if self.header._root != self._root:
-            raise kaitaistruct.ConsistencyError(u"header", self.header._root, self._root)
+            raise kaitaistruct.ConsistencyError(u"header", self._root, self.header._root)
         if self.header._parent != self:
-            raise kaitaistruct.ConsistencyError(u"header", self.header._parent, self)
+            raise kaitaistruct.ConsistencyError(u"header", self, self.header._parent)
         if self.bsphere._root != self._root:
-            raise kaitaistruct.ConsistencyError(u"bsphere", self.bsphere._root, self._root)
+            raise kaitaistruct.ConsistencyError(u"bsphere", self._root, self.bsphere._root)
         if self.bsphere._parent != self:
-            raise kaitaistruct.ConsistencyError(u"bsphere", self.bsphere._parent, self)
+            raise kaitaistruct.ConsistencyError(u"bsphere", self, self.bsphere._parent)
         if self.bbox_min._root != self._root:
-            raise kaitaistruct.ConsistencyError(u"bbox_min", self.bbox_min._root, self._root)
+            raise kaitaistruct.ConsistencyError(u"bbox_min", self._root, self.bbox_min._root)
         if self.bbox_min._parent != self:
-            raise kaitaistruct.ConsistencyError(u"bbox_min", self.bbox_min._parent, self)
+            raise kaitaistruct.ConsistencyError(u"bbox_min", self, self.bbox_min._parent)
         if self.bbox_max._root != self._root:
-            raise kaitaistruct.ConsistencyError(u"bbox_max", self.bbox_max._root, self._root)
+            raise kaitaistruct.ConsistencyError(u"bbox_max", self._root, self.bbox_max._root)
         if self.bbox_max._parent != self:
-            raise kaitaistruct.ConsistencyError(u"bbox_max", self.bbox_max._parent, self)
+            raise kaitaistruct.ConsistencyError(u"bbox_max", self, self.bbox_max._parent)
         if self.model_info._root != self._root:
-            raise kaitaistruct.ConsistencyError(u"model_info", self.model_info._root, self._root)
+            raise kaitaistruct.ConsistencyError(u"model_info", self._root, self.model_info._root)
         if self.model_info._parent != self:
-            raise kaitaistruct.ConsistencyError(u"model_info", self.model_info._parent, self)
-        if  (((self._root.header.version == 210)) or ((self._root.header.version == 212))) :
+            raise kaitaistruct.ConsistencyError(u"model_info", self, self.model_info._parent)
+        if  ((self._root.header.version == 210) or (self._root.header.version == 212)) :
             pass
 
+        if self.bones_data__enabled:
+            pass
+            if self.header.num_bones != 0:
+                pass
+                if self._m_bones_data._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"bones_data", self._root, self._m_bones_data._root)
+                if self._m_bones_data._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"bones_data", self, self._m_bones_data._parent)
 
-    class Vec4(ReadWriteKaitaiStruct):
+
+        if self.groups__enabled:
+            pass
+            if len(self._m_groups) != self.header.num_groups:
+                raise kaitaistruct.ConsistencyError(u"groups", self.header.num_groups, len(self._m_groups))
+            for i in range(len(self._m_groups)):
+                pass
+                if self._m_groups[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"groups", self._root, self._m_groups[i]._root)
+                if self._m_groups[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"groups", self, self._m_groups[i]._parent)
+
+
+        if self.index_buffer__enabled:
+            pass
+            if len(self._m_index_buffer) != self.header.num_faces * 2:
+                raise kaitaistruct.ConsistencyError(u"index_buffer", self.header.num_faces * 2, len(self._m_index_buffer))
+
+        if self.materials_data__enabled:
+            pass
+            if self.header.offset_materials_data > 0:
+                pass
+                if self._m_materials_data._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"materials_data", self._root, self._m_materials_data._root)
+                if self._m_materials_data._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"materials_data", self, self._m_materials_data._parent)
+
+
+        if self.meshes_data__enabled:
+            pass
+            if self.header.offset_meshes_data > 0:
+                pass
+                if self._m_meshes_data._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"meshes_data", self._root, self._m_meshes_data._root)
+                if self._m_meshes_data._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"meshes_data", self, self._m_meshes_data._parent)
+
+
+        if self.vertex_buffer__enabled:
+            pass
+            if len(self._m_vertex_buffer) != self.header.size_vertex_buffer:
+                raise kaitaistruct.ConsistencyError(u"vertex_buffer", self.header.size_vertex_buffer, len(self._m_vertex_buffer))
+
+        self._dirty = False
+
+    class Bone(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod21.Bone, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
-            self.x = self._io.read_f4le()
-            self.y = self._io.read_f4le()
-            self.z = self._io.read_f4le()
-            self.w = self._io.read_f4le()
+            self.idx_anim_map = self._io.read_u1()
+            self.idx_parent = self._io.read_u1()
+            self.idx_mirror = self._io.read_u1()
+            self.idx_mapping = self._io.read_u1()
+            self.length = self._io.read_f4le()
+            self.parent_distance = self._io.read_f4le()
+            self.location = Mod21.Vec3(self._io, self, self._root)
+            self.location._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
+            self.location._fetch_instances()
 
 
         def _write__seq(self, io=None):
-            super(Mod21.Vec4, self)._write__seq(io)
-            self._io.write_f4le(self.x)
-            self._io.write_f4le(self.y)
-            self._io.write_f4le(self.z)
-            self._io.write_f4le(self.w)
+            super(Mod21.Bone, self)._write__seq(io)
+            self._io.write_u1(self.idx_anim_map)
+            self._io.write_u1(self.idx_parent)
+            self._io.write_u1(self.idx_mirror)
+            self._io.write_u1(self.idx_mapping)
+            self._io.write_f4le(self.length)
+            self._io.write_f4le(self.parent_distance)
+            self.location._write__seq(self._io)
 
 
         def _check(self):
-            pass
+            if self.location._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"location", self._root, self.location._root)
+            if self.location._parent != self:
+                raise kaitaistruct.ConsistencyError(u"location", self, self.location._parent)
+            self._dirty = False
 
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 24
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class BonesData(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.BonesData, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.bones_hierarchy = []
+            for i in range(self._root.header.num_bones):
+                _t_bones_hierarchy = Mod21.Bone(self._io, self, self._root)
+                try:
+                    _t_bones_hierarchy._read()
+                finally:
+                    self.bones_hierarchy.append(_t_bones_hierarchy)
+
+            self.parent_space_matrices = []
+            for i in range(self._root.header.num_bones):
+                _t_parent_space_matrices = Mod21.Matrix4x4(self._io, self, self._root)
+                try:
+                    _t_parent_space_matrices._read()
+                finally:
+                    self.parent_space_matrices.append(_t_parent_space_matrices)
+
+            self.inverse_bind_matrices = []
+            for i in range(self._root.header.num_bones):
+                _t_inverse_bind_matrices = Mod21.Matrix4x4(self._io, self, self._root)
+                try:
+                    _t_inverse_bind_matrices._read()
+                finally:
+                    self.inverse_bind_matrices.append(_t_inverse_bind_matrices)
+
+            if self._root.header.num_bones != 0:
+                pass
+                self.bone_map = self._io.read_bytes(256)
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.bones_hierarchy)):
+                pass
+                self.bones_hierarchy[i]._fetch_instances()
+
+            for i in range(len(self.parent_space_matrices)):
+                pass
+                self.parent_space_matrices[i]._fetch_instances()
+
+            for i in range(len(self.inverse_bind_matrices)):
+                pass
+                self.inverse_bind_matrices[i]._fetch_instances()
+
+            if self._root.header.num_bones != 0:
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.BonesData, self)._write__seq(io)
+            for i in range(len(self.bones_hierarchy)):
+                pass
+                self.bones_hierarchy[i]._write__seq(self._io)
+
+            for i in range(len(self.parent_space_matrices)):
+                pass
+                self.parent_space_matrices[i]._write__seq(self._io)
+
+            for i in range(len(self.inverse_bind_matrices)):
+                pass
+                self.inverse_bind_matrices[i]._write__seq(self._io)
+
+            if self._root.header.num_bones != 0:
+                pass
+                self._io.write_bytes(self.bone_map)
+
+
+
+        def _check(self):
+            if len(self.bones_hierarchy) != self._root.header.num_bones:
+                raise kaitaistruct.ConsistencyError(u"bones_hierarchy", self._root.header.num_bones, len(self.bones_hierarchy))
+            for i in range(len(self.bones_hierarchy)):
+                pass
+                if self.bones_hierarchy[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"bones_hierarchy", self._root, self.bones_hierarchy[i]._root)
+                if self.bones_hierarchy[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"bones_hierarchy", self, self.bones_hierarchy[i]._parent)
+
+            if len(self.parent_space_matrices) != self._root.header.num_bones:
+                raise kaitaistruct.ConsistencyError(u"parent_space_matrices", self._root.header.num_bones, len(self.parent_space_matrices))
+            for i in range(len(self.parent_space_matrices)):
+                pass
+                if self.parent_space_matrices[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"parent_space_matrices", self._root, self.parent_space_matrices[i]._root)
+                if self.parent_space_matrices[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"parent_space_matrices", self, self.parent_space_matrices[i]._parent)
+
+            if len(self.inverse_bind_matrices) != self._root.header.num_bones:
+                raise kaitaistruct.ConsistencyError(u"inverse_bind_matrices", self._root.header.num_bones, len(self.inverse_bind_matrices))
+            for i in range(len(self.inverse_bind_matrices)):
+                pass
+                if self.inverse_bind_matrices[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"inverse_bind_matrices", self._root, self.inverse_bind_matrices[i]._root)
+                if self.inverse_bind_matrices[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"inverse_bind_matrices", self, self.inverse_bind_matrices[i]._parent)
+
+            if self._root.header.num_bones != 0:
+                pass
+                if len(self.bone_map) != 256:
+                    raise kaitaistruct.ConsistencyError(u"bone_map", 256, len(self.bone_map))
+
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = (((self._root.header.num_bones * self.bones_hierarchy[0].size_ + self._root.header.num_bones * 64) + self._root.header.num_bones * 64) + 256 if self._root.header.num_bones > 0 else 0)
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class Group(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Group, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.group_index = self._io.read_u4le()
+            self.reserved = []
+            for i in range(3):
+                self.reserved.append(self._io.read_u4le())
+
+            self.pos = Mod21.Vec3(self._io, self, self._root)
+            self.pos._read()
+            self.radius = self._io.read_f4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.reserved)):
+                pass
+
+            self.pos._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Group, self)._write__seq(io)
+            self._io.write_u4le(self.group_index)
+            for i in range(len(self.reserved)):
+                pass
+                self._io.write_u4le(self.reserved[i])
+
+            self.pos._write__seq(self._io)
+            self._io.write_f4le(self.radius)
+
+
+        def _check(self):
+            if len(self.reserved) != 3:
+                raise kaitaistruct.ConsistencyError(u"reserved", 3, len(self.reserved))
+            for i in range(len(self.reserved)):
+                pass
+
+            if self.pos._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"pos", self._root, self.pos._root)
+            if self.pos._parent != self:
+                raise kaitaistruct.ConsistencyError(u"pos", self, self.pos._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 32
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class Material(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Material, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.unk_01 = self._io.read_u2le()
+            self.unk_02 = self._io.read_u2le()
+            self.unk_floats = []
+            for i in range(30):
+                self.unk_floats.append(self._io.read_f4le())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.unk_floats)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Material, self)._write__seq(io)
+            self._io.write_u2le(self.unk_01)
+            self._io.write_u2le(self.unk_02)
+            for i in range(len(self.unk_floats)):
+                pass
+                self._io.write_f4le(self.unk_floats[i])
+
+
+
+        def _check(self):
+            if len(self.unk_floats) != 30:
+                raise kaitaistruct.ConsistencyError(u"unk_floats", 30, len(self.unk_floats))
+            for i in range(len(self.unk_floats)):
+                pass
+
+            self._dirty = False
+
+
+    class MaterialsData(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.MaterialsData, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            if  ((self._root.header.version == 210) or (self._root.header.version == 212)) :
+                pass
+                self.material_names = []
+                for i in range(self._root.header.num_materials):
+                    self.material_names.append((KaitaiStream.bytes_terminate(self._io.read_bytes(128), 0, False)).decode(u"ASCII"))
+
+
+            if self._root.header.version == 211:
+                pass
+                self.material_hashes = []
+                for i in range(self._root.header.num_materials):
+                    self.material_hashes.append(self._io.read_u4le())
+
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            if  ((self._root.header.version == 210) or (self._root.header.version == 212)) :
+                pass
+                for i in range(len(self.material_names)):
+                    pass
+
+
+            if self._root.header.version == 211:
+                pass
+                for i in range(len(self.material_hashes)):
+                    pass
+
+
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.MaterialsData, self)._write__seq(io)
+            if  ((self._root.header.version == 210) or (self._root.header.version == 212)) :
+                pass
+                for i in range(len(self.material_names)):
+                    pass
+                    self._io.write_bytes_limit((self.material_names[i]).encode(u"ASCII"), 128, 0, 0)
+
+
+            if self._root.header.version == 211:
+                pass
+                for i in range(len(self.material_hashes)):
+                    pass
+                    self._io.write_u4le(self.material_hashes[i])
+
+
+
+
+        def _check(self):
+            if  ((self._root.header.version == 210) or (self._root.header.version == 212)) :
+                pass
+                if len(self.material_names) != self._root.header.num_materials:
+                    raise kaitaistruct.ConsistencyError(u"material_names", self._root.header.num_materials, len(self.material_names))
+                for i in range(len(self.material_names)):
+                    pass
+                    if len((self.material_names[i]).encode(u"ASCII")) > 128:
+                        raise kaitaistruct.ConsistencyError(u"material_names", 128, len((self.material_names[i]).encode(u"ASCII")))
+                    if KaitaiStream.byte_array_index_of((self.material_names[i]).encode(u"ASCII"), 0) != -1:
+                        raise kaitaistruct.ConsistencyError(u"material_names", -1, KaitaiStream.byte_array_index_of((self.material_names[i]).encode(u"ASCII"), 0))
+
+
+            if self._root.header.version == 211:
+                pass
+                if len(self.material_hashes) != self._root.header.num_materials:
+                    raise kaitaistruct.ConsistencyError(u"material_hashes", self._root.header.num_materials, len(self.material_hashes))
+                for i in range(len(self.material_hashes)):
+                    pass
+
+
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = (128 * self._root.header.num_materials if  ((self._root.header.version == 210) or (self._root.header.version == 212))  else 4 * self._root.header.num_materials)
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class Matrix4x4(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Matrix4x4, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.row_1 = Mod21.Vec4(self._io, self, self._root)
+            self.row_1._read()
+            self.row_2 = Mod21.Vec4(self._io, self, self._root)
+            self.row_2._read()
+            self.row_3 = Mod21.Vec4(self._io, self, self._root)
+            self.row_3._read()
+            self.row_4 = Mod21.Vec4(self._io, self, self._root)
+            self.row_4._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.row_1._fetch_instances()
+            self.row_2._fetch_instances()
+            self.row_3._fetch_instances()
+            self.row_4._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Matrix4x4, self)._write__seq(io)
+            self.row_1._write__seq(self._io)
+            self.row_2._write__seq(self._io)
+            self.row_3._write__seq(self._io)
+            self.row_4._write__seq(self._io)
+
+
+        def _check(self):
+            if self.row_1._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"row_1", self._root, self.row_1._root)
+            if self.row_1._parent != self:
+                raise kaitaistruct.ConsistencyError(u"row_1", self, self.row_1._parent)
+            if self.row_2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"row_2", self._root, self.row_2._root)
+            if self.row_2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"row_2", self, self.row_2._parent)
+            if self.row_3._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"row_3", self._root, self.row_3._root)
+            if self.row_3._parent != self:
+                raise kaitaistruct.ConsistencyError(u"row_3", self, self.row_3._parent)
+            if self.row_4._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"row_4", self._root, self.row_4._root)
+            if self.row_4._parent != self:
+                raise kaitaistruct.ConsistencyError(u"row_4", self, self.row_4._parent)
+            self._dirty = False
+
+
+    class Mesh(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Mesh, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_indices = False
+            self.indices__enabled = True
+            self._should_write_vertices = False
+            self.vertices__enabled = True
+
+        def _read(self):
+            self.draw_mode = self._io.read_u2le()
+            self.num_vertices = self._io.read_u2le()
+            self.idx_group = self._io.read_bits_int_le(12)
+            self.idx_material = self._io.read_bits_int_le(12)
+            self.level_of_detail = self._io.read_bits_int_le(8)
+            self.disp = self._io.read_bits_int_le(1) != 0
+            self.shape = self._io.read_bits_int_le(1) != 0
+            self.sort = self._io.read_bits_int_le(1) != 0
+            self.max_bones_per_vertex = self._io.read_bits_int_le(5)
+            self.alpha_priority = self._io.read_bits_int_le(8)
+            self.vertex_stride = self._io.read_u1()
+            self.topology = self._io.read_bits_int_le(6)
+            self.binormal_flip = self._io.read_bits_int_le(1) != 0
+            self.bridge = self._io.read_bits_int_le(1) != 0
+            self.vertex_position = self._io.read_u4le()
+            self.vertex_offset = self._io.read_u4le()
+            self.vertex_format = self._io.read_u4le()
+            self.face_position = self._io.read_u4le()
+            self.num_indices = self._io.read_u4le()
+            self.face_offset = self._io.read_u4le()
+            self.bone_id_start = self._io.read_u1()
+            self.num_weight_bounds = self._io.read_u1()
+            self.connect_id = self._io.read_u2le()
+            self.min_index = self._io.read_u2le()
+            self.max_index = self._io.read_u2le()
+            self.boundary = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.indices
+            if hasattr(self, '_m_indices'):
+                pass
+                for i in range(len(self._m_indices)):
+                    pass
+
+
+            _ = self.vertices
+            if hasattr(self, '_m_vertices'):
+                pass
+                for i in range(len(self._m_vertices)):
+                    pass
+                    _on = self.vertex_format
+                    if _on == 1126539326:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 1236594729:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 1585389612:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 1672921135:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 1683566627:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 1719341081:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 1954353201:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 1975771173:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 2010673186:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 213286933:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 228491293:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 2456801326:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 2476326963:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 2685620254:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 2706243644:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 2736832534:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 2815938614:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 2835001368:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 2946904109:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 2962763795:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 3012694047:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 3060273204:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 307572786:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 3094208554:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 3141681188:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 3273596956:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 3329204282:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 3419369511:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 3421945882:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 349437984:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 3517214776:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 3626594344:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 3629002790:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 3631710235:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 3663044641:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 3682443284:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 545087543:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 545452091:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 794148925:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+                    elif _on == 933552181:
+                        pass
+                        self._m_vertices[i]._fetch_instances()
+
+
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Mesh, self)._write__seq(io)
+            self._should_write_indices = self.indices__enabled
+            self._should_write_vertices = self.vertices__enabled
+            self._io.write_u2le(self.draw_mode)
+            self._io.write_u2le(self.num_vertices)
+            self._io.write_bits_int_le(12, self.idx_group)
+            self._io.write_bits_int_le(12, self.idx_material)
+            self._io.write_bits_int_le(8, self.level_of_detail)
+            self._io.write_bits_int_le(1, int(self.disp))
+            self._io.write_bits_int_le(1, int(self.shape))
+            self._io.write_bits_int_le(1, int(self.sort))
+            self._io.write_bits_int_le(5, self.max_bones_per_vertex)
+            self._io.write_bits_int_le(8, self.alpha_priority)
+            self._io.write_u1(self.vertex_stride)
+            self._io.write_bits_int_le(6, self.topology)
+            self._io.write_bits_int_le(1, int(self.binormal_flip))
+            self._io.write_bits_int_le(1, int(self.bridge))
+            self._io.write_u4le(self.vertex_position)
+            self._io.write_u4le(self.vertex_offset)
+            self._io.write_u4le(self.vertex_format)
+            self._io.write_u4le(self.face_position)
+            self._io.write_u4le(self.num_indices)
+            self._io.write_u4le(self.face_offset)
+            self._io.write_u1(self.bone_id_start)
+            self._io.write_u1(self.num_weight_bounds)
+            self._io.write_u2le(self.connect_id)
+            self._io.write_u2le(self.min_index)
+            self._io.write_u2le(self.max_index)
+            self._io.write_u4le(self.boundary)
+
+
+        def _check(self):
+            if self.indices__enabled:
+                pass
+                if len(self._m_indices) != self.num_indices:
+                    raise kaitaistruct.ConsistencyError(u"indices", self.num_indices, len(self._m_indices))
+                for i in range(len(self._m_indices)):
+                    pass
+
+
+            if self.vertices__enabled:
+                pass
+                if len(self._m_vertices) != self.num_vertices:
+                    raise kaitaistruct.ConsistencyError(u"vertices", self.num_vertices, len(self._m_vertices))
+                for i in range(len(self._m_vertices)):
+                    pass
+                    _on = self.vertex_format
+                    if _on == 1126539326:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 1236594729:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 1585389612:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 1672921135:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 1683566627:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 1719341081:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 1954353201:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 1975771173:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 2010673186:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 213286933:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 228491293:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 2456801326:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 2476326963:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 2685620254:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 2706243644:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 2736832534:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 2815938614:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 2835001368:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 2946904109:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 2962763795:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 3012694047:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 3060273204:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 307572786:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 3094208554:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 3141681188:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 3273596956:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 3329204282:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 3419369511:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 3421945882:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 349437984:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 3517214776:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 3626594344:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 3629002790:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 3631710235:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 3663044641:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 3682443284:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 545087543:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 545452091:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 794148925:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+                    elif _on == 933552181:
+                        pass
+                        if self._m_vertices[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self._root, self._m_vertices[i]._root)
+                        if self._m_vertices[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"vertices", self, self._m_vertices[i]._parent)
+
+
+            self._dirty = False
+
+        @property
+        def indices(self):
+            if self._should_write_indices:
+                self._write_indices()
+            if hasattr(self, '_m_indices'):
+                return self._m_indices
+
+            if not self.indices__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek((self._root.header.offset_index_buffer + self.face_offset * 2) + self.face_position * 2)
+            self._m_indices = []
+            for i in range(self.num_indices):
+                self._m_indices.append(self._io.read_u2le())
+
+            self._io.seek(_pos)
+            return getattr(self, '_m_indices', None)
+
+        @indices.setter
+        def indices(self, v):
+            self._dirty = True
+            self._m_indices = v
+
+        def _write_indices(self):
+            self._should_write_indices = False
+            _pos = self._io.pos()
+            self._io.seek((self._root.header.offset_index_buffer + self.face_offset * 2) + self.face_position * 2)
+            for i in range(len(self._m_indices)):
+                pass
+                self._io.write_u2le(self._m_indices[i])
+
+            self._io.seek(_pos)
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 48
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+        @property
+        def vertices(self):
+            if self._should_write_vertices:
+                self._write_vertices()
+            if hasattr(self, '_m_vertices'):
+                return self._m_vertices
+
+            if not self.vertices__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek((self._root.header.offset_vertex_buffer + self.vertex_offset) + self.vertex_position * self.vertex_stride)
+            self._m_vertices = []
+            for i in range(self.num_vertices):
+                _on = self.vertex_format
+                if _on == 1126539326:
+                    pass
+                    _t__m_vertices = Mod21.Vertex4325(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 1236594729:
+                    pass
+                    _t__m_vertices = Mod21.Vertex49b4(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 1585389612:
+                    pass
+                    _t__m_vertices = Mod21.Vertex5e7f(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 1672921135:
+                    pass
+                    _t__m_vertices = Mod21.Vertex63b6(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 1683566627:
+                    pass
+                    _t__m_vertices = Mod21.Vertex6459(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 1719341081:
+                    pass
+                    _t__m_vertices = Mod21.Vertex667b(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 1954353201:
+                    pass
+                    _t__m_vertices = Mod21.Vertex747d(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 1975771173:
+                    pass
+                    _t__m_vertices = Mod21.Vertex75c3(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 2010673186:
+                    pass
+                    _t__m_vertices = Mod21.Vertex77d8(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 213286933:
+                    pass
+                    _t__m_vertices = Mod21.VertexCb68(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 228491293:
+                    pass
+                    _t__m_vertices = Mod21.VertexD9e8(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 2456801326:
+                    pass
+                    _t__m_vertices = Mod21.Vertex926f(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 2476326963:
+                    pass
+                    _t__m_vertices = Mod21.Vertex9399(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 2685620254:
+                    pass
+                    _t__m_vertices = Mod21.VertexA013(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 2706243644:
+                    pass
+                    _t__m_vertices = Mod21.VertexA14e(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 2736832534:
+                    pass
+                    _t__m_vertices = Mod21.VertexA320(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 2815938614:
+                    pass
+                    _t__m_vertices = Mod21.VertexA7d7(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 2835001368:
+                    pass
+                    _t__m_vertices = Mod21.VertexA8fa(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 2946904109:
+                    pass
+                    _t__m_vertices = Mod21.VertexAfa6(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 2962763795:
+                    pass
+                    _t__m_vertices = Mod21.VertexB098(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 3012694047:
+                    pass
+                    _t__m_vertices = Mod21.VertexB392(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 3060273204:
+                    pass
+                    _t__m_vertices = Mod21.VertexB668(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 307572786:
+                    pass
+                    _t__m_vertices = Mod21.Vertex1255(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 3094208554:
+                    pass
+                    _t__m_vertices = Mod21.VertexB86d(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 3141681188:
+                    pass
+                    _t__m_vertices = Mod21.VertexBb42(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 3273596956:
+                    pass
+                    _t__m_vertices = Mod21.VertexC31f(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 3329204282:
+                    pass
+                    _t__m_vertices = Mod21.VertexC66f(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 3419369511:
+                    pass
+                    _t__m_vertices = Mod21.VertexCbcf(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 3421945882:
+                    pass
+                    _t__m_vertices = Mod21.VertexCbf6(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 349437984:
+                    pass
+                    _t__m_vertices = Mod21.Vertex14d4(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 3517214776:
+                    pass
+                    _t__m_vertices = Mod21.VertexD1a4(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 3626594344:
+                    pass
+                    _t__m_vertices = Mod21.Vertex8297(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 3629002790:
+                    pass
+                    _t__m_vertices = Mod21.VertexD84e(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 3631710235:
+                    pass
+                    _t__m_vertices = Mod21.VertexD877(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 3663044641:
+                    pass
+                    _t__m_vertices = Mod21.VertexDa55(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 3682443284:
+                    pass
+                    _t__m_vertices = Mod21.VertexDb7d(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 545087543:
+                    pass
+                    _t__m_vertices = Mod21.Vertex207d(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 545452091:
+                    pass
+                    _t__m_vertices = Mod21.Vertex2082(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 794148925:
+                    pass
+                    _t__m_vertices = Mod21.Vertex2f55(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+                elif _on == 933552181:
+                    pass
+                    _t__m_vertices = Mod21.Vertex37a4(self._io, self, self._root)
+                    try:
+                        _t__m_vertices._read()
+                    finally:
+                        self._m_vertices.append(_t__m_vertices)
+
+            self._io.seek(_pos)
+            return getattr(self, '_m_vertices', None)
+
+        @vertices.setter
+        def vertices(self, v):
+            self._dirty = True
+            self._m_vertices = v
+
+        def _write_vertices(self):
+            self._should_write_vertices = False
+            _pos = self._io.pos()
+            self._io.seek((self._root.header.offset_vertex_buffer + self.vertex_offset) + self.vertex_position * self.vertex_stride)
+            for i in range(len(self._m_vertices)):
+                pass
+                _on = self.vertex_format
+                if _on == 1126539326:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 1236594729:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 1585389612:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 1672921135:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 1683566627:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 1719341081:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 1954353201:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 1975771173:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 2010673186:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 213286933:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 228491293:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 2456801326:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 2476326963:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 2685620254:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 2706243644:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 2736832534:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 2815938614:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 2835001368:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 2946904109:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 2962763795:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 3012694047:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 3060273204:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 307572786:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 3094208554:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 3141681188:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 3273596956:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 3329204282:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 3419369511:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 3421945882:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 349437984:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 3517214776:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 3626594344:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 3629002790:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 3631710235:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 3663044641:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 3682443284:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 545087543:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 545452091:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 794148925:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+                elif _on == 933552181:
+                    pass
+                    self._m_vertices[i]._write__seq(self._io)
+
+            self._io.seek(_pos)
+
+
+    class MeshesData(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.MeshesData, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.meshes = []
+            for i in range(self._root.header.num_meshes):
+                _t_meshes = Mod21.Mesh(self._io, self, self._root)
+                try:
+                    _t_meshes._read()
+                finally:
+                    self.meshes.append(_t_meshes)
+
+            if self._root.header.version == 211:
+                pass
+                self.num_weight_bounds = self._io.read_u4le()
+
+            self.weight_bounds = []
+            for i in range((self._root.num_weight_bounds if  ((self._root.header.version == 210) or (self._root.header.version == 212))  else self.num_weight_bounds)):
+                _t_weight_bounds = Mod21.WeightBound(self._io, self, self._root)
+                try:
+                    _t_weight_bounds._read()
+                finally:
+                    self.weight_bounds.append(_t_weight_bounds)
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.meshes)):
+                pass
+                self.meshes[i]._fetch_instances()
+
+            if self._root.header.version == 211:
+                pass
+
+            for i in range(len(self.weight_bounds)):
+                pass
+                self.weight_bounds[i]._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.MeshesData, self)._write__seq(io)
+            for i in range(len(self.meshes)):
+                pass
+                self.meshes[i]._write__seq(self._io)
+
+            if self._root.header.version == 211:
+                pass
+                self._io.write_u4le(self.num_weight_bounds)
+
+            for i in range(len(self.weight_bounds)):
+                pass
+                self.weight_bounds[i]._write__seq(self._io)
+
+
+
+        def _check(self):
+            if len(self.meshes) != self._root.header.num_meshes:
+                raise kaitaistruct.ConsistencyError(u"meshes", self._root.header.num_meshes, len(self.meshes))
+            for i in range(len(self.meshes)):
+                pass
+                if self.meshes[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"meshes", self._root, self.meshes[i]._root)
+                if self.meshes[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"meshes", self, self.meshes[i]._parent)
+
+            if self._root.header.version == 211:
+                pass
+
+            if len(self.weight_bounds) != (self._root.num_weight_bounds if  ((self._root.header.version == 210) or (self._root.header.version == 212))  else self.num_weight_bounds):
+                raise kaitaistruct.ConsistencyError(u"weight_bounds", (self._root.num_weight_bounds if  ((self._root.header.version == 210) or (self._root.header.version == 212))  else self.num_weight_bounds), len(self.weight_bounds))
+            for i in range(len(self.weight_bounds)):
+                pass
+                if self.weight_bounds[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"weight_bounds", self._root, self.weight_bounds[i]._root)
+                if self.weight_bounds[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"weight_bounds", self, self.weight_bounds[i]._parent)
+
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = (self._root.header.num_meshes * self.meshes[0].size_ + self._root.num_weight_bounds * self.weight_bounds[0].size_ if  ((self._root.header.version == 210) or (self._root.header.version == 212))  else (self._root.header.num_meshes * self.meshes[0].size_ + self.num_weight_bounds * self.weight_bounds[0].size_) + 4)
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
 
     class ModHeader(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod21.ModHeader, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
             self.ident = self._io.read_bytes(4)
-            if not (self.ident == b"\x4D\x4F\x44\x00"):
+            if not self.ident == b"\x4D\x4F\x44\x00":
                 raise kaitaistruct.ValidationNotEqualError(b"\x4D\x4F\x44\x00", self.ident, self._io, u"/types/mod_header/seq/0")
             self.version = self._io.read_u1()
             self.revision = self._io.read_u1()
@@ -179,6 +1681,7 @@ class Mod21(ReadWriteKaitaiStruct):
             self.offset_vertex_buffer = self._io.read_u4le()
             self.offset_index_buffer = self._io.read_u4le()
             self.size_file = self._io.read_u4le()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -209,11 +1712,11 @@ class Mod21(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
-            if (len(self.ident) != 4):
-                raise kaitaistruct.ConsistencyError(u"ident", len(self.ident), 4)
-            if not (self.ident == b"\x4D\x4F\x44\x00"):
+            if len(self.ident) != 4:
+                raise kaitaistruct.ConsistencyError(u"ident", 4, len(self.ident))
+            if not self.ident == b"\x4D\x4F\x44\x00":
                 raise kaitaistruct.ValidationNotEqualError(b"\x4D\x4F\x44\x00", self.ident, None, u"/types/mod_header/seq/0")
+            self._dirty = False
 
         @property
         def size_(self):
@@ -226,9 +1729,439 @@ class Mod21(ReadWriteKaitaiStruct):
         def _invalidate_size_(self):
             del self._m_size_
 
-    class VertexA7d7(ReadWriteKaitaiStruct):
+    class ModelInfo(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod21.ModelInfo, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.middist = self._io.read_s4le()
+            self.lowdist = self._io.read_s4le()
+            self.light_group = self._io.read_u4le()
+            self.strip_type = self._io.read_u1()
+            self.memory = self._io.read_u1()
+            self.reserved = self._io.read_u2le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.ModelInfo, self)._write__seq(io)
+            self._io.write_s4le(self.middist)
+            self._io.write_s4le(self.lowdist)
+            self._io.write_u4le(self.light_group)
+            self._io.write_u1(self.strip_type)
+            self._io.write_u1(self.memory)
+            self._io.write_u2le(self.reserved)
+
+
+        def _check(self):
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 16
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class Vec2HalfFloat(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Vec2HalfFloat, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.u = self._io.read_bytes(2)
+            self.v = self._io.read_bytes(2)
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Vec2HalfFloat, self)._write__seq(io)
+            self._io.write_bytes(self.u)
+            self._io.write_bytes(self.v)
+
+
+        def _check(self):
+            if len(self.u) != 2:
+                raise kaitaistruct.ConsistencyError(u"u", 2, len(self.u))
+            if len(self.v) != 2:
+                raise kaitaistruct.ConsistencyError(u"v", 2, len(self.v))
+            self._dirty = False
+
+
+    class Vec3(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Vec3, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.x = self._io.read_f4le()
+            self.y = self._io.read_f4le()
+            self.z = self._io.read_f4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Vec3, self)._write__seq(io)
+            self._io.write_f4le(self.x)
+            self._io.write_f4le(self.y)
+            self._io.write_f4le(self.z)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Vec3S2(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Vec3S2, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.x = self._io.read_s2le()
+            self.y = self._io.read_s2le()
+            self.z = self._io.read_s2le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Vec3S2, self)._write__seq(io)
+            self._io.write_s2le(self.x)
+            self._io.write_s2le(self.y)
+            self._io.write_s2le(self.z)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Vec3U1(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Vec3U1, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.x = self._io.read_u1()
+            self.y = self._io.read_u1()
+            self.z = self._io.read_u1()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Vec3U1, self)._write__seq(io)
+            self._io.write_u1(self.x)
+            self._io.write_u1(self.y)
+            self._io.write_u1(self.z)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Vec4(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Vec4, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.x = self._io.read_f4le()
+            self.y = self._io.read_f4le()
+            self.z = self._io.read_f4le()
+            self.w = self._io.read_f4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Vec4, self)._write__seq(io)
+            self._io.write_f4le(self.x)
+            self._io.write_f4le(self.y)
+            self._io.write_f4le(self.z)
+            self._io.write_f4le(self.w)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Vec4S2(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Vec4S2, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.x = self._io.read_s2le()
+            self.y = self._io.read_s2le()
+            self.z = self._io.read_s2le()
+            self.w = self._io.read_s2le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Vec4S2, self)._write__seq(io)
+            self._io.write_s2le(self.x)
+            self._io.write_s2le(self.y)
+            self._io.write_s2le(self.z)
+            self._io.write_s2le(self.w)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Vec4U1(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Vec4U1, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.x = self._io.read_u1()
+            self.y = self._io.read_u1()
+            self.z = self._io.read_u1()
+            self.w = self._io.read_u1()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Vec4U1, self)._write__seq(io)
+            self._io.write_u1(self.x)
+            self._io.write_u1(self.y)
+            self._io.write_u1(self.z)
+            self._io.write_u1(self.w)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Vertex1255(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Vertex1255, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec3(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.normal._read()
+            self.occlusion = self._io.read_u1()
+            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self.uv3 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv3._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
+            self.uv3._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Vertex1255, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self._io.write_u1(self.occlusion)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+            self.uv3._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            if self.uv3._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv3", self._root, self.uv3._root)
+            if self.uv3._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv3", self, self.uv3._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 32
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class Vertex14d4(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Vertex14d4, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec4S2(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.normal._read()
+            self.occlusion = self._io.read_u1()
+            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.bone_indices = []
+            for i in range(4):
+                self.bone_indices.append(self._io.read_u1())
+
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.weight_values = []
+            for i in range(2):
+                self.weight_values.append(self._io.read_bytes(2))
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            for i in range(len(self.bone_indices)):
+                pass
+
+            self.uv._fetch_instances()
+            for i in range(len(self.weight_values)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Vertex14d4, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self._io.write_u1(self.occlusion)
+            self.tangent._write__seq(self._io)
+            for i in range(len(self.bone_indices)):
+                pass
+                self._io.write_u1(self.bone_indices[i])
+
+            self.uv._write__seq(self._io)
+            for i in range(len(self.weight_values)):
+                pass
+                self._io.write_bytes(self.weight_values[i])
+
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if len(self.bone_indices) != 4:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 4, len(self.bone_indices))
+            for i in range(len(self.bone_indices)):
+                pass
+
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if len(self.weight_values) != 2:
+                raise kaitaistruct.ConsistencyError(u"weight_values", 2, len(self.weight_values))
+            for i in range(len(self.weight_values)):
+                pass
+                if len(self.weight_values[i]) != 2:
+                    raise kaitaistruct.ConsistencyError(u"weight_values", 2, len(self.weight_values[i]))
+
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 28
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class Vertex207d(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Vertex207d, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -239,6 +2172,9 @@ class Mod21(ReadWriteKaitaiStruct):
             self.normal._read()
             self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
             self.uv._read()
+            self.rgba = Mod21.Vec4U1(self._io, self, self._root)
+            self.rgba._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -246,36 +2182,42 @@ class Mod21(ReadWriteKaitaiStruct):
             self.position._fetch_instances()
             self.normal._fetch_instances()
             self.uv._fetch_instances()
+            self.rgba._fetch_instances()
 
 
         def _write__seq(self, io=None):
-            super(Mod21.VertexA7d7, self)._write__seq(io)
+            super(Mod21.Vertex207d, self)._write__seq(io)
             self.position._write__seq(self._io)
             self.normal._write__seq(self._io)
             self.uv._write__seq(self._io)
+            self.rgba._write__seq(self._io)
 
 
         def _check(self):
-            pass
             if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
             if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
             if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
             if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
             if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
             if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.rgba._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"rgba", self._root, self.rgba._root)
+            if self.rgba._parent != self:
+                raise kaitaistruct.ConsistencyError(u"rgba", self, self.rgba._parent)
+            self._dirty = False
 
         @property
         def size_(self):
             if hasattr(self, '_m_size_'):
                 return self._m_size_
 
-            self._m_size_ = 20
+            self._m_size_ = 24
             return getattr(self, '_m_size_', None)
 
         def _invalidate_size_(self):
@@ -283,7 +2225,7 @@ class Mod21(ReadWriteKaitaiStruct):
 
     class Vertex2082(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod21.Vertex2082, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -298,6 +2240,7 @@ class Mod21(ReadWriteKaitaiStruct):
             self.uv2._read()
             self.uv3 = Mod21.Vec2HalfFloat(self._io, self, self._root)
             self.uv3._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -319,27 +2262,27 @@ class Mod21(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
             if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
             if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
             if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
             if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
             if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
             if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
             if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
             if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
             if self.uv3._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv3", self._root, self.uv3._root)
             if self.uv3._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._parent, self)
+                raise kaitaistruct.ConsistencyError(u"uv3", self, self.uv3._parent)
+            self._dirty = False
 
         @property
         def size_(self):
@@ -347,1559 +2290,6 @@ class Mod21(ReadWriteKaitaiStruct):
                 return self._m_size_
 
             self._m_size_ = 28
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Vec2HalfFloat(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.u = self._io.read_bytes(2)
-            self.v = self._io.read_bytes(2)
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.Vec2HalfFloat, self)._write__seq(io)
-            self._io.write_bytes(self.u)
-            self._io.write_bytes(self.v)
-
-
-        def _check(self):
-            pass
-            if (len(self.u) != 2):
-                raise kaitaistruct.ConsistencyError(u"u", len(self.u), 2)
-            if (len(self.v) != 2):
-                raise kaitaistruct.ConsistencyError(u"v", len(self.v), 2)
-
-
-    class VertexA8fa(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec3S2(self._io, self, self._root)
-            self.position._read()
-            self.bone_indices = []
-            for i in range(1):
-                self.bone_indices.append(self._io.read_u2le())
-
-            self.normal = Mod21.Vec3U1(self._io, self, self._root)
-            self.normal._read()
-            self.occlusion = self._io.read_u1()
-            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            for i in range(len(self.bone_indices)):
-                pass
-
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            self.uv._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.VertexA8fa, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            for i in range(len(self.bone_indices)):
-                pass
-                self._io.write_u2le(self.bone_indices[i])
-
-            self.normal._write__seq(self._io)
-            self._io.write_u1(self.occlusion)
-            self.tangent._write__seq(self._io)
-            self.uv._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if (len(self.bone_indices) != 1):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 1)
-            for i in range(len(self.bone_indices)):
-                pass
-
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 20
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Vec3U1(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.x = self._io.read_u1()
-            self.y = self._io.read_u1()
-            self.z = self._io.read_u1()
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.Vec3U1, self)._write__seq(io)
-            self._io.write_u1(self.x)
-            self._io.write_u1(self.y)
-            self._io.write_u1(self.z)
-
-
-        def _check(self):
-            pass
-
-
-    class VertexB098(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec3S2(self._io, self, self._root)
-            self.position._read()
-            self.bone_indices = []
-            for i in range(1):
-                self.bone_indices.append(self._io.read_u2le())
-
-            self.normal = Mod21.Vec4U1(self._io, self, self._root)
-            self.normal._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            for i in range(len(self.bone_indices)):
-                pass
-
-            self.normal._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.VertexB098, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            for i in range(len(self.bone_indices)):
-                pass
-                self._io.write_u2le(self.bone_indices[i])
-
-            self.normal._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if (len(self.bone_indices) != 1):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 1)
-            for i in range(len(self.bone_indices)):
-                pass
-
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 12
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class VertexB668(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec3(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod21.Vec3U1(self._io, self, self._root)
-            self.normal._read()
-            self.occlusion = self._io.read_u1()
-            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-            self.rgba = Mod21.Vec4U1(self._io, self, self._root)
-            self.rgba._read()
-            self.uv3 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv3._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
-            self.rgba._fetch_instances()
-            self.uv3._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.VertexB668, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self._io.write_u1(self.occlusion)
-            self.tangent._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
-            self.rgba._write__seq(self._io)
-            self.uv3._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-            if self.rgba._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._root, self._root)
-            if self.rgba._parent != self:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._parent, self)
-            if self.uv3._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._root, self._root)
-            if self.uv3._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 36
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Matrix4x4(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.row_1 = Mod21.Vec4(self._io, self, self._root)
-            self.row_1._read()
-            self.row_2 = Mod21.Vec4(self._io, self, self._root)
-            self.row_2._read()
-            self.row_3 = Mod21.Vec4(self._io, self, self._root)
-            self.row_3._read()
-            self.row_4 = Mod21.Vec4(self._io, self, self._root)
-            self.row_4._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.row_1._fetch_instances()
-            self.row_2._fetch_instances()
-            self.row_3._fetch_instances()
-            self.row_4._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.Matrix4x4, self)._write__seq(io)
-            self.row_1._write__seq(self._io)
-            self.row_2._write__seq(self._io)
-            self.row_3._write__seq(self._io)
-            self.row_4._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.row_1._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"row_1", self.row_1._root, self._root)
-            if self.row_1._parent != self:
-                raise kaitaistruct.ConsistencyError(u"row_1", self.row_1._parent, self)
-            if self.row_2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"row_2", self.row_2._root, self._root)
-            if self.row_2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"row_2", self.row_2._parent, self)
-            if self.row_3._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"row_3", self.row_3._root, self._root)
-            if self.row_3._parent != self:
-                raise kaitaistruct.ConsistencyError(u"row_3", self.row_3._parent, self)
-            if self.row_4._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"row_4", self.row_4._root, self._root)
-            if self.row_4._parent != self:
-                raise kaitaistruct.ConsistencyError(u"row_4", self.row_4._parent, self)
-
-
-    class VertexBb42(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec4S2(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod21.Vec3U1(self._io, self, self._root)
-            self.normal._read()
-            self.occlusion = self._io.read_u1()
-            self.weight_values = []
-            for i in range(4):
-                self.weight_values.append(self._io.read_u1())
-
-            self.bone_indices = []
-            for i in range(8):
-                self.bone_indices.append(self._io.read_u1())
-
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.weight_values2 = []
-            for i in range(2):
-                self.weight_values2.append(self._io.read_bytes(2))
-
-            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            for i in range(len(self.weight_values)):
-                pass
-
-            for i in range(len(self.bone_indices)):
-                pass
-
-            self.uv._fetch_instances()
-            for i in range(len(self.weight_values2)):
-                pass
-
-            self.tangent._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.VertexBb42, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self._io.write_u1(self.occlusion)
-            for i in range(len(self.weight_values)):
-                pass
-                self._io.write_u1(self.weight_values[i])
-
-            for i in range(len(self.bone_indices)):
-                pass
-                self._io.write_u1(self.bone_indices[i])
-
-            self.uv._write__seq(self._io)
-            for i in range(len(self.weight_values2)):
-                pass
-                self._io.write_bytes(self.weight_values2[i])
-
-            self.tangent._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if (len(self.weight_values) != 4):
-                raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values), 4)
-            for i in range(len(self.weight_values)):
-                pass
-
-            if (len(self.bone_indices) != 8):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 8)
-            for i in range(len(self.bone_indices)):
-                pass
-
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if (len(self.weight_values2) != 2):
-                raise kaitaistruct.ConsistencyError(u"weight_values2", len(self.weight_values2), 2)
-            for i in range(len(self.weight_values2)):
-                pass
-                if (len(self.weight_values2[i]) != 2):
-                    raise kaitaistruct.ConsistencyError(u"weight_values2", len(self.weight_values2[i]), 2)
-
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 36
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class VertexD877(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec3S2(self._io, self, self._root)
-            self.position._read()
-            self.bone_indices = []
-            for i in range(1):
-                self.bone_indices.append(self._io.read_u2le())
-
-            self.normal = Mod21.Vec3U1(self._io, self, self._root)
-            self.normal._read()
-            self.occlusion = self._io.read_u1()
-            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-            self.uv3 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv3._read()
-            self.uv4 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv4._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            for i in range(len(self.bone_indices)):
-                pass
-
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
-            self.uv3._fetch_instances()
-            self.uv4._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.VertexD877, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            for i in range(len(self.bone_indices)):
-                pass
-                self._io.write_u2le(self.bone_indices[i])
-
-            self.normal._write__seq(self._io)
-            self._io.write_u1(self.occlusion)
-            self.tangent._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
-            self.uv3._write__seq(self._io)
-            self.uv4._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if (len(self.bone_indices) != 1):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 1)
-            for i in range(len(self.bone_indices)):
-                pass
-
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-            if self.uv3._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._root, self._root)
-            if self.uv3._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._parent, self)
-            if self.uv4._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv4", self.uv4._root, self._root)
-            if self.uv4._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv4", self.uv4._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 32
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class VertexD84e(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec4S2(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod21.Vec3U1(self._io, self, self._root)
-            self.normal._read()
-            self.occlusion = self._io.read_u1()
-            self.weight_values = []
-            for i in range(4):
-                self.weight_values.append(self._io.read_u1())
-
-            self.bone_indices = []
-            for i in range(8):
-                self.bone_indices.append(self._io.read_u1())
-
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.weight_values2 = []
-            for i in range(2):
-                self.weight_values2.append(self._io.read_bytes(2))
-
-            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.rgba = Mod21.Vec4U1(self._io, self, self._root)
-            self.rgba._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            for i in range(len(self.weight_values)):
-                pass
-
-            for i in range(len(self.bone_indices)):
-                pass
-
-            self.uv._fetch_instances()
-            for i in range(len(self.weight_values2)):
-                pass
-
-            self.tangent._fetch_instances()
-            self.rgba._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.VertexD84e, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self._io.write_u1(self.occlusion)
-            for i in range(len(self.weight_values)):
-                pass
-                self._io.write_u1(self.weight_values[i])
-
-            for i in range(len(self.bone_indices)):
-                pass
-                self._io.write_u1(self.bone_indices[i])
-
-            self.uv._write__seq(self._io)
-            for i in range(len(self.weight_values2)):
-                pass
-                self._io.write_bytes(self.weight_values2[i])
-
-            self.tangent._write__seq(self._io)
-            self.rgba._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if (len(self.weight_values) != 4):
-                raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values), 4)
-            for i in range(len(self.weight_values)):
-                pass
-
-            if (len(self.bone_indices) != 8):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 8)
-            for i in range(len(self.bone_indices)):
-                pass
-
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if (len(self.weight_values2) != 2):
-                raise kaitaistruct.ConsistencyError(u"weight_values2", len(self.weight_values2), 2)
-            for i in range(len(self.weight_values2)):
-                pass
-                if (len(self.weight_values2[i]) != 2):
-                    raise kaitaistruct.ConsistencyError(u"weight_values2", len(self.weight_values2[i]), 2)
-
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if self.rgba._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._root, self._root)
-            if self.rgba._parent != self:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 40
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Vertex6459(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec4S2(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod21.Vec3U1(self._io, self, self._root)
-            self.normal._read()
-            self.occlusion = self._io.read_u1()
-            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.bone_indices = []
-            for i in range(4):
-                self.bone_indices.append(self._io.read_u1())
-
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.weight_values = []
-            for i in range(2):
-                self.weight_values.append(self._io.read_bytes(2))
-
-            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-            self.uv3 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv3._read()
-            self.uv4 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv4._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            for i in range(len(self.bone_indices)):
-                pass
-
-            self.uv._fetch_instances()
-            for i in range(len(self.weight_values)):
-                pass
-
-            self.uv2._fetch_instances()
-            self.uv3._fetch_instances()
-            self.uv4._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.Vertex6459, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self._io.write_u1(self.occlusion)
-            self.tangent._write__seq(self._io)
-            for i in range(len(self.bone_indices)):
-                pass
-                self._io.write_u1(self.bone_indices[i])
-
-            self.uv._write__seq(self._io)
-            for i in range(len(self.weight_values)):
-                pass
-                self._io.write_bytes(self.weight_values[i])
-
-            self.uv2._write__seq(self._io)
-            self.uv3._write__seq(self._io)
-            self.uv4._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if (len(self.bone_indices) != 4):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 4)
-            for i in range(len(self.bone_indices)):
-                pass
-
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if (len(self.weight_values) != 2):
-                raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values), 2)
-            for i in range(len(self.weight_values)):
-                pass
-                if (len(self.weight_values[i]) != 2):
-                    raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values[i]), 2)
-
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-            if self.uv3._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._root, self._root)
-            if self.uv3._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._parent, self)
-            if self.uv4._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv4", self.uv4._root, self._root)
-            if self.uv4._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv4", self.uv4._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 40
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Vertex926f(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec3(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod21.Vec3U1(self._io, self, self._root)
-            self.normal._read()
-            self.occlusion = self._io.read_u1()
-            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-            self.rgba = Mod21.Vec4U1(self._io, self, self._root)
-            self.rgba._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
-            self.rgba._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.Vertex926f, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self._io.write_u1(self.occlusion)
-            self.tangent._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
-            self.rgba._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-            if self.rgba._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._root, self._root)
-            if self.rgba._parent != self:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 32
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Vertex667b(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec3S2(self._io, self, self._root)
-            self.position._read()
-            self.bone_indices = []
-            for i in range(1):
-                self.bone_indices.append(self._io.read_u2le())
-
-            self.normal = Mod21.Vec3U1(self._io, self, self._root)
-            self.normal._read()
-            self.occlusion = self._io.read_u1()
-            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            for i in range(len(self.bone_indices)):
-                pass
-
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.Vertex667b, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            for i in range(len(self.bone_indices)):
-                pass
-                self._io.write_u2le(self.bone_indices[i])
-
-            self.normal._write__seq(self._io)
-            self._io.write_u1(self.occlusion)
-            self.tangent._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if (len(self.bone_indices) != 1):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 1)
-            for i in range(len(self.bone_indices)):
-                pass
-
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 24
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Vertex77d8(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec4S2(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod21.Vec3U1(self._io, self, self._root)
-            self.normal._read()
-            self.occlusion = self._io.read_u1()
-            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.bone_indices = []
-            for i in range(4):
-                self.bone_indices.append(self._io.read_u1())
-
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.weight_values = []
-            for i in range(2):
-                self.weight_values.append(self._io.read_bytes(2))
-
-            self.rgba = Mod21.Vec4U1(self._io, self, self._root)
-            self.rgba._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            for i in range(len(self.bone_indices)):
-                pass
-
-            self.uv._fetch_instances()
-            for i in range(len(self.weight_values)):
-                pass
-
-            self.rgba._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.Vertex77d8, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self._io.write_u1(self.occlusion)
-            self.tangent._write__seq(self._io)
-            for i in range(len(self.bone_indices)):
-                pass
-                self._io.write_u1(self.bone_indices[i])
-
-            self.uv._write__seq(self._io)
-            for i in range(len(self.weight_values)):
-                pass
-                self._io.write_bytes(self.weight_values[i])
-
-            self.rgba._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if (len(self.bone_indices) != 4):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 4)
-            for i in range(len(self.bone_indices)):
-                pass
-
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if (len(self.weight_values) != 2):
-                raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values), 2)
-            for i in range(len(self.weight_values)):
-                pass
-                if (len(self.weight_values[i]) != 2):
-                    raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values[i]), 2)
-
-            if self.rgba._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._root, self._root)
-            if self.rgba._parent != self:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 32
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Vertex63b6(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec3(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod21.Vec3U1(self._io, self, self._root)
-            self.normal._read()
-            self.vertex_alpha = self._io.read_u1()
-            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-            self.uv3 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv3._read()
-            self.occlusion = self._io.read_u4le()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
-            self.uv3._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.Vertex63b6, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self._io.write_u1(self.vertex_alpha)
-            self.tangent._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
-            self.uv3._write__seq(self._io)
-            self._io.write_u4le(self.occlusion)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-            if self.uv3._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._root, self._root)
-            if self.uv3._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 36
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Vertex5e7f(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec3(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod21.Vec3U1(self._io, self, self._root)
-            self.normal._read()
-            self.occlusion = self._io.read_u1()
-            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.Vertex5e7f, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self._io.write_u1(self.occlusion)
-            self.tangent._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 28
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class VertexA14e(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec3(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod21.Vec4U1(self._io, self, self._root)
-            self.normal._read()
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-            self.rgba = Mod21.Vec4U1(self._io, self, self._root)
-            self.rgba._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
-            self.rgba._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.VertexA14e, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
-            self.rgba._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-            if self.rgba._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._root, self._root)
-            if self.rgba._parent != self:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 28
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class VertexB392(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec4S2(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod21.Vec3U1(self._io, self, self._root)
-            self.normal._read()
-            self.occlusion = self._io.read_u1()
-            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.bone_indices = []
-            for i in range(2):
-                self.bone_indices.append(self._io.read_bytes(2))
-
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-            self.uv3 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv3._read()
-            self.uv4 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv4._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            for i in range(len(self.bone_indices)):
-                pass
-
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
-            self.uv3._fetch_instances()
-            self.uv4._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.VertexB392, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self._io.write_u1(self.occlusion)
-            self.tangent._write__seq(self._io)
-            for i in range(len(self.bone_indices)):
-                pass
-                self._io.write_bytes(self.bone_indices[i])
-
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
-            self.uv3._write__seq(self._io)
-            self.uv4._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if (len(self.bone_indices) != 2):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 2)
-            for i in range(len(self.bone_indices)):
-                pass
-                if (len(self.bone_indices[i]) != 2):
-                    raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices[i]), 2)
-
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-            if self.uv3._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._root, self._root)
-            if self.uv3._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._parent, self)
-            if self.uv4._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv4", self.uv4._root, self._root)
-            if self.uv4._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv4", self.uv4._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 36
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class VertexD9e8(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec4S2(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod21.Vec3U1(self._io, self, self._root)
-            self.normal._read()
-            self.occlusion = self._io.read_u1()
-            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.bone_indices = []
-            for i in range(2):
-                self.bone_indices.append(self._io.read_bytes(2))
-
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            for i in range(len(self.bone_indices)):
-                pass
-
-            self.uv._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.VertexD9e8, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self._io.write_u1(self.occlusion)
-            self.tangent._write__seq(self._io)
-            for i in range(len(self.bone_indices)):
-                pass
-                self._io.write_bytes(self.bone_indices[i])
-
-            self.uv._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if (len(self.bone_indices) != 2):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 2)
-            for i in range(len(self.bone_indices)):
-                pass
-                if (len(self.bone_indices[i]) != 2):
-                    raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices[i]), 2)
-
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 28
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Bone(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.idx_anim_map = self._io.read_u1()
-            self.idx_parent = self._io.read_u1()
-            self.idx_mirror = self._io.read_u1()
-            self.idx_mapping = self._io.read_u1()
-            self.length = self._io.read_f4le()
-            self.parent_distance = self._io.read_f4le()
-            self.location = Mod21.Vec3(self._io, self, self._root)
-            self.location._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.location._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.Bone, self)._write__seq(io)
-            self._io.write_u1(self.idx_anim_map)
-            self._io.write_u1(self.idx_parent)
-            self._io.write_u1(self.idx_mirror)
-            self._io.write_u1(self.idx_mapping)
-            self._io.write_f4le(self.length)
-            self._io.write_f4le(self.parent_distance)
-            self.location._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.location._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"location", self.location._root, self._root)
-            if self.location._parent != self:
-                raise kaitaistruct.ConsistencyError(u"location", self.location._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 24
             return getattr(self, '_m_size_', None)
 
         def _invalidate_size_(self):
@@ -1907,7 +2297,7 @@ class Mod21(ReadWriteKaitaiStruct):
 
     class Vertex2f55(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod21.Vertex2f55, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -1945,6 +2335,7 @@ class Mod21(ReadWriteKaitaiStruct):
             self.morph_normal3._read()
             self.morph_normal4 = Mod21.Vec3U1(self._io, self, self._root)
             self.morph_normal4._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -1995,67 +2386,67 @@ class Mod21(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
             if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
             if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
             if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
             if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
             if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
             if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if (len(self.bone_indices) != 4):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 4)
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if len(self.bone_indices) != 4:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 4, len(self.bone_indices))
             for i in range(len(self.bone_indices)):
                 pass
 
             if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
             if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if (len(self.weight_values) != 2):
-                raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values), 2)
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if len(self.weight_values) != 2:
+                raise kaitaistruct.ConsistencyError(u"weight_values", 2, len(self.weight_values))
             for i in range(len(self.weight_values)):
                 pass
-                if (len(self.weight_values[i]) != 2):
-                    raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values[i]), 2)
+                if len(self.weight_values[i]) != 2:
+                    raise kaitaistruct.ConsistencyError(u"weight_values", 2, len(self.weight_values[i]))
 
             if self.morph_position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"morph_position", self.morph_position._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"morph_position", self._root, self.morph_position._root)
             if self.morph_position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"morph_position", self.morph_position._parent, self)
+                raise kaitaistruct.ConsistencyError(u"morph_position", self, self.morph_position._parent)
             if self.morph_position2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"morph_position2", self.morph_position2._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"morph_position2", self._root, self.morph_position2._root)
             if self.morph_position2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"morph_position2", self.morph_position2._parent, self)
+                raise kaitaistruct.ConsistencyError(u"morph_position2", self, self.morph_position2._parent)
             if self.morph_position3._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"morph_position3", self.morph_position3._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"morph_position3", self._root, self.morph_position3._root)
             if self.morph_position3._parent != self:
-                raise kaitaistruct.ConsistencyError(u"morph_position3", self.morph_position3._parent, self)
+                raise kaitaistruct.ConsistencyError(u"morph_position3", self, self.morph_position3._parent)
             if self.morph_position4._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"morph_position4", self.morph_position4._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"morph_position4", self._root, self.morph_position4._root)
             if self.morph_position4._parent != self:
-                raise kaitaistruct.ConsistencyError(u"morph_position4", self.morph_position4._parent, self)
+                raise kaitaistruct.ConsistencyError(u"morph_position4", self, self.morph_position4._parent)
             if self.morph_normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"morph_normal", self.morph_normal._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"morph_normal", self._root, self.morph_normal._root)
             if self.morph_normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"morph_normal", self.morph_normal._parent, self)
+                raise kaitaistruct.ConsistencyError(u"morph_normal", self, self.morph_normal._parent)
             if self.morph_normal2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"morph_normal2", self.morph_normal2._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"morph_normal2", self._root, self.morph_normal2._root)
             if self.morph_normal2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"morph_normal2", self.morph_normal2._parent, self)
+                raise kaitaistruct.ConsistencyError(u"morph_normal2", self, self.morph_normal2._parent)
             if self.morph_normal3._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"morph_normal3", self.morph_normal3._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"morph_normal3", self._root, self.morph_normal3._root)
             if self.morph_normal3._parent != self:
-                raise kaitaistruct.ConsistencyError(u"morph_normal3", self.morph_normal3._parent, self)
+                raise kaitaistruct.ConsistencyError(u"morph_normal3", self, self.morph_normal3._parent)
             if self.morph_normal4._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"morph_normal4", self.morph_normal4._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"morph_normal4", self._root, self.morph_normal4._root)
             if self.morph_normal4._parent != self:
-                raise kaitaistruct.ConsistencyError(u"morph_normal4", self.morph_normal4._parent, self)
+                raise kaitaistruct.ConsistencyError(u"morph_normal4", self, self.morph_normal4._parent)
+            self._dirty = False
 
         @property
         def size_(self):
@@ -2068,9 +2459,9 @@ class Mod21(ReadWriteKaitaiStruct):
         def _invalidate_size_(self):
             del self._m_size_
 
-    class Vertex747d(ReadWriteKaitaiStruct):
+    class Vertex37a4(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod21.Vertex37a4, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -2088,6 +2479,681 @@ class Mod21(ReadWriteKaitaiStruct):
             self.uv2._read()
             self.uv3 = Mod21.Vec2HalfFloat(self._io, self, self._root)
             self.uv3._read()
+            self.uv4 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv4._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
+            self.uv3._fetch_instances()
+            self.uv4._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Vertex37a4, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self._io.write_u1(self.occlusion)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+            self.uv3._write__seq(self._io)
+            self.uv4._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            if self.uv3._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv3", self._root, self.uv3._root)
+            if self.uv3._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv3", self, self.uv3._parent)
+            if self.uv4._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv4", self._root, self.uv4._root)
+            if self.uv4._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv4", self, self.uv4._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 36
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class Vertex4325(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Vertex4325, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec3(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.normal._read()
+            self.occlusion = self._io.read_u1()
+            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self.morph_position = Mod21.Vec3S2(self._io, self, self._root)
+            self.morph_position._read()
+            self.morph_position2 = Mod21.Vec3S2(self._io, self, self._root)
+            self.morph_position2._read()
+            self.morph_position3 = Mod21.Vec3S2(self._io, self, self._root)
+            self.morph_position3._read()
+            self.morph_position4 = Mod21.Vec3S2(self._io, self, self._root)
+            self.morph_position4._read()
+            self.morph_normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.morph_normal._read()
+            self.morph_normal2 = Mod21.Vec3U1(self._io, self, self._root)
+            self.morph_normal2._read()
+            self.morph_normal3 = Mod21.Vec3U1(self._io, self, self._root)
+            self.morph_normal3._read()
+            self.morph_normal4 = Mod21.Vec3U1(self._io, self, self._root)
+            self.morph_normal4._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
+            self.morph_position._fetch_instances()
+            self.morph_position2._fetch_instances()
+            self.morph_position3._fetch_instances()
+            self.morph_position4._fetch_instances()
+            self.morph_normal._fetch_instances()
+            self.morph_normal2._fetch_instances()
+            self.morph_normal3._fetch_instances()
+            self.morph_normal4._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Vertex4325, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self._io.write_u1(self.occlusion)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+            self.morph_position._write__seq(self._io)
+            self.morph_position2._write__seq(self._io)
+            self.morph_position3._write__seq(self._io)
+            self.morph_position4._write__seq(self._io)
+            self.morph_normal._write__seq(self._io)
+            self.morph_normal2._write__seq(self._io)
+            self.morph_normal3._write__seq(self._io)
+            self.morph_normal4._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            if self.morph_position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"morph_position", self._root, self.morph_position._root)
+            if self.morph_position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"morph_position", self, self.morph_position._parent)
+            if self.morph_position2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"morph_position2", self._root, self.morph_position2._root)
+            if self.morph_position2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"morph_position2", self, self.morph_position2._parent)
+            if self.morph_position3._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"morph_position3", self._root, self.morph_position3._root)
+            if self.morph_position3._parent != self:
+                raise kaitaistruct.ConsistencyError(u"morph_position3", self, self.morph_position3._parent)
+            if self.morph_position4._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"morph_position4", self._root, self.morph_position4._root)
+            if self.morph_position4._parent != self:
+                raise kaitaistruct.ConsistencyError(u"morph_position4", self, self.morph_position4._parent)
+            if self.morph_normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"morph_normal", self._root, self.morph_normal._root)
+            if self.morph_normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"morph_normal", self, self.morph_normal._parent)
+            if self.morph_normal2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"morph_normal2", self._root, self.morph_normal2._root)
+            if self.morph_normal2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"morph_normal2", self, self.morph_normal2._parent)
+            if self.morph_normal3._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"morph_normal3", self._root, self.morph_normal3._root)
+            if self.morph_normal3._parent != self:
+                raise kaitaistruct.ConsistencyError(u"morph_normal3", self, self.morph_normal3._parent)
+            if self.morph_normal4._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"morph_normal4", self._root, self.morph_normal4._root)
+            if self.morph_normal4._parent != self:
+                raise kaitaistruct.ConsistencyError(u"morph_normal4", self, self.morph_normal4._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 64
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class Vertex49b4(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Vertex49b4, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec3(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.normal._read()
+            self.occlusion = self._io.read_u1()
+            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.rgba = Mod21.Vec4U1(self._io, self, self._root)
+            self.rgba._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+            self.rgba._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Vertex49b4, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self._io.write_u1(self.occlusion)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.rgba._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.rgba._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"rgba", self._root, self.rgba._root)
+            if self.rgba._parent != self:
+                raise kaitaistruct.ConsistencyError(u"rgba", self, self.rgba._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 28
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class Vertex5e7f(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Vertex5e7f, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec3(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.normal._read()
+            self.occlusion = self._io.read_u1()
+            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Vertex5e7f, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self._io.write_u1(self.occlusion)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 28
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class Vertex63b6(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Vertex63b6, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec3(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.normal._read()
+            self.vertex_alpha = self._io.read_u1()
+            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self.uv3 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv3._read()
+            self.occlusion = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
+            self.uv3._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Vertex63b6, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self._io.write_u1(self.vertex_alpha)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+            self.uv3._write__seq(self._io)
+            self._io.write_u4le(self.occlusion)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            if self.uv3._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv3", self._root, self.uv3._root)
+            if self.uv3._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv3", self, self.uv3._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 36
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class Vertex6459(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Vertex6459, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec4S2(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.normal._read()
+            self.occlusion = self._io.read_u1()
+            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.bone_indices = []
+            for i in range(4):
+                self.bone_indices.append(self._io.read_u1())
+
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.weight_values = []
+            for i in range(2):
+                self.weight_values.append(self._io.read_bytes(2))
+
+            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self.uv3 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv3._read()
+            self.uv4 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv4._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            for i in range(len(self.bone_indices)):
+                pass
+
+            self.uv._fetch_instances()
+            for i in range(len(self.weight_values)):
+                pass
+
+            self.uv2._fetch_instances()
+            self.uv3._fetch_instances()
+            self.uv4._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Vertex6459, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self._io.write_u1(self.occlusion)
+            self.tangent._write__seq(self._io)
+            for i in range(len(self.bone_indices)):
+                pass
+                self._io.write_u1(self.bone_indices[i])
+
+            self.uv._write__seq(self._io)
+            for i in range(len(self.weight_values)):
+                pass
+                self._io.write_bytes(self.weight_values[i])
+
+            self.uv2._write__seq(self._io)
+            self.uv3._write__seq(self._io)
+            self.uv4._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if len(self.bone_indices) != 4:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 4, len(self.bone_indices))
+            for i in range(len(self.bone_indices)):
+                pass
+
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if len(self.weight_values) != 2:
+                raise kaitaistruct.ConsistencyError(u"weight_values", 2, len(self.weight_values))
+            for i in range(len(self.weight_values)):
+                pass
+                if len(self.weight_values[i]) != 2:
+                    raise kaitaistruct.ConsistencyError(u"weight_values", 2, len(self.weight_values[i]))
+
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            if self.uv3._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv3", self._root, self.uv3._root)
+            if self.uv3._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv3", self, self.uv3._parent)
+            if self.uv4._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv4", self._root, self.uv4._root)
+            if self.uv4._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv4", self, self.uv4._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 40
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class Vertex667b(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Vertex667b, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec3S2(self._io, self, self._root)
+            self.position._read()
+            self.bone_indices = []
+            for i in range(1):
+                self.bone_indices.append(self._io.read_u2le())
+
+            self.normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.normal._read()
+            self.occlusion = self._io.read_u1()
+            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            for i in range(len(self.bone_indices)):
+                pass
+
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Vertex667b, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            for i in range(len(self.bone_indices)):
+                pass
+                self._io.write_u2le(self.bone_indices[i])
+
+            self.normal._write__seq(self._io)
+            self._io.write_u1(self.occlusion)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if len(self.bone_indices) != 1:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 1, len(self.bone_indices))
+            for i in range(len(self.bone_indices)):
+                pass
+
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 24
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class Vertex747d(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Vertex747d, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec3(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.normal._read()
+            self.occlusion = self._io.read_u1()
+            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self.uv3 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv3._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -2112,31 +3178,31 @@ class Mod21(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
             if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
             if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
             if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
             if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
             if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
             if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
             if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
             if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
             if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
             if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
             if self.uv3._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv3", self._root, self.uv3._root)
             if self.uv3._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._parent, self)
+                raise kaitaistruct.ConsistencyError(u"uv3", self, self.uv3._parent)
+            self._dirty = False
 
         @property
         def size_(self):
@@ -2149,135 +3215,9 @@ class Mod21(ReadWriteKaitaiStruct):
         def _invalidate_size_(self):
             del self._m_size_
 
-    class VertexC31f(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec4S2(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod21.Vec3U1(self._io, self, self._root)
-            self.normal._read()
-            self.occlusion = self._io.read_u1()
-            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.bone_indices = []
-            for i in range(2):
-                self.bone_indices.append(self._io.read_bytes(2))
-
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            self.uv._fetch_instances()
-            for i in range(len(self.bone_indices)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.VertexC31f, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self._io.write_u1(self.occlusion)
-            self.tangent._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            for i in range(len(self.bone_indices)):
-                pass
-                self._io.write_bytes(self.bone_indices[i])
-
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if (len(self.bone_indices) != 2):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 2)
-            for i in range(len(self.bone_indices)):
-                pass
-                if (len(self.bone_indices[i]) != 2):
-                    raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices[i]), 2)
-
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 24
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class ModelInfo(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.middist = self._io.read_s4le()
-            self.lowdist = self._io.read_s4le()
-            self.light_group = self._io.read_u4le()
-            self.strip_type = self._io.read_u1()
-            self.memory = self._io.read_u1()
-            self.reserved = self._io.read_u2le()
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.ModelInfo, self)._write__seq(io)
-            self._io.write_s4le(self.middist)
-            self._io.write_s4le(self.lowdist)
-            self._io.write_u4le(self.light_group)
-            self._io.write_u1(self.strip_type)
-            self._io.write_u1(self.memory)
-            self._io.write_u2le(self.reserved)
-
-
-        def _check(self):
-            pass
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 16
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
     class Vertex75c3(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod21.Vertex75c3, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -2305,6 +3245,7 @@ class Mod21(ReadWriteKaitaiStruct):
             self.tangent._read()
             self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
             self.uv2._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -2348,44 +3289,44 @@ class Mod21(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
             if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
             if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
             if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
             if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if (len(self.weight_values) != 4):
-                raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values), 4)
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if len(self.weight_values) != 4:
+                raise kaitaistruct.ConsistencyError(u"weight_values", 4, len(self.weight_values))
             for i in range(len(self.weight_values)):
                 pass
 
-            if (len(self.bone_indices) != 8):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 8)
+            if len(self.bone_indices) != 8:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 8, len(self.bone_indices))
             for i in range(len(self.bone_indices)):
                 pass
 
             if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
             if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if (len(self.weight_values2) != 2):
-                raise kaitaistruct.ConsistencyError(u"weight_values2", len(self.weight_values2), 2)
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if len(self.weight_values2) != 2:
+                raise kaitaistruct.ConsistencyError(u"weight_values2", 2, len(self.weight_values2))
             for i in range(len(self.weight_values2)):
                 pass
-                if (len(self.weight_values2[i]) != 2):
-                    raise kaitaistruct.ConsistencyError(u"weight_values2", len(self.weight_values2[i]), 2)
+                if len(self.weight_values2[i]) != 2:
+                    raise kaitaistruct.ConsistencyError(u"weight_values2", 2, len(self.weight_values2[i]))
 
             if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
             if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
             if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
             if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            self._dirty = False
 
         @property
         def size_(self):
@@ -2398,19 +3339,123 @@ class Mod21(ReadWriteKaitaiStruct):
         def _invalidate_size_(self):
             del self._m_size_
 
-    class VertexCbf6(ReadWriteKaitaiStruct):
+    class Vertex77d8(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod21.Vertex77d8, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
-            self.position = Mod21.Vec3S2(self._io, self, self._root)
+            self.position = Mod21.Vec4S2(self._io, self, self._root)
             self.position._read()
+            self.normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.normal._read()
+            self.occlusion = self._io.read_u1()
+            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
             self.bone_indices = []
-            for i in range(1):
-                self.bone_indices.append(self._io.read_u2le())
+            for i in range(4):
+                self.bone_indices.append(self._io.read_u1())
 
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.weight_values = []
+            for i in range(2):
+                self.weight_values.append(self._io.read_bytes(2))
+
+            self.rgba = Mod21.Vec4U1(self._io, self, self._root)
+            self.rgba._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            for i in range(len(self.bone_indices)):
+                pass
+
+            self.uv._fetch_instances()
+            for i in range(len(self.weight_values)):
+                pass
+
+            self.rgba._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Vertex77d8, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self._io.write_u1(self.occlusion)
+            self.tangent._write__seq(self._io)
+            for i in range(len(self.bone_indices)):
+                pass
+                self._io.write_u1(self.bone_indices[i])
+
+            self.uv._write__seq(self._io)
+            for i in range(len(self.weight_values)):
+                pass
+                self._io.write_bytes(self.weight_values[i])
+
+            self.rgba._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if len(self.bone_indices) != 4:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 4, len(self.bone_indices))
+            for i in range(len(self.bone_indices)):
+                pass
+
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if len(self.weight_values) != 2:
+                raise kaitaistruct.ConsistencyError(u"weight_values", 2, len(self.weight_values))
+            for i in range(len(self.weight_values)):
+                pass
+                if len(self.weight_values[i]) != 2:
+                    raise kaitaistruct.ConsistencyError(u"weight_values", 2, len(self.weight_values[i]))
+
+            if self.rgba._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"rgba", self._root, self.rgba._root)
+            if self.rgba._parent != self:
+                raise kaitaistruct.ConsistencyError(u"rgba", self, self.rgba._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 32
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class Vertex8297(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Vertex8297, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec3(self._io, self, self._root)
+            self.position._read()
             self.normal = Mod21.Vec3U1(self._io, self, self._root)
             self.normal._read()
             self.occlusion = self._io.read_u1()
@@ -2418,63 +3463,44 @@ class Mod21(ReadWriteKaitaiStruct):
             self.tangent._read()
             self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
             self.uv._read()
-            self.rgba = Mod21.Vec4U1(self._io, self, self._root)
-            self.rgba._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
             self.position._fetch_instances()
-            for i in range(len(self.bone_indices)):
-                pass
-
             self.normal._fetch_instances()
             self.tangent._fetch_instances()
             self.uv._fetch_instances()
-            self.rgba._fetch_instances()
 
 
         def _write__seq(self, io=None):
-            super(Mod21.VertexCbf6, self)._write__seq(io)
+            super(Mod21.Vertex8297, self)._write__seq(io)
             self.position._write__seq(self._io)
-            for i in range(len(self.bone_indices)):
-                pass
-                self._io.write_u2le(self.bone_indices[i])
-
             self.normal._write__seq(self._io)
             self._io.write_u1(self.occlusion)
             self.tangent._write__seq(self._io)
             self.uv._write__seq(self._io)
-            self.rgba._write__seq(self._io)
 
 
         def _check(self):
-            pass
             if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
             if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if (len(self.bone_indices) != 1):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 1)
-            for i in range(len(self.bone_indices)):
-                pass
-
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
             if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
             if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
             if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
             if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
             if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
             if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.rgba._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._root, self._root)
-            if self.rgba._parent != self:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._parent, self)
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            self._dirty = False
 
         @property
         def size_(self):
@@ -2487,121 +3513,165 @@ class Mod21(ReadWriteKaitaiStruct):
         def _invalidate_size_(self):
             del self._m_size_
 
-    class Vec4U1(ReadWriteKaitaiStruct):
+    class Vertex926f(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod21.Vertex926f, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
-            self.x = self._io.read_u1()
-            self.y = self._io.read_u1()
-            self.z = self._io.read_u1()
-            self.w = self._io.read_u1()
+            self.position = Mod21.Vec3(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.normal._read()
+            self.occlusion = self._io.read_u1()
+            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self.rgba = Mod21.Vec4U1(self._io, self, self._root)
+            self.rgba._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
+            self.rgba._fetch_instances()
 
 
         def _write__seq(self, io=None):
-            super(Mod21.Vec4U1, self)._write__seq(io)
-            self._io.write_u1(self.x)
-            self._io.write_u1(self.y)
-            self._io.write_u1(self.z)
-            self._io.write_u1(self.w)
+            super(Mod21.Vertex926f, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self._io.write_u1(self.occlusion)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+            self.rgba._write__seq(self._io)
 
 
         def _check(self):
-            pass
-
-
-    class MeshesData(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.meshes = []
-            for i in range(self._root.header.num_meshes):
-                _t_meshes = Mod21.Mesh(self._io, self, self._root)
-                _t_meshes._read()
-                self.meshes.append(_t_meshes)
-
-            if (self._root.header.version == 211):
-                pass
-                self.num_weight_bounds = self._io.read_u4le()
-
-            self.weight_bounds = []
-            for i in range((self._root.num_weight_bounds if  (((self._root.header.version == 210)) or ((self._root.header.version == 212)))  else self.num_weight_bounds)):
-                _t_weight_bounds = Mod21.WeightBound(self._io, self, self._root)
-                _t_weight_bounds._read()
-                self.weight_bounds.append(_t_weight_bounds)
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.meshes)):
-                pass
-                self.meshes[i]._fetch_instances()
-
-            if (self._root.header.version == 211):
-                pass
-
-            for i in range(len(self.weight_bounds)):
-                pass
-                self.weight_bounds[i]._fetch_instances()
-
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.MeshesData, self)._write__seq(io)
-            for i in range(len(self.meshes)):
-                pass
-                self.meshes[i]._write__seq(self._io)
-
-            if (self._root.header.version == 211):
-                pass
-                self._io.write_u4le(self.num_weight_bounds)
-
-            for i in range(len(self.weight_bounds)):
-                pass
-                self.weight_bounds[i]._write__seq(self._io)
-
-
-
-        def _check(self):
-            pass
-            if (len(self.meshes) != self._root.header.num_meshes):
-                raise kaitaistruct.ConsistencyError(u"meshes", len(self.meshes), self._root.header.num_meshes)
-            for i in range(len(self.meshes)):
-                pass
-                if self.meshes[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"meshes", self.meshes[i]._root, self._root)
-                if self.meshes[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"meshes", self.meshes[i]._parent, self)
-
-            if (self._root.header.version == 211):
-                pass
-
-            if (len(self.weight_bounds) != (self._root.num_weight_bounds if  (((self._root.header.version == 210)) or ((self._root.header.version == 212)))  else self.num_weight_bounds)):
-                raise kaitaistruct.ConsistencyError(u"weight_bounds", len(self.weight_bounds), (self._root.num_weight_bounds if  (((self._root.header.version == 210)) or ((self._root.header.version == 212)))  else self.num_weight_bounds))
-            for i in range(len(self.weight_bounds)):
-                pass
-                if self.weight_bounds[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"weight_bounds", self.weight_bounds[i]._root, self._root)
-                if self.weight_bounds[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"weight_bounds", self.weight_bounds[i]._parent, self)
-
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            if self.rgba._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"rgba", self._root, self.rgba._root)
+            if self.rgba._parent != self:
+                raise kaitaistruct.ConsistencyError(u"rgba", self, self.rgba._parent)
+            self._dirty = False
 
         @property
         def size_(self):
             if hasattr(self, '_m_size_'):
                 return self._m_size_
 
-            self._m_size_ = (((self._root.header.num_meshes * self.meshes[0].size_) + (self._root.num_weight_bounds * self.weight_bounds[0].size_)) if  (((self._root.header.version == 210)) or ((self._root.header.version == 212)))  else (((self._root.header.num_meshes * self.meshes[0].size_) + (self.num_weight_bounds * self.weight_bounds[0].size_)) + 4))
+            self._m_size_ = 32
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class Vertex9399(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.Vertex9399, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec3(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.normal._read()
+            self.occlusion = self._io.read_u1()
+            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self.rgba = Mod21.Vec4U1(self._io, self, self._root)
+            self.rgba._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
+            self.rgba._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.Vertex9399, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self._io.write_u1(self.occlusion)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+            self.rgba._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            if self.rgba._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"rgba", self._root, self.rgba._root)
+            if self.rgba._parent != self:
+                raise kaitaistruct.ConsistencyError(u"rgba", self, self.rgba._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 32
             return getattr(self, '_m_size_', None)
 
         def _invalidate_size_(self):
@@ -2609,7 +3679,7 @@ class Mod21(ReadWriteKaitaiStruct):
 
     class VertexA013(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod21.VertexA013, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -2629,6 +3699,7 @@ class Mod21(ReadWriteKaitaiStruct):
 
             self.rgba = Mod21.Vec4U1(self._io, self, self._root)
             self.rgba._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -2658,34 +3729,34 @@ class Mod21(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
             if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
             if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
             if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
             if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
             if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
             if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
             if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
             if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if (len(self.bone_indices) != 2):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 2)
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if len(self.bone_indices) != 2:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 2, len(self.bone_indices))
             for i in range(len(self.bone_indices)):
                 pass
-                if (len(self.bone_indices[i]) != 2):
-                    raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices[i]), 2)
+                if len(self.bone_indices[i]) != 2:
+                    raise kaitaistruct.ConsistencyError(u"bone_indices", 2, len(self.bone_indices[i]))
 
             if self.rgba._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"rgba", self._root, self.rgba._root)
             if self.rgba._parent != self:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._parent, self)
+                raise kaitaistruct.ConsistencyError(u"rgba", self, self.rgba._parent)
+            self._dirty = False
 
         @property
         def size_(self):
@@ -2698,1023 +3769,66 @@ class Mod21(ReadWriteKaitaiStruct):
         def _invalidate_size_(self):
             del self._m_size_
 
-    class Vertex14d4(ReadWriteKaitaiStruct):
+    class VertexA14e(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec4S2(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod21.Vec3U1(self._io, self, self._root)
-            self.normal._read()
-            self.occlusion = self._io.read_u1()
-            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.bone_indices = []
-            for i in range(4):
-                self.bone_indices.append(self._io.read_u1())
-
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.weight_values = []
-            for i in range(2):
-                self.weight_values.append(self._io.read_bytes(2))
-
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            for i in range(len(self.bone_indices)):
-                pass
-
-            self.uv._fetch_instances()
-            for i in range(len(self.weight_values)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.Vertex14d4, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self._io.write_u1(self.occlusion)
-            self.tangent._write__seq(self._io)
-            for i in range(len(self.bone_indices)):
-                pass
-                self._io.write_u1(self.bone_indices[i])
-
-            self.uv._write__seq(self._io)
-            for i in range(len(self.weight_values)):
-                pass
-                self._io.write_bytes(self.weight_values[i])
-
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if (len(self.bone_indices) != 4):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 4)
-            for i in range(len(self.bone_indices)):
-                pass
-
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if (len(self.weight_values) != 2):
-                raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values), 2)
-            for i in range(len(self.weight_values)):
-                pass
-                if (len(self.weight_values[i]) != 2):
-                    raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values[i]), 2)
-
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 28
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Mesh(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-            self._should_write_indices = False
-            self.indices__to_write = True
-            self._should_write_vertices = False
-            self.vertices__to_write = True
-
-        def _read(self):
-            self.draw_mode = self._io.read_u2le()
-            self.num_vertices = self._io.read_u2le()
-            self.idx_group = self._io.read_bits_int_le(12)
-            self.idx_material = self._io.read_bits_int_le(12)
-            self.level_of_detail = self._io.read_bits_int_le(8)
-            self.disp = self._io.read_bits_int_le(1) != 0
-            self.shape = self._io.read_bits_int_le(1) != 0
-            self.sort = self._io.read_bits_int_le(1) != 0
-            self.max_bones_per_vertex = self._io.read_bits_int_le(5)
-            self.alpha_priority = self._io.read_bits_int_le(8)
-            self.vertex_stride = self._io.read_u1()
-            self.topology = self._io.read_bits_int_le(6)
-            self.binormal_flip = self._io.read_bits_int_le(1) != 0
-            self.bridge = self._io.read_bits_int_le(1) != 0
-            self.vertex_position = self._io.read_u4le()
-            self.vertex_offset = self._io.read_u4le()
-            self.vertex_format = self._io.read_u4le()
-            self.face_position = self._io.read_u4le()
-            self.num_indices = self._io.read_u4le()
-            self.face_offset = self._io.read_u4le()
-            self.bone_id_start = self._io.read_u1()
-            self.num_weight_bounds = self._io.read_u1()
-            self.connect_id = self._io.read_u2le()
-            self.min_index = self._io.read_u2le()
-            self.max_index = self._io.read_u2le()
-            self.boundary = self._io.read_u4le()
-
-
-        def _fetch_instances(self):
-            pass
-            _ = self.indices
-            for i in range(len(self._m_indices)):
-                pass
-
-            _ = self.vertices
-            for i in range(len(self._m_vertices)):
-                pass
-                _on = self.vertex_format
-                if _on == 1585389612:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 3094208554:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 1672921135:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 933552181:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 3663044641:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 794148925:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 3273596956:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 2456801326:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 3329204282:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 2685620254:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 3141681188:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 2706243644:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 3626594344:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 3421945882:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 2835001368:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 2476326963:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 3012694047:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 307572786:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 1126539326:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 545452091:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 3060273204:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 349437984:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 545087543:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 213286933:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 1719341081:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 3682443284:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 1236594729:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 228491293:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 2010673186:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 3631710235:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 2815938614:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 3517214776:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 2736832534:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 3419369511:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 1683566627:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 1975771173:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 3629002790:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 2946904109:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 2962763795:
-                    pass
-                    self.vertices[i]._fetch_instances()
-                elif _on == 1954353201:
-                    pass
-                    self.vertices[i]._fetch_instances()
-
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.Mesh, self)._write__seq(io)
-            self._should_write_indices = self.indices__to_write
-            self._should_write_vertices = self.vertices__to_write
-            self._io.write_u2le(self.draw_mode)
-            self._io.write_u2le(self.num_vertices)
-            self._io.write_bits_int_le(12, self.idx_group)
-            self._io.write_bits_int_le(12, self.idx_material)
-            self._io.write_bits_int_le(8, self.level_of_detail)
-            self._io.write_bits_int_le(1, int(self.disp))
-            self._io.write_bits_int_le(1, int(self.shape))
-            self._io.write_bits_int_le(1, int(self.sort))
-            self._io.write_bits_int_le(5, self.max_bones_per_vertex)
-            self._io.write_bits_int_le(8, self.alpha_priority)
-            self._io.write_u1(self.vertex_stride)
-            self._io.write_bits_int_le(6, self.topology)
-            self._io.write_bits_int_le(1, int(self.binormal_flip))
-            self._io.write_bits_int_le(1, int(self.bridge))
-            self._io.write_u4le(self.vertex_position)
-            self._io.write_u4le(self.vertex_offset)
-            self._io.write_u4le(self.vertex_format)
-            self._io.write_u4le(self.face_position)
-            self._io.write_u4le(self.num_indices)
-            self._io.write_u4le(self.face_offset)
-            self._io.write_u1(self.bone_id_start)
-            self._io.write_u1(self.num_weight_bounds)
-            self._io.write_u2le(self.connect_id)
-            self._io.write_u2le(self.min_index)
-            self._io.write_u2le(self.max_index)
-            self._io.write_u4le(self.boundary)
-
-
-        def _check(self):
-            pass
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 48
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-        @property
-        def indices(self):
-            if self._should_write_indices:
-                self._write_indices()
-            if hasattr(self, '_m_indices'):
-                return self._m_indices
-
-            _pos = self._io.pos()
-            self._io.seek(((self._root.header.offset_index_buffer + (self.face_offset * 2)) + (self.face_position * 2)))
-            self._m_indices = []
-            for i in range(self.num_indices):
-                self._m_indices.append(self._io.read_u2le())
-
-            self._io.seek(_pos)
-            return getattr(self, '_m_indices', None)
-
-        @indices.setter
-        def indices(self, v):
-            self._m_indices = v
-
-        def _write_indices(self):
-            self._should_write_indices = False
-            _pos = self._io.pos()
-            self._io.seek(((self._root.header.offset_index_buffer + (self.face_offset * 2)) + (self.face_position * 2)))
-            for i in range(len(self._m_indices)):
-                pass
-                self._io.write_u2le(self.indices[i])
-
-            self._io.seek(_pos)
-
-
-        def _check_indices(self):
-            pass
-            if (len(self.indices) != self.num_indices):
-                raise kaitaistruct.ConsistencyError(u"indices", len(self.indices), self.num_indices)
-            for i in range(len(self._m_indices)):
-                pass
-
-
-        @property
-        def vertices(self):
-            if self._should_write_vertices:
-                self._write_vertices()
-            if hasattr(self, '_m_vertices'):
-                return self._m_vertices
-
-            _pos = self._io.pos()
-            self._io.seek(((self._root.header.offset_vertex_buffer + self.vertex_offset) + (self.vertex_position * self.vertex_stride)))
-            self._m_vertices = []
-            for i in range(self.num_vertices):
-                _on = self.vertex_format
-                if _on == 1585389612:
-                    pass
-                    _t__m_vertices = Mod21.Vertex5e7f(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 3094208554:
-                    pass
-                    _t__m_vertices = Mod21.VertexB86d(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 1672921135:
-                    pass
-                    _t__m_vertices = Mod21.Vertex63b6(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 933552181:
-                    pass
-                    _t__m_vertices = Mod21.Vertex37a4(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 3663044641:
-                    pass
-                    _t__m_vertices = Mod21.VertexDa55(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 794148925:
-                    pass
-                    _t__m_vertices = Mod21.Vertex2f55(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 3273596956:
-                    pass
-                    _t__m_vertices = Mod21.VertexC31f(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 2456801326:
-                    pass
-                    _t__m_vertices = Mod21.Vertex926f(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 3329204282:
-                    pass
-                    _t__m_vertices = Mod21.VertexC66f(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 2685620254:
-                    pass
-                    _t__m_vertices = Mod21.VertexA013(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 3141681188:
-                    pass
-                    _t__m_vertices = Mod21.VertexBb42(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 2706243644:
-                    pass
-                    _t__m_vertices = Mod21.VertexA14e(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 3626594344:
-                    pass
-                    _t__m_vertices = Mod21.Vertex8297(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 3421945882:
-                    pass
-                    _t__m_vertices = Mod21.VertexCbf6(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 2835001368:
-                    pass
-                    _t__m_vertices = Mod21.VertexA8fa(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 2476326963:
-                    pass
-                    _t__m_vertices = Mod21.Vertex9399(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 3012694047:
-                    pass
-                    _t__m_vertices = Mod21.VertexB392(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 307572786:
-                    pass
-                    _t__m_vertices = Mod21.Vertex1255(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 1126539326:
-                    pass
-                    _t__m_vertices = Mod21.Vertex4325(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 545452091:
-                    pass
-                    _t__m_vertices = Mod21.Vertex2082(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 3060273204:
-                    pass
-                    _t__m_vertices = Mod21.VertexB668(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 349437984:
-                    pass
-                    _t__m_vertices = Mod21.Vertex14d4(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 545087543:
-                    pass
-                    _t__m_vertices = Mod21.Vertex207d(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 213286933:
-                    pass
-                    _t__m_vertices = Mod21.VertexCb68(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 1719341081:
-                    pass
-                    _t__m_vertices = Mod21.Vertex667b(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 3682443284:
-                    pass
-                    _t__m_vertices = Mod21.VertexDb7d(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 1236594729:
-                    pass
-                    _t__m_vertices = Mod21.Vertex49b4(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 228491293:
-                    pass
-                    _t__m_vertices = Mod21.VertexD9e8(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 2010673186:
-                    pass
-                    _t__m_vertices = Mod21.Vertex77d8(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 3631710235:
-                    pass
-                    _t__m_vertices = Mod21.VertexD877(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 2815938614:
-                    pass
-                    _t__m_vertices = Mod21.VertexA7d7(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 3517214776:
-                    pass
-                    _t__m_vertices = Mod21.VertexD1a4(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 2736832534:
-                    pass
-                    _t__m_vertices = Mod21.VertexA320(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 3419369511:
-                    pass
-                    _t__m_vertices = Mod21.VertexCbcf(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 1683566627:
-                    pass
-                    _t__m_vertices = Mod21.Vertex6459(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 1975771173:
-                    pass
-                    _t__m_vertices = Mod21.Vertex75c3(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 3629002790:
-                    pass
-                    _t__m_vertices = Mod21.VertexD84e(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 2946904109:
-                    pass
-                    _t__m_vertices = Mod21.VertexAfa6(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 2962763795:
-                    pass
-                    _t__m_vertices = Mod21.VertexB098(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-                elif _on == 1954353201:
-                    pass
-                    _t__m_vertices = Mod21.Vertex747d(self._io, self, self._root)
-                    _t__m_vertices._read()
-                    self._m_vertices.append(_t__m_vertices)
-
-            self._io.seek(_pos)
-            return getattr(self, '_m_vertices', None)
-
-        @vertices.setter
-        def vertices(self, v):
-            self._m_vertices = v
-
-        def _write_vertices(self):
-            self._should_write_vertices = False
-            _pos = self._io.pos()
-            self._io.seek(((self._root.header.offset_vertex_buffer + self.vertex_offset) + (self.vertex_position * self.vertex_stride)))
-            for i in range(len(self._m_vertices)):
-                pass
-                _on = self.vertex_format
-                if _on == 1585389612:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 3094208554:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 1672921135:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 933552181:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 3663044641:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 794148925:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 3273596956:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 2456801326:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 3329204282:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 2685620254:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 3141681188:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 2706243644:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 3626594344:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 3421945882:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 2835001368:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 2476326963:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 3012694047:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 307572786:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 1126539326:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 545452091:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 3060273204:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 349437984:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 545087543:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 213286933:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 1719341081:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 3682443284:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 1236594729:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 228491293:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 2010673186:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 3631710235:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 2815938614:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 3517214776:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 2736832534:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 3419369511:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 1683566627:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 1975771173:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 3629002790:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 2946904109:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 2962763795:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-                elif _on == 1954353201:
-                    pass
-                    self.vertices[i]._write__seq(self._io)
-
-            self._io.seek(_pos)
-
-
-        def _check_vertices(self):
-            pass
-            if (len(self.vertices) != self.num_vertices):
-                raise kaitaistruct.ConsistencyError(u"vertices", len(self.vertices), self.num_vertices)
-            for i in range(len(self._m_vertices)):
-                pass
-                _on = self.vertex_format
-                if _on == 1585389612:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 3094208554:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 1672921135:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 933552181:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 3663044641:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 794148925:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 3273596956:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 2456801326:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 3329204282:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 2685620254:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 3141681188:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 2706243644:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 3626594344:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 3421945882:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 2835001368:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 2476326963:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 3012694047:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 307572786:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 1126539326:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 545452091:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 3060273204:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 349437984:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 545087543:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 213286933:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 1719341081:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 3682443284:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 1236594729:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 228491293:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 2010673186:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 3631710235:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 2815938614:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 3517214776:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 2736832534:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 3419369511:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 1683566627:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 1975771173:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 3629002790:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 2946904109:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 2962763795:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-                elif _on == 1954353201:
-                    pass
-                    if self.vertices[i]._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._root, self._root)
-                    if self.vertices[i]._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"vertices", self.vertices[i]._parent, self)
-
-
-
-    class Vertex49b4(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod21.VertexA14e, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
             self.position = Mod21.Vec3(self._io, self, self._root)
             self.position._read()
-            self.normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.normal = Mod21.Vec4U1(self._io, self, self._root)
             self.normal._read()
-            self.occlusion = self._io.read_u1()
-            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
             self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
             self.uv._read()
+            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
             self.rgba = Mod21.Vec4U1(self._io, self, self._root)
             self.rgba._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
             self.position._fetch_instances()
             self.normal._fetch_instances()
-            self.tangent._fetch_instances()
             self.uv._fetch_instances()
+            self.uv2._fetch_instances()
             self.rgba._fetch_instances()
 
 
         def _write__seq(self, io=None):
-            super(Mod21.Vertex49b4, self)._write__seq(io)
+            super(Mod21.VertexA14e, self)._write__seq(io)
             self.position._write__seq(self._io)
             self.normal._write__seq(self._io)
-            self._io.write_u1(self.occlusion)
-            self.tangent._write__seq(self._io)
             self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
             self.rgba._write__seq(self._io)
 
 
         def _check(self):
-            pass
             if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
             if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
             if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
             if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
             if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
             if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
             if self.rgba._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"rgba", self._root, self.rgba._root)
             if self.rgba._parent != self:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._parent, self)
+                raise kaitaistruct.ConsistencyError(u"rgba", self, self.rgba._parent)
+            self._dirty = False
 
         @property
         def size_(self):
@@ -3726,712 +3840,10 @@ class Mod21(ReadWriteKaitaiStruct):
 
         def _invalidate_size_(self):
             del self._m_size_
-
-    class VertexD1a4(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec3(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod21.Vec4U1(self._io, self, self._root)
-            self.normal._read()
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.VertexD1a4, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 24
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Vertex37a4(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec3(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod21.Vec3U1(self._io, self, self._root)
-            self.normal._read()
-            self.occlusion = self._io.read_u1()
-            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-            self.uv3 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv3._read()
-            self.uv4 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv4._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
-            self.uv3._fetch_instances()
-            self.uv4._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.Vertex37a4, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self._io.write_u1(self.occlusion)
-            self.tangent._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
-            self.uv3._write__seq(self._io)
-            self.uv4._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-            if self.uv3._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._root, self._root)
-            if self.uv3._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._parent, self)
-            if self.uv4._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv4", self.uv4._root, self._root)
-            if self.uv4._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv4", self.uv4._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 36
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Vertex4325(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec3(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod21.Vec3U1(self._io, self, self._root)
-            self.normal._read()
-            self.occlusion = self._io.read_u1()
-            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-            self.morph_position = Mod21.Vec3S2(self._io, self, self._root)
-            self.morph_position._read()
-            self.morph_position2 = Mod21.Vec3S2(self._io, self, self._root)
-            self.morph_position2._read()
-            self.morph_position3 = Mod21.Vec3S2(self._io, self, self._root)
-            self.morph_position3._read()
-            self.morph_position4 = Mod21.Vec3S2(self._io, self, self._root)
-            self.morph_position4._read()
-            self.morph_normal = Mod21.Vec3U1(self._io, self, self._root)
-            self.morph_normal._read()
-            self.morph_normal2 = Mod21.Vec3U1(self._io, self, self._root)
-            self.morph_normal2._read()
-            self.morph_normal3 = Mod21.Vec3U1(self._io, self, self._root)
-            self.morph_normal3._read()
-            self.morph_normal4 = Mod21.Vec3U1(self._io, self, self._root)
-            self.morph_normal4._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
-            self.morph_position._fetch_instances()
-            self.morph_position2._fetch_instances()
-            self.morph_position3._fetch_instances()
-            self.morph_position4._fetch_instances()
-            self.morph_normal._fetch_instances()
-            self.morph_normal2._fetch_instances()
-            self.morph_normal3._fetch_instances()
-            self.morph_normal4._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.Vertex4325, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self._io.write_u1(self.occlusion)
-            self.tangent._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
-            self.morph_position._write__seq(self._io)
-            self.morph_position2._write__seq(self._io)
-            self.morph_position3._write__seq(self._io)
-            self.morph_position4._write__seq(self._io)
-            self.morph_normal._write__seq(self._io)
-            self.morph_normal2._write__seq(self._io)
-            self.morph_normal3._write__seq(self._io)
-            self.morph_normal4._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-            if self.morph_position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"morph_position", self.morph_position._root, self._root)
-            if self.morph_position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"morph_position", self.morph_position._parent, self)
-            if self.morph_position2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"morph_position2", self.morph_position2._root, self._root)
-            if self.morph_position2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"morph_position2", self.morph_position2._parent, self)
-            if self.morph_position3._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"morph_position3", self.morph_position3._root, self._root)
-            if self.morph_position3._parent != self:
-                raise kaitaistruct.ConsistencyError(u"morph_position3", self.morph_position3._parent, self)
-            if self.morph_position4._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"morph_position4", self.morph_position4._root, self._root)
-            if self.morph_position4._parent != self:
-                raise kaitaistruct.ConsistencyError(u"morph_position4", self.morph_position4._parent, self)
-            if self.morph_normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"morph_normal", self.morph_normal._root, self._root)
-            if self.morph_normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"morph_normal", self.morph_normal._parent, self)
-            if self.morph_normal2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"morph_normal2", self.morph_normal2._root, self._root)
-            if self.morph_normal2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"morph_normal2", self.morph_normal2._parent, self)
-            if self.morph_normal3._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"morph_normal3", self.morph_normal3._root, self._root)
-            if self.morph_normal3._parent != self:
-                raise kaitaistruct.ConsistencyError(u"morph_normal3", self.morph_normal3._parent, self)
-            if self.morph_normal4._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"morph_normal4", self.morph_normal4._root, self._root)
-            if self.morph_normal4._parent != self:
-                raise kaitaistruct.ConsistencyError(u"morph_normal4", self.morph_normal4._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 64
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class VertexDb7d(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec4S2(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod21.Vec4U1(self._io, self, self._root)
-            self.normal._read()
-            self.bone_indices = []
-            for i in range(4):
-                self.bone_indices.append(self._io.read_u1())
-
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            for i in range(len(self.bone_indices)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.VertexDb7d, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            for i in range(len(self.bone_indices)):
-                pass
-                self._io.write_u1(self.bone_indices[i])
-
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if (len(self.bone_indices) != 4):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 4)
-            for i in range(len(self.bone_indices)):
-                pass
-
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 16
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class VertexC66f(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec3(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod21.Vec4U1(self._io, self, self._root)
-            self.normal._read()
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.VertexC66f, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 24
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class VertexB86d(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec3(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod21.Vec3U1(self._io, self, self._root)
-            self.normal._read()
-            self.vertex_alpha = self._io.read_u1()
-            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-            self.occlusion = self._io.read_u4le()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.VertexB86d, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self._io.write_u1(self.vertex_alpha)
-            self.tangent._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
-            self._io.write_u4le(self.occlusion)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 32
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Material(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.unk_01 = self._io.read_u2le()
-            self.unk_02 = self._io.read_u2le()
-            self.unk_floats = []
-            for i in range(30):
-                self.unk_floats.append(self._io.read_f4le())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.unk_floats)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.Material, self)._write__seq(io)
-            self._io.write_u2le(self.unk_01)
-            self._io.write_u2le(self.unk_02)
-            for i in range(len(self.unk_floats)):
-                pass
-                self._io.write_f4le(self.unk_floats[i])
-
-
-
-        def _check(self):
-            pass
-            if (len(self.unk_floats) != 30):
-                raise kaitaistruct.ConsistencyError(u"unk_floats", len(self.unk_floats), 30)
-            for i in range(len(self.unk_floats)):
-                pass
-
-
-
-    class Vertex207d(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec3(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod21.Vec4U1(self._io, self, self._root)
-            self.normal._read()
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.rgba = Mod21.Vec4U1(self._io, self, self._root)
-            self.rgba._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.uv._fetch_instances()
-            self.rgba._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.Vertex207d, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.rgba._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.rgba._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._root, self._root)
-            if self.rgba._parent != self:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 24
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class WeightBound(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.bone_id = self._io.read_u4le()
-            self.unk_01 = Mod21.Vec3(self._io, self, self._root)
-            self.unk_01._read()
-            self.bsphere = Mod21.Vec4(self._io, self, self._root)
-            self.bsphere._read()
-            self.bbox_min = Mod21.Vec4(self._io, self, self._root)
-            self.bbox_min._read()
-            self.bbox_max = Mod21.Vec4(self._io, self, self._root)
-            self.bbox_max._read()
-            self.oabb = Mod21.Matrix4x4(self._io, self, self._root)
-            self.oabb._read()
-            self.oabb_dimension = Mod21.Vec4(self._io, self, self._root)
-            self.oabb_dimension._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.unk_01._fetch_instances()
-            self.bsphere._fetch_instances()
-            self.bbox_min._fetch_instances()
-            self.bbox_max._fetch_instances()
-            self.oabb._fetch_instances()
-            self.oabb_dimension._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.WeightBound, self)._write__seq(io)
-            self._io.write_u4le(self.bone_id)
-            self.unk_01._write__seq(self._io)
-            self.bsphere._write__seq(self._io)
-            self.bbox_min._write__seq(self._io)
-            self.bbox_max._write__seq(self._io)
-            self.oabb._write__seq(self._io)
-            self.oabb_dimension._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.unk_01._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"unk_01", self.unk_01._root, self._root)
-            if self.unk_01._parent != self:
-                raise kaitaistruct.ConsistencyError(u"unk_01", self.unk_01._parent, self)
-            if self.bsphere._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"bsphere", self.bsphere._root, self._root)
-            if self.bsphere._parent != self:
-                raise kaitaistruct.ConsistencyError(u"bsphere", self.bsphere._parent, self)
-            if self.bbox_min._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"bbox_min", self.bbox_min._root, self._root)
-            if self.bbox_min._parent != self:
-                raise kaitaistruct.ConsistencyError(u"bbox_min", self.bbox_min._parent, self)
-            if self.bbox_max._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"bbox_max", self.bbox_max._root, self._root)
-            if self.bbox_max._parent != self:
-                raise kaitaistruct.ConsistencyError(u"bbox_max", self.bbox_max._parent, self)
-            if self.oabb._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"oabb", self.oabb._root, self._root)
-            if self.oabb._parent != self:
-                raise kaitaistruct.ConsistencyError(u"oabb", self.oabb._parent, self)
-            if self.oabb_dimension._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"oabb_dimension", self.oabb_dimension._root, self._root)
-            if self.oabb_dimension._parent != self:
-                raise kaitaistruct.ConsistencyError(u"oabb_dimension", self.oabb_dimension._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 144
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Vec3(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.x = self._io.read_f4le()
-            self.y = self._io.read_f4le()
-            self.z = self._io.read_f4le()
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.Vec3, self)._write__seq(io)
-            self._io.write_f4le(self.x)
-            self._io.write_f4le(self.y)
-            self._io.write_f4le(self.z)
-
-
-        def _check(self):
-            pass
-
 
     class VertexA320(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod21.VertexA320, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -4448,6 +3860,7 @@ class Mod21(ReadWriteKaitaiStruct):
 
             self.normal = Mod21.Vec4U1(self._io, self, self._root)
             self.normal._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -4477,25 +3890,25 @@ class Mod21(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
             if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
             if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if (len(self.bone_indices) != 8):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 8)
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if len(self.bone_indices) != 8:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 8, len(self.bone_indices))
             for i in range(len(self.bone_indices)):
                 pass
 
-            if (len(self.weight_values) != 8):
-                raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values), 8)
+            if len(self.weight_values) != 8:
+                raise kaitaistruct.ConsistencyError(u"weight_values", 8, len(self.weight_values))
             for i in range(len(self.weight_values)):
                 pass
 
             if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
             if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            self._dirty = False
 
         @property
         def size_(self):
@@ -4508,119 +3921,895 @@ class Mod21(ReadWriteKaitaiStruct):
         def _invalidate_size_(self):
             del self._m_size_
 
-    class Vec3S2(ReadWriteKaitaiStruct):
+    class VertexA7d7(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod21.VertexA7d7, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
-            self.x = self._io.read_s2le()
-            self.y = self._io.read_s2le()
-            self.z = self._io.read_s2le()
+            self.position = Mod21.Vec3(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod21.Vec4U1(self._io, self, self._root)
+            self.normal._read()
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.uv._fetch_instances()
 
 
         def _write__seq(self, io=None):
-            super(Mod21.Vec3S2, self)._write__seq(io)
-            self._io.write_s2le(self.x)
-            self._io.write_s2le(self.y)
-            self._io.write_s2le(self.z)
+            super(Mod21.VertexA7d7, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self.uv._write__seq(self._io)
 
 
         def _check(self):
-            pass
-
-
-    class MaterialsData(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            if  (((self._root.header.version == 210)) or ((self._root.header.version == 212))) :
-                pass
-                self.material_names = []
-                for i in range(self._root.header.num_materials):
-                    self.material_names.append((KaitaiStream.bytes_terminate(self._io.read_bytes(128), 0, False)).decode("ASCII"))
-
-
-            if (self._root.header.version == 211):
-                pass
-                self.material_hashes = []
-                for i in range(self._root.header.num_materials):
-                    self.material_hashes.append(self._io.read_u4le())
-
-
-
-
-        def _fetch_instances(self):
-            pass
-            if  (((self._root.header.version == 210)) or ((self._root.header.version == 212))) :
-                pass
-                for i in range(len(self.material_names)):
-                    pass
-
-
-            if (self._root.header.version == 211):
-                pass
-                for i in range(len(self.material_hashes)):
-                    pass
-
-
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.MaterialsData, self)._write__seq(io)
-            if  (((self._root.header.version == 210)) or ((self._root.header.version == 212))) :
-                pass
-                for i in range(len(self.material_names)):
-                    pass
-                    self._io.write_bytes_limit((self.material_names[i]).encode(u"ASCII"), 128, 0, 0)
-
-
-            if (self._root.header.version == 211):
-                pass
-                for i in range(len(self.material_hashes)):
-                    pass
-                    self._io.write_u4le(self.material_hashes[i])
-
-
-
-
-        def _check(self):
-            pass
-            if  (((self._root.header.version == 210)) or ((self._root.header.version == 212))) :
-                pass
-                if (len(self.material_names) != self._root.header.num_materials):
-                    raise kaitaistruct.ConsistencyError(u"material_names", len(self.material_names), self._root.header.num_materials)
-                for i in range(len(self.material_names)):
-                    pass
-                    if (len((self.material_names[i]).encode(u"ASCII")) > 128):
-                        raise kaitaistruct.ConsistencyError(u"material_names", len((self.material_names[i]).encode(u"ASCII")), 128)
-                    if (KaitaiStream.byte_array_index_of((self.material_names[i]).encode(u"ASCII"), 0) != -1):
-                        raise kaitaistruct.ConsistencyError(u"material_names", KaitaiStream.byte_array_index_of((self.material_names[i]).encode(u"ASCII"), 0), -1)
-
-
-            if (self._root.header.version == 211):
-                pass
-                if (len(self.material_hashes) != self._root.header.num_materials):
-                    raise kaitaistruct.ConsistencyError(u"material_hashes", len(self.material_hashes), self._root.header.num_materials)
-                for i in range(len(self.material_hashes)):
-                    pass
-
-
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            self._dirty = False
 
         @property
         def size_(self):
             if hasattr(self, '_m_size_'):
                 return self._m_size_
 
-            self._m_size_ = ((128 * self._root.header.num_materials) if  (((self._root.header.version == 210)) or ((self._root.header.version == 212)))  else (4 * self._root.header.num_materials))
+            self._m_size_ = 20
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class VertexA8fa(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.VertexA8fa, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec3S2(self._io, self, self._root)
+            self.position._read()
+            self.bone_indices = []
+            for i in range(1):
+                self.bone_indices.append(self._io.read_u2le())
+
+            self.normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.normal._read()
+            self.occlusion = self._io.read_u1()
+            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            for i in range(len(self.bone_indices)):
+                pass
+
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.VertexA8fa, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            for i in range(len(self.bone_indices)):
+                pass
+                self._io.write_u2le(self.bone_indices[i])
+
+            self.normal._write__seq(self._io)
+            self._io.write_u1(self.occlusion)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if len(self.bone_indices) != 1:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 1, len(self.bone_indices))
+            for i in range(len(self.bone_indices)):
+                pass
+
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 20
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class VertexAfa6(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.VertexAfa6, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec3(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.normal._read()
+            self.occlusion = self._io.read_u1()
+            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.VertexAfa6, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self._io.write_u1(self.occlusion)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 28
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class VertexB098(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.VertexB098, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec3S2(self._io, self, self._root)
+            self.position._read()
+            self.bone_indices = []
+            for i in range(1):
+                self.bone_indices.append(self._io.read_u2le())
+
+            self.normal = Mod21.Vec4U1(self._io, self, self._root)
+            self.normal._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            for i in range(len(self.bone_indices)):
+                pass
+
+            self.normal._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.VertexB098, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            for i in range(len(self.bone_indices)):
+                pass
+                self._io.write_u2le(self.bone_indices[i])
+
+            self.normal._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if len(self.bone_indices) != 1:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 1, len(self.bone_indices))
+            for i in range(len(self.bone_indices)):
+                pass
+
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 12
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class VertexB392(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.VertexB392, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec4S2(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.normal._read()
+            self.occlusion = self._io.read_u1()
+            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.bone_indices = []
+            for i in range(2):
+                self.bone_indices.append(self._io.read_bytes(2))
+
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self.uv3 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv3._read()
+            self.uv4 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv4._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            for i in range(len(self.bone_indices)):
+                pass
+
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
+            self.uv3._fetch_instances()
+            self.uv4._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.VertexB392, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self._io.write_u1(self.occlusion)
+            self.tangent._write__seq(self._io)
+            for i in range(len(self.bone_indices)):
+                pass
+                self._io.write_bytes(self.bone_indices[i])
+
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+            self.uv3._write__seq(self._io)
+            self.uv4._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if len(self.bone_indices) != 2:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 2, len(self.bone_indices))
+            for i in range(len(self.bone_indices)):
+                pass
+                if len(self.bone_indices[i]) != 2:
+                    raise kaitaistruct.ConsistencyError(u"bone_indices", 2, len(self.bone_indices[i]))
+
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            if self.uv3._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv3", self._root, self.uv3._root)
+            if self.uv3._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv3", self, self.uv3._parent)
+            if self.uv4._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv4", self._root, self.uv4._root)
+            if self.uv4._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv4", self, self.uv4._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 36
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class VertexB668(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.VertexB668, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec3(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.normal._read()
+            self.occlusion = self._io.read_u1()
+            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self.rgba = Mod21.Vec4U1(self._io, self, self._root)
+            self.rgba._read()
+            self.uv3 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv3._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
+            self.rgba._fetch_instances()
+            self.uv3._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.VertexB668, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self._io.write_u1(self.occlusion)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+            self.rgba._write__seq(self._io)
+            self.uv3._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            if self.rgba._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"rgba", self._root, self.rgba._root)
+            if self.rgba._parent != self:
+                raise kaitaistruct.ConsistencyError(u"rgba", self, self.rgba._parent)
+            if self.uv3._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv3", self._root, self.uv3._root)
+            if self.uv3._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv3", self, self.uv3._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 36
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class VertexB86d(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.VertexB86d, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec3(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.normal._read()
+            self.vertex_alpha = self._io.read_u1()
+            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self.occlusion = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.VertexB86d, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self._io.write_u1(self.vertex_alpha)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+            self._io.write_u4le(self.occlusion)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 32
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class VertexBb42(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.VertexBb42, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec4S2(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.normal._read()
+            self.occlusion = self._io.read_u1()
+            self.weight_values = []
+            for i in range(4):
+                self.weight_values.append(self._io.read_u1())
+
+            self.bone_indices = []
+            for i in range(8):
+                self.bone_indices.append(self._io.read_u1())
+
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.weight_values2 = []
+            for i in range(2):
+                self.weight_values2.append(self._io.read_bytes(2))
+
+            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            for i in range(len(self.weight_values)):
+                pass
+
+            for i in range(len(self.bone_indices)):
+                pass
+
+            self.uv._fetch_instances()
+            for i in range(len(self.weight_values2)):
+                pass
+
+            self.tangent._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.VertexBb42, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self._io.write_u1(self.occlusion)
+            for i in range(len(self.weight_values)):
+                pass
+                self._io.write_u1(self.weight_values[i])
+
+            for i in range(len(self.bone_indices)):
+                pass
+                self._io.write_u1(self.bone_indices[i])
+
+            self.uv._write__seq(self._io)
+            for i in range(len(self.weight_values2)):
+                pass
+                self._io.write_bytes(self.weight_values2[i])
+
+            self.tangent._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if len(self.weight_values) != 4:
+                raise kaitaistruct.ConsistencyError(u"weight_values", 4, len(self.weight_values))
+            for i in range(len(self.weight_values)):
+                pass
+
+            if len(self.bone_indices) != 8:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 8, len(self.bone_indices))
+            for i in range(len(self.bone_indices)):
+                pass
+
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if len(self.weight_values2) != 2:
+                raise kaitaistruct.ConsistencyError(u"weight_values2", 2, len(self.weight_values2))
+            for i in range(len(self.weight_values2)):
+                pass
+                if len(self.weight_values2[i]) != 2:
+                    raise kaitaistruct.ConsistencyError(u"weight_values2", 2, len(self.weight_values2[i]))
+
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 36
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class VertexC31f(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.VertexC31f, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec4S2(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.normal._read()
+            self.occlusion = self._io.read_u1()
+            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.bone_indices = []
+            for i in range(2):
+                self.bone_indices.append(self._io.read_bytes(2))
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.tangent._fetch_instances()
+            self.uv._fetch_instances()
+            for i in range(len(self.bone_indices)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.VertexC31f, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self._io.write_u1(self.occlusion)
+            self.tangent._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            for i in range(len(self.bone_indices)):
+                pass
+                self._io.write_bytes(self.bone_indices[i])
+
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if len(self.bone_indices) != 2:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 2, len(self.bone_indices))
+            for i in range(len(self.bone_indices)):
+                pass
+                if len(self.bone_indices[i]) != 2:
+                    raise kaitaistruct.ConsistencyError(u"bone_indices", 2, len(self.bone_indices[i]))
+
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 24
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class VertexC66f(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.VertexC66f, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec3(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod21.Vec4U1(self._io, self, self._root)
+            self.normal._read()
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.VertexC66f, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 24
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class VertexCb68(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.VertexCb68, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec4S2(self._io, self, self._root)
+            self.position._read()
+            self.bone_indices = []
+            for i in range(4):
+                self.bone_indices.append(self._io.read_u1())
+
+            self.weight_values = []
+            for i in range(4):
+                self.weight_values.append(self._io.read_u1())
+
+            self.normal = Mod21.Vec4U1(self._io, self, self._root)
+            self.normal._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            for i in range(len(self.bone_indices)):
+                pass
+
+            for i in range(len(self.weight_values)):
+                pass
+
+            self.normal._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.VertexCb68, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            for i in range(len(self.bone_indices)):
+                pass
+                self._io.write_u1(self.bone_indices[i])
+
+            for i in range(len(self.weight_values)):
+                pass
+                self._io.write_u1(self.weight_values[i])
+
+            self.normal._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if len(self.bone_indices) != 4:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 4, len(self.bone_indices))
+            for i in range(len(self.bone_indices)):
+                pass
+
+            if len(self.weight_values) != 4:
+                raise kaitaistruct.ConsistencyError(u"weight_values", 4, len(self.weight_values))
+            for i in range(len(self.weight_values)):
+                pass
+
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 20
             return getattr(self, '_m_size_', None)
 
         def _invalidate_size_(self):
@@ -4628,7 +4817,7 @@ class Mod21(ReadWriteKaitaiStruct):
 
     class VertexCbcf(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod21.VertexCbcf, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -4660,6 +4849,7 @@ class Mod21(ReadWriteKaitaiStruct):
             self.uv3._read()
             self.uv4 = Mod21.Vec2HalfFloat(self._io, self, self._root)
             self.uv4._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -4707,52 +4897,52 @@ class Mod21(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
             if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
             if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
             if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
             if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if (len(self.weight_values) != 4):
-                raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values), 4)
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if len(self.weight_values) != 4:
+                raise kaitaistruct.ConsistencyError(u"weight_values", 4, len(self.weight_values))
             for i in range(len(self.weight_values)):
                 pass
 
-            if (len(self.bone_indices) != 8):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 8)
+            if len(self.bone_indices) != 8:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 8, len(self.bone_indices))
             for i in range(len(self.bone_indices)):
                 pass
 
             if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
             if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if (len(self.weight_values2) != 2):
-                raise kaitaistruct.ConsistencyError(u"weight_values2", len(self.weight_values2), 2)
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if len(self.weight_values2) != 2:
+                raise kaitaistruct.ConsistencyError(u"weight_values2", 2, len(self.weight_values2))
             for i in range(len(self.weight_values2)):
                 pass
-                if (len(self.weight_values2[i]) != 2):
-                    raise kaitaistruct.ConsistencyError(u"weight_values2", len(self.weight_values2[i]), 2)
+                if len(self.weight_values2[i]) != 2:
+                    raise kaitaistruct.ConsistencyError(u"weight_values2", 2, len(self.weight_values2[i]))
 
             if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
             if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
             if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
             if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
             if self.uv3._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv3", self._root, self.uv3._root)
             if self.uv3._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._parent, self)
+                raise kaitaistruct.ConsistencyError(u"uv3", self, self.uv3._parent)
             if self.uv4._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv4", self.uv4._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv4", self._root, self.uv4._root)
             if self.uv4._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv4", self.uv4._parent, self)
+                raise kaitaistruct.ConsistencyError(u"uv4", self, self.uv4._parent)
+            self._dirty = False
 
         @property
         def size_(self):
@@ -4765,131 +4955,19 @@ class Mod21(ReadWriteKaitaiStruct):
         def _invalidate_size_(self):
             del self._m_size_
 
-    class BonesData(ReadWriteKaitaiStruct):
+    class VertexCbf6(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod21.VertexCbf6, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
-            self.bones_hierarchy = []
-            for i in range(self._root.header.num_bones):
-                _t_bones_hierarchy = Mod21.Bone(self._io, self, self._root)
-                _t_bones_hierarchy._read()
-                self.bones_hierarchy.append(_t_bones_hierarchy)
-
-            self.parent_space_matrices = []
-            for i in range(self._root.header.num_bones):
-                _t_parent_space_matrices = Mod21.Matrix4x4(self._io, self, self._root)
-                _t_parent_space_matrices._read()
-                self.parent_space_matrices.append(_t_parent_space_matrices)
-
-            self.inverse_bind_matrices = []
-            for i in range(self._root.header.num_bones):
-                _t_inverse_bind_matrices = Mod21.Matrix4x4(self._io, self, self._root)
-                _t_inverse_bind_matrices._read()
-                self.inverse_bind_matrices.append(_t_inverse_bind_matrices)
-
-            if (self._root.header.num_bones != 0):
-                pass
-                self.bone_map = self._io.read_bytes(256)
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.bones_hierarchy)):
-                pass
-                self.bones_hierarchy[i]._fetch_instances()
-
-            for i in range(len(self.parent_space_matrices)):
-                pass
-                self.parent_space_matrices[i]._fetch_instances()
-
-            for i in range(len(self.inverse_bind_matrices)):
-                pass
-                self.inverse_bind_matrices[i]._fetch_instances()
-
-            if (self._root.header.num_bones != 0):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.BonesData, self)._write__seq(io)
-            for i in range(len(self.bones_hierarchy)):
-                pass
-                self.bones_hierarchy[i]._write__seq(self._io)
-
-            for i in range(len(self.parent_space_matrices)):
-                pass
-                self.parent_space_matrices[i]._write__seq(self._io)
-
-            for i in range(len(self.inverse_bind_matrices)):
-                pass
-                self.inverse_bind_matrices[i]._write__seq(self._io)
-
-            if (self._root.header.num_bones != 0):
-                pass
-                self._io.write_bytes(self.bone_map)
-
-
-
-        def _check(self):
-            pass
-            if (len(self.bones_hierarchy) != self._root.header.num_bones):
-                raise kaitaistruct.ConsistencyError(u"bones_hierarchy", len(self.bones_hierarchy), self._root.header.num_bones)
-            for i in range(len(self.bones_hierarchy)):
-                pass
-                if self.bones_hierarchy[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"bones_hierarchy", self.bones_hierarchy[i]._root, self._root)
-                if self.bones_hierarchy[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"bones_hierarchy", self.bones_hierarchy[i]._parent, self)
-
-            if (len(self.parent_space_matrices) != self._root.header.num_bones):
-                raise kaitaistruct.ConsistencyError(u"parent_space_matrices", len(self.parent_space_matrices), self._root.header.num_bones)
-            for i in range(len(self.parent_space_matrices)):
-                pass
-                if self.parent_space_matrices[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"parent_space_matrices", self.parent_space_matrices[i]._root, self._root)
-                if self.parent_space_matrices[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"parent_space_matrices", self.parent_space_matrices[i]._parent, self)
-
-            if (len(self.inverse_bind_matrices) != self._root.header.num_bones):
-                raise kaitaistruct.ConsistencyError(u"inverse_bind_matrices", len(self.inverse_bind_matrices), self._root.header.num_bones)
-            for i in range(len(self.inverse_bind_matrices)):
-                pass
-                if self.inverse_bind_matrices[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"inverse_bind_matrices", self.inverse_bind_matrices[i]._root, self._root)
-                if self.inverse_bind_matrices[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"inverse_bind_matrices", self.inverse_bind_matrices[i]._parent, self)
-
-            if (self._root.header.num_bones != 0):
-                pass
-                if (len(self.bone_map) != 256):
-                    raise kaitaistruct.ConsistencyError(u"bone_map", len(self.bone_map), 256)
-
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = (((((self._root.header.num_bones * self.bones_hierarchy[0].size_) + (self._root.header.num_bones * 64)) + (self._root.header.num_bones * 64)) + 256) if (self._root.header.num_bones > 0) else 0)
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Vertex8297(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec3(self._io, self, self._root)
+            self.position = Mod21.Vec3S2(self._io, self, self._root)
             self.position._read()
+            self.bone_indices = []
+            for i in range(1):
+                self.bone_indices.append(self._io.read_u2le())
+
             self.normal = Mod21.Vec3U1(self._io, self, self._root)
             self.normal._read()
             self.occlusion = self._io.read_u1()
@@ -4897,43 +4975,64 @@ class Mod21(ReadWriteKaitaiStruct):
             self.tangent._read()
             self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
             self.uv._read()
+            self.rgba = Mod21.Vec4U1(self._io, self, self._root)
+            self.rgba._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
             self.position._fetch_instances()
+            for i in range(len(self.bone_indices)):
+                pass
+
             self.normal._fetch_instances()
             self.tangent._fetch_instances()
             self.uv._fetch_instances()
+            self.rgba._fetch_instances()
 
 
         def _write__seq(self, io=None):
-            super(Mod21.Vertex8297, self)._write__seq(io)
+            super(Mod21.VertexCbf6, self)._write__seq(io)
             self.position._write__seq(self._io)
+            for i in range(len(self.bone_indices)):
+                pass
+                self._io.write_u2le(self.bone_indices[i])
+
             self.normal._write__seq(self._io)
             self._io.write_u1(self.occlusion)
             self.tangent._write__seq(self._io)
             self.uv._write__seq(self._io)
+            self.rgba._write__seq(self._io)
 
 
         def _check(self):
-            pass
             if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
             if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if len(self.bone_indices) != 1:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 1, len(self.bone_indices))
+            for i in range(len(self.bone_indices)):
+                pass
+
             if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
             if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
             if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
             if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
             if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
             if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.rgba._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"rgba", self._root, self.rgba._root)
+            if self.rgba._parent != self:
+                raise kaitaistruct.ConsistencyError(u"rgba", self, self.rgba._parent)
+            self._dirty = False
 
         @property
         def size_(self):
@@ -4946,15 +5045,207 @@ class Mod21(ReadWriteKaitaiStruct):
         def _invalidate_size_(self):
             del self._m_size_
 
-    class Vertex1255(ReadWriteKaitaiStruct):
+    class VertexD1a4(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod21.VertexD1a4, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
             self.position = Mod21.Vec3(self._io, self, self._root)
             self.position._read()
+            self.normal = Mod21.Vec4U1(self._io, self, self._root)
+            self.normal._read()
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv2._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            self.uv._fetch_instances()
+            self.uv2._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.VertexD1a4, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self.uv._write__seq(self._io)
+            self.uv2._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if self.uv2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
+            if self.uv2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 24
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class VertexD84e(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.VertexD84e, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec4S2(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod21.Vec3U1(self._io, self, self._root)
+            self.normal._read()
+            self.occlusion = self._io.read_u1()
+            self.weight_values = []
+            for i in range(4):
+                self.weight_values.append(self._io.read_u1())
+
+            self.bone_indices = []
+            for i in range(8):
+                self.bone_indices.append(self._io.read_u1())
+
+            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv._read()
+            self.weight_values2 = []
+            for i in range(2):
+                self.weight_values2.append(self._io.read_bytes(2))
+
+            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
+            self.tangent._read()
+            self.rgba = Mod21.Vec4U1(self._io, self, self._root)
+            self.rgba._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            for i in range(len(self.weight_values)):
+                pass
+
+            for i in range(len(self.bone_indices)):
+                pass
+
+            self.uv._fetch_instances()
+            for i in range(len(self.weight_values2)):
+                pass
+
+            self.tangent._fetch_instances()
+            self.rgba._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mod21.VertexD84e, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            self._io.write_u1(self.occlusion)
+            for i in range(len(self.weight_values)):
+                pass
+                self._io.write_u1(self.weight_values[i])
+
+            for i in range(len(self.bone_indices)):
+                pass
+                self._io.write_u1(self.bone_indices[i])
+
+            self.uv._write__seq(self._io)
+            for i in range(len(self.weight_values2)):
+                pass
+                self._io.write_bytes(self.weight_values2[i])
+
+            self.tangent._write__seq(self._io)
+            self.rgba._write__seq(self._io)
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if len(self.weight_values) != 4:
+                raise kaitaistruct.ConsistencyError(u"weight_values", 4, len(self.weight_values))
+            for i in range(len(self.weight_values)):
+                pass
+
+            if len(self.bone_indices) != 8:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 8, len(self.bone_indices))
+            for i in range(len(self.bone_indices)):
+                pass
+
+            if self.uv._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
+            if self.uv._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if len(self.weight_values2) != 2:
+                raise kaitaistruct.ConsistencyError(u"weight_values2", 2, len(self.weight_values2))
+            for i in range(len(self.weight_values2)):
+                pass
+                if len(self.weight_values2[i]) != 2:
+                    raise kaitaistruct.ConsistencyError(u"weight_values2", 2, len(self.weight_values2[i]))
+
+            if self.tangent._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
+            if self.tangent._parent != self:
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if self.rgba._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"rgba", self._root, self.rgba._root)
+            if self.rgba._parent != self:
+                raise kaitaistruct.ConsistencyError(u"rgba", self, self.rgba._parent)
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 40
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class VertexD877(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.VertexD877, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.position = Mod21.Vec3S2(self._io, self, self._root)
+            self.position._read()
+            self.bone_indices = []
+            for i in range(1):
+                self.bone_indices.append(self._io.read_u2le())
+
             self.normal = Mod21.Vec3U1(self._io, self, self._root)
             self.normal._read()
             self.occlusion = self._io.read_u1()
@@ -4966,55 +5257,76 @@ class Mod21(ReadWriteKaitaiStruct):
             self.uv2._read()
             self.uv3 = Mod21.Vec2HalfFloat(self._io, self, self._root)
             self.uv3._read()
+            self.uv4 = Mod21.Vec2HalfFloat(self._io, self, self._root)
+            self.uv4._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
             self.position._fetch_instances()
+            for i in range(len(self.bone_indices)):
+                pass
+
             self.normal._fetch_instances()
             self.tangent._fetch_instances()
             self.uv._fetch_instances()
             self.uv2._fetch_instances()
             self.uv3._fetch_instances()
+            self.uv4._fetch_instances()
 
 
         def _write__seq(self, io=None):
-            super(Mod21.Vertex1255, self)._write__seq(io)
+            super(Mod21.VertexD877, self)._write__seq(io)
             self.position._write__seq(self._io)
+            for i in range(len(self.bone_indices)):
+                pass
+                self._io.write_u2le(self.bone_indices[i])
+
             self.normal._write__seq(self._io)
             self._io.write_u1(self.occlusion)
             self.tangent._write__seq(self._io)
             self.uv._write__seq(self._io)
             self.uv2._write__seq(self._io)
             self.uv3._write__seq(self._io)
+            self.uv4._write__seq(self._io)
 
 
         def _check(self):
-            pass
             if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
             if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if len(self.bone_indices) != 1:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 1, len(self.bone_indices))
+            for i in range(len(self.bone_indices)):
+                pass
+
             if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
             if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
             if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
             if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
             if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
             if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
             if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
             if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
             if self.uv3._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv3", self._root, self.uv3._root)
             if self.uv3._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv3", self.uv3._parent, self)
+                raise kaitaistruct.ConsistencyError(u"uv3", self, self.uv3._parent)
+            if self.uv4._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"uv4", self._root, self.uv4._root)
+            if self.uv4._parent != self:
+                raise kaitaistruct.ConsistencyError(u"uv4", self, self.uv4._parent)
+            self._dirty = False
 
         @property
         def size_(self):
@@ -5027,112 +5339,27 @@ class Mod21(ReadWriteKaitaiStruct):
         def _invalidate_size_(self):
             del self._m_size_
 
-    class Vec4S2(ReadWriteKaitaiStruct):
+    class VertexD9e8(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod21.VertexD9e8, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
-            self.x = self._io.read_s2le()
-            self.y = self._io.read_s2le()
-            self.z = self._io.read_s2le()
-            self.w = self._io.read_s2le()
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.Vec4S2, self)._write__seq(io)
-            self._io.write_s2le(self.x)
-            self._io.write_s2le(self.y)
-            self._io.write_s2le(self.z)
-            self._io.write_s2le(self.w)
-
-
-        def _check(self):
-            pass
-
-
-    class Group(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.group_index = self._io.read_u4le()
-            self.reserved = []
-            for i in range(3):
-                self.reserved.append(self._io.read_u4le())
-
-            self.pos = Mod21.Vec3(self._io, self, self._root)
-            self.pos._read()
-            self.radius = self._io.read_f4le()
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.reserved)):
-                pass
-
-            self.pos._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.Group, self)._write__seq(io)
-            self._io.write_u4le(self.group_index)
-            for i in range(len(self.reserved)):
-                pass
-                self._io.write_u4le(self.reserved[i])
-
-            self.pos._write__seq(self._io)
-            self._io.write_f4le(self.radius)
-
-
-        def _check(self):
-            pass
-            if (len(self.reserved) != 3):
-                raise kaitaistruct.ConsistencyError(u"reserved", len(self.reserved), 3)
-            for i in range(len(self.reserved)):
-                pass
-
-            if self.pos._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"pos", self.pos._root, self._root)
-            if self.pos._parent != self:
-                raise kaitaistruct.ConsistencyError(u"pos", self.pos._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 32
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class VertexAfa6(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec3(self._io, self, self._root)
+            self.position = Mod21.Vec4S2(self._io, self, self._root)
             self.position._read()
             self.normal = Mod21.Vec3U1(self._io, self, self._root)
             self.normal._read()
             self.occlusion = self._io.read_u1()
             self.tangent = Mod21.Vec4U1(self._io, self, self._root)
             self.tangent._read()
+            self.bone_indices = []
+            for i in range(2):
+                self.bone_indices.append(self._io.read_bytes(2))
+
             self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
             self.uv._read()
-            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -5140,42 +5367,50 @@ class Mod21(ReadWriteKaitaiStruct):
             self.position._fetch_instances()
             self.normal._fetch_instances()
             self.tangent._fetch_instances()
+            for i in range(len(self.bone_indices)):
+                pass
+
             self.uv._fetch_instances()
-            self.uv2._fetch_instances()
 
 
         def _write__seq(self, io=None):
-            super(Mod21.VertexAfa6, self)._write__seq(io)
+            super(Mod21.VertexD9e8, self)._write__seq(io)
             self.position._write__seq(self._io)
             self.normal._write__seq(self._io)
             self._io.write_u1(self.occlusion)
             self.tangent._write__seq(self._io)
+            for i in range(len(self.bone_indices)):
+                pass
+                self._io.write_bytes(self.bone_indices[i])
+
             self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
 
 
         def _check(self):
-            pass
             if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
             if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
             if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
             if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
             if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
             if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if len(self.bone_indices) != 2:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 2, len(self.bone_indices))
+            for i in range(len(self.bone_indices)):
+                pass
+                if len(self.bone_indices[i]) != 2:
+                    raise kaitaistruct.ConsistencyError(u"bone_indices", 2, len(self.bone_indices[i]))
+
             if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
             if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            self._dirty = False
 
         @property
         def size_(self):
@@ -5188,169 +5423,9 @@ class Mod21(ReadWriteKaitaiStruct):
         def _invalidate_size_(self):
             del self._m_size_
 
-    class VertexCb68(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec4S2(self._io, self, self._root)
-            self.position._read()
-            self.bone_indices = []
-            for i in range(4):
-                self.bone_indices.append(self._io.read_u1())
-
-            self.weight_values = []
-            for i in range(4):
-                self.weight_values.append(self._io.read_u1())
-
-            self.normal = Mod21.Vec4U1(self._io, self, self._root)
-            self.normal._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            for i in range(len(self.bone_indices)):
-                pass
-
-            for i in range(len(self.weight_values)):
-                pass
-
-            self.normal._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.VertexCb68, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            for i in range(len(self.bone_indices)):
-                pass
-                self._io.write_u1(self.bone_indices[i])
-
-            for i in range(len(self.weight_values)):
-                pass
-                self._io.write_u1(self.weight_values[i])
-
-            self.normal._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if (len(self.bone_indices) != 4):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 4)
-            for i in range(len(self.bone_indices)):
-                pass
-
-            if (len(self.weight_values) != 4):
-                raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values), 4)
-            for i in range(len(self.weight_values)):
-                pass
-
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 20
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class Vertex9399(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.position = Mod21.Vec3(self._io, self, self._root)
-            self.position._read()
-            self.normal = Mod21.Vec3U1(self._io, self, self._root)
-            self.normal._read()
-            self.occlusion = self._io.read_u1()
-            self.tangent = Mod21.Vec4U1(self._io, self, self._root)
-            self.tangent._read()
-            self.uv = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv._read()
-            self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
-            self.uv2._read()
-            self.rgba = Mod21.Vec4U1(self._io, self, self._root)
-            self.rgba._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.position._fetch_instances()
-            self.normal._fetch_instances()
-            self.tangent._fetch_instances()
-            self.uv._fetch_instances()
-            self.uv2._fetch_instances()
-            self.rgba._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mod21.Vertex9399, self)._write__seq(io)
-            self.position._write__seq(self._io)
-            self.normal._write__seq(self._io)
-            self._io.write_u1(self.occlusion)
-            self.tangent._write__seq(self._io)
-            self.uv._write__seq(self._io)
-            self.uv2._write__seq(self._io)
-            self.rgba._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
-            if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
-            if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
-            if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
-            if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
-            if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
-            if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
-            if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
-            if self.rgba._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._root, self._root)
-            if self.rgba._parent != self:
-                raise kaitaistruct.ConsistencyError(u"rgba", self.rgba._parent, self)
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 32
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
     class VertexDa55(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mod21.VertexDa55, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -5374,6 +5449,7 @@ class Mod21(ReadWriteKaitaiStruct):
 
             self.uv2 = Mod21.Vec2HalfFloat(self._io, self, self._root)
             self.uv2._read()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -5410,39 +5486,39 @@ class Mod21(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
             if self.position._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
             if self.position._parent != self:
-                raise kaitaistruct.ConsistencyError(u"position", self.position._parent, self)
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
             if self.normal._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
             if self.normal._parent != self:
-                raise kaitaistruct.ConsistencyError(u"normal", self.normal._parent, self)
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
             if self.tangent._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"tangent", self._root, self.tangent._root)
             if self.tangent._parent != self:
-                raise kaitaistruct.ConsistencyError(u"tangent", self.tangent._parent, self)
-            if (len(self.bone_indices) != 4):
-                raise kaitaistruct.ConsistencyError(u"bone_indices", len(self.bone_indices), 4)
+                raise kaitaistruct.ConsistencyError(u"tangent", self, self.tangent._parent)
+            if len(self.bone_indices) != 4:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 4, len(self.bone_indices))
             for i in range(len(self.bone_indices)):
                 pass
 
             if self.uv._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv", self._root, self.uv._root)
             if self.uv._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv", self.uv._parent, self)
-            if (len(self.weight_values) != 2):
-                raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values), 2)
+                raise kaitaistruct.ConsistencyError(u"uv", self, self.uv._parent)
+            if len(self.weight_values) != 2:
+                raise kaitaistruct.ConsistencyError(u"weight_values", 2, len(self.weight_values))
             for i in range(len(self.weight_values)):
                 pass
-                if (len(self.weight_values[i]) != 2):
-                    raise kaitaistruct.ConsistencyError(u"weight_values", len(self.weight_values[i]), 2)
+                if len(self.weight_values[i]) != 2:
+                    raise kaitaistruct.ConsistencyError(u"weight_values", 2, len(self.weight_values[i]))
 
             if self.uv2._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"uv2", self._root, self.uv2._root)
             if self.uv2._parent != self:
-                raise kaitaistruct.ConsistencyError(u"uv2", self.uv2._parent, self)
+                raise kaitaistruct.ConsistencyError(u"uv2", self, self.uv2._parent)
+            self._dirty = False
 
         @property
         def size_(self):
@@ -5455,170 +5531,152 @@ class Mod21(ReadWriteKaitaiStruct):
         def _invalidate_size_(self):
             del self._m_size_
 
-    @property
-    def vertex_buffer(self):
-        if self._should_write_vertex_buffer:
-            self._write_vertex_buffer()
-        if hasattr(self, '_m_vertex_buffer'):
-            return self._m_vertex_buffer
+    class VertexDb7d(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.VertexDb7d, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
 
-        _pos = self._io.pos()
-        self._io.seek(self.header.offset_vertex_buffer)
-        self._m_vertex_buffer = self._io.read_bytes(self.header.size_vertex_buffer)
-        self._io.seek(_pos)
-        return getattr(self, '_m_vertex_buffer', None)
+        def _read(self):
+            self.position = Mod21.Vec4S2(self._io, self, self._root)
+            self.position._read()
+            self.normal = Mod21.Vec4U1(self._io, self, self._root)
+            self.normal._read()
+            self.bone_indices = []
+            for i in range(4):
+                self.bone_indices.append(self._io.read_u1())
 
-    @vertex_buffer.setter
-    def vertex_buffer(self, v):
-        self._m_vertex_buffer = v
-
-    def _write_vertex_buffer(self):
-        self._should_write_vertex_buffer = False
-        _pos = self._io.pos()
-        self._io.seek(self.header.offset_vertex_buffer)
-        self._io.write_bytes(self.vertex_buffer)
-        self._io.seek(_pos)
+            self._dirty = False
 
 
-    def _check_vertex_buffer(self):
-        pass
-        if (len(self.vertex_buffer) != self.header.size_vertex_buffer):
-            raise kaitaistruct.ConsistencyError(u"vertex_buffer", len(self.vertex_buffer), self.header.size_vertex_buffer)
-
-    @property
-    def materials_data(self):
-        if self._should_write_materials_data:
-            self._write_materials_data()
-        if hasattr(self, '_m_materials_data'):
-            return self._m_materials_data
-
-        if (self.header.offset_materials_data > 0):
+        def _fetch_instances(self):
             pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_materials_data)
-            self._m_materials_data = Mod21.MaterialsData(self._io, self, self._root)
-            self._m_materials_data._read()
-            self._io.seek(_pos)
+            self.position._fetch_instances()
+            self.normal._fetch_instances()
+            for i in range(len(self.bone_indices)):
+                pass
 
-        return getattr(self, '_m_materials_data', None)
 
-    @materials_data.setter
-    def materials_data(self, v):
-        self._m_materials_data = v
 
-    def _write_materials_data(self):
-        self._should_write_materials_data = False
-        if (self.header.offset_materials_data > 0):
+        def _write__seq(self, io=None):
+            super(Mod21.VertexDb7d, self)._write__seq(io)
+            self.position._write__seq(self._io)
+            self.normal._write__seq(self._io)
+            for i in range(len(self.bone_indices)):
+                pass
+                self._io.write_u1(self.bone_indices[i])
+
+
+
+        def _check(self):
+            if self.position._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"position", self._root, self.position._root)
+            if self.position._parent != self:
+                raise kaitaistruct.ConsistencyError(u"position", self, self.position._parent)
+            if self.normal._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"normal", self._root, self.normal._root)
+            if self.normal._parent != self:
+                raise kaitaistruct.ConsistencyError(u"normal", self, self.normal._parent)
+            if len(self.bone_indices) != 4:
+                raise kaitaistruct.ConsistencyError(u"bone_indices", 4, len(self.bone_indices))
+            for i in range(len(self.bone_indices)):
+                pass
+
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 16
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class WeightBound(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mod21.WeightBound, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.bone_id = self._io.read_u4le()
+            self.unk_01 = Mod21.Vec3(self._io, self, self._root)
+            self.unk_01._read()
+            self.bsphere = Mod21.Vec4(self._io, self, self._root)
+            self.bsphere._read()
+            self.bbox_min = Mod21.Vec4(self._io, self, self._root)
+            self.bbox_min._read()
+            self.bbox_max = Mod21.Vec4(self._io, self, self._root)
+            self.bbox_max._read()
+            self.oabb = Mod21.Matrix4x4(self._io, self, self._root)
+            self.oabb._read()
+            self.oabb_dimension = Mod21.Vec4(self._io, self, self._root)
+            self.oabb_dimension._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
             pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_materials_data)
-            self.materials_data._write__seq(self._io)
-            self._io.seek(_pos)
+            self.unk_01._fetch_instances()
+            self.bsphere._fetch_instances()
+            self.bbox_min._fetch_instances()
+            self.bbox_max._fetch_instances()
+            self.oabb._fetch_instances()
+            self.oabb_dimension._fetch_instances()
 
 
-
-    def _check_materials_data(self):
-        pass
-        if (self.header.offset_materials_data > 0):
-            pass
-            if self.materials_data._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"materials_data", self.materials_data._root, self._root)
-            if self.materials_data._parent != self:
-                raise kaitaistruct.ConsistencyError(u"materials_data", self.materials_data._parent, self)
-
-
-    @property
-    def bones_data_size_(self):
-        if hasattr(self, '_m_bones_data_size_'):
-            return self._m_bones_data_size_
-
-        self._m_bones_data_size_ = (0 if (self.header.num_bones == 0) else self.bones_data.size_)
-        return getattr(self, '_m_bones_data_size_', None)
-
-    def _invalidate_bones_data_size_(self):
-        del self._m_bones_data_size_
-    @property
-    def meshes_data(self):
-        if self._should_write_meshes_data:
-            self._write_meshes_data()
-        if hasattr(self, '_m_meshes_data'):
-            return self._m_meshes_data
-
-        if (self.header.offset_meshes_data > 0):
-            pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_meshes_data)
-            self._m_meshes_data = Mod21.MeshesData(self._io, self, self._root)
-            self._m_meshes_data._read()
-            self._io.seek(_pos)
-
-        return getattr(self, '_m_meshes_data', None)
-
-    @meshes_data.setter
-    def meshes_data(self, v):
-        self._m_meshes_data = v
-
-    def _write_meshes_data(self):
-        self._should_write_meshes_data = False
-        if (self.header.offset_meshes_data > 0):
-            pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_meshes_data)
-            self.meshes_data._write__seq(self._io)
-            self._io.seek(_pos)
+        def _write__seq(self, io=None):
+            super(Mod21.WeightBound, self)._write__seq(io)
+            self._io.write_u4le(self.bone_id)
+            self.unk_01._write__seq(self._io)
+            self.bsphere._write__seq(self._io)
+            self.bbox_min._write__seq(self._io)
+            self.bbox_max._write__seq(self._io)
+            self.oabb._write__seq(self._io)
+            self.oabb_dimension._write__seq(self._io)
 
 
+        def _check(self):
+            if self.unk_01._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"unk_01", self._root, self.unk_01._root)
+            if self.unk_01._parent != self:
+                raise kaitaistruct.ConsistencyError(u"unk_01", self, self.unk_01._parent)
+            if self.bsphere._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"bsphere", self._root, self.bsphere._root)
+            if self.bsphere._parent != self:
+                raise kaitaistruct.ConsistencyError(u"bsphere", self, self.bsphere._parent)
+            if self.bbox_min._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"bbox_min", self._root, self.bbox_min._root)
+            if self.bbox_min._parent != self:
+                raise kaitaistruct.ConsistencyError(u"bbox_min", self, self.bbox_min._parent)
+            if self.bbox_max._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"bbox_max", self._root, self.bbox_max._root)
+            if self.bbox_max._parent != self:
+                raise kaitaistruct.ConsistencyError(u"bbox_max", self, self.bbox_max._parent)
+            if self.oabb._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"oabb", self._root, self.oabb._root)
+            if self.oabb._parent != self:
+                raise kaitaistruct.ConsistencyError(u"oabb", self, self.oabb._parent)
+            if self.oabb_dimension._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"oabb_dimension", self._root, self.oabb_dimension._root)
+            if self.oabb_dimension._parent != self:
+                raise kaitaistruct.ConsistencyError(u"oabb_dimension", self, self.oabb_dimension._parent)
+            self._dirty = False
 
-    def _check_meshes_data(self):
-        pass
-        if (self.header.offset_meshes_data > 0):
-            pass
-            if self.meshes_data._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"meshes_data", self.meshes_data._root, self._root)
-            if self.meshes_data._parent != self:
-                raise kaitaistruct.ConsistencyError(u"meshes_data", self.meshes_data._parent, self)
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
 
+            self._m_size_ = 144
+            return getattr(self, '_m_size_', None)
 
-    @property
-    def index_buffer(self):
-        if self._should_write_index_buffer:
-            self._write_index_buffer()
-        if hasattr(self, '_m_index_buffer'):
-            return self._m_index_buffer
+        def _invalidate_size_(self):
+            del self._m_size_
 
-        _pos = self._io.pos()
-        self._io.seek(self.header.offset_index_buffer)
-        self._m_index_buffer = self._io.read_bytes((self.header.num_faces * 2))
-        self._io.seek(_pos)
-        return getattr(self, '_m_index_buffer', None)
-
-    @index_buffer.setter
-    def index_buffer(self, v):
-        self._m_index_buffer = v
-
-    def _write_index_buffer(self):
-        self._should_write_index_buffer = False
-        _pos = self._io.pos()
-        self._io.seek(self.header.offset_index_buffer)
-        self._io.write_bytes(self.index_buffer)
-        self._io.seek(_pos)
-
-
-    def _check_index_buffer(self):
-        pass
-        if (len(self.index_buffer) != (self.header.num_faces * 2)):
-            raise kaitaistruct.ConsistencyError(u"index_buffer", len(self.index_buffer), (self.header.num_faces * 2))
-
-    @property
-    def size_top_level_(self):
-        if hasattr(self, '_m_size_top_level_'):
-            return self._m_size_top_level_
-
-        self._m_size_top_level_ = ((self._root.header.size_ + 68) if  (((self._root.header.version == 210)) or ((self._root.header.version == 212)))  else (self._root.header.size_ + 64))
-        return getattr(self, '_m_size_top_level_', None)
-
-    def _invalidate_size_top_level_(self):
-        del self._m_size_top_level_
     @property
     def bones_data(self):
         if self._should_write_bones_data:
@@ -5626,7 +5684,10 @@ class Mod21(ReadWriteKaitaiStruct):
         if hasattr(self, '_m_bones_data'):
             return self._m_bones_data
 
-        if (self.header.num_bones != 0):
+        if not self.bones_data__enabled:
+            return None
+
+        if self.header.num_bones != 0:
             pass
             _pos = self._io.pos()
             self._io.seek(self.header.offset_bones_data)
@@ -5638,29 +5699,29 @@ class Mod21(ReadWriteKaitaiStruct):
 
     @bones_data.setter
     def bones_data(self, v):
+        self._dirty = True
         self._m_bones_data = v
 
     def _write_bones_data(self):
         self._should_write_bones_data = False
-        if (self.header.num_bones != 0):
+        if self.header.num_bones != 0:
             pass
             _pos = self._io.pos()
             self._io.seek(self.header.offset_bones_data)
-            self.bones_data._write__seq(self._io)
+            self._m_bones_data._write__seq(self._io)
             self._io.seek(_pos)
 
 
+    @property
+    def bones_data_size_(self):
+        if hasattr(self, '_m_bones_data_size_'):
+            return self._m_bones_data_size_
 
-    def _check_bones_data(self):
-        pass
-        if (self.header.num_bones != 0):
-            pass
-            if self.bones_data._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"bones_data", self.bones_data._root, self._root)
-            if self.bones_data._parent != self:
-                raise kaitaistruct.ConsistencyError(u"bones_data", self.bones_data._parent, self)
+        self._m_bones_data_size_ = (0 if self.header.num_bones == 0 else self.bones_data.size_)
+        return getattr(self, '_m_bones_data_size_', None)
 
-
+    def _invalidate_bones_data_size_(self):
+        del self._m_bones_data_size_
     @property
     def groups(self):
         if self._should_write_groups:
@@ -5668,19 +5729,25 @@ class Mod21(ReadWriteKaitaiStruct):
         if hasattr(self, '_m_groups'):
             return self._m_groups
 
+        if not self.groups__enabled:
+            return None
+
         _pos = self._io.pos()
         self._io.seek(self.header.offset_groups)
         self._m_groups = []
         for i in range(self.header.num_groups):
             _t__m_groups = Mod21.Group(self._io, self, self._root)
-            _t__m_groups._read()
-            self._m_groups.append(_t__m_groups)
+            try:
+                _t__m_groups._read()
+            finally:
+                self._m_groups.append(_t__m_groups)
 
         self._io.seek(_pos)
         return getattr(self, '_m_groups', None)
 
     @groups.setter
     def groups(self, v):
+        self._dirty = True
         self._m_groups = v
 
     def _write_groups(self):
@@ -5689,31 +5756,154 @@ class Mod21(ReadWriteKaitaiStruct):
         self._io.seek(self.header.offset_groups)
         for i in range(len(self._m_groups)):
             pass
-            self.groups[i]._write__seq(self._io)
+            self._m_groups[i]._write__seq(self._io)
 
         self._io.seek(_pos)
-
-
-    def _check_groups(self):
-        pass
-        if (len(self.groups) != self.header.num_groups):
-            raise kaitaistruct.ConsistencyError(u"groups", len(self.groups), self.header.num_groups)
-        for i in range(len(self._m_groups)):
-            pass
-            if self.groups[i]._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"groups", self.groups[i]._root, self._root)
-            if self.groups[i]._parent != self:
-                raise kaitaistruct.ConsistencyError(u"groups", self.groups[i]._parent, self)
-
 
     @property
     def groups_size_(self):
         if hasattr(self, '_m_groups_size_'):
             return self._m_groups_size_
 
-        self._m_groups_size_ = (self.groups[0].size_ * self.header.num_groups)
+        self._m_groups_size_ = self.groups[0].size_ * self.header.num_groups
         return getattr(self, '_m_groups_size_', None)
 
     def _invalidate_groups_size_(self):
         del self._m_groups_size_
+    @property
+    def index_buffer(self):
+        if self._should_write_index_buffer:
+            self._write_index_buffer()
+        if hasattr(self, '_m_index_buffer'):
+            return self._m_index_buffer
+
+        if not self.index_buffer__enabled:
+            return None
+
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_index_buffer)
+        self._m_index_buffer = self._io.read_bytes(self.header.num_faces * 2)
+        self._io.seek(_pos)
+        return getattr(self, '_m_index_buffer', None)
+
+    @index_buffer.setter
+    def index_buffer(self, v):
+        self._dirty = True
+        self._m_index_buffer = v
+
+    def _write_index_buffer(self):
+        self._should_write_index_buffer = False
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_index_buffer)
+        self._io.write_bytes(self._m_index_buffer)
+        self._io.seek(_pos)
+
+    @property
+    def materials_data(self):
+        if self._should_write_materials_data:
+            self._write_materials_data()
+        if hasattr(self, '_m_materials_data'):
+            return self._m_materials_data
+
+        if not self.materials_data__enabled:
+            return None
+
+        if self.header.offset_materials_data > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_materials_data)
+            self._m_materials_data = Mod21.MaterialsData(self._io, self, self._root)
+            self._m_materials_data._read()
+            self._io.seek(_pos)
+
+        return getattr(self, '_m_materials_data', None)
+
+    @materials_data.setter
+    def materials_data(self, v):
+        self._dirty = True
+        self._m_materials_data = v
+
+    def _write_materials_data(self):
+        self._should_write_materials_data = False
+        if self.header.offset_materials_data > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_materials_data)
+            self._m_materials_data._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    @property
+    def meshes_data(self):
+        if self._should_write_meshes_data:
+            self._write_meshes_data()
+        if hasattr(self, '_m_meshes_data'):
+            return self._m_meshes_data
+
+        if not self.meshes_data__enabled:
+            return None
+
+        if self.header.offset_meshes_data > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_meshes_data)
+            self._m_meshes_data = Mod21.MeshesData(self._io, self, self._root)
+            self._m_meshes_data._read()
+            self._io.seek(_pos)
+
+        return getattr(self, '_m_meshes_data', None)
+
+    @meshes_data.setter
+    def meshes_data(self, v):
+        self._dirty = True
+        self._m_meshes_data = v
+
+    def _write_meshes_data(self):
+        self._should_write_meshes_data = False
+        if self.header.offset_meshes_data > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_meshes_data)
+            self._m_meshes_data._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    @property
+    def size_top_level_(self):
+        if hasattr(self, '_m_size_top_level_'):
+            return self._m_size_top_level_
+
+        self._m_size_top_level_ = (self._root.header.size_ + 68 if  ((self._root.header.version == 210) or (self._root.header.version == 212))  else self._root.header.size_ + 64)
+        return getattr(self, '_m_size_top_level_', None)
+
+    def _invalidate_size_top_level_(self):
+        del self._m_size_top_level_
+    @property
+    def vertex_buffer(self):
+        if self._should_write_vertex_buffer:
+            self._write_vertex_buffer()
+        if hasattr(self, '_m_vertex_buffer'):
+            return self._m_vertex_buffer
+
+        if not self.vertex_buffer__enabled:
+            return None
+
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_vertex_buffer)
+        self._m_vertex_buffer = self._io.read_bytes(self.header.size_vertex_buffer)
+        self._io.seek(_pos)
+        return getattr(self, '_m_vertex_buffer', None)
+
+    @vertex_buffer.setter
+    def vertex_buffer(self, v):
+        self._dirty = True
+        self._m_vertex_buffer = v
+
+    def _write_vertex_buffer(self):
+        self._should_write_vertex_buffer = False
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_vertex_buffer)
+        self._io.write_bytes(self._m_vertex_buffer)
+        self._io.seek(_pos)
+
 

--- a/albam/engines/mtfw/structs/mrl.ksy
+++ b/albam/engines/mtfw/structs/mrl.ksy
@@ -3,7 +3,7 @@ meta:
   bit-endian: le
   file-extension: mrl
   id: mrl
-  ks-version: 0.10
+  ks-version: '0.11'
   title: MTFramework material format
 
 params:

--- a/albam/engines/mtfw/structs/mrl.py
+++ b/albam/engines/mtfw/structs/mrl.py
@@ -6,10 +6,17 @@ from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
 from enum import IntEnum
 
 
-if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 11):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.11 or later is required, but you have %s" % (kaitaistruct.__version__))
 
 class Mrl(ReadWriteKaitaiStruct):
+
+    class CmdType(IntEnum):
+        set_flag = 0
+        set_constant_buffer = 1
+        set_sampler_state = 2
+        set_texture = 3
+        set_unk = 4
 
     class MaterialType(IntEnum):
         type_n_draw__material_null = 139777156
@@ -18,17 +25,6 @@ class Mrl(ReadWriteKaitaiStruct):
         type_n_draw__dd_material_water = 819701071
         type_n_draw__material_std = 1605430244
         type_n_draw__material_std_est = 2099982771
-
-    class TextureType(IntEnum):
-        type_r_texture = 606035435
-        type_r_render_target_texture = 2013850128
-
-    class CmdType(IntEnum):
-        set_flag = 0
-        set_constant_buffer = 1
-        set_sampler_state = 2
-        set_texture = 3
-        set_unk = 4
 
     class ShaderObjectHash(IntEnum):
         flinearcolor = 144
@@ -3015,15 +3011,19 @@ class Mrl(ReadWriteKaitaiStruct):
         cbshadowreceive0 = 1048082
         fgrassbillboardposition = 1048090
         fsystemcopygamma = 1048350
+
+    class TextureType(IntEnum):
+        type_r_texture = 606035435
+        type_r_render_target_texture = 2013850128
     def __init__(self, app_id, _io=None, _parent=None, _root=None):
-        self._io = _io
+        super(Mrl, self).__init__(_io)
         self._parent = _parent
-        self._root = _root if _root else self
+        self._root = _root or self
         self.app_id = app_id
 
     def _read(self):
         self.id_magic = self._io.read_bytes(4)
-        if not (self.id_magic == b"\x4D\x52\x4C\x00"):
+        if not self.id_magic == b"\x4D\x52\x4C\x00":
             raise kaitaistruct.ValidationNotEqualError(b"\x4D\x52\x4C\x00", self.id_magic, self._io, u"/seq/0")
         self.version = self._io.read_u4le()
         self.num_materials = self._io.read_u4le()
@@ -3034,15 +3034,20 @@ class Mrl(ReadWriteKaitaiStruct):
         self.textures = []
         for i in range(self.num_textures):
             _t_textures = Mrl.TextureSlot(self._io, self, self._root)
-            _t_textures._read()
-            self.textures.append(_t_textures)
+            try:
+                _t_textures._read()
+            finally:
+                self.textures.append(_t_textures)
 
         self.materials = []
         for i in range(self.num_materials):
             _t_materials = Mrl.Material(self._io, self, self._root)
-            _t_materials._read()
-            self.materials.append(_t_materials)
+            try:
+                _t_materials._read()
+            finally:
+                self.materials.append(_t_materials)
 
+        self._dirty = False
 
 
     def _fetch_instances(self):
@@ -3077,33 +3082,520 @@ class Mrl(ReadWriteKaitaiStruct):
 
 
     def _check(self):
-        pass
-        if (len(self.id_magic) != 4):
-            raise kaitaistruct.ConsistencyError(u"id_magic", len(self.id_magic), 4)
-        if not (self.id_magic == b"\x4D\x52\x4C\x00"):
+        if len(self.id_magic) != 4:
+            raise kaitaistruct.ConsistencyError(u"id_magic", 4, len(self.id_magic))
+        if not self.id_magic == b"\x4D\x52\x4C\x00":
             raise kaitaistruct.ValidationNotEqualError(b"\x4D\x52\x4C\x00", self.id_magic, None, u"/seq/0")
-        if (len(self.textures) != self.num_textures):
-            raise kaitaistruct.ConsistencyError(u"textures", len(self.textures), self.num_textures)
+        if len(self.textures) != self.num_textures:
+            raise kaitaistruct.ConsistencyError(u"textures", self.num_textures, len(self.textures))
         for i in range(len(self.textures)):
             pass
             if self.textures[i]._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"textures", self.textures[i]._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"textures", self._root, self.textures[i]._root)
             if self.textures[i]._parent != self:
-                raise kaitaistruct.ConsistencyError(u"textures", self.textures[i]._parent, self)
+                raise kaitaistruct.ConsistencyError(u"textures", self, self.textures[i]._parent)
 
-        if (len(self.materials) != self.num_materials):
-            raise kaitaistruct.ConsistencyError(u"materials", len(self.materials), self.num_materials)
+        if len(self.materials) != self.num_materials:
+            raise kaitaistruct.ConsistencyError(u"materials", self.num_materials, len(self.materials))
         for i in range(len(self.materials)):
             pass
             if self.materials[i]._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"materials", self.materials[i]._root, self._root)
+                raise kaitaistruct.ConsistencyError(u"materials", self._root, self.materials[i]._root)
             if self.materials[i]._parent != self:
-                raise kaitaistruct.ConsistencyError(u"materials", self.materials[i]._parent, self)
+                raise kaitaistruct.ConsistencyError(u"materials", self, self.materials[i]._parent)
+
+        self._dirty = False
+
+    class AnimData(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.AnimData, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.entry_count = self._io.read_u4le()
+            self.ofs_to_info = []
+            for i in range(self.entry_count):
+                _t_ofs_to_info = Mrl.AnimOfs(self._io, self, self._root)
+                try:
+                    _t_ofs_to_info._read()
+                finally:
+                    self.ofs_to_info.append(_t_ofs_to_info)
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.ofs_to_info)):
+                pass
+                self.ofs_to_info[i]._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.AnimData, self)._write__seq(io)
+            self._io.write_u4le(self.entry_count)
+            for i in range(len(self.ofs_to_info)):
+                pass
+                self.ofs_to_info[i]._write__seq(self._io)
+
+
+
+        def _check(self):
+            if len(self.ofs_to_info) != self.entry_count:
+                raise kaitaistruct.ConsistencyError(u"ofs_to_info", self.entry_count, len(self.ofs_to_info))
+            for i in range(len(self.ofs_to_info)):
+                pass
+                if self.ofs_to_info[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"ofs_to_info", self._root, self.ofs_to_info[i]._root)
+                if self.ofs_to_info[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"ofs_to_info", self, self.ofs_to_info[i]._parent)
+
+            self._dirty = False
+
+        @property
+        def ofs_base(self):
+            if hasattr(self, '_m_ofs_base'):
+                return self._m_ofs_base
+
+            self._m_ofs_base = self._parent.ofs_anim_data
+            return getattr(self, '_m_ofs_base', None)
+
+        def _invalidate_ofs_base(self):
+            del self._m_ofs_base
+
+    class AnimDataInfo(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.AnimDataInfo, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.type = self._io.read_bits_int_le(4)
+            self.unk_00 = self._io.read_bits_int_le(4)
+            self.num_entry = self._io.read_bits_int_le(24)
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.AnimDataInfo, self)._write__seq(io)
+            self._io.write_bits_int_le(4, self.type)
+            self._io.write_bits_int_le(4, self.unk_00)
+            self._io.write_bits_int_le(24, self.num_entry)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class AnimEntry(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.AnimEntry, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.unk_00 = self._io.read_u4le()
+            self.info = Mrl.AnimInfo(self._io, self, self._root)
+            self.info._read()
+            self.ofs_list_entry1 = self._io.read_u4le()
+            self.unk_hash = self._io.read_u4le()
+            self.ofs_entry2 = []
+            for i in range(self.info.num_entry2):
+                _t_ofs_entry2 = Mrl.BlockOffset(self._io, self, self._root)
+                try:
+                    _t_ofs_entry2._read()
+                finally:
+                    self.ofs_entry2.append(_t_ofs_entry2)
+
+            self.set_buff_hash = []
+            for i in range(self.info.num_entry1):
+                self.set_buff_hash.append(self._io.read_u4le())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.info._fetch_instances()
+            for i in range(len(self.ofs_entry2)):
+                pass
+                self.ofs_entry2[i]._fetch_instances()
+
+            for i in range(len(self.set_buff_hash)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.AnimEntry, self)._write__seq(io)
+            self._io.write_u4le(self.unk_00)
+            self.info._write__seq(self._io)
+            self._io.write_u4le(self.ofs_list_entry1)
+            self._io.write_u4le(self.unk_hash)
+            for i in range(len(self.ofs_entry2)):
+                pass
+                self.ofs_entry2[i]._write__seq(self._io)
+
+            for i in range(len(self.set_buff_hash)):
+                pass
+                self._io.write_u4le(self.set_buff_hash[i])
+
+
+
+        def _check(self):
+            if self.info._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"info", self._root, self.info._root)
+            if self.info._parent != self:
+                raise kaitaistruct.ConsistencyError(u"info", self, self.info._parent)
+            if len(self.ofs_entry2) != self.info.num_entry2:
+                raise kaitaistruct.ConsistencyError(u"ofs_entry2", self.info.num_entry2, len(self.ofs_entry2))
+            for i in range(len(self.ofs_entry2)):
+                pass
+                if self.ofs_entry2[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"ofs_entry2", self._root, self.ofs_entry2[i]._root)
+                if self.ofs_entry2[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"ofs_entry2", self, self.ofs_entry2[i]._parent)
+
+            if len(self.set_buff_hash) != self.info.num_entry1:
+                raise kaitaistruct.ConsistencyError(u"set_buff_hash", self.info.num_entry1, len(self.set_buff_hash))
+            for i in range(len(self.set_buff_hash)):
+                pass
+
+            self._dirty = False
+
+
+    class AnimInfo(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.AnimInfo, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.unk = self._io.read_bits_int_le(2)
+            self.num_entry2 = self._io.read_bits_int_le(16)
+            self.num_entry1 = self._io.read_bits_int_le(14)
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.AnimInfo, self)._write__seq(io)
+            self._io.write_bits_int_le(2, self.unk)
+            self._io.write_bits_int_le(16, self.num_entry2)
+            self._io.write_bits_int_le(14, self.num_entry1)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class AnimOfs(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.AnimOfs, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_anim_entries = False
+            self.anim_entries__enabled = True
+
+        def _read(self):
+            self.ofs_block = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.anim_entries
+            if hasattr(self, '_m_anim_entries'):
+                pass
+                self._m_anim_entries._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.AnimOfs, self)._write__seq(io)
+            self._should_write_anim_entries = self.anim_entries__enabled
+            self._io.write_u4le(self.ofs_block)
+
+
+        def _check(self):
+            if self.anim_entries__enabled:
+                pass
+                if self._m_anim_entries._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"anim_entries", self._root, self._m_anim_entries._root)
+                if self._m_anim_entries._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"anim_entries", self, self._m_anim_entries._parent)
+
+            self._dirty = False
+
+        @property
+        def anim_entries(self):
+            if self._should_write_anim_entries:
+                self._write_anim_entries()
+            if hasattr(self, '_m_anim_entries'):
+                return self._m_anim_entries
+
+            if not self.anim_entries__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_anim_data + self.ofs_block)
+            self._m_anim_entries = Mrl.AnimEntry(self._io, self, self._root)
+            self._m_anim_entries._read()
+            self._io.seek(_pos)
+            return getattr(self, '_m_anim_entries', None)
+
+        @anim_entries.setter
+        def anim_entries(self, v):
+            self._dirty = True
+            self._m_anim_entries = v
+
+        def _write_anim_entries(self):
+            self._should_write_anim_entries = False
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_anim_data + self.ofs_block)
+            self._m_anim_entries._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    class AnimSubEntry(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.AnimSubEntry, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.shader_hash = self._io.read_u4le()
+            self.info = Mrl.AnimDataInfo(self._io, self, self._root)
+            self.info._read()
+            _on = self.info.type
+            if _on == 0:
+                pass
+                self.entry = Mrl.AnimSubEntry0(self._io, self, self._root)
+                self.entry._read()
+            elif _on == 1:
+                pass
+                self.entry = Mrl.AnimSubEntry1(self._io, self, self._root)
+                self.entry._read()
+            elif _on == 2:
+                pass
+                self.entry = Mrl.AnimSubEntry2(self._io, self, self._root)
+                self.entry._read()
+            elif _on == 3:
+                pass
+                self.entry = Mrl.AnimSubEntry3(self._io, self, self._root)
+                self.entry._read()
+            elif _on == 4:
+                pass
+                self.entry = Mrl.AnimSubEntry4(self._io, self, self._root)
+                self.entry._read()
+            elif _on == 5:
+                pass
+                self.entry = Mrl.AnimSubEntry5(self._io, self, self._root)
+                self.entry._read()
+            elif _on == 6:
+                pass
+                self.entry = Mrl.AnimSubEntry6(self._io, self, self._root)
+                self.entry._read()
+            elif _on == 7:
+                pass
+                self.entry = Mrl.AnimSubEntry7(self._io, self, self._root)
+                self.entry._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.info._fetch_instances()
+            _on = self.info.type
+            if _on == 0:
+                pass
+                self.entry._fetch_instances()
+            elif _on == 1:
+                pass
+                self.entry._fetch_instances()
+            elif _on == 2:
+                pass
+                self.entry._fetch_instances()
+            elif _on == 3:
+                pass
+                self.entry._fetch_instances()
+            elif _on == 4:
+                pass
+                self.entry._fetch_instances()
+            elif _on == 5:
+                pass
+                self.entry._fetch_instances()
+            elif _on == 6:
+                pass
+                self.entry._fetch_instances()
+            elif _on == 7:
+                pass
+                self.entry._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.AnimSubEntry, self)._write__seq(io)
+            self._io.write_u4le(self.shader_hash)
+            self.info._write__seq(self._io)
+            _on = self.info.type
+            if _on == 0:
+                pass
+                self.entry._write__seq(self._io)
+            elif _on == 1:
+                pass
+                self.entry._write__seq(self._io)
+            elif _on == 2:
+                pass
+                self.entry._write__seq(self._io)
+            elif _on == 3:
+                pass
+                self.entry._write__seq(self._io)
+            elif _on == 4:
+                pass
+                self.entry._write__seq(self._io)
+            elif _on == 5:
+                pass
+                self.entry._write__seq(self._io)
+            elif _on == 6:
+                pass
+                self.entry._write__seq(self._io)
+            elif _on == 7:
+                pass
+                self.entry._write__seq(self._io)
+
+
+        def _check(self):
+            if self.info._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"info", self._root, self.info._root)
+            if self.info._parent != self:
+                raise kaitaistruct.ConsistencyError(u"info", self, self.info._parent)
+            _on = self.info.type
+            if _on == 0:
+                pass
+                if self.entry._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"entry", self._root, self.entry._root)
+                if self.entry._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"entry", self, self.entry._parent)
+            elif _on == 1:
+                pass
+                if self.entry._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"entry", self._root, self.entry._root)
+                if self.entry._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"entry", self, self.entry._parent)
+            elif _on == 2:
+                pass
+                if self.entry._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"entry", self._root, self.entry._root)
+                if self.entry._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"entry", self, self.entry._parent)
+            elif _on == 3:
+                pass
+                if self.entry._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"entry", self._root, self.entry._root)
+                if self.entry._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"entry", self, self.entry._parent)
+            elif _on == 4:
+                pass
+                if self.entry._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"entry", self._root, self.entry._root)
+                if self.entry._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"entry", self, self.entry._parent)
+            elif _on == 5:
+                pass
+                if self.entry._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"entry", self._root, self.entry._root)
+                if self.entry._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"entry", self, self.entry._parent)
+            elif _on == 6:
+                pass
+                if self.entry._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"entry", self._root, self.entry._root)
+                if self.entry._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"entry", self, self.entry._parent)
+            elif _on == 7:
+                pass
+                if self.entry._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"entry", self._root, self.entry._root)
+                if self.entry._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"entry", self, self.entry._parent)
+            self._dirty = False
+
+
+    class AnimSubEntry0(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.AnimSubEntry0, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.header = []
+            for i in range(4):
+                self.header.append(self._io.read_u1())
+
+            self.values = []
+            for i in range(self._parent.info.num_entry):
+                _t_values = Mrl.AnimType0(self._io, self, self._root)
+                try:
+                    _t_values._read()
+                finally:
+                    self.values.append(_t_values)
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.header)):
+                pass
+
+            for i in range(len(self.values)):
+                pass
+                self.values[i]._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.AnimSubEntry0, self)._write__seq(io)
+            for i in range(len(self.header)):
+                pass
+                self._io.write_u1(self.header[i])
+
+            for i in range(len(self.values)):
+                pass
+                self.values[i]._write__seq(self._io)
+
+
+
+        def _check(self):
+            if len(self.header) != 4:
+                raise kaitaistruct.ConsistencyError(u"header", 4, len(self.header))
+            for i in range(len(self.header)):
+                pass
+
+            if len(self.values) != self._parent.info.num_entry:
+                raise kaitaistruct.ConsistencyError(u"values", self._parent.info.num_entry, len(self.values))
+            for i in range(len(self.values)):
+                pass
+                if self.values[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"values", self._root, self.values[i]._root)
+                if self.values[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"values", self, self.values[i]._parent)
+
+            self._dirty = False
 
 
     class AnimSubEntry1(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mrl.AnimSubEntry1, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -3115,9 +3607,12 @@ class Mrl(ReadWriteKaitaiStruct):
             self.values = []
             for i in range(self._parent.info.num_entry):
                 _t_values = Mrl.AnimType1(self._io, self, self._root)
-                _t_values._read()
-                self.values.append(_t_values)
+                try:
+                    _t_values._read()
+                finally:
+                    self.values.append(_t_values)
 
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -3144,66 +3639,660 @@ class Mrl(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
-            if (len(self.header) != 4):
-                raise kaitaistruct.ConsistencyError(u"header", len(self.header), 4)
+            if len(self.header) != 4:
+                raise kaitaistruct.ConsistencyError(u"header", 4, len(self.header))
             for i in range(len(self.header)):
                 pass
 
-            if (len(self.values) != self._parent.info.num_entry):
-                raise kaitaistruct.ConsistencyError(u"values", len(self.values), self._parent.info.num_entry)
+            if len(self.values) != self._parent.info.num_entry:
+                raise kaitaistruct.ConsistencyError(u"values", self._parent.info.num_entry, len(self.values))
             for i in range(len(self.values)):
                 pass
                 if self.values[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"values", self.values[i]._root, self._root)
+                    raise kaitaistruct.ConsistencyError(u"values", self._root, self.values[i]._root)
                 if self.values[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"values", self.values[i]._parent, self)
+                    raise kaitaistruct.ConsistencyError(u"values", self, self.values[i]._parent)
+
+            self._dirty = False
 
 
-
-    class CbMaterial(ReadWriteKaitaiStruct):
+    class AnimSubEntry2(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mrl.AnimSubEntry2, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.header = []
+            for i in range(12):
+                self.header.append(self._io.read_u1())
+
+            self.values = []
+            for i in range(8 * self._parent.info.num_entry):
+                self.values.append(self._io.read_u1())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.header)):
+                pass
+
+            for i in range(len(self.values)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.AnimSubEntry2, self)._write__seq(io)
+            for i in range(len(self.header)):
+                pass
+                self._io.write_u1(self.header[i])
+
+            for i in range(len(self.values)):
+                pass
+                self._io.write_u1(self.values[i])
+
+
+
+        def _check(self):
+            if len(self.header) != 12:
+                raise kaitaistruct.ConsistencyError(u"header", 12, len(self.header))
+            for i in range(len(self.header)):
+                pass
+
+            if len(self.values) != 8 * self._parent.info.num_entry:
+                raise kaitaistruct.ConsistencyError(u"values", 8 * self._parent.info.num_entry, len(self.values))
+            for i in range(len(self.values)):
+                pass
+
+            self._dirty = False
+
+
+    class AnimSubEntry3(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.AnimSubEntry3, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.header = []
+            for i in range(24):
+                self.header.append(self._io.read_u1())
+
+            self.values = []
+            for i in range(16 * (self._parent.info.num_entry - 1)):
+                self.values.append(self._io.read_u1())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.header)):
+                pass
+
+            for i in range(len(self.values)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.AnimSubEntry3, self)._write__seq(io)
+            for i in range(len(self.header)):
+                pass
+                self._io.write_u1(self.header[i])
+
+            for i in range(len(self.values)):
+                pass
+                self._io.write_u1(self.values[i])
+
+
+
+        def _check(self):
+            if len(self.header) != 24:
+                raise kaitaistruct.ConsistencyError(u"header", 24, len(self.header))
+            for i in range(len(self.header)):
+                pass
+
+            if len(self.values) != 16 * (self._parent.info.num_entry - 1):
+                raise kaitaistruct.ConsistencyError(u"values", 16 * (self._parent.info.num_entry - 1), len(self.values))
+            for i in range(len(self.values)):
+                pass
+
+            self._dirty = False
+
+
+    class AnimSubEntry4(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.AnimSubEntry4, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.header = []
+            for i in range(4):
+                self.header.append(self._io.read_u1())
+
+            self.values = []
+            for i in range(self._parent.info.num_entry):
+                _t_values = Mrl.AnimType4(self._io, self, self._root)
+                try:
+                    _t_values._read()
+                finally:
+                    self.values.append(_t_values)
+
+            self.hash = []
+            for i in range(self._parent.info.num_entry):
+                self.hash.append(self._io.read_u4le())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.header)):
+                pass
+
+            for i in range(len(self.values)):
+                pass
+                self.values[i]._fetch_instances()
+
+            for i in range(len(self.hash)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.AnimSubEntry4, self)._write__seq(io)
+            for i in range(len(self.header)):
+                pass
+                self._io.write_u1(self.header[i])
+
+            for i in range(len(self.values)):
+                pass
+                self.values[i]._write__seq(self._io)
+
+            for i in range(len(self.hash)):
+                pass
+                self._io.write_u4le(self.hash[i])
+
+
+
+        def _check(self):
+            if len(self.header) != 4:
+                raise kaitaistruct.ConsistencyError(u"header", 4, len(self.header))
+            for i in range(len(self.header)):
+                pass
+
+            if len(self.values) != self._parent.info.num_entry:
+                raise kaitaistruct.ConsistencyError(u"values", self._parent.info.num_entry, len(self.values))
+            for i in range(len(self.values)):
+                pass
+                if self.values[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"values", self._root, self.values[i]._root)
+                if self.values[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"values", self, self.values[i]._parent)
+
+            if len(self.hash) != self._parent.info.num_entry:
+                raise kaitaistruct.ConsistencyError(u"hash", self._parent.info.num_entry, len(self.hash))
+            for i in range(len(self.hash)):
+                pass
+
+            self._dirty = False
+
+
+    class AnimSubEntry5(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.AnimSubEntry5, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.header = []
+            for i in range(12):
+                self.header.append(self._io.read_u1())
+
+            self.values = []
+            for i in range(8 * self._parent.info.num_entry):
+                self.values.append(self._io.read_u1())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.header)):
+                pass
+
+            for i in range(len(self.values)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.AnimSubEntry5, self)._write__seq(io)
+            for i in range(len(self.header)):
+                pass
+                self._io.write_u1(self.header[i])
+
+            for i in range(len(self.values)):
+                pass
+                self._io.write_u1(self.values[i])
+
+
+
+        def _check(self):
+            if len(self.header) != 12:
+                raise kaitaistruct.ConsistencyError(u"header", 12, len(self.header))
+            for i in range(len(self.header)):
+                pass
+
+            if len(self.values) != 8 * self._parent.info.num_entry:
+                raise kaitaistruct.ConsistencyError(u"values", 8 * self._parent.info.num_entry, len(self.values))
+            for i in range(len(self.values)):
+                pass
+
+            self._dirty = False
+
+
+    class AnimSubEntry6(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.AnimSubEntry6, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.header = []
+            for i in range(4):
+                self.header.append(self._io.read_u1())
+
+            self.values = []
+            for i in range(self._parent.info.num_entry):
+                _t_values = Mrl.AnimType6(self._io, self, self._root)
+                try:
+                    _t_values._read()
+                finally:
+                    self.values.append(_t_values)
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.header)):
+                pass
+
+            for i in range(len(self.values)):
+                pass
+                self.values[i]._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.AnimSubEntry6, self)._write__seq(io)
+            for i in range(len(self.header)):
+                pass
+                self._io.write_u1(self.header[i])
+
+            for i in range(len(self.values)):
+                pass
+                self.values[i]._write__seq(self._io)
+
+
+
+        def _check(self):
+            if len(self.header) != 4:
+                raise kaitaistruct.ConsistencyError(u"header", 4, len(self.header))
+            for i in range(len(self.header)):
+                pass
+
+            if len(self.values) != self._parent.info.num_entry:
+                raise kaitaistruct.ConsistencyError(u"values", self._parent.info.num_entry, len(self.values))
+            for i in range(len(self.values)):
+                pass
+                if self.values[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"values", self._root, self.values[i]._root)
+                if self.values[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"values", self, self.values[i]._parent)
+
+            self._dirty = False
+
+
+    class AnimSubEntry7(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.AnimSubEntry7, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.header = []
+            for i in range(36):
+                self.header.append(self._io.read_u1())
+
+            self.values = []
+            for i in range(24 * (self._parent.info.num_entry - 1)):
+                self.values.append(self._io.read_u1())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.header)):
+                pass
+
+            for i in range(len(self.values)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.AnimSubEntry7, self)._write__seq(io)
+            for i in range(len(self.header)):
+                pass
+                self._io.write_u1(self.header[i])
+
+            for i in range(len(self.values)):
+                pass
+                self._io.write_u1(self.values[i])
+
+
+
+        def _check(self):
+            if len(self.header) != 36:
+                raise kaitaistruct.ConsistencyError(u"header", 36, len(self.header))
+            for i in range(len(self.header)):
+                pass
+
+            if len(self.values) != 24 * (self._parent.info.num_entry - 1):
+                raise kaitaistruct.ConsistencyError(u"values", 24 * (self._parent.info.num_entry - 1), len(self.values))
+            for i in range(len(self.values)):
+                pass
+
+            self._dirty = False
+
+
+    class AnimType0(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.AnimType0, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.unk_00 = self._io.read_u4le()
+            self.unk_01 = self._io.read_f4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.AnimType0, self)._write__seq(io)
+            self._io.write_u4le(self.unk_00)
+            self._io.write_f4le(self.unk_01)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class AnimType1(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.AnimType1, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.unk_00 = self._io.read_u4le()
+            self.unk_01 = []
+            for i in range(4):
+                self.unk_01.append(self._io.read_f4le())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.unk_01)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.AnimType1, self)._write__seq(io)
+            self._io.write_u4le(self.unk_00)
+            for i in range(len(self.unk_01)):
+                pass
+                self._io.write_f4le(self.unk_01[i])
+
+
+
+        def _check(self):
+            if len(self.unk_01) != 4:
+                raise kaitaistruct.ConsistencyError(u"unk_01", 4, len(self.unk_01))
+            for i in range(len(self.unk_01)):
+                pass
+
+            self._dirty = False
+
+
+    class AnimType4(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.AnimType4, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.unk_00 = self._io.read_u4le()
+            self.unk_01 = []
+            for i in range(19):
+                self.unk_01.append(self._io.read_f4le())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.unk_01)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.AnimType4, self)._write__seq(io)
+            self._io.write_u4le(self.unk_00)
+            for i in range(len(self.unk_01)):
+                pass
+                self._io.write_f4le(self.unk_01[i])
+
+
+
+        def _check(self):
+            if len(self.unk_01) != 19:
+                raise kaitaistruct.ConsistencyError(u"unk_01", 19, len(self.unk_01))
+            for i in range(len(self.unk_01)):
+                pass
+
+            self._dirty = False
+
+
+    class AnimType6(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.AnimType6, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.unk_00 = []
+            for i in range(2):
+                self.unk_00.append(self._io.read_u4le())
+
+            self.unk_01 = []
+            for i in range(4):
+                self.unk_01.append(self._io.read_f4le())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.unk_00)):
+                pass
+
+            for i in range(len(self.unk_01)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.AnimType6, self)._write__seq(io)
+            for i in range(len(self.unk_00)):
+                pass
+                self._io.write_u4le(self.unk_00[i])
+
+            for i in range(len(self.unk_01)):
+                pass
+                self._io.write_f4le(self.unk_01[i])
+
+
+
+        def _check(self):
+            if len(self.unk_00) != 2:
+                raise kaitaistruct.ConsistencyError(u"unk_00", 2, len(self.unk_00))
+            for i in range(len(self.unk_00)):
+                pass
+
+            if len(self.unk_01) != 4:
+                raise kaitaistruct.ConsistencyError(u"unk_01", 4, len(self.unk_01))
+            for i in range(len(self.unk_01)):
+                pass
+
+            self._dirty = False
+
+
+    class BlockOffset(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.BlockOffset, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_body = False
+            self.body__enabled = True
+
+        def _read(self):
+            self.ofc_block = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.body
+            if hasattr(self, '_m_body'):
+                pass
+                self._m_body._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.BlockOffset, self)._write__seq(io)
+            self._should_write_body = self.body__enabled
+            self._io.write_u4le(self.ofc_block)
+
+
+        def _check(self):
+            if self.body__enabled:
+                pass
+                if self._m_body._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"body", self._root, self._m_body._root)
+                if self._m_body._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"body", self, self._m_body._parent)
+
+            self._dirty = False
+
+        @property
+        def body(self):
+            if self._should_write_body:
+                self._write_body()
+            if hasattr(self, '_m_body'):
+                return self._m_body
+
+            if not self.body__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent._parent.ofs_base + self.ofc_block)
+            self._m_body = Mrl.AnimSubEntry(self._io, self, self._root)
+            self._m_body._read()
+            self._io.seek(_pos)
+            return getattr(self, '_m_body', None)
+
+        @body.setter
+        def body(self, v):
+            self._dirty = True
+            self._m_body = v
+
+        def _write_body(self):
+            self._should_write_body = False
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent._parent.ofs_base + self.ofc_block)
+            self._m_body._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    class CbAppClipPlane(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbAppClipPlane, self).__init__(_io)
             self._parent = _parent
             self._root = _root
             self._should_write_app_specific = False
-            self.app_specific__to_write = True
+            self.app_specific__enabled = True
 
         def _read(self):
             pass
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
             _ = self.app_specific
-            _on = self._root.app_id
-            if _on == u"re1":
+            if hasattr(self, '_m_app_specific'):
                 pass
-                self.app_specific._fetch_instances()
-            elif _on == u"rev1":
-                pass
-                self.app_specific._fetch_instances()
-            elif _on == u"re0":
-                pass
-                self.app_specific._fetch_instances()
-            elif _on == u"dd":
-                pass
-                self.app_specific._fetch_instances()
-            elif _on == u"rev2":
-                pass
-                self.app_specific._fetch_instances()
-            else:
-                pass
-                self.app_specific._fetch_instances()
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                else:
+                    pass
+                    self._m_app_specific._fetch_instances()
+
 
 
         def _write__seq(self, io=None):
-            super(Mrl.CbMaterial, self)._write__seq(io)
-            self._should_write_app_specific = self.app_specific__to_write
+            super(Mrl.CbAppClipPlane, self)._write__seq(io)
+            self._should_write_app_specific = self.app_specific__enabled
 
 
         def _check(self):
-            pass
+            if self.app_specific__enabled:
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                else:
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+
+            self._dirty = False
 
         @property
         def app_specific(self):
@@ -3212,110 +4301,1631 @@ class Mrl(ReadWriteKaitaiStruct):
             if hasattr(self, '_m_app_specific'):
                 return self._m_app_specific
 
+            if not self.app_specific__enabled:
+                return None
+
             _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
             _on = self._root.app_id
-            if _on == u"re1":
+            if _on == u"dd":
                 pass
-                self._m_app_specific = Mrl.CbMaterial1(self._io, self, self._root)
-                self._m_app_specific._read()
-            elif _on == u"rev1":
-                pass
-                self._m_app_specific = Mrl.CbMaterial1(self._io, self, self._root)
-                self._m_app_specific._read()
-            elif _on == u"re0":
-                pass
-                self._m_app_specific = Mrl.CbMaterial1(self._io, self, self._root)
-                self._m_app_specific._read()
-            elif _on == u"dd":
-                pass
-                self._m_app_specific = Mrl.CbMaterial1(self._io, self, self._root)
-                self._m_app_specific._read()
-            elif _on == u"rev2":
-                pass
-                self._m_app_specific = Mrl.CbMaterial1(self._io, self, self._root)
+                self._m_app_specific = Mrl.CbAppClipPlane1(self._io, self, self._root)
                 self._m_app_specific._read()
             else:
                 pass
-                self._m_app_specific = Mrl.CbMaterial1(self._io, self, self._root)
+                self._m_app_specific = Mrl.CbAppClipPlane1(self._io, self, self._root)
                 self._m_app_specific._read()
             self._io.seek(_pos)
             return getattr(self, '_m_app_specific', None)
 
         @app_specific.setter
         def app_specific(self, v):
+            self._dirty = True
             self._m_app_specific = v
 
         def _write_app_specific(self):
             self._should_write_app_specific = False
             _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
             _on = self._root.app_id
-            if _on == u"re1":
+            if _on == u"dd":
                 pass
-                self.app_specific._write__seq(self._io)
-            elif _on == u"rev1":
-                pass
-                self.app_specific._write__seq(self._io)
-            elif _on == u"re0":
-                pass
-                self.app_specific._write__seq(self._io)
-            elif _on == u"dd":
-                pass
-                self.app_specific._write__seq(self._io)
-            elif _on == u"rev2":
-                pass
-                self.app_specific._write__seq(self._io)
+                self._m_app_specific._write__seq(self._io)
             else:
                 pass
-                self.app_specific._write__seq(self._io)
+                self._m_app_specific._write__seq(self._io)
             self._io.seek(_pos)
 
 
-        def _check_app_specific(self):
+    class CbAppClipPlane1(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbAppClipPlane1, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.f_plane_normal = []
+            for i in range(3):
+                self.f_plane_normal.append(self._io.read_f4le())
+
+            self.padding_1 = self._io.read_f4le()
+            self.f_plane_point = []
+            for i in range(3):
+                self.f_plane_point.append(self._io.read_f4le())
+
+            self.padding_2 = self._io.read_f4le()
+            self.f_app_clip_mask = self._io.read_f4le()
+            self.padding_3 = self._io.read_f4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
             pass
+            for i in range(len(self.f_plane_normal)):
+                pass
+
+            for i in range(len(self.f_plane_point)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbAppClipPlane1, self)._write__seq(io)
+            for i in range(len(self.f_plane_normal)):
+                pass
+                self._io.write_f4le(self.f_plane_normal[i])
+
+            self._io.write_f4le(self.padding_1)
+            for i in range(len(self.f_plane_point)):
+                pass
+                self._io.write_f4le(self.f_plane_point[i])
+
+            self._io.write_f4le(self.padding_2)
+            self._io.write_f4le(self.f_app_clip_mask)
+            self._io.write_f4le(self.padding_3)
+
+
+        def _check(self):
+            if len(self.f_plane_normal) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_plane_normal", 3, len(self.f_plane_normal))
+            for i in range(len(self.f_plane_normal)):
+                pass
+
+            if len(self.f_plane_point) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_plane_point", 3, len(self.f_plane_point))
+            for i in range(len(self.f_plane_point)):
+                pass
+
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 48
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class CbAppReflect(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbAppReflect, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_app_specific = False
+            self.app_specific__enabled = True
+
+        def _read(self):
+            pass
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.app_specific
+            if hasattr(self, '_m_app_specific'):
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                else:
+                    pass
+                    self._m_app_specific._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbAppReflect, self)._write__seq(io)
+            self._should_write_app_specific = self.app_specific__enabled
+
+
+        def _check(self):
+            if self.app_specific__enabled:
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                else:
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+
+            self._dirty = False
+
+        @property
+        def app_specific(self):
+            if self._should_write_app_specific:
+                self._write_app_specific()
+            if hasattr(self, '_m_app_specific'):
+                return self._m_app_specific
+
+            if not self.app_specific__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
             _on = self._root.app_id
-            if _on == u"re1":
+            if _on == u"dd":
                 pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            elif _on == u"rev1":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            elif _on == u"re0":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            elif _on == u"dd":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            elif _on == u"rev2":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
+                self._m_app_specific = Mrl.CbAppReflect1(self._io, self, self._root)
+                self._m_app_specific._read()
             else:
                 pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
+                self._m_app_specific = Mrl.CbAppReflect1(self._io, self, self._root)
+                self._m_app_specific._read()
+            self._io.seek(_pos)
+            return getattr(self, '_m_app_specific', None)
+
+        @app_specific.setter
+        def app_specific(self, v):
+            self._dirty = True
+            self._m_app_specific = v
+
+        def _write_app_specific(self):
+            self._should_write_app_specific = False
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            else:
+                pass
+                self._m_app_specific._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    class CbAppReflect1(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbAppReflect1, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.f_app_water_reflect_scale = self._io.read_f4le()
+            self.f_app_shadow_light_scale = self._io.read_f4le()
+            self.padding = []
+            for i in range(2):
+                self.padding.append(self._io.read_f4le())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.padding)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbAppReflect1, self)._write__seq(io)
+            self._io.write_f4le(self.f_app_water_reflect_scale)
+            self._io.write_f4le(self.f_app_shadow_light_scale)
+            for i in range(len(self.padding)):
+                pass
+                self._io.write_f4le(self.padding[i])
+
+
+
+        def _check(self):
+            if len(self.padding) != 2:
+                raise kaitaistruct.ConsistencyError(u"padding", 2, len(self.padding))
+            for i in range(len(self.padding)):
+                pass
+
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 16
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class CbAppReflectShadowLight(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbAppReflectShadowLight, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_app_specific = False
+            self.app_specific__enabled = True
+
+        def _read(self):
+            pass
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.app_specific
+            if hasattr(self, '_m_app_specific'):
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                else:
+                    pass
+                    self._m_app_specific._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbAppReflectShadowLight, self)._write__seq(io)
+            self._should_write_app_specific = self.app_specific__enabled
+
+
+        def _check(self):
+            if self.app_specific__enabled:
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                else:
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+
+            self._dirty = False
+
+        @property
+        def app_specific(self):
+            if self._should_write_app_specific:
+                self._write_app_specific()
+            if hasattr(self, '_m_app_specific'):
+                return self._m_app_specific
+
+            if not self.app_specific__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific = Mrl.CbAppReflectShadowLight1(self._io, self, self._root)
+                self._m_app_specific._read()
+            else:
+                pass
+                self._m_app_specific = Mrl.CbAppReflectShadowLight1(self._io, self, self._root)
+                self._m_app_specific._read()
+            self._io.seek(_pos)
+            return getattr(self, '_m_app_specific', None)
+
+        @app_specific.setter
+        def app_specific(self, v):
+            self._dirty = True
+            self._m_app_specific = v
+
+        def _write_app_specific(self):
+            self._should_write_app_specific = False
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            else:
+                pass
+                self._m_app_specific._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    class CbAppReflectShadowLight1(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbAppReflectShadowLight1, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.f_app_reflect_shadow_dir = []
+            for i in range(3):
+                self.f_app_reflect_shadow_dir.append(self._io.read_f4le())
+
+            self.padding = self._io.read_f4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.f_app_reflect_shadow_dir)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbAppReflectShadowLight1, self)._write__seq(io)
+            for i in range(len(self.f_app_reflect_shadow_dir)):
+                pass
+                self._io.write_f4le(self.f_app_reflect_shadow_dir[i])
+
+            self._io.write_f4le(self.padding)
+
+
+        def _check(self):
+            if len(self.f_app_reflect_shadow_dir) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_app_reflect_shadow_dir", 3, len(self.f_app_reflect_shadow_dir))
+            for i in range(len(self.f_app_reflect_shadow_dir)):
+                pass
+
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 16
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class CbBurnCommon(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbBurnCommon, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_app_specific = False
+            self.app_specific__enabled = True
+
+        def _read(self):
+            pass
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.app_specific
+            if hasattr(self, '_m_app_specific'):
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                else:
+                    pass
+                    self._m_app_specific._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbBurnCommon, self)._write__seq(io)
+            self._should_write_app_specific = self.app_specific__enabled
+
+
+        def _check(self):
+            if self.app_specific__enabled:
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                else:
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+
+            self._dirty = False
+
+        @property
+        def app_specific(self):
+            if self._should_write_app_specific:
+                self._write_app_specific()
+            if hasattr(self, '_m_app_specific'):
+                return self._m_app_specific
+
+            if not self.app_specific__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific = Mrl.CbBurnCommon1(self._io, self, self._root)
+                self._m_app_specific._read()
+            else:
+                pass
+                self._m_app_specific = Mrl.CbBurnCommon1(self._io, self, self._root)
+                self._m_app_specific._read()
+            self._io.seek(_pos)
+            return getattr(self, '_m_app_specific', None)
+
+        @app_specific.setter
+        def app_specific(self, v):
+            self._dirty = True
+            self._m_app_specific = v
+
+        def _write_app_specific(self):
+            self._should_write_app_specific = False
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            else:
+                pass
+                self._m_app_specific._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    class CbBurnCommon1(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbBurnCommon1, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.f_b_blend_map_color = []
+            for i in range(3):
+                self.f_b_blend_map_color.append(self._io.read_f4le())
+
+            self.f_b_alpha_clip_threshold = self._io.read_f4le()
+            self.f_b_blend_alpha_threshold = self._io.read_f4le()
+            self.f_b_blend_alpha_band = self._io.read_f4le()
+            self.f_b_specular_blend_rate = self._io.read_f4le()
+            self.f_b_albedo_blend_rate = self._io.read_f4le()
+            self.f_b_albedo_blend_rate2 = self._io.read_f4le()
+            self.padding = []
+            for i in range(3):
+                self.padding.append(self._io.read_f4le())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.f_b_blend_map_color)):
+                pass
+
+            for i in range(len(self.padding)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbBurnCommon1, self)._write__seq(io)
+            for i in range(len(self.f_b_blend_map_color)):
+                pass
+                self._io.write_f4le(self.f_b_blend_map_color[i])
+
+            self._io.write_f4le(self.f_b_alpha_clip_threshold)
+            self._io.write_f4le(self.f_b_blend_alpha_threshold)
+            self._io.write_f4le(self.f_b_blend_alpha_band)
+            self._io.write_f4le(self.f_b_specular_blend_rate)
+            self._io.write_f4le(self.f_b_albedo_blend_rate)
+            self._io.write_f4le(self.f_b_albedo_blend_rate2)
+            for i in range(len(self.padding)):
+                pass
+                self._io.write_f4le(self.padding[i])
+
+
+
+        def _check(self):
+            if len(self.f_b_blend_map_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_b_blend_map_color", 3, len(self.f_b_blend_map_color))
+            for i in range(len(self.f_b_blend_map_color)):
+                pass
+
+            if len(self.padding) != 3:
+                raise kaitaistruct.ConsistencyError(u"padding", 3, len(self.padding))
+            for i in range(len(self.padding)):
+                pass
+
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 48
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class CbBurnEmission(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbBurnEmission, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_app_specific = False
+            self.app_specific__enabled = True
+
+        def _read(self):
+            pass
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.app_specific
+            if hasattr(self, '_m_app_specific'):
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                else:
+                    pass
+                    self._m_app_specific._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbBurnEmission, self)._write__seq(io)
+            self._should_write_app_specific = self.app_specific__enabled
+
+
+        def _check(self):
+            if self.app_specific__enabled:
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                else:
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+
+            self._dirty = False
+
+        @property
+        def app_specific(self):
+            if self._should_write_app_specific:
+                self._write_app_specific()
+            if hasattr(self, '_m_app_specific'):
+                return self._m_app_specific
+
+            if not self.app_specific__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific = Mrl.CbBurnEmission1(self._io, self, self._root)
+                self._m_app_specific._read()
+            else:
+                pass
+                self._m_app_specific = Mrl.CbBurnEmission1(self._io, self, self._root)
+                self._m_app_specific._read()
+            self._io.seek(_pos)
+            return getattr(self, '_m_app_specific', None)
+
+        @app_specific.setter
+        def app_specific(self, v):
+            self._dirty = True
+            self._m_app_specific = v
+
+        def _write_app_specific(self):
+            self._should_write_app_specific = False
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            else:
+                pass
+                self._m_app_specific._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    class CbBurnEmission1(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbBurnEmission1, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.f_b_emission_factor = self._io.read_f4le()
+            self.f_b_emission_alpha_band = self._io.read_f4le()
+            self.padding_1 = []
+            for i in range(2):
+                self.padding_1.append(self._io.read_f4le())
+
+            self.f_burn_emission_color = []
+            for i in range(3):
+                self.f_burn_emission_color.append(self._io.read_f4le())
+
+            self.padding_2 = self._io.read_f4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.padding_1)):
+                pass
+
+            for i in range(len(self.f_burn_emission_color)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbBurnEmission1, self)._write__seq(io)
+            self._io.write_f4le(self.f_b_emission_factor)
+            self._io.write_f4le(self.f_b_emission_alpha_band)
+            for i in range(len(self.padding_1)):
+                pass
+                self._io.write_f4le(self.padding_1[i])
+
+            for i in range(len(self.f_burn_emission_color)):
+                pass
+                self._io.write_f4le(self.f_burn_emission_color[i])
+
+            self._io.write_f4le(self.padding_2)
+
+
+        def _check(self):
+            if len(self.padding_1) != 2:
+                raise kaitaistruct.ConsistencyError(u"padding_1", 2, len(self.padding_1))
+            for i in range(len(self.padding_1)):
+                pass
+
+            if len(self.f_burn_emission_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_burn_emission_color", 3, len(self.f_burn_emission_color))
+            for i in range(len(self.f_burn_emission_color)):
+                pass
+
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 32
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class CbColorMask(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbColorMask, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_app_specific = False
+            self.app_specific__enabled = True
+
+        def _read(self):
+            pass
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.app_specific
+            if hasattr(self, '_m_app_specific'):
+                pass
+                _on = self._root.app_id
+                if _on == u"re6":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                elif _on == u"rev2":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                else:
+                    pass
+                    self._m_app_specific._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbColorMask, self)._write__seq(io)
+            self._should_write_app_specific = self.app_specific__enabled
+
+
+        def _check(self):
+            if self.app_specific__enabled:
+                pass
+                _on = self._root.app_id
+                if _on == u"re6":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                elif _on == u"rev2":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                else:
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+
+            self._dirty = False
+
+        @property
+        def app_specific(self):
+            if self._should_write_app_specific:
+                self._write_app_specific()
+            if hasattr(self, '_m_app_specific'):
+                return self._m_app_specific
+
+            if not self.app_specific__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"re6":
+                pass
+                self._m_app_specific = Mrl.CbColorMask1(self._io, self, self._root)
+                self._m_app_specific._read()
+            elif _on == u"rev2":
+                pass
+                self._m_app_specific = Mrl.CbColorMask1(self._io, self, self._root)
+                self._m_app_specific._read()
+            else:
+                pass
+                self._m_app_specific = Mrl.CbColorMask1(self._io, self, self._root)
+                self._m_app_specific._read()
+            self._io.seek(_pos)
+            return getattr(self, '_m_app_specific', None)
+
+        @app_specific.setter
+        def app_specific(self, v):
+            self._dirty = True
+            self._m_app_specific = v
+
+        def _write_app_specific(self):
+            self._should_write_app_specific = False
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"re6":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            elif _on == u"rev2":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            else:
+                pass
+                self._m_app_specific._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    class CbColorMask1(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbColorMask1, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.f_color_mask_threshold = []
+            for i in range(4):
+                self.f_color_mask_threshold.append(self._io.read_f4le())
+
+            self.f_color_mask_offset = []
+            for i in range(4):
+                self.f_color_mask_offset.append(self._io.read_f4le())
+
+            self.f_clip_threshold = []
+            for i in range(4):
+                self.f_clip_threshold.append(self._io.read_f4le())
+
+            self.f_color_mask_color = []
+            for i in range(4):
+                self.f_color_mask_color.append(self._io.read_f4le())
+
+            self.f_color_mask2_threshold = []
+            for i in range(4):
+                self.f_color_mask2_threshold.append(self._io.read_f4le())
+
+            self.f_color_mask2_color = []
+            for i in range(4):
+                self.f_color_mask2_color.append(self._io.read_f4le())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.f_color_mask_threshold)):
+                pass
+
+            for i in range(len(self.f_color_mask_offset)):
+                pass
+
+            for i in range(len(self.f_clip_threshold)):
+                pass
+
+            for i in range(len(self.f_color_mask_color)):
+                pass
+
+            for i in range(len(self.f_color_mask2_threshold)):
+                pass
+
+            for i in range(len(self.f_color_mask2_color)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbColorMask1, self)._write__seq(io)
+            for i in range(len(self.f_color_mask_threshold)):
+                pass
+                self._io.write_f4le(self.f_color_mask_threshold[i])
+
+            for i in range(len(self.f_color_mask_offset)):
+                pass
+                self._io.write_f4le(self.f_color_mask_offset[i])
+
+            for i in range(len(self.f_clip_threshold)):
+                pass
+                self._io.write_f4le(self.f_clip_threshold[i])
+
+            for i in range(len(self.f_color_mask_color)):
+                pass
+                self._io.write_f4le(self.f_color_mask_color[i])
+
+            for i in range(len(self.f_color_mask2_threshold)):
+                pass
+                self._io.write_f4le(self.f_color_mask2_threshold[i])
+
+            for i in range(len(self.f_color_mask2_color)):
+                pass
+                self._io.write_f4le(self.f_color_mask2_color[i])
+
+
+
+        def _check(self):
+            if len(self.f_color_mask_threshold) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_color_mask_threshold", 4, len(self.f_color_mask_threshold))
+            for i in range(len(self.f_color_mask_threshold)):
+                pass
+
+            if len(self.f_color_mask_offset) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_color_mask_offset", 4, len(self.f_color_mask_offset))
+            for i in range(len(self.f_color_mask_offset)):
+                pass
+
+            if len(self.f_clip_threshold) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_clip_threshold", 4, len(self.f_clip_threshold))
+            for i in range(len(self.f_clip_threshold)):
+                pass
+
+            if len(self.f_color_mask_color) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_color_mask_color", 4, len(self.f_color_mask_color))
+            for i in range(len(self.f_color_mask_color)):
+                pass
+
+            if len(self.f_color_mask2_threshold) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_color_mask2_threshold", 4, len(self.f_color_mask2_threshold))
+            for i in range(len(self.f_color_mask2_threshold)):
+                pass
+
+            if len(self.f_color_mask2_color) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_color_mask2_color", 4, len(self.f_color_mask2_color))
+            for i in range(len(self.f_color_mask2_color)):
+                pass
+
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 96
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class CbDdMaterialParam(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbDdMaterialParam, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_app_specific = False
+            self.app_specific__enabled = True
+
+        def _read(self):
+            pass
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.app_specific
+            if hasattr(self, '_m_app_specific'):
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                else:
+                    pass
+                    self._m_app_specific._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbDdMaterialParam, self)._write__seq(io)
+            self._should_write_app_specific = self.app_specific__enabled
+
+
+        def _check(self):
+            if self.app_specific__enabled:
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                else:
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+
+            self._dirty = False
+
+        @property
+        def app_specific(self):
+            if self._should_write_app_specific:
+                self._write_app_specific()
+            if hasattr(self, '_m_app_specific'):
+                return self._m_app_specific
+
+            if not self.app_specific__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific = Mrl.CbDdMaterialParam1(self._io, self, self._root)
+                self._m_app_specific._read()
+            else:
+                pass
+                self._m_app_specific = Mrl.CbDdMaterialParam1(self._io, self, self._root)
+                self._m_app_specific._read()
+            self._io.seek(_pos)
+            return getattr(self, '_m_app_specific', None)
+
+        @app_specific.setter
+        def app_specific(self, v):
+            self._dirty = True
+            self._m_app_specific = v
+
+        def _write_app_specific(self):
+            self._should_write_app_specific = False
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            else:
+                pass
+                self._m_app_specific._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    class CbDdMaterialParam1(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbDdMaterialParam1, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.f_dd_material_blend_color = []
+            for i in range(4):
+                self.f_dd_material_blend_color.append(self._io.read_f4le())
+
+            self.f_dd_material_color_blend_rate = []
+            for i in range(2):
+                self.f_dd_material_color_blend_rate.append(self._io.read_f4le())
+
+            self.f_dd_material_area_mask = []
+            for i in range(2):
+                self.f_dd_material_area_mask.append(self._io.read_f4le())
+
+            self.f_dd_material_border_blend_mask = []
+            for i in range(4):
+                self.f_dd_material_border_blend_mask.append(self._io.read_f4le())
+
+            self.f_dd_material_border_shade_band = self._io.read_f4le()
+            self.f_dd_material_base_power = self._io.read_f4le()
+            self.f_dd_material_normal_blend_rate = self._io.read_f4le()
+            self.f_dd_material_reflect_blend_color = self._io.read_f4le()
+            self.f_dd_material_specular_factor = self._io.read_f4le()
+            self.f_dd_material_specular_map_factor = self._io.read_f4le()
+            self.f_dd_material_env_map_blend_color = self._io.read_f4le()
+            self.f_dd_material_area_alpha = self._io.read_f4le()
+            self.f_dd_material_area_pos = []
+            for i in range(4):
+                self.f_dd_material_area_pos.append(self._io.read_f4le())
+
+            self.f_dd_material_albedo_uv_scale = self._io.read_f4le()
+            self.f_dd_material_normal_uv_scale = self._io.read_f4le()
+            self.f_dd_material_normal_power = self._io.read_f4le()
+            self.f_dd_material_base_env_map_power = self._io.read_f4le()
+            self.f_dd_material_lantern_color = []
+            for i in range(3):
+                self.f_dd_material_lantern_color.append(self._io.read_f4le())
+
+            self.padding_1 = self._io.read_f4le()
+            self.f_dd_material_lantern_pos = []
+            for i in range(3):
+                self.f_dd_material_lantern_pos.append(self._io.read_f4le())
+
+            self.padding_2 = self._io.read_f4le()
+            self.f_dd_material_lantern_param = []
+            for i in range(3):
+                self.f_dd_material_lantern_param.append(self._io.read_f4le())
+
+            self.padding_3 = self._io.read_f4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.f_dd_material_blend_color)):
+                pass
+
+            for i in range(len(self.f_dd_material_color_blend_rate)):
+                pass
+
+            for i in range(len(self.f_dd_material_area_mask)):
+                pass
+
+            for i in range(len(self.f_dd_material_border_blend_mask)):
+                pass
+
+            for i in range(len(self.f_dd_material_area_pos)):
+                pass
+
+            for i in range(len(self.f_dd_material_lantern_color)):
+                pass
+
+            for i in range(len(self.f_dd_material_lantern_pos)):
+                pass
+
+            for i in range(len(self.f_dd_material_lantern_param)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbDdMaterialParam1, self)._write__seq(io)
+            for i in range(len(self.f_dd_material_blend_color)):
+                pass
+                self._io.write_f4le(self.f_dd_material_blend_color[i])
+
+            for i in range(len(self.f_dd_material_color_blend_rate)):
+                pass
+                self._io.write_f4le(self.f_dd_material_color_blend_rate[i])
+
+            for i in range(len(self.f_dd_material_area_mask)):
+                pass
+                self._io.write_f4le(self.f_dd_material_area_mask[i])
+
+            for i in range(len(self.f_dd_material_border_blend_mask)):
+                pass
+                self._io.write_f4le(self.f_dd_material_border_blend_mask[i])
+
+            self._io.write_f4le(self.f_dd_material_border_shade_band)
+            self._io.write_f4le(self.f_dd_material_base_power)
+            self._io.write_f4le(self.f_dd_material_normal_blend_rate)
+            self._io.write_f4le(self.f_dd_material_reflect_blend_color)
+            self._io.write_f4le(self.f_dd_material_specular_factor)
+            self._io.write_f4le(self.f_dd_material_specular_map_factor)
+            self._io.write_f4le(self.f_dd_material_env_map_blend_color)
+            self._io.write_f4le(self.f_dd_material_area_alpha)
+            for i in range(len(self.f_dd_material_area_pos)):
+                pass
+                self._io.write_f4le(self.f_dd_material_area_pos[i])
+
+            self._io.write_f4le(self.f_dd_material_albedo_uv_scale)
+            self._io.write_f4le(self.f_dd_material_normal_uv_scale)
+            self._io.write_f4le(self.f_dd_material_normal_power)
+            self._io.write_f4le(self.f_dd_material_base_env_map_power)
+            for i in range(len(self.f_dd_material_lantern_color)):
+                pass
+                self._io.write_f4le(self.f_dd_material_lantern_color[i])
+
+            self._io.write_f4le(self.padding_1)
+            for i in range(len(self.f_dd_material_lantern_pos)):
+                pass
+                self._io.write_f4le(self.f_dd_material_lantern_pos[i])
+
+            self._io.write_f4le(self.padding_2)
+            for i in range(len(self.f_dd_material_lantern_param)):
+                pass
+                self._io.write_f4le(self.f_dd_material_lantern_param[i])
+
+            self._io.write_f4le(self.padding_3)
+
+
+        def _check(self):
+            if len(self.f_dd_material_blend_color) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_dd_material_blend_color", 4, len(self.f_dd_material_blend_color))
+            for i in range(len(self.f_dd_material_blend_color)):
+                pass
+
+            if len(self.f_dd_material_color_blend_rate) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_dd_material_color_blend_rate", 2, len(self.f_dd_material_color_blend_rate))
+            for i in range(len(self.f_dd_material_color_blend_rate)):
+                pass
+
+            if len(self.f_dd_material_area_mask) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_dd_material_area_mask", 2, len(self.f_dd_material_area_mask))
+            for i in range(len(self.f_dd_material_area_mask)):
+                pass
+
+            if len(self.f_dd_material_border_blend_mask) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_dd_material_border_blend_mask", 4, len(self.f_dd_material_border_blend_mask))
+            for i in range(len(self.f_dd_material_border_blend_mask)):
+                pass
+
+            if len(self.f_dd_material_area_pos) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_dd_material_area_pos", 4, len(self.f_dd_material_area_pos))
+            for i in range(len(self.f_dd_material_area_pos)):
+                pass
+
+            if len(self.f_dd_material_lantern_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_dd_material_lantern_color", 3, len(self.f_dd_material_lantern_color))
+            for i in range(len(self.f_dd_material_lantern_color)):
+                pass
+
+            if len(self.f_dd_material_lantern_pos) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_dd_material_lantern_pos", 3, len(self.f_dd_material_lantern_pos))
+            for i in range(len(self.f_dd_material_lantern_pos)):
+                pass
+
+            if len(self.f_dd_material_lantern_param) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_dd_material_lantern_param", 3, len(self.f_dd_material_lantern_param))
+            for i in range(len(self.f_dd_material_lantern_param)):
+                pass
+
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 160
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class CbDdMaterialParamInnerCorrect(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbDdMaterialParamInnerCorrect, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_app_specific = False
+            self.app_specific__enabled = True
+
+        def _read(self):
+            pass
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.app_specific
+            if hasattr(self, '_m_app_specific'):
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                else:
+                    pass
+                    self._m_app_specific._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbDdMaterialParamInnerCorrect, self)._write__seq(io)
+            self._should_write_app_specific = self.app_specific__enabled
+
+
+        def _check(self):
+            if self.app_specific__enabled:
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                else:
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+
+            self._dirty = False
+
+        @property
+        def app_specific(self):
+            if self._should_write_app_specific:
+                self._write_app_specific()
+            if hasattr(self, '_m_app_specific'):
+                return self._m_app_specific
+
+            if not self.app_specific__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific = Mrl.CbDdMaterialParamInnerCorrect1(self._io, self, self._root)
+                self._m_app_specific._read()
+            else:
+                pass
+                self._m_app_specific = Mrl.CbDdMaterialParamInnerCorrect1(self._io, self, self._root)
+                self._m_app_specific._read()
+            self._io.seek(_pos)
+            return getattr(self, '_m_app_specific', None)
+
+        @app_specific.setter
+        def app_specific(self, v):
+            self._dirty = True
+            self._m_app_specific = v
+
+        def _write_app_specific(self):
+            self._should_write_app_specific = False
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            else:
+                pass
+                self._m_app_specific._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    class CbDdMaterialParamInnerCorrect1(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbDdMaterialParamInnerCorrect1, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.f_dd_material_inner_correct_offset = self._io.read_f4le()
+            self.padding = []
+            for i in range(3):
+                self.padding.append(self._io.read_f4le())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.padding)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbDdMaterialParamInnerCorrect1, self)._write__seq(io)
+            self._io.write_f4le(self.f_dd_material_inner_correct_offset)
+            for i in range(len(self.padding)):
+                pass
+                self._io.write_f4le(self.padding[i])
+
+
+
+        def _check(self):
+            if len(self.padding) != 3:
+                raise kaitaistruct.ConsistencyError(u"padding", 3, len(self.padding))
+            for i in range(len(self.padding)):
+                pass
+
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 16
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class CbDistortion(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbDistortion, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.f_distortion_factor = self._io.read_f4le()
+            self.f_distortion_blend = self._io.read_f4le()
+            self.filler = []
+            for i in range(2):
+                self.filler.append(self._io.read_f4le())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.filler)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbDistortion, self)._write__seq(io)
+            self._io.write_f4le(self.f_distortion_factor)
+            self._io.write_f4le(self.f_distortion_blend)
+            for i in range(len(self.filler)):
+                pass
+                self._io.write_f4le(self.filler[i])
+
+
+
+        def _check(self):
+            if len(self.filler) != 2:
+                raise kaitaistruct.ConsistencyError(u"filler", 2, len(self.filler))
+            for i in range(len(self.filler)):
+                pass
+
+            self._dirty = False
+
+
+    class CbGlobals(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbGlobals, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_app_specific = False
+            self.app_specific__enabled = True
+
+        def _read(self):
+            pass
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.app_specific
+            if hasattr(self, '_m_app_specific'):
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                elif _on == u"re0":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                elif _on == u"re1":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                elif _on == u"re6":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                elif _on == u"rev1":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                elif _on == u"rev2":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                else:
+                    pass
+                    self._m_app_specific._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbGlobals, self)._write__seq(io)
+            self._should_write_app_specific = self.app_specific__enabled
+
+
+        def _check(self):
+            if self.app_specific__enabled:
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                elif _on == u"re0":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                elif _on == u"re1":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                elif _on == u"re6":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                elif _on == u"rev1":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                elif _on == u"rev2":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                else:
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+
+            self._dirty = False
+
+        @property
+        def app_specific(self):
+            if self._should_write_app_specific:
+                self._write_app_specific()
+            if hasattr(self, '_m_app_specific'):
+                return self._m_app_specific
+
+            if not self.app_specific__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific = Mrl.CbGlobals4(self._io, self, self._root)
+                self._m_app_specific._read()
+            elif _on == u"re0":
+                pass
+                self._m_app_specific = Mrl.CbGlobals1(self._io, self, self._root)
+                self._m_app_specific._read()
+            elif _on == u"re1":
+                pass
+                self._m_app_specific = Mrl.CbGlobals1(self._io, self, self._root)
+                self._m_app_specific._read()
+            elif _on == u"re6":
+                pass
+                self._m_app_specific = Mrl.CbGlobals3(self._io, self, self._root)
+                self._m_app_specific._read()
+            elif _on == u"rev1":
+                pass
+                self._m_app_specific = Mrl.CbGlobals1(self._io, self, self._root)
+                self._m_app_specific._read()
+            elif _on == u"rev2":
+                pass
+                self._m_app_specific = Mrl.CbGlobals2(self._io, self, self._root)
+                self._m_app_specific._read()
+            else:
+                pass
+                self._m_app_specific = Mrl.CbGlobals1(self._io, self, self._root)
+                self._m_app_specific._read()
+            self._io.seek(_pos)
+            return getattr(self, '_m_app_specific', None)
+
+        @app_specific.setter
+        def app_specific(self, v):
+            self._dirty = True
+            self._m_app_specific = v
+
+        def _write_app_specific(self):
+            self._should_write_app_specific = False
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            elif _on == u"re0":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            elif _on == u"re1":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            elif _on == u"re6":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            elif _on == u"rev1":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            elif _on == u"rev2":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            else:
+                pass
+                self._m_app_specific._write__seq(self._io)
+            self._io.seek(_pos)
 
 
     class CbGlobals1(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mrl.CbGlobals1, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -3410,6 +6020,7 @@ class Mrl(ReadWriteKaitaiStruct):
             for i in range(4):
                 self.f_secondary_color.append(self._io.read_f4le())
 
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -3565,97 +6176,97 @@ class Mrl(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
-            if (len(self.f_albedo_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_albedo_color", len(self.f_albedo_color), 3)
+            if len(self.f_albedo_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_albedo_color", 3, len(self.f_albedo_color))
             for i in range(len(self.f_albedo_color)):
                 pass
 
-            if (len(self.f_albedo_blend_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_albedo_blend_color", len(self.f_albedo_blend_color), 4)
+            if len(self.f_albedo_blend_color) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_albedo_blend_color", 4, len(self.f_albedo_blend_color))
             for i in range(len(self.f_albedo_blend_color)):
                 pass
 
-            if (len(self.f_parallax_max_sample) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_parallax_max_sample", len(self.f_parallax_max_sample), 3)
+            if len(self.f_parallax_max_sample) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_parallax_max_sample", 3, len(self.f_parallax_max_sample))
             for i in range(len(self.f_parallax_max_sample)):
                 pass
 
-            if (len(self.f_light_map_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_light_map_color", len(self.f_light_map_color), 4)
+            if len(self.f_light_map_color) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_light_map_color", 4, len(self.f_light_map_color))
             for i in range(len(self.f_light_map_color)):
                 pass
 
-            if (len(self.f_thin_map_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_thin_map_color", len(self.f_thin_map_color), 3)
+            if len(self.f_thin_map_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_thin_map_color", 3, len(self.f_thin_map_color))
             for i in range(len(self.f_thin_map_color)):
                 pass
 
-            if (len(self.f_screen_uv_scale) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_screen_uv_scale", len(self.f_screen_uv_scale), 2)
+            if len(self.f_screen_uv_scale) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_screen_uv_scale", 2, len(self.f_screen_uv_scale))
             for i in range(len(self.f_screen_uv_scale)):
                 pass
 
-            if (len(self.f_screen_uv_offset) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_screen_uv_offset", len(self.f_screen_uv_offset), 2)
+            if len(self.f_screen_uv_offset) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_screen_uv_offset", 2, len(self.f_screen_uv_offset))
             for i in range(len(self.f_screen_uv_offset)):
                 pass
 
-            if (len(self.f_indirect_offset) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_indirect_offset", len(self.f_indirect_offset), 2)
+            if len(self.f_indirect_offset) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_indirect_offset", 2, len(self.f_indirect_offset))
             for i in range(len(self.f_indirect_offset)):
                 pass
 
-            if (len(self.f_indirect_scale) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_indirect_scale", len(self.f_indirect_scale), 2)
+            if len(self.f_indirect_scale) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_indirect_scale", 2, len(self.f_indirect_scale))
             for i in range(len(self.f_indirect_scale)):
                 pass
 
-            if (len(self.f_fresnel_schlick_rgb) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_fresnel_schlick_rgb", len(self.f_fresnel_schlick_rgb), 3)
+            if len(self.f_fresnel_schlick_rgb) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_fresnel_schlick_rgb", 3, len(self.f_fresnel_schlick_rgb))
             for i in range(len(self.f_fresnel_schlick_rgb)):
                 pass
 
-            if (len(self.f_specular_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_specular_color", len(self.f_specular_color), 3)
+            if len(self.f_specular_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_specular_color", 3, len(self.f_specular_color))
             for i in range(len(self.f_specular_color)):
                 pass
 
-            if (len(self.f_emission_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_emission_color", len(self.f_emission_color), 3)
+            if len(self.f_emission_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_emission_color", 3, len(self.f_emission_color))
             for i in range(len(self.f_emission_color)):
                 pass
 
-            if (len(self.f_constant_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_constant_color", len(self.f_constant_color), 4)
+            if len(self.f_constant_color) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_constant_color", 4, len(self.f_constant_color))
             for i in range(len(self.f_constant_color)):
                 pass
 
-            if (len(self.f_roughness_rgb) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_roughness_rgb", len(self.f_roughness_rgb), 3)
+            if len(self.f_roughness_rgb) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_roughness_rgb", 3, len(self.f_roughness_rgb))
             for i in range(len(self.f_roughness_rgb)):
                 pass
 
-            if (len(self.f_anisotoropic_direction) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_anisotoropic_direction", len(self.f_anisotoropic_direction), 3)
+            if len(self.f_anisotoropic_direction) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_anisotoropic_direction", 3, len(self.f_anisotoropic_direction))
             for i in range(len(self.f_anisotoropic_direction)):
                 pass
 
-            if (len(self.f_anistropic_uv) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_anistropic_uv", len(self.f_anistropic_uv), 2)
+            if len(self.f_anistropic_uv) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_anistropic_uv", 2, len(self.f_anistropic_uv))
             for i in range(len(self.f_anistropic_uv)):
                 pass
 
-            if (len(self.f_primary_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_primary_color", len(self.f_primary_color), 4)
+            if len(self.f_primary_color) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_primary_color", 4, len(self.f_primary_color))
             for i in range(len(self.f_primary_color)):
                 pass
 
-            if (len(self.f_secondary_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_secondary_color", len(self.f_secondary_color), 4)
+            if len(self.f_secondary_color) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_secondary_color", 4, len(self.f_secondary_color))
             for i in range(len(self.f_secondary_color)):
                 pass
 
+            self._dirty = False
 
         @property
         def size_(self):
@@ -3668,3523 +6279,9 @@ class Mrl(ReadWriteKaitaiStruct):
         def _invalidate_size_(self):
             del self._m_size_
 
-    class AnimSubEntry5(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.header = []
-            for i in range(12):
-                self.header.append(self._io.read_u1())
-
-            self.values = []
-            for i in range((8 * self._parent.info.num_entry)):
-                self.values.append(self._io.read_u1())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.header)):
-                pass
-
-            for i in range(len(self.values)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.AnimSubEntry5, self)._write__seq(io)
-            for i in range(len(self.header)):
-                pass
-                self._io.write_u1(self.header[i])
-
-            for i in range(len(self.values)):
-                pass
-                self._io.write_u1(self.values[i])
-
-
-
-        def _check(self):
-            pass
-            if (len(self.header) != 12):
-                raise kaitaistruct.ConsistencyError(u"header", len(self.header), 12)
-            for i in range(len(self.header)):
-                pass
-
-            if (len(self.values) != (8 * self._parent.info.num_entry)):
-                raise kaitaistruct.ConsistencyError(u"values", len(self.values), (8 * self._parent.info.num_entry))
-            for i in range(len(self.values)):
-                pass
-
-
-
-    class CmdTexIdx(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.tex_idx = self._io.read_u4le()
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CmdTexIdx, self)._write__seq(io)
-            self._io.write_u4le(self.tex_idx)
-
-
-        def _check(self):
-            pass
-
-
-    class CbColorMask(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-            self._should_write_app_specific = False
-            self.app_specific__to_write = True
-
-        def _read(self):
-            pass
-
-
-        def _fetch_instances(self):
-            pass
-            _ = self.app_specific
-            _on = self._root.app_id
-            if _on == u"re6":
-                pass
-                self.app_specific._fetch_instances()
-            elif _on == u"rev2":
-                pass
-                self.app_specific._fetch_instances()
-            else:
-                pass
-                self.app_specific._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbColorMask, self)._write__seq(io)
-            self._should_write_app_specific = self.app_specific__to_write
-
-
-        def _check(self):
-            pass
-
-        @property
-        def app_specific(self):
-            if self._should_write_app_specific:
-                self._write_app_specific()
-            if hasattr(self, '_m_app_specific'):
-                return self._m_app_specific
-
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"re6":
-                pass
-                self._m_app_specific = Mrl.CbColorMask1(self._io, self, self._root)
-                self._m_app_specific._read()
-            elif _on == u"rev2":
-                pass
-                self._m_app_specific = Mrl.CbColorMask1(self._io, self, self._root)
-                self._m_app_specific._read()
-            else:
-                pass
-                self._m_app_specific = Mrl.CbColorMask1(self._io, self, self._root)
-                self._m_app_specific._read()
-            self._io.seek(_pos)
-            return getattr(self, '_m_app_specific', None)
-
-        @app_specific.setter
-        def app_specific(self, v):
-            self._m_app_specific = v
-
-        def _write_app_specific(self):
-            self._should_write_app_specific = False
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"re6":
-                pass
-                self.app_specific._write__seq(self._io)
-            elif _on == u"rev2":
-                pass
-                self.app_specific._write__seq(self._io)
-            else:
-                pass
-                self.app_specific._write__seq(self._io)
-            self._io.seek(_pos)
-
-
-        def _check_app_specific(self):
-            pass
-            _on = self._root.app_id
-            if _on == u"re6":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            elif _on == u"rev2":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            else:
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-
-
-    class CbVertexDisplacement(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-            self._should_write_app_specific = False
-            self.app_specific__to_write = True
-
-        def _read(self):
-            pass
-
-
-        def _fetch_instances(self):
-            pass
-            _ = self.app_specific
-            _on = self._root.app_id
-            if _on == u"re1":
-                pass
-                self.app_specific._fetch_instances()
-            elif _on == u"rev1":
-                pass
-                self.app_specific._fetch_instances()
-            elif _on == u"re6":
-                pass
-                self.app_specific._fetch_instances()
-            elif _on == u"re0":
-                pass
-                self.app_specific._fetch_instances()
-            elif _on == u"dd":
-                pass
-                self.app_specific._fetch_instances()
-            elif _on == u"rev2":
-                pass
-                self.app_specific._fetch_instances()
-            else:
-                pass
-                self.app_specific._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbVertexDisplacement, self)._write__seq(io)
-            self._should_write_app_specific = self.app_specific__to_write
-
-
-        def _check(self):
-            pass
-
-        @property
-        def app_specific(self):
-            if self._should_write_app_specific:
-                self._write_app_specific()
-            if hasattr(self, '_m_app_specific'):
-                return self._m_app_specific
-
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"re1":
-                pass
-                self._m_app_specific = Mrl.CbVertexDisplacement1(self._io, self, self._root)
-                self._m_app_specific._read()
-            elif _on == u"rev1":
-                pass
-                self._m_app_specific = Mrl.CbVertexDisplacement1(self._io, self, self._root)
-                self._m_app_specific._read()
-            elif _on == u"re6":
-                pass
-                self._m_app_specific = Mrl.CbVertexDisplacement1(self._io, self, self._root)
-                self._m_app_specific._read()
-            elif _on == u"re0":
-                pass
-                self._m_app_specific = Mrl.CbVertexDisplacement1(self._io, self, self._root)
-                self._m_app_specific._read()
-            elif _on == u"dd":
-                pass
-                self._m_app_specific = Mrl.CbVertexDisplacement1(self._io, self, self._root)
-                self._m_app_specific._read()
-            elif _on == u"rev2":
-                pass
-                self._m_app_specific = Mrl.CbVertexDisplacement1(self._io, self, self._root)
-                self._m_app_specific._read()
-            else:
-                pass
-                self._m_app_specific = Mrl.CbVertexDisplacement1(self._io, self, self._root)
-                self._m_app_specific._read()
-            self._io.seek(_pos)
-            return getattr(self, '_m_app_specific', None)
-
-        @app_specific.setter
-        def app_specific(self, v):
-            self._m_app_specific = v
-
-        def _write_app_specific(self):
-            self._should_write_app_specific = False
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"re1":
-                pass
-                self.app_specific._write__seq(self._io)
-            elif _on == u"rev1":
-                pass
-                self.app_specific._write__seq(self._io)
-            elif _on == u"re6":
-                pass
-                self.app_specific._write__seq(self._io)
-            elif _on == u"re0":
-                pass
-                self.app_specific._write__seq(self._io)
-            elif _on == u"dd":
-                pass
-                self.app_specific._write__seq(self._io)
-            elif _on == u"rev2":
-                pass
-                self.app_specific._write__seq(self._io)
-            else:
-                pass
-                self.app_specific._write__seq(self._io)
-            self._io.seek(_pos)
-
-
-        def _check_app_specific(self):
-            pass
-            _on = self._root.app_id
-            if _on == u"re1":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            elif _on == u"rev1":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            elif _on == u"re6":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            elif _on == u"re0":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            elif _on == u"dd":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            elif _on == u"rev2":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            else:
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-
-
-    class AnimInfo(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.unk = self._io.read_bits_int_le(2)
-            self.num_entry2 = self._io.read_bits_int_le(16)
-            self.num_entry1 = self._io.read_bits_int_le(14)
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.AnimInfo, self)._write__seq(io)
-            self._io.write_bits_int_le(2, self.unk)
-            self._io.write_bits_int_le(16, self.num_entry2)
-            self._io.write_bits_int_le(14, self.num_entry1)
-
-
-        def _check(self):
-            pass
-
-
-    class AnimType4(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.unk_00 = self._io.read_u4le()
-            self.unk_01 = []
-            for i in range(19):
-                self.unk_01.append(self._io.read_f4le())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.unk_01)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.AnimType4, self)._write__seq(io)
-            self._io.write_u4le(self.unk_00)
-            for i in range(len(self.unk_01)):
-                pass
-                self._io.write_f4le(self.unk_01[i])
-
-
-
-        def _check(self):
-            pass
-            if (len(self.unk_01) != 19):
-                raise kaitaistruct.ConsistencyError(u"unk_01", len(self.unk_01), 19)
-            for i in range(len(self.unk_01)):
-                pass
-
-
-
-    class CbOutlineEx(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-            self._should_write_app_specific = False
-            self.app_specific__to_write = True
-
-        def _read(self):
-            pass
-
-
-        def _fetch_instances(self):
-            pass
-            _ = self.app_specific
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self.app_specific._fetch_instances()
-            else:
-                pass
-                self.app_specific._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbOutlineEx, self)._write__seq(io)
-            self._should_write_app_specific = self.app_specific__to_write
-
-
-        def _check(self):
-            pass
-
-        @property
-        def app_specific(self):
-            if self._should_write_app_specific:
-                self._write_app_specific()
-            if hasattr(self, '_m_app_specific'):
-                return self._m_app_specific
-
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self._m_app_specific = Mrl.CbOutlineEx1(self._io, self, self._root)
-                self._m_app_specific._read()
-            else:
-                pass
-                self._m_app_specific = Mrl.CbOutlineEx1(self._io, self, self._root)
-                self._m_app_specific._read()
-            self._io.seek(_pos)
-            return getattr(self, '_m_app_specific', None)
-
-        @app_specific.setter
-        def app_specific(self, v):
-            self._m_app_specific = v
-
-        def _write_app_specific(self):
-            self._should_write_app_specific = False
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self.app_specific._write__seq(self._io)
-            else:
-                pass
-                self.app_specific._write__seq(self._io)
-            self._io.seek(_pos)
-
-
-        def _check_app_specific(self):
-            pass
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            else:
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-
-
-    class ShaderObject(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.index = self._io.read_bits_int_le(12)
-            self.name_hash = KaitaiStream.resolve_enum(Mrl.ShaderObjectHash, self._io.read_bits_int_le(20))
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.ShaderObject, self)._write__seq(io)
-            self._io.write_bits_int_le(12, self.index)
-            self._io.write_bits_int_le(20, int(self.name_hash))
-
-
-        def _check(self):
-            pass
-
-
-    class CbVertexDisplacement21(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.f_vtx_disp_start2 = self._io.read_f4le()
-            self.f_vtx_disp_scale2 = self._io.read_f4le()
-            self.f_vtx_disp_inv_area2 = self._io.read_f4le()
-            self.f_vtx_disp_rcn2 = self._io.read_f4le()
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbVertexDisplacement21, self)._write__seq(io)
-            self._io.write_f4le(self.f_vtx_disp_start2)
-            self._io.write_f4le(self.f_vtx_disp_scale2)
-            self._io.write_f4le(self.f_vtx_disp_inv_area2)
-            self._io.write_f4le(self.f_vtx_disp_rcn2)
-
-
-        def _check(self):
-            pass
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 16
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class CbGlobals(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-            self._should_write_app_specific = False
-            self.app_specific__to_write = True
-
-        def _read(self):
-            pass
-
-
-        def _fetch_instances(self):
-            pass
-            _ = self.app_specific
-            _on = self._root.app_id
-            if _on == u"re1":
-                pass
-                self.app_specific._fetch_instances()
-            elif _on == u"rev1":
-                pass
-                self.app_specific._fetch_instances()
-            elif _on == u"re6":
-                pass
-                self.app_specific._fetch_instances()
-            elif _on == u"re0":
-                pass
-                self.app_specific._fetch_instances()
-            elif _on == u"dd":
-                pass
-                self.app_specific._fetch_instances()
-            elif _on == u"rev2":
-                pass
-                self.app_specific._fetch_instances()
-            else:
-                pass
-                self.app_specific._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbGlobals, self)._write__seq(io)
-            self._should_write_app_specific = self.app_specific__to_write
-
-
-        def _check(self):
-            pass
-
-        @property
-        def app_specific(self):
-            if self._should_write_app_specific:
-                self._write_app_specific()
-            if hasattr(self, '_m_app_specific'):
-                return self._m_app_specific
-
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"re1":
-                pass
-                self._m_app_specific = Mrl.CbGlobals1(self._io, self, self._root)
-                self._m_app_specific._read()
-            elif _on == u"rev1":
-                pass
-                self._m_app_specific = Mrl.CbGlobals1(self._io, self, self._root)
-                self._m_app_specific._read()
-            elif _on == u"re6":
-                pass
-                self._m_app_specific = Mrl.CbGlobals3(self._io, self, self._root)
-                self._m_app_specific._read()
-            elif _on == u"re0":
-                pass
-                self._m_app_specific = Mrl.CbGlobals1(self._io, self, self._root)
-                self._m_app_specific._read()
-            elif _on == u"dd":
-                pass
-                self._m_app_specific = Mrl.CbGlobals4(self._io, self, self._root)
-                self._m_app_specific._read()
-            elif _on == u"rev2":
-                pass
-                self._m_app_specific = Mrl.CbGlobals2(self._io, self, self._root)
-                self._m_app_specific._read()
-            else:
-                pass
-                self._m_app_specific = Mrl.CbGlobals1(self._io, self, self._root)
-                self._m_app_specific._read()
-            self._io.seek(_pos)
-            return getattr(self, '_m_app_specific', None)
-
-        @app_specific.setter
-        def app_specific(self, v):
-            self._m_app_specific = v
-
-        def _write_app_specific(self):
-            self._should_write_app_specific = False
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"re1":
-                pass
-                self.app_specific._write__seq(self._io)
-            elif _on == u"rev1":
-                pass
-                self.app_specific._write__seq(self._io)
-            elif _on == u"re6":
-                pass
-                self.app_specific._write__seq(self._io)
-            elif _on == u"re0":
-                pass
-                self.app_specific._write__seq(self._io)
-            elif _on == u"dd":
-                pass
-                self.app_specific._write__seq(self._io)
-            elif _on == u"rev2":
-                pass
-                self.app_specific._write__seq(self._io)
-            else:
-                pass
-                self.app_specific._write__seq(self._io)
-            self._io.seek(_pos)
-
-
-        def _check_app_specific(self):
-            pass
-            _on = self._root.app_id
-            if _on == u"re1":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            elif _on == u"rev1":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            elif _on == u"re6":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            elif _on == u"re0":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            elif _on == u"dd":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            elif _on == u"rev2":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            else:
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-
-
-    class CbSpecularBlend1(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.f_specular_blend_color = []
-            for i in range(4):
-                self.f_specular_blend_color.append(self._io.read_f4le())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.f_specular_blend_color)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbSpecularBlend1, self)._write__seq(io)
-            for i in range(len(self.f_specular_blend_color)):
-                pass
-                self._io.write_f4le(self.f_specular_blend_color[i])
-
-
-
-        def _check(self):
-            pass
-            if (len(self.f_specular_blend_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_specular_blend_color", len(self.f_specular_blend_color), 4)
-            for i in range(len(self.f_specular_blend_color)):
-                pass
-
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 16
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class CbMaterial1(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.f_diffuse_color = []
-            for i in range(3):
-                self.f_diffuse_color.append(self._io.read_f4le())
-
-            self.f_transparency = self._io.read_f4le()
-            self.f_reflective_color = []
-            for i in range(3):
-                self.f_reflective_color.append(self._io.read_f4le())
-
-            self.f_transparency_volume = self._io.read_f4le()
-            self.f_uv_transform = []
-            for i in range(8):
-                self.f_uv_transform.append(self._io.read_f4le())
-
-            self.f_uv_transform2 = []
-            for i in range(8):
-                self.f_uv_transform2.append(self._io.read_f4le())
-
-            self.f_uv_transform3 = []
-            for i in range(8):
-                self.f_uv_transform3.append(self._io.read_f4le())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.f_diffuse_color)):
-                pass
-
-            for i in range(len(self.f_reflective_color)):
-                pass
-
-            for i in range(len(self.f_uv_transform)):
-                pass
-
-            for i in range(len(self.f_uv_transform2)):
-                pass
-
-            for i in range(len(self.f_uv_transform3)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbMaterial1, self)._write__seq(io)
-            for i in range(len(self.f_diffuse_color)):
-                pass
-                self._io.write_f4le(self.f_diffuse_color[i])
-
-            self._io.write_f4le(self.f_transparency)
-            for i in range(len(self.f_reflective_color)):
-                pass
-                self._io.write_f4le(self.f_reflective_color[i])
-
-            self._io.write_f4le(self.f_transparency_volume)
-            for i in range(len(self.f_uv_transform)):
-                pass
-                self._io.write_f4le(self.f_uv_transform[i])
-
-            for i in range(len(self.f_uv_transform2)):
-                pass
-                self._io.write_f4le(self.f_uv_transform2[i])
-
-            for i in range(len(self.f_uv_transform3)):
-                pass
-                self._io.write_f4le(self.f_uv_transform3[i])
-
-
-
-        def _check(self):
-            pass
-            if (len(self.f_diffuse_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_diffuse_color", len(self.f_diffuse_color), 3)
-            for i in range(len(self.f_diffuse_color)):
-                pass
-
-            if (len(self.f_reflective_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_reflective_color", len(self.f_reflective_color), 3)
-            for i in range(len(self.f_reflective_color)):
-                pass
-
-            if (len(self.f_uv_transform) != 8):
-                raise kaitaistruct.ConsistencyError(u"f_uv_transform", len(self.f_uv_transform), 8)
-            for i in range(len(self.f_uv_transform)):
-                pass
-
-            if (len(self.f_uv_transform2) != 8):
-                raise kaitaistruct.ConsistencyError(u"f_uv_transform2", len(self.f_uv_transform2), 8)
-            for i in range(len(self.f_uv_transform2)):
-                pass
-
-            if (len(self.f_uv_transform3) != 8):
-                raise kaitaistruct.ConsistencyError(u"f_uv_transform3", len(self.f_uv_transform3), 8)
-            for i in range(len(self.f_uv_transform3)):
-                pass
-
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 128
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class CbAppReflect1(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.f_app_water_reflect_scale = self._io.read_f4le()
-            self.f_app_shadow_light_scale = self._io.read_f4le()
-            self.padding = []
-            for i in range(2):
-                self.padding.append(self._io.read_f4le())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.padding)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbAppReflect1, self)._write__seq(io)
-            self._io.write_f4le(self.f_app_water_reflect_scale)
-            self._io.write_f4le(self.f_app_shadow_light_scale)
-            for i in range(len(self.padding)):
-                pass
-                self._io.write_f4le(self.padding[i])
-
-
-
-        def _check(self):
-            pass
-            if (len(self.padding) != 2):
-                raise kaitaistruct.ConsistencyError(u"padding", len(self.padding), 2)
-            for i in range(len(self.padding)):
-                pass
-
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 16
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class CbAppReflect(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-            self._should_write_app_specific = False
-            self.app_specific__to_write = True
-
-        def _read(self):
-            pass
-
-
-        def _fetch_instances(self):
-            pass
-            _ = self.app_specific
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self.app_specific._fetch_instances()
-            else:
-                pass
-                self.app_specific._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbAppReflect, self)._write__seq(io)
-            self._should_write_app_specific = self.app_specific__to_write
-
-
-        def _check(self):
-            pass
-
-        @property
-        def app_specific(self):
-            if self._should_write_app_specific:
-                self._write_app_specific()
-            if hasattr(self, '_m_app_specific'):
-                return self._m_app_specific
-
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self._m_app_specific = Mrl.CbAppReflect1(self._io, self, self._root)
-                self._m_app_specific._read()
-            else:
-                pass
-                self._m_app_specific = Mrl.CbAppReflect1(self._io, self, self._root)
-                self._m_app_specific._read()
-            self._io.seek(_pos)
-            return getattr(self, '_m_app_specific', None)
-
-        @app_specific.setter
-        def app_specific(self, v):
-            self._m_app_specific = v
-
-        def _write_app_specific(self):
-            self._should_write_app_specific = False
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self.app_specific._write__seq(self._io)
-            else:
-                pass
-                self.app_specific._write__seq(self._io)
-            self._io.seek(_pos)
-
-
-        def _check_app_specific(self):
-            pass
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            else:
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-
-
-    class CbGlobals4(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.f_albedo_color = []
-            for i in range(3):
-                self.f_albedo_color.append(self._io.read_f4le())
-
-            self.padding_1 = self._io.read_f4le()
-            self.f_albedo_blend_color = []
-            for i in range(4):
-                self.f_albedo_blend_color.append(self._io.read_f4le())
-
-            self.f_detail_normal_power = self._io.read_f4le()
-            self.f_detail_normal_uv_scale = self._io.read_f4le()
-            self.f_detail_normal2_power = self._io.read_f4le()
-            self.f_detail_normal2_uv_scale = self._io.read_f4le()
-            self.f_primary_shift = self._io.read_f4le()
-            self.f_secondary_shift = self._io.read_f4le()
-            self.f_parallax_factor = self._io.read_f4le()
-            self.f_parallax_self_occlusion = self._io.read_f4le()
-            self.f_parallax_min_sample = self._io.read_f4le()
-            self.f_parallax_max_sample = self._io.read_f4le()
-            self.padding_2 = []
-            for i in range(2):
-                self.padding_2.append(self._io.read_f4le())
-
-            self.f_light_map_color = []
-            for i in range(3):
-                self.f_light_map_color.append(self._io.read_f4le())
-
-            self.padding_3 = self._io.read_f4le()
-            self.f_thin_map_color = []
-            for i in range(3):
-                self.f_thin_map_color.append(self._io.read_f4le())
-
-            self.f_thin_scattering = self._io.read_f4le()
-            self.f_indirect_offset = []
-            for i in range(2):
-                self.f_indirect_offset.append(self._io.read_f4le())
-
-            self.f_indirect_scale = []
-            for i in range(2):
-                self.f_indirect_scale.append(self._io.read_f4le())
-
-            self.f_fresnel_schlick = self._io.read_f4le()
-            self.f_fresnel_schlick_rgb = []
-            for i in range(3):
-                self.f_fresnel_schlick_rgb.append(self._io.read_f4le())
-
-            self.f_specular_color = []
-            for i in range(3):
-                self.f_specular_color.append(self._io.read_f4le())
-
-            self.f_shininess = self._io.read_f4le()
-            self.f_emission_color = []
-            for i in range(3):
-                self.f_emission_color.append(self._io.read_f4le())
-
-            self.f_alpha_clip_threshold = self._io.read_f4le()
-            self.f_roughness = self._io.read_f4le()
-            self.f_roughness_rgb = []
-            for i in range(3):
-                self.f_roughness_rgb.append(self._io.read_f4le())
-
-            self.f_anisotoropic_direction = []
-            for i in range(3):
-                self.f_anisotoropic_direction.append(self._io.read_f4le())
-
-            self.f_smoothness = self._io.read_f4le()
-            self.f_anistropic_uv = []
-            for i in range(2):
-                self.f_anistropic_uv.append(self._io.read_f4le())
-
-            self.f_primary_expo = self._io.read_f4le()
-            self.f_secondary_expo = self._io.read_f4le()
-            self.f_primary_color = []
-            for i in range(3):
-                self.f_primary_color.append(self._io.read_f4le())
-
-            self.padding_4 = self._io.read_f4le()
-            self.f_secondary_color = []
-            for i in range(3):
-                self.f_secondary_color.append(self._io.read_f4le())
-
-            self.padding_5 = self._io.read_f4le()
-            self.xyzw_sepalate = []
-            for i in range(16):
-                self.xyzw_sepalate.append(self._io.read_f4le())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.f_albedo_color)):
-                pass
-
-            for i in range(len(self.f_albedo_blend_color)):
-                pass
-
-            for i in range(len(self.padding_2)):
-                pass
-
-            for i in range(len(self.f_light_map_color)):
-                pass
-
-            for i in range(len(self.f_thin_map_color)):
-                pass
-
-            for i in range(len(self.f_indirect_offset)):
-                pass
-
-            for i in range(len(self.f_indirect_scale)):
-                pass
-
-            for i in range(len(self.f_fresnel_schlick_rgb)):
-                pass
-
-            for i in range(len(self.f_specular_color)):
-                pass
-
-            for i in range(len(self.f_emission_color)):
-                pass
-
-            for i in range(len(self.f_roughness_rgb)):
-                pass
-
-            for i in range(len(self.f_anisotoropic_direction)):
-                pass
-
-            for i in range(len(self.f_anistropic_uv)):
-                pass
-
-            for i in range(len(self.f_primary_color)):
-                pass
-
-            for i in range(len(self.f_secondary_color)):
-                pass
-
-            for i in range(len(self.xyzw_sepalate)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbGlobals4, self)._write__seq(io)
-            for i in range(len(self.f_albedo_color)):
-                pass
-                self._io.write_f4le(self.f_albedo_color[i])
-
-            self._io.write_f4le(self.padding_1)
-            for i in range(len(self.f_albedo_blend_color)):
-                pass
-                self._io.write_f4le(self.f_albedo_blend_color[i])
-
-            self._io.write_f4le(self.f_detail_normal_power)
-            self._io.write_f4le(self.f_detail_normal_uv_scale)
-            self._io.write_f4le(self.f_detail_normal2_power)
-            self._io.write_f4le(self.f_detail_normal2_uv_scale)
-            self._io.write_f4le(self.f_primary_shift)
-            self._io.write_f4le(self.f_secondary_shift)
-            self._io.write_f4le(self.f_parallax_factor)
-            self._io.write_f4le(self.f_parallax_self_occlusion)
-            self._io.write_f4le(self.f_parallax_min_sample)
-            self._io.write_f4le(self.f_parallax_max_sample)
-            for i in range(len(self.padding_2)):
-                pass
-                self._io.write_f4le(self.padding_2[i])
-
-            for i in range(len(self.f_light_map_color)):
-                pass
-                self._io.write_f4le(self.f_light_map_color[i])
-
-            self._io.write_f4le(self.padding_3)
-            for i in range(len(self.f_thin_map_color)):
-                pass
-                self._io.write_f4le(self.f_thin_map_color[i])
-
-            self._io.write_f4le(self.f_thin_scattering)
-            for i in range(len(self.f_indirect_offset)):
-                pass
-                self._io.write_f4le(self.f_indirect_offset[i])
-
-            for i in range(len(self.f_indirect_scale)):
-                pass
-                self._io.write_f4le(self.f_indirect_scale[i])
-
-            self._io.write_f4le(self.f_fresnel_schlick)
-            for i in range(len(self.f_fresnel_schlick_rgb)):
-                pass
-                self._io.write_f4le(self.f_fresnel_schlick_rgb[i])
-
-            for i in range(len(self.f_specular_color)):
-                pass
-                self._io.write_f4le(self.f_specular_color[i])
-
-            self._io.write_f4le(self.f_shininess)
-            for i in range(len(self.f_emission_color)):
-                pass
-                self._io.write_f4le(self.f_emission_color[i])
-
-            self._io.write_f4le(self.f_alpha_clip_threshold)
-            self._io.write_f4le(self.f_roughness)
-            for i in range(len(self.f_roughness_rgb)):
-                pass
-                self._io.write_f4le(self.f_roughness_rgb[i])
-
-            for i in range(len(self.f_anisotoropic_direction)):
-                pass
-                self._io.write_f4le(self.f_anisotoropic_direction[i])
-
-            self._io.write_f4le(self.f_smoothness)
-            for i in range(len(self.f_anistropic_uv)):
-                pass
-                self._io.write_f4le(self.f_anistropic_uv[i])
-
-            self._io.write_f4le(self.f_primary_expo)
-            self._io.write_f4le(self.f_secondary_expo)
-            for i in range(len(self.f_primary_color)):
-                pass
-                self._io.write_f4le(self.f_primary_color[i])
-
-            self._io.write_f4le(self.padding_4)
-            for i in range(len(self.f_secondary_color)):
-                pass
-                self._io.write_f4le(self.f_secondary_color[i])
-
-            self._io.write_f4le(self.padding_5)
-            for i in range(len(self.xyzw_sepalate)):
-                pass
-                self._io.write_f4le(self.xyzw_sepalate[i])
-
-
-
-        def _check(self):
-            pass
-            if (len(self.f_albedo_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_albedo_color", len(self.f_albedo_color), 3)
-            for i in range(len(self.f_albedo_color)):
-                pass
-
-            if (len(self.f_albedo_blend_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_albedo_blend_color", len(self.f_albedo_blend_color), 4)
-            for i in range(len(self.f_albedo_blend_color)):
-                pass
-
-            if (len(self.padding_2) != 2):
-                raise kaitaistruct.ConsistencyError(u"padding_2", len(self.padding_2), 2)
-            for i in range(len(self.padding_2)):
-                pass
-
-            if (len(self.f_light_map_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_light_map_color", len(self.f_light_map_color), 3)
-            for i in range(len(self.f_light_map_color)):
-                pass
-
-            if (len(self.f_thin_map_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_thin_map_color", len(self.f_thin_map_color), 3)
-            for i in range(len(self.f_thin_map_color)):
-                pass
-
-            if (len(self.f_indirect_offset) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_indirect_offset", len(self.f_indirect_offset), 2)
-            for i in range(len(self.f_indirect_offset)):
-                pass
-
-            if (len(self.f_indirect_scale) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_indirect_scale", len(self.f_indirect_scale), 2)
-            for i in range(len(self.f_indirect_scale)):
-                pass
-
-            if (len(self.f_fresnel_schlick_rgb) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_fresnel_schlick_rgb", len(self.f_fresnel_schlick_rgb), 3)
-            for i in range(len(self.f_fresnel_schlick_rgb)):
-                pass
-
-            if (len(self.f_specular_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_specular_color", len(self.f_specular_color), 3)
-            for i in range(len(self.f_specular_color)):
-                pass
-
-            if (len(self.f_emission_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_emission_color", len(self.f_emission_color), 3)
-            for i in range(len(self.f_emission_color)):
-                pass
-
-            if (len(self.f_roughness_rgb) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_roughness_rgb", len(self.f_roughness_rgb), 3)
-            for i in range(len(self.f_roughness_rgb)):
-                pass
-
-            if (len(self.f_anisotoropic_direction) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_anisotoropic_direction", len(self.f_anisotoropic_direction), 3)
-            for i in range(len(self.f_anisotoropic_direction)):
-                pass
-
-            if (len(self.f_anistropic_uv) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_anistropic_uv", len(self.f_anistropic_uv), 2)
-            for i in range(len(self.f_anistropic_uv)):
-                pass
-
-            if (len(self.f_primary_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_primary_color", len(self.f_primary_color), 3)
-            for i in range(len(self.f_primary_color)):
-                pass
-
-            if (len(self.f_secondary_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_secondary_color", len(self.f_secondary_color), 3)
-            for i in range(len(self.f_secondary_color)):
-                pass
-
-            if (len(self.xyzw_sepalate) != 16):
-                raise kaitaistruct.ConsistencyError(u"xyzw_sepalate", len(self.xyzw_sepalate), 16)
-            for i in range(len(self.xyzw_sepalate)):
-                pass
-
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 320
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class CbBurnCommon1(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.f_b_blend_map_color = []
-            for i in range(3):
-                self.f_b_blend_map_color.append(self._io.read_f4le())
-
-            self.f_b_alpha_clip_threshold = self._io.read_f4le()
-            self.f_b_blend_alpha_threshold = self._io.read_f4le()
-            self.f_b_blend_alpha_band = self._io.read_f4le()
-            self.f_b_specular_blend_rate = self._io.read_f4le()
-            self.f_b_albedo_blend_rate = self._io.read_f4le()
-            self.f_b_albedo_blend_rate2 = self._io.read_f4le()
-            self.padding = []
-            for i in range(3):
-                self.padding.append(self._io.read_f4le())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.f_b_blend_map_color)):
-                pass
-
-            for i in range(len(self.padding)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbBurnCommon1, self)._write__seq(io)
-            for i in range(len(self.f_b_blend_map_color)):
-                pass
-                self._io.write_f4le(self.f_b_blend_map_color[i])
-
-            self._io.write_f4le(self.f_b_alpha_clip_threshold)
-            self._io.write_f4le(self.f_b_blend_alpha_threshold)
-            self._io.write_f4le(self.f_b_blend_alpha_band)
-            self._io.write_f4le(self.f_b_specular_blend_rate)
-            self._io.write_f4le(self.f_b_albedo_blend_rate)
-            self._io.write_f4le(self.f_b_albedo_blend_rate2)
-            for i in range(len(self.padding)):
-                pass
-                self._io.write_f4le(self.padding[i])
-
-
-
-        def _check(self):
-            pass
-            if (len(self.f_b_blend_map_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_b_blend_map_color", len(self.f_b_blend_map_color), 3)
-            for i in range(len(self.f_b_blend_map_color)):
-                pass
-
-            if (len(self.padding) != 3):
-                raise kaitaistruct.ConsistencyError(u"padding", len(self.padding), 3)
-            for i in range(len(self.padding)):
-                pass
-
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 48
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class AnimOfs(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-            self._should_write_anim_entries = False
-            self.anim_entries__to_write = True
-
-        def _read(self):
-            self.ofs_block = self._io.read_u4le()
-
-
-        def _fetch_instances(self):
-            pass
-            _ = self.anim_entries
-            self.anim_entries._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.AnimOfs, self)._write__seq(io)
-            self._should_write_anim_entries = self.anim_entries__to_write
-            self._io.write_u4le(self.ofs_block)
-
-
-        def _check(self):
-            pass
-
-        @property
-        def anim_entries(self):
-            if self._should_write_anim_entries:
-                self._write_anim_entries()
-            if hasattr(self, '_m_anim_entries'):
-                return self._m_anim_entries
-
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_anim_data + self.ofs_block))
-            self._m_anim_entries = Mrl.AnimEntry(self._io, self, self._root)
-            self._m_anim_entries._read()
-            self._io.seek(_pos)
-            return getattr(self, '_m_anim_entries', None)
-
-        @anim_entries.setter
-        def anim_entries(self, v):
-            self._m_anim_entries = v
-
-        def _write_anim_entries(self):
-            self._should_write_anim_entries = False
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_anim_data + self.ofs_block))
-            self.anim_entries._write__seq(self._io)
-            self._io.seek(_pos)
-
-
-        def _check_anim_entries(self):
-            pass
-            if self.anim_entries._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"anim_entries", self.anim_entries._root, self._root)
-            if self.anim_entries._parent != self:
-                raise kaitaistruct.ConsistencyError(u"anim_entries", self.anim_entries._parent, self)
-
-
-    class AnimSubEntry0(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.header = []
-            for i in range(4):
-                self.header.append(self._io.read_u1())
-
-            self.values = []
-            for i in range(self._parent.info.num_entry):
-                _t_values = Mrl.AnimType0(self._io, self, self._root)
-                _t_values._read()
-                self.values.append(_t_values)
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.header)):
-                pass
-
-            for i in range(len(self.values)):
-                pass
-                self.values[i]._fetch_instances()
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.AnimSubEntry0, self)._write__seq(io)
-            for i in range(len(self.header)):
-                pass
-                self._io.write_u1(self.header[i])
-
-            for i in range(len(self.values)):
-                pass
-                self.values[i]._write__seq(self._io)
-
-
-
-        def _check(self):
-            pass
-            if (len(self.header) != 4):
-                raise kaitaistruct.ConsistencyError(u"header", len(self.header), 4)
-            for i in range(len(self.header)):
-                pass
-
-            if (len(self.values) != self._parent.info.num_entry):
-                raise kaitaistruct.ConsistencyError(u"values", len(self.values), self._parent.info.num_entry)
-            for i in range(len(self.values)):
-                pass
-                if self.values[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"values", self.values[i]._root, self._root)
-                if self.values[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"values", self.values[i]._parent, self)
-
-
-
-    class CbDdMaterialParamInnerCorrect(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-            self._should_write_app_specific = False
-            self.app_specific__to_write = True
-
-        def _read(self):
-            pass
-
-
-        def _fetch_instances(self):
-            pass
-            _ = self.app_specific
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self.app_specific._fetch_instances()
-            else:
-                pass
-                self.app_specific._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbDdMaterialParamInnerCorrect, self)._write__seq(io)
-            self._should_write_app_specific = self.app_specific__to_write
-
-
-        def _check(self):
-            pass
-
-        @property
-        def app_specific(self):
-            if self._should_write_app_specific:
-                self._write_app_specific()
-            if hasattr(self, '_m_app_specific'):
-                return self._m_app_specific
-
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self._m_app_specific = Mrl.CbDdMaterialParamInnerCorrect1(self._io, self, self._root)
-                self._m_app_specific._read()
-            else:
-                pass
-                self._m_app_specific = Mrl.CbDdMaterialParamInnerCorrect1(self._io, self, self._root)
-                self._m_app_specific._read()
-            self._io.seek(_pos)
-            return getattr(self, '_m_app_specific', None)
-
-        @app_specific.setter
-        def app_specific(self, v):
-            self._m_app_specific = v
-
-        def _write_app_specific(self):
-            self._should_write_app_specific = False
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self.app_specific._write__seq(self._io)
-            else:
-                pass
-                self.app_specific._write__seq(self._io)
-            self._io.seek(_pos)
-
-
-        def _check_app_specific(self):
-            pass
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            else:
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-
-
-    class CbBurnEmission(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-            self._should_write_app_specific = False
-            self.app_specific__to_write = True
-
-        def _read(self):
-            pass
-
-
-        def _fetch_instances(self):
-            pass
-            _ = self.app_specific
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self.app_specific._fetch_instances()
-            else:
-                pass
-                self.app_specific._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbBurnEmission, self)._write__seq(io)
-            self._should_write_app_specific = self.app_specific__to_write
-
-
-        def _check(self):
-            pass
-
-        @property
-        def app_specific(self):
-            if self._should_write_app_specific:
-                self._write_app_specific()
-            if hasattr(self, '_m_app_specific'):
-                return self._m_app_specific
-
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self._m_app_specific = Mrl.CbBurnEmission1(self._io, self, self._root)
-                self._m_app_specific._read()
-            else:
-                pass
-                self._m_app_specific = Mrl.CbBurnEmission1(self._io, self, self._root)
-                self._m_app_specific._read()
-            self._io.seek(_pos)
-            return getattr(self, '_m_app_specific', None)
-
-        @app_specific.setter
-        def app_specific(self, v):
-            self._m_app_specific = v
-
-        def _write_app_specific(self):
-            self._should_write_app_specific = False
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self.app_specific._write__seq(self._io)
-            else:
-                pass
-                self.app_specific._write__seq(self._io)
-            self._io.seek(_pos)
-
-
-        def _check_app_specific(self):
-            pass
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            else:
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-
-
-    class CbUvRotationOffset1(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.f_uv_rotation_center = []
-            for i in range(2):
-                self.f_uv_rotation_center.append(self._io.read_f4le())
-
-            self.f_uv_rotation_angle = self._io.read_f4le()
-            self.padding = self._io.read_f4le()
-            self.f_uv_rotation_offset = []
-            for i in range(2):
-                self.f_uv_rotation_offset.append(self._io.read_f4le())
-
-            self.f_uv_rotation_scale = []
-            for i in range(2):
-                self.f_uv_rotation_scale.append(self._io.read_f4le())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.f_uv_rotation_center)):
-                pass
-
-            for i in range(len(self.f_uv_rotation_offset)):
-                pass
-
-            for i in range(len(self.f_uv_rotation_scale)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbUvRotationOffset1, self)._write__seq(io)
-            for i in range(len(self.f_uv_rotation_center)):
-                pass
-                self._io.write_f4le(self.f_uv_rotation_center[i])
-
-            self._io.write_f4le(self.f_uv_rotation_angle)
-            self._io.write_f4le(self.padding)
-            for i in range(len(self.f_uv_rotation_offset)):
-                pass
-                self._io.write_f4le(self.f_uv_rotation_offset[i])
-
-            for i in range(len(self.f_uv_rotation_scale)):
-                pass
-                self._io.write_f4le(self.f_uv_rotation_scale[i])
-
-
-
-        def _check(self):
-            pass
-            if (len(self.f_uv_rotation_center) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_uv_rotation_center", len(self.f_uv_rotation_center), 2)
-            for i in range(len(self.f_uv_rotation_center)):
-                pass
-
-            if (len(self.f_uv_rotation_offset) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_uv_rotation_offset", len(self.f_uv_rotation_offset), 2)
-            for i in range(len(self.f_uv_rotation_offset)):
-                pass
-
-            if (len(self.f_uv_rotation_scale) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_uv_rotation_scale", len(self.f_uv_rotation_scale), 2)
-            for i in range(len(self.f_uv_rotation_scale)):
-                pass
-
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 32
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class CbUvRotationOffset(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-            self._should_write_app_specific = False
-            self.app_specific__to_write = True
-
-        def _read(self):
-            pass
-
-
-        def _fetch_instances(self):
-            pass
-            _ = self.app_specific
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self.app_specific._fetch_instances()
-            else:
-                pass
-                self.app_specific._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbUvRotationOffset, self)._write__seq(io)
-            self._should_write_app_specific = self.app_specific__to_write
-
-
-        def _check(self):
-            pass
-
-        @property
-        def app_specific(self):
-            if self._should_write_app_specific:
-                self._write_app_specific()
-            if hasattr(self, '_m_app_specific'):
-                return self._m_app_specific
-
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self._m_app_specific = Mrl.CbUvRotationOffset1(self._io, self, self._root)
-                self._m_app_specific._read()
-            else:
-                pass
-                self._m_app_specific = Mrl.CbUvRotationOffset1(self._io, self, self._root)
-                self._m_app_specific._read()
-            self._io.seek(_pos)
-            return getattr(self, '_m_app_specific', None)
-
-        @app_specific.setter
-        def app_specific(self, v):
-            self._m_app_specific = v
-
-        def _write_app_specific(self):
-            self._should_write_app_specific = False
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self.app_specific._write__seq(self._io)
-            else:
-                pass
-                self.app_specific._write__seq(self._io)
-            self._io.seek(_pos)
-
-
-        def _check_app_specific(self):
-            pass
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            else:
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-
-
-    class CbVertexDisplacement1(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.f_vtx_disp_start = self._io.read_f4le()
-            self.f_vtx_disp_scale = self._io.read_f4le()
-            self.f_vtx_disp_inv_area = self._io.read_f4le()
-            self.f_vtx_disp_rcn = self._io.read_f4le()
-            self.f_vtx_disp_tilt_u = self._io.read_f4le()
-            self.f_vtx_disp_tilt_v = self._io.read_f4le()
-            self.filler = []
-            for i in range(2):
-                self.filler.append(self._io.read_f4le())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.filler)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbVertexDisplacement1, self)._write__seq(io)
-            self._io.write_f4le(self.f_vtx_disp_start)
-            self._io.write_f4le(self.f_vtx_disp_scale)
-            self._io.write_f4le(self.f_vtx_disp_inv_area)
-            self._io.write_f4le(self.f_vtx_disp_rcn)
-            self._io.write_f4le(self.f_vtx_disp_tilt_u)
-            self._io.write_f4le(self.f_vtx_disp_tilt_v)
-            for i in range(len(self.filler)):
-                pass
-                self._io.write_f4le(self.filler[i])
-
-
-
-        def _check(self):
-            pass
-            if (len(self.filler) != 2):
-                raise kaitaistruct.ConsistencyError(u"filler", len(self.filler), 2)
-            for i in range(len(self.filler)):
-                pass
-
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 32
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class AnimSubEntry7(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.header = []
-            for i in range(36):
-                self.header.append(self._io.read_u1())
-
-            self.values = []
-            for i in range((24 * (self._parent.info.num_entry - 1))):
-                self.values.append(self._io.read_u1())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.header)):
-                pass
-
-            for i in range(len(self.values)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.AnimSubEntry7, self)._write__seq(io)
-            for i in range(len(self.header)):
-                pass
-                self._io.write_u1(self.header[i])
-
-            for i in range(len(self.values)):
-                pass
-                self._io.write_u1(self.values[i])
-
-
-
-        def _check(self):
-            pass
-            if (len(self.header) != 36):
-                raise kaitaistruct.ConsistencyError(u"header", len(self.header), 36)
-            for i in range(len(self.header)):
-                pass
-
-            if (len(self.values) != (24 * (self._parent.info.num_entry - 1))):
-                raise kaitaistruct.ConsistencyError(u"values", len(self.values), (24 * (self._parent.info.num_entry - 1)))
-            for i in range(len(self.values)):
-                pass
-
-
-
-    class ShdHash(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.shader_hash = self._io.read_u4le()
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.ShdHash, self)._write__seq(io)
-            self._io.write_u4le(self.shader_hash)
-
-
-        def _check(self):
-            pass
-
-
-    class AnimType0(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.unk_00 = self._io.read_u4le()
-            self.unk_01 = self._io.read_f4le()
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.AnimType0, self)._write__seq(io)
-            self._io.write_u4le(self.unk_00)
-            self._io.write_f4le(self.unk_01)
-
-
-        def _check(self):
-            pass
-
-
-    class CbBurnCommon(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-            self._should_write_app_specific = False
-            self.app_specific__to_write = True
-
-        def _read(self):
-            pass
-
-
-        def _fetch_instances(self):
-            pass
-            _ = self.app_specific
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self.app_specific._fetch_instances()
-            else:
-                pass
-                self.app_specific._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbBurnCommon, self)._write__seq(io)
-            self._should_write_app_specific = self.app_specific__to_write
-
-
-        def _check(self):
-            pass
-
-        @property
-        def app_specific(self):
-            if self._should_write_app_specific:
-                self._write_app_specific()
-            if hasattr(self, '_m_app_specific'):
-                return self._m_app_specific
-
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self._m_app_specific = Mrl.CbBurnCommon1(self._io, self, self._root)
-                self._m_app_specific._read()
-            else:
-                pass
-                self._m_app_specific = Mrl.CbBurnCommon1(self._io, self, self._root)
-                self._m_app_specific._read()
-            self._io.seek(_pos)
-            return getattr(self, '_m_app_specific', None)
-
-        @app_specific.setter
-        def app_specific(self, v):
-            self._m_app_specific = v
-
-        def _write_app_specific(self):
-            self._should_write_app_specific = False
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self.app_specific._write__seq(self._io)
-            else:
-                pass
-                self.app_specific._write__seq(self._io)
-            self._io.seek(_pos)
-
-
-        def _check_app_specific(self):
-            pass
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            else:
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-
-
-    class TextureSlot(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.type_hash = KaitaiStream.resolve_enum(Mrl.TextureType, self._io.read_u4le())
-            self.unk_02 = self._io.read_u4le()
-            self.unk_03 = self._io.read_u4le()
-            self.texture_path = (self._io.read_bytes_term(0, False, True, True)).decode("ASCII")
-            self.filler = []
-            for i in range(((64 - len(self.texture_path)) - 1)):
-                self.filler.append(self._io.read_u1())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.filler)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.TextureSlot, self)._write__seq(io)
-            self._io.write_u4le(int(self.type_hash))
-            self._io.write_u4le(self.unk_02)
-            self._io.write_u4le(self.unk_03)
-            self._io.write_bytes((self.texture_path).encode(u"ASCII"))
-            self._io.write_u1(0)
-            for i in range(len(self.filler)):
-                pass
-                self._io.write_u1(self.filler[i])
-
-
-
-        def _check(self):
-            pass
-            if (KaitaiStream.byte_array_index_of((self.texture_path).encode(u"ASCII"), 0) != -1):
-                raise kaitaistruct.ConsistencyError(u"texture_path", KaitaiStream.byte_array_index_of((self.texture_path).encode(u"ASCII"), 0), -1)
-            if (len(self.filler) != ((64 - len(self.texture_path)) - 1)):
-                raise kaitaistruct.ConsistencyError(u"filler", len(self.filler), ((64 - len(self.texture_path)) - 1))
-            for i in range(len(self.filler)):
-                pass
-
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 76
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class BlockOffset(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-            self._should_write_body = False
-            self.body__to_write = True
-
-        def _read(self):
-            self.ofc_block = self._io.read_u4le()
-
-
-        def _fetch_instances(self):
-            pass
-            _ = self.body
-            self.body._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.BlockOffset, self)._write__seq(io)
-            self._should_write_body = self.body__to_write
-            self._io.write_u4le(self.ofc_block)
-
-
-        def _check(self):
-            pass
-
-        @property
-        def body(self):
-            if self._should_write_body:
-                self._write_body()
-            if hasattr(self, '_m_body'):
-                return self._m_body
-
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent._parent.ofs_base + self.ofc_block))
-            self._m_body = Mrl.AnimSubEntry(self._io, self, self._root)
-            self._m_body._read()
-            self._io.seek(_pos)
-            return getattr(self, '_m_body', None)
-
-        @body.setter
-        def body(self, v):
-            self._m_body = v
-
-        def _write_body(self):
-            self._should_write_body = False
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent._parent.ofs_base + self.ofc_block))
-            self.body._write__seq(self._io)
-            self._io.seek(_pos)
-
-
-        def _check_body(self):
-            pass
-            if self.body._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"body", self.body._root, self._root)
-            if self.body._parent != self:
-                raise kaitaistruct.ConsistencyError(u"body", self.body._parent, self)
-
-
-    class CbGlobals3(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.f_albedo_color = []
-            for i in range(3):
-                self.f_albedo_color.append(self._io.read_f4le())
-
-            self.padding_1 = self._io.read_f4le()
-            self.f_albedo_blend_color = []
-            for i in range(4):
-                self.f_albedo_blend_color.append(self._io.read_f4le())
-
-            self.f_detail_normal_power = self._io.read_f4le()
-            self.f_detail_normal_uv_scale = self._io.read_f4le()
-            self.f_detail_normal2_power = self._io.read_f4le()
-            self.f_detail_normal2_uv_scale = self._io.read_f4le()
-            self.f_primary_shift = self._io.read_f4le()
-            self.f_secondary_shift = self._io.read_f4le()
-            self.f_parallax_factor = self._io.read_f4le()
-            self.f_parallax_self_occlusion = self._io.read_f4le()
-            self.f_parallax_min_sample = self._io.read_f4le()
-            self.f_parallax_max_sample = self._io.read_f4le()
-            self.padding_2 = []
-            for i in range(2):
-                self.padding_2.append(self._io.read_f4le())
-
-            self.f_light_map_color = []
-            for i in range(3):
-                self.f_light_map_color.append(self._io.read_f4le())
-
-            self.padding_3 = self._io.read_f4le()
-            self.f_thin_map_color = []
-            for i in range(3):
-                self.f_thin_map_color.append(self._io.read_f4le())
-
-            self.f_thin_scattering = self._io.read_f4le()
-            self.f_indirect_offset = []
-            for i in range(2):
-                self.f_indirect_offset.append(self._io.read_f4le())
-
-            self.f_indirect_scale = []
-            for i in range(2):
-                self.f_indirect_scale.append(self._io.read_f4le())
-
-            self.f_fresnel_schlick = self._io.read_f4le()
-            self.f_fresnel_schlick_rgb = []
-            for i in range(3):
-                self.f_fresnel_schlick_rgb.append(self._io.read_f4le())
-
-            self.f_specular_color = []
-            for i in range(3):
-                self.f_specular_color.append(self._io.read_f4le())
-
-            self.f_shininess = self._io.read_f4le()
-            self.f_emission_color = []
-            for i in range(3):
-                self.f_emission_color.append(self._io.read_f4le())
-
-            self.f_alpha_clip_threshold = self._io.read_f4le()
-            self.f_primary_expo = self._io.read_f4le()
-            self.f_secondary_expo = self._io.read_f4le()
-            self.padding_4 = []
-            for i in range(2):
-                self.padding_4.append(self._io.read_f4le())
-
-            self.f_primary_color = []
-            for i in range(3):
-                self.f_primary_color.append(self._io.read_f4le())
-
-            self.padding_5 = self._io.read_f4le()
-            self.f_secondary_color = []
-            for i in range(3):
-                self.f_secondary_color.append(self._io.read_f4le())
-
-            self.padding_6 = self._io.read_f4le()
-            self.f_albedo_color_2 = []
-            for i in range(3):
-                self.f_albedo_color_2.append(self._io.read_f4le())
-
-            self.padding_7 = self._io.read_f4le()
-            self.f_specular_color_2 = []
-            for i in range(3):
-                self.f_specular_color_2.append(self._io.read_f4le())
-
-            self.f_fresnel_schlick_2 = self._io.read_f4le()
-            self.f_shininess_2 = self._io.read_f4le()
-            self.padding_8 = []
-            for i in range(3):
-                self.padding_8.append(self._io.read_f4le())
-
-            self.f_transparency_clip_threshold = []
-            for i in range(4):
-                self.f_transparency_clip_threshold.append(self._io.read_f4le())
-
-            self.f_blend_uv = self._io.read_f4le()
-            self.padding_9 = []
-            for i in range(3):
-                self.padding_9.append(self._io.read_f4le())
-
-            self.f_albedo_blend2_color = []
-            for i in range(4):
-                self.f_albedo_blend2_color.append(self._io.read_f4le())
-
-            self.f_detail_normalu_vscale = []
-            for i in range(2):
-                self.f_detail_normalu_vscale.append(self._io.read_f4le())
-
-            self.padding_10 = []
-            for i in range(2):
-                self.padding_10.append(self._io.read_f4le())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.f_albedo_color)):
-                pass
-
-            for i in range(len(self.f_albedo_blend_color)):
-                pass
-
-            for i in range(len(self.padding_2)):
-                pass
-
-            for i in range(len(self.f_light_map_color)):
-                pass
-
-            for i in range(len(self.f_thin_map_color)):
-                pass
-
-            for i in range(len(self.f_indirect_offset)):
-                pass
-
-            for i in range(len(self.f_indirect_scale)):
-                pass
-
-            for i in range(len(self.f_fresnel_schlick_rgb)):
-                pass
-
-            for i in range(len(self.f_specular_color)):
-                pass
-
-            for i in range(len(self.f_emission_color)):
-                pass
-
-            for i in range(len(self.padding_4)):
-                pass
-
-            for i in range(len(self.f_primary_color)):
-                pass
-
-            for i in range(len(self.f_secondary_color)):
-                pass
-
-            for i in range(len(self.f_albedo_color_2)):
-                pass
-
-            for i in range(len(self.f_specular_color_2)):
-                pass
-
-            for i in range(len(self.padding_8)):
-                pass
-
-            for i in range(len(self.f_transparency_clip_threshold)):
-                pass
-
-            for i in range(len(self.padding_9)):
-                pass
-
-            for i in range(len(self.f_albedo_blend2_color)):
-                pass
-
-            for i in range(len(self.f_detail_normalu_vscale)):
-                pass
-
-            for i in range(len(self.padding_10)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbGlobals3, self)._write__seq(io)
-            for i in range(len(self.f_albedo_color)):
-                pass
-                self._io.write_f4le(self.f_albedo_color[i])
-
-            self._io.write_f4le(self.padding_1)
-            for i in range(len(self.f_albedo_blend_color)):
-                pass
-                self._io.write_f4le(self.f_albedo_blend_color[i])
-
-            self._io.write_f4le(self.f_detail_normal_power)
-            self._io.write_f4le(self.f_detail_normal_uv_scale)
-            self._io.write_f4le(self.f_detail_normal2_power)
-            self._io.write_f4le(self.f_detail_normal2_uv_scale)
-            self._io.write_f4le(self.f_primary_shift)
-            self._io.write_f4le(self.f_secondary_shift)
-            self._io.write_f4le(self.f_parallax_factor)
-            self._io.write_f4le(self.f_parallax_self_occlusion)
-            self._io.write_f4le(self.f_parallax_min_sample)
-            self._io.write_f4le(self.f_parallax_max_sample)
-            for i in range(len(self.padding_2)):
-                pass
-                self._io.write_f4le(self.padding_2[i])
-
-            for i in range(len(self.f_light_map_color)):
-                pass
-                self._io.write_f4le(self.f_light_map_color[i])
-
-            self._io.write_f4le(self.padding_3)
-            for i in range(len(self.f_thin_map_color)):
-                pass
-                self._io.write_f4le(self.f_thin_map_color[i])
-
-            self._io.write_f4le(self.f_thin_scattering)
-            for i in range(len(self.f_indirect_offset)):
-                pass
-                self._io.write_f4le(self.f_indirect_offset[i])
-
-            for i in range(len(self.f_indirect_scale)):
-                pass
-                self._io.write_f4le(self.f_indirect_scale[i])
-
-            self._io.write_f4le(self.f_fresnel_schlick)
-            for i in range(len(self.f_fresnel_schlick_rgb)):
-                pass
-                self._io.write_f4le(self.f_fresnel_schlick_rgb[i])
-
-            for i in range(len(self.f_specular_color)):
-                pass
-                self._io.write_f4le(self.f_specular_color[i])
-
-            self._io.write_f4le(self.f_shininess)
-            for i in range(len(self.f_emission_color)):
-                pass
-                self._io.write_f4le(self.f_emission_color[i])
-
-            self._io.write_f4le(self.f_alpha_clip_threshold)
-            self._io.write_f4le(self.f_primary_expo)
-            self._io.write_f4le(self.f_secondary_expo)
-            for i in range(len(self.padding_4)):
-                pass
-                self._io.write_f4le(self.padding_4[i])
-
-            for i in range(len(self.f_primary_color)):
-                pass
-                self._io.write_f4le(self.f_primary_color[i])
-
-            self._io.write_f4le(self.padding_5)
-            for i in range(len(self.f_secondary_color)):
-                pass
-                self._io.write_f4le(self.f_secondary_color[i])
-
-            self._io.write_f4le(self.padding_6)
-            for i in range(len(self.f_albedo_color_2)):
-                pass
-                self._io.write_f4le(self.f_albedo_color_2[i])
-
-            self._io.write_f4le(self.padding_7)
-            for i in range(len(self.f_specular_color_2)):
-                pass
-                self._io.write_f4le(self.f_specular_color_2[i])
-
-            self._io.write_f4le(self.f_fresnel_schlick_2)
-            self._io.write_f4le(self.f_shininess_2)
-            for i in range(len(self.padding_8)):
-                pass
-                self._io.write_f4le(self.padding_8[i])
-
-            for i in range(len(self.f_transparency_clip_threshold)):
-                pass
-                self._io.write_f4le(self.f_transparency_clip_threshold[i])
-
-            self._io.write_f4le(self.f_blend_uv)
-            for i in range(len(self.padding_9)):
-                pass
-                self._io.write_f4le(self.padding_9[i])
-
-            for i in range(len(self.f_albedo_blend2_color)):
-                pass
-                self._io.write_f4le(self.f_albedo_blend2_color[i])
-
-            for i in range(len(self.f_detail_normalu_vscale)):
-                pass
-                self._io.write_f4le(self.f_detail_normalu_vscale[i])
-
-            for i in range(len(self.padding_10)):
-                pass
-                self._io.write_f4le(self.padding_10[i])
-
-
-
-        def _check(self):
-            pass
-            if (len(self.f_albedo_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_albedo_color", len(self.f_albedo_color), 3)
-            for i in range(len(self.f_albedo_color)):
-                pass
-
-            if (len(self.f_albedo_blend_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_albedo_blend_color", len(self.f_albedo_blend_color), 4)
-            for i in range(len(self.f_albedo_blend_color)):
-                pass
-
-            if (len(self.padding_2) != 2):
-                raise kaitaistruct.ConsistencyError(u"padding_2", len(self.padding_2), 2)
-            for i in range(len(self.padding_2)):
-                pass
-
-            if (len(self.f_light_map_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_light_map_color", len(self.f_light_map_color), 3)
-            for i in range(len(self.f_light_map_color)):
-                pass
-
-            if (len(self.f_thin_map_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_thin_map_color", len(self.f_thin_map_color), 3)
-            for i in range(len(self.f_thin_map_color)):
-                pass
-
-            if (len(self.f_indirect_offset) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_indirect_offset", len(self.f_indirect_offset), 2)
-            for i in range(len(self.f_indirect_offset)):
-                pass
-
-            if (len(self.f_indirect_scale) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_indirect_scale", len(self.f_indirect_scale), 2)
-            for i in range(len(self.f_indirect_scale)):
-                pass
-
-            if (len(self.f_fresnel_schlick_rgb) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_fresnel_schlick_rgb", len(self.f_fresnel_schlick_rgb), 3)
-            for i in range(len(self.f_fresnel_schlick_rgb)):
-                pass
-
-            if (len(self.f_specular_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_specular_color", len(self.f_specular_color), 3)
-            for i in range(len(self.f_specular_color)):
-                pass
-
-            if (len(self.f_emission_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_emission_color", len(self.f_emission_color), 3)
-            for i in range(len(self.f_emission_color)):
-                pass
-
-            if (len(self.padding_4) != 2):
-                raise kaitaistruct.ConsistencyError(u"padding_4", len(self.padding_4), 2)
-            for i in range(len(self.padding_4)):
-                pass
-
-            if (len(self.f_primary_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_primary_color", len(self.f_primary_color), 3)
-            for i in range(len(self.f_primary_color)):
-                pass
-
-            if (len(self.f_secondary_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_secondary_color", len(self.f_secondary_color), 3)
-            for i in range(len(self.f_secondary_color)):
-                pass
-
-            if (len(self.f_albedo_color_2) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_albedo_color_2", len(self.f_albedo_color_2), 3)
-            for i in range(len(self.f_albedo_color_2)):
-                pass
-
-            if (len(self.f_specular_color_2) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_specular_color_2", len(self.f_specular_color_2), 3)
-            for i in range(len(self.f_specular_color_2)):
-                pass
-
-            if (len(self.padding_8) != 3):
-                raise kaitaistruct.ConsistencyError(u"padding_8", len(self.padding_8), 3)
-            for i in range(len(self.padding_8)):
-                pass
-
-            if (len(self.f_transparency_clip_threshold) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_transparency_clip_threshold", len(self.f_transparency_clip_threshold), 4)
-            for i in range(len(self.f_transparency_clip_threshold)):
-                pass
-
-            if (len(self.padding_9) != 3):
-                raise kaitaistruct.ConsistencyError(u"padding_9", len(self.padding_9), 3)
-            for i in range(len(self.padding_9)):
-                pass
-
-            if (len(self.f_albedo_blend2_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_albedo_blend2_color", len(self.f_albedo_blend2_color), 4)
-            for i in range(len(self.f_albedo_blend2_color)):
-                pass
-
-            if (len(self.f_detail_normalu_vscale) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_detail_normalu_vscale", len(self.f_detail_normalu_vscale), 2)
-            for i in range(len(self.f_detail_normalu_vscale)):
-                pass
-
-            if (len(self.padding_10) != 2):
-                raise kaitaistruct.ConsistencyError(u"padding_10", len(self.padding_10), 2)
-            for i in range(len(self.padding_10)):
-                pass
-
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 336
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class CmdOfsBuffer(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.ofs_float_buff = self._io.read_u4le()
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CmdOfsBuffer, self)._write__seq(io)
-            self._io.write_u4le(self.ofs_float_buff)
-
-
-        def _check(self):
-            pass
-
-
-    class CbDistortion(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.f_distortion_factor = self._io.read_f4le()
-            self.f_distortion_blend = self._io.read_f4le()
-            self.filler = []
-            for i in range(2):
-                self.filler.append(self._io.read_f4le())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.filler)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbDistortion, self)._write__seq(io)
-            self._io.write_f4le(self.f_distortion_factor)
-            self._io.write_f4le(self.f_distortion_blend)
-            for i in range(len(self.filler)):
-                pass
-                self._io.write_f4le(self.filler[i])
-
-
-
-        def _check(self):
-            pass
-            if (len(self.filler) != 2):
-                raise kaitaistruct.ConsistencyError(u"filler", len(self.filler), 2)
-            for i in range(len(self.filler)):
-                pass
-
-
-
-    class CbAppReflectShadowLight(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-            self._should_write_app_specific = False
-            self.app_specific__to_write = True
-
-        def _read(self):
-            pass
-
-
-        def _fetch_instances(self):
-            pass
-            _ = self.app_specific
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self.app_specific._fetch_instances()
-            else:
-                pass
-                self.app_specific._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbAppReflectShadowLight, self)._write__seq(io)
-            self._should_write_app_specific = self.app_specific__to_write
-
-
-        def _check(self):
-            pass
-
-        @property
-        def app_specific(self):
-            if self._should_write_app_specific:
-                self._write_app_specific()
-            if hasattr(self, '_m_app_specific'):
-                return self._m_app_specific
-
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self._m_app_specific = Mrl.CbAppReflectShadowLight1(self._io, self, self._root)
-                self._m_app_specific._read()
-            else:
-                pass
-                self._m_app_specific = Mrl.CbAppReflectShadowLight1(self._io, self, self._root)
-                self._m_app_specific._read()
-            self._io.seek(_pos)
-            return getattr(self, '_m_app_specific', None)
-
-        @app_specific.setter
-        def app_specific(self, v):
-            self._m_app_specific = v
-
-        def _write_app_specific(self):
-            self._should_write_app_specific = False
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self.app_specific._write__seq(self._io)
-            else:
-                pass
-                self.app_specific._write__seq(self._io)
-            self._io.seek(_pos)
-
-
-        def _check_app_specific(self):
-            pass
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            else:
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-
-
-    class CbColorMask1(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.f_color_mask_threshold = []
-            for i in range(4):
-                self.f_color_mask_threshold.append(self._io.read_f4le())
-
-            self.f_color_mask_offset = []
-            for i in range(4):
-                self.f_color_mask_offset.append(self._io.read_f4le())
-
-            self.f_clip_threshold = []
-            for i in range(4):
-                self.f_clip_threshold.append(self._io.read_f4le())
-
-            self.f_color_mask_color = []
-            for i in range(4):
-                self.f_color_mask_color.append(self._io.read_f4le())
-
-            self.f_color_mask2_threshold = []
-            for i in range(4):
-                self.f_color_mask2_threshold.append(self._io.read_f4le())
-
-            self.f_color_mask2_color = []
-            for i in range(4):
-                self.f_color_mask2_color.append(self._io.read_f4le())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.f_color_mask_threshold)):
-                pass
-
-            for i in range(len(self.f_color_mask_offset)):
-                pass
-
-            for i in range(len(self.f_clip_threshold)):
-                pass
-
-            for i in range(len(self.f_color_mask_color)):
-                pass
-
-            for i in range(len(self.f_color_mask2_threshold)):
-                pass
-
-            for i in range(len(self.f_color_mask2_color)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbColorMask1, self)._write__seq(io)
-            for i in range(len(self.f_color_mask_threshold)):
-                pass
-                self._io.write_f4le(self.f_color_mask_threshold[i])
-
-            for i in range(len(self.f_color_mask_offset)):
-                pass
-                self._io.write_f4le(self.f_color_mask_offset[i])
-
-            for i in range(len(self.f_clip_threshold)):
-                pass
-                self._io.write_f4le(self.f_clip_threshold[i])
-
-            for i in range(len(self.f_color_mask_color)):
-                pass
-                self._io.write_f4le(self.f_color_mask_color[i])
-
-            for i in range(len(self.f_color_mask2_threshold)):
-                pass
-                self._io.write_f4le(self.f_color_mask2_threshold[i])
-
-            for i in range(len(self.f_color_mask2_color)):
-                pass
-                self._io.write_f4le(self.f_color_mask2_color[i])
-
-
-
-        def _check(self):
-            pass
-            if (len(self.f_color_mask_threshold) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_color_mask_threshold", len(self.f_color_mask_threshold), 4)
-            for i in range(len(self.f_color_mask_threshold)):
-                pass
-
-            if (len(self.f_color_mask_offset) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_color_mask_offset", len(self.f_color_mask_offset), 4)
-            for i in range(len(self.f_color_mask_offset)):
-                pass
-
-            if (len(self.f_clip_threshold) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_clip_threshold", len(self.f_clip_threshold), 4)
-            for i in range(len(self.f_clip_threshold)):
-                pass
-
-            if (len(self.f_color_mask_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_color_mask_color", len(self.f_color_mask_color), 4)
-            for i in range(len(self.f_color_mask_color)):
-                pass
-
-            if (len(self.f_color_mask2_threshold) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_color_mask2_threshold", len(self.f_color_mask2_threshold), 4)
-            for i in range(len(self.f_color_mask2_threshold)):
-                pass
-
-            if (len(self.f_color_mask2_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_color_mask2_color", len(self.f_color_mask2_color), 4)
-            for i in range(len(self.f_color_mask2_color)):
-                pass
-
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 96
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class AnimType6(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.unk_00 = []
-            for i in range(2):
-                self.unk_00.append(self._io.read_u4le())
-
-            self.unk_01 = []
-            for i in range(4):
-                self.unk_01.append(self._io.read_f4le())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.unk_00)):
-                pass
-
-            for i in range(len(self.unk_01)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.AnimType6, self)._write__seq(io)
-            for i in range(len(self.unk_00)):
-                pass
-                self._io.write_u4le(self.unk_00[i])
-
-            for i in range(len(self.unk_01)):
-                pass
-                self._io.write_f4le(self.unk_01[i])
-
-
-
-        def _check(self):
-            pass
-            if (len(self.unk_00) != 2):
-                raise kaitaistruct.ConsistencyError(u"unk_00", len(self.unk_00), 2)
-            for i in range(len(self.unk_00)):
-                pass
-
-            if (len(self.unk_01) != 4):
-                raise kaitaistruct.ConsistencyError(u"unk_01", len(self.unk_01), 4)
-            for i in range(len(self.unk_01)):
-                pass
-
-
-
-    class AnimDataInfo(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.type = self._io.read_bits_int_le(4)
-            self.unk_00 = self._io.read_bits_int_le(4)
-            self.num_entry = self._io.read_bits_int_le(24)
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.AnimDataInfo, self)._write__seq(io)
-            self._io.write_bits_int_le(4, self.type)
-            self._io.write_bits_int_le(4, self.unk_00)
-            self._io.write_bits_int_le(24, self.num_entry)
-
-
-        def _check(self):
-            pass
-
-
-    class AnimSubEntry(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.shader_hash = self._io.read_u4le()
-            self.info = Mrl.AnimDataInfo(self._io, self, self._root)
-            self.info._read()
-            _on = self.info.type
-            if _on == 0:
-                pass
-                self.entry = Mrl.AnimSubEntry0(self._io, self, self._root)
-                self.entry._read()
-            elif _on == 4:
-                pass
-                self.entry = Mrl.AnimSubEntry4(self._io, self, self._root)
-                self.entry._read()
-            elif _on == 6:
-                pass
-                self.entry = Mrl.AnimSubEntry6(self._io, self, self._root)
-                self.entry._read()
-            elif _on == 7:
-                pass
-                self.entry = Mrl.AnimSubEntry7(self._io, self, self._root)
-                self.entry._read()
-            elif _on == 1:
-                pass
-                self.entry = Mrl.AnimSubEntry1(self._io, self, self._root)
-                self.entry._read()
-            elif _on == 3:
-                pass
-                self.entry = Mrl.AnimSubEntry3(self._io, self, self._root)
-                self.entry._read()
-            elif _on == 5:
-                pass
-                self.entry = Mrl.AnimSubEntry5(self._io, self, self._root)
-                self.entry._read()
-            elif _on == 2:
-                pass
-                self.entry = Mrl.AnimSubEntry2(self._io, self, self._root)
-                self.entry._read()
-
-
-        def _fetch_instances(self):
-            pass
-            self.info._fetch_instances()
-            _on = self.info.type
-            if _on == 0:
-                pass
-                self.entry._fetch_instances()
-            elif _on == 4:
-                pass
-                self.entry._fetch_instances()
-            elif _on == 6:
-                pass
-                self.entry._fetch_instances()
-            elif _on == 7:
-                pass
-                self.entry._fetch_instances()
-            elif _on == 1:
-                pass
-                self.entry._fetch_instances()
-            elif _on == 3:
-                pass
-                self.entry._fetch_instances()
-            elif _on == 5:
-                pass
-                self.entry._fetch_instances()
-            elif _on == 2:
-                pass
-                self.entry._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.AnimSubEntry, self)._write__seq(io)
-            self._io.write_u4le(self.shader_hash)
-            self.info._write__seq(self._io)
-            _on = self.info.type
-            if _on == 0:
-                pass
-                self.entry._write__seq(self._io)
-            elif _on == 4:
-                pass
-                self.entry._write__seq(self._io)
-            elif _on == 6:
-                pass
-                self.entry._write__seq(self._io)
-            elif _on == 7:
-                pass
-                self.entry._write__seq(self._io)
-            elif _on == 1:
-                pass
-                self.entry._write__seq(self._io)
-            elif _on == 3:
-                pass
-                self.entry._write__seq(self._io)
-            elif _on == 5:
-                pass
-                self.entry._write__seq(self._io)
-            elif _on == 2:
-                pass
-                self.entry._write__seq(self._io)
-
-
-        def _check(self):
-            pass
-            if self.info._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"info", self.info._root, self._root)
-            if self.info._parent != self:
-                raise kaitaistruct.ConsistencyError(u"info", self.info._parent, self)
-            _on = self.info.type
-            if _on == 0:
-                pass
-                if self.entry._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"entry", self.entry._root, self._root)
-                if self.entry._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"entry", self.entry._parent, self)
-            elif _on == 4:
-                pass
-                if self.entry._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"entry", self.entry._root, self._root)
-                if self.entry._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"entry", self.entry._parent, self)
-            elif _on == 6:
-                pass
-                if self.entry._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"entry", self.entry._root, self._root)
-                if self.entry._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"entry", self.entry._parent, self)
-            elif _on == 7:
-                pass
-                if self.entry._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"entry", self.entry._root, self._root)
-                if self.entry._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"entry", self.entry._parent, self)
-            elif _on == 1:
-                pass
-                if self.entry._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"entry", self.entry._root, self._root)
-                if self.entry._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"entry", self.entry._parent, self)
-            elif _on == 3:
-                pass
-                if self.entry._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"entry", self.entry._root, self._root)
-                if self.entry._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"entry", self.entry._parent, self)
-            elif _on == 5:
-                pass
-                if self.entry._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"entry", self.entry._root, self._root)
-                if self.entry._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"entry", self.entry._parent, self)
-            elif _on == 2:
-                pass
-                if self.entry._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"entry", self.entry._root, self._root)
-                if self.entry._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"entry", self.entry._parent, self)
-
-
-    class AnimSubEntry4(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.header = []
-            for i in range(4):
-                self.header.append(self._io.read_u1())
-
-            self.values = []
-            for i in range(self._parent.info.num_entry):
-                _t_values = Mrl.AnimType4(self._io, self, self._root)
-                _t_values._read()
-                self.values.append(_t_values)
-
-            self.hash = []
-            for i in range(self._parent.info.num_entry):
-                self.hash.append(self._io.read_u4le())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.header)):
-                pass
-
-            for i in range(len(self.values)):
-                pass
-                self.values[i]._fetch_instances()
-
-            for i in range(len(self.hash)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.AnimSubEntry4, self)._write__seq(io)
-            for i in range(len(self.header)):
-                pass
-                self._io.write_u1(self.header[i])
-
-            for i in range(len(self.values)):
-                pass
-                self.values[i]._write__seq(self._io)
-
-            for i in range(len(self.hash)):
-                pass
-                self._io.write_u4le(self.hash[i])
-
-
-
-        def _check(self):
-            pass
-            if (len(self.header) != 4):
-                raise kaitaistruct.ConsistencyError(u"header", len(self.header), 4)
-            for i in range(len(self.header)):
-                pass
-
-            if (len(self.values) != self._parent.info.num_entry):
-                raise kaitaistruct.ConsistencyError(u"values", len(self.values), self._parent.info.num_entry)
-            for i in range(len(self.values)):
-                pass
-                if self.values[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"values", self.values[i]._root, self._root)
-                if self.values[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"values", self.values[i]._parent, self)
-
-            if (len(self.hash) != self._parent.info.num_entry):
-                raise kaitaistruct.ConsistencyError(u"hash", len(self.hash), self._parent.info.num_entry)
-            for i in range(len(self.hash)):
-                pass
-
-
-
-    class CbSpecularBlend(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-            self._should_write_app_specific = False
-            self.app_specific__to_write = True
-
-        def _read(self):
-            pass
-
-
-        def _fetch_instances(self):
-            pass
-            _ = self.app_specific
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self.app_specific._fetch_instances()
-            else:
-                pass
-                self.app_specific._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbSpecularBlend, self)._write__seq(io)
-            self._should_write_app_specific = self.app_specific__to_write
-
-
-        def _check(self):
-            pass
-
-        @property
-        def app_specific(self):
-            if self._should_write_app_specific:
-                self._write_app_specific()
-            if hasattr(self, '_m_app_specific'):
-                return self._m_app_specific
-
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self._m_app_specific = Mrl.CbSpecularBlend1(self._io, self, self._root)
-                self._m_app_specific._read()
-            else:
-                pass
-                self._m_app_specific = Mrl.CbSpecularBlend1(self._io, self, self._root)
-                self._m_app_specific._read()
-            self._io.seek(_pos)
-            return getattr(self, '_m_app_specific', None)
-
-        @app_specific.setter
-        def app_specific(self, v):
-            self._m_app_specific = v
-
-        def _write_app_specific(self):
-            self._should_write_app_specific = False
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self.app_specific._write__seq(self._io)
-            else:
-                pass
-                self.app_specific._write__seq(self._io)
-            self._io.seek(_pos)
-
-
-        def _check_app_specific(self):
-            pass
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            else:
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-
-
-    class CbDdMaterialParamInnerCorrect1(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.f_dd_material_inner_correct_offset = self._io.read_f4le()
-            self.padding = []
-            for i in range(3):
-                self.padding.append(self._io.read_f4le())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.padding)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbDdMaterialParamInnerCorrect1, self)._write__seq(io)
-            self._io.write_f4le(self.f_dd_material_inner_correct_offset)
-            for i in range(len(self.padding)):
-                pass
-                self._io.write_f4le(self.padding[i])
-
-
-
-        def _check(self):
-            pass
-            if (len(self.padding) != 3):
-                raise kaitaistruct.ConsistencyError(u"padding", len(self.padding), 3)
-            for i in range(len(self.padding)):
-                pass
-
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 16
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class CbDdMaterialParam(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-            self._should_write_app_specific = False
-            self.app_specific__to_write = True
-
-        def _read(self):
-            pass
-
-
-        def _fetch_instances(self):
-            pass
-            _ = self.app_specific
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self.app_specific._fetch_instances()
-            else:
-                pass
-                self.app_specific._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbDdMaterialParam, self)._write__seq(io)
-            self._should_write_app_specific = self.app_specific__to_write
-
-
-        def _check(self):
-            pass
-
-        @property
-        def app_specific(self):
-            if self._should_write_app_specific:
-                self._write_app_specific()
-            if hasattr(self, '_m_app_specific'):
-                return self._m_app_specific
-
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self._m_app_specific = Mrl.CbDdMaterialParam1(self._io, self, self._root)
-                self._m_app_specific._read()
-            else:
-                pass
-                self._m_app_specific = Mrl.CbDdMaterialParam1(self._io, self, self._root)
-                self._m_app_specific._read()
-            self._io.seek(_pos)
-            return getattr(self, '_m_app_specific', None)
-
-        @app_specific.setter
-        def app_specific(self, v):
-            self._m_app_specific = v
-
-        def _write_app_specific(self):
-            self._should_write_app_specific = False
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self.app_specific._write__seq(self._io)
-            else:
-                pass
-                self.app_specific._write__seq(self._io)
-            self._io.seek(_pos)
-
-
-        def _check_app_specific(self):
-            pass
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            else:
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-
-
     class CbGlobals2(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mrl.CbGlobals2, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -7333,6 +6430,7 @@ class Mrl(ReadWriteKaitaiStruct):
             for i in range(4):
                 self.f_texture_blend_color.append(self._io.read_f4le())
 
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -7581,162 +6679,162 @@ class Mrl(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
-            if (len(self.f_albedo_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_albedo_color", len(self.f_albedo_color), 3)
+            if len(self.f_albedo_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_albedo_color", 3, len(self.f_albedo_color))
             for i in range(len(self.f_albedo_color)):
                 pass
 
-            if (len(self.f_albedo_blend_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_albedo_blend_color", len(self.f_albedo_blend_color), 4)
+            if len(self.f_albedo_blend_color) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_albedo_blend_color", 4, len(self.f_albedo_blend_color))
             for i in range(len(self.f_albedo_blend_color)):
                 pass
 
-            if (len(self.f_parallax_max_sample) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_parallax_max_sample", len(self.f_parallax_max_sample), 3)
+            if len(self.f_parallax_max_sample) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_parallax_max_sample", 3, len(self.f_parallax_max_sample))
             for i in range(len(self.f_parallax_max_sample)):
                 pass
 
-            if (len(self.f_light_map_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_light_map_color", len(self.f_light_map_color), 4)
+            if len(self.f_light_map_color) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_light_map_color", 4, len(self.f_light_map_color))
             for i in range(len(self.f_light_map_color)):
                 pass
 
-            if (len(self.f_thin_map_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_thin_map_color", len(self.f_thin_map_color), 3)
+            if len(self.f_thin_map_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_thin_map_color", 3, len(self.f_thin_map_color))
             for i in range(len(self.f_thin_map_color)):
                 pass
 
-            if (len(self.f_screen_uv_scale) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_screen_uv_scale", len(self.f_screen_uv_scale), 2)
+            if len(self.f_screen_uv_scale) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_screen_uv_scale", 2, len(self.f_screen_uv_scale))
             for i in range(len(self.f_screen_uv_scale)):
                 pass
 
-            if (len(self.f_screen_uv_offset) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_screen_uv_offset", len(self.f_screen_uv_offset), 2)
+            if len(self.f_screen_uv_offset) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_screen_uv_offset", 2, len(self.f_screen_uv_offset))
             for i in range(len(self.f_screen_uv_offset)):
                 pass
 
-            if (len(self.f_indirect_offset) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_indirect_offset", len(self.f_indirect_offset), 2)
+            if len(self.f_indirect_offset) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_indirect_offset", 2, len(self.f_indirect_offset))
             for i in range(len(self.f_indirect_offset)):
                 pass
 
-            if (len(self.f_indirect_scale) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_indirect_scale", len(self.f_indirect_scale), 2)
+            if len(self.f_indirect_scale) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_indirect_scale", 2, len(self.f_indirect_scale))
             for i in range(len(self.f_indirect_scale)):
                 pass
 
-            if (len(self.f_fresnel_schlick_rgb) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_fresnel_schlick_rgb", len(self.f_fresnel_schlick_rgb), 3)
+            if len(self.f_fresnel_schlick_rgb) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_fresnel_schlick_rgb", 3, len(self.f_fresnel_schlick_rgb))
             for i in range(len(self.f_fresnel_schlick_rgb)):
                 pass
 
-            if (len(self.f_specular_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_specular_color", len(self.f_specular_color), 3)
+            if len(self.f_specular_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_specular_color", 3, len(self.f_specular_color))
             for i in range(len(self.f_specular_color)):
                 pass
 
-            if (len(self.f_emission_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_emission_color", len(self.f_emission_color), 3)
+            if len(self.f_emission_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_emission_color", 3, len(self.f_emission_color))
             for i in range(len(self.f_emission_color)):
                 pass
 
-            if (len(self.f_constant_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_constant_color", len(self.f_constant_color), 4)
+            if len(self.f_constant_color) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_constant_color", 4, len(self.f_constant_color))
             for i in range(len(self.f_constant_color)):
                 pass
 
-            if (len(self.f_roughness_rgb) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_roughness_rgb", len(self.f_roughness_rgb), 3)
+            if len(self.f_roughness_rgb) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_roughness_rgb", 3, len(self.f_roughness_rgb))
             for i in range(len(self.f_roughness_rgb)):
                 pass
 
-            if (len(self.f_anisotoropic_direction) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_anisotoropic_direction", len(self.f_anisotoropic_direction), 3)
+            if len(self.f_anisotoropic_direction) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_anisotoropic_direction", 3, len(self.f_anisotoropic_direction))
             for i in range(len(self.f_anisotoropic_direction)):
                 pass
 
-            if (len(self.f_anistropic_uv) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_anistropic_uv", len(self.f_anistropic_uv), 2)
+            if len(self.f_anistropic_uv) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_anistropic_uv", 2, len(self.f_anistropic_uv))
             for i in range(len(self.f_anistropic_uv)):
                 pass
 
-            if (len(self.f_primary_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_primary_color", len(self.f_primary_color), 4)
+            if len(self.f_primary_color) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_primary_color", 4, len(self.f_primary_color))
             for i in range(len(self.f_primary_color)):
                 pass
 
-            if (len(self.f_secondary_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_secondary_color", len(self.f_secondary_color), 4)
+            if len(self.f_secondary_color) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_secondary_color", 4, len(self.f_secondary_color))
             for i in range(len(self.f_secondary_color)):
                 pass
 
-            if (len(self.f_albedo_color2) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_albedo_color2", len(self.f_albedo_color2), 4)
+            if len(self.f_albedo_color2) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_albedo_color2", 4, len(self.f_albedo_color2))
             for i in range(len(self.f_albedo_color2)):
                 pass
 
-            if (len(self.f_specular_color2) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_specular_color2", len(self.f_specular_color2), 3)
+            if len(self.f_specular_color2) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_specular_color2", 3, len(self.f_specular_color2))
             for i in range(len(self.f_specular_color2)):
                 pass
 
-            if (len(self.f_shininess2) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_shininess2", len(self.f_shininess2), 4)
+            if len(self.f_shininess2) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_shininess2", 4, len(self.f_shininess2))
             for i in range(len(self.f_shininess2)):
                 pass
 
-            if (len(self.f_transparency_clip_threshold) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_transparency_clip_threshold", len(self.f_transparency_clip_threshold), 4)
+            if len(self.f_transparency_clip_threshold) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_transparency_clip_threshold", 4, len(self.f_transparency_clip_threshold))
             for i in range(len(self.f_transparency_clip_threshold)):
                 pass
 
-            if (len(self.f_normal_power) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_normal_power", len(self.f_normal_power), 3)
+            if len(self.f_normal_power) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_normal_power", 3, len(self.f_normal_power))
             for i in range(len(self.f_normal_power)):
                 pass
 
-            if (len(self.f_albedo_blend2_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_albedo_blend2_color", len(self.f_albedo_blend2_color), 4)
+            if len(self.f_albedo_blend2_color) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_albedo_blend2_color", 4, len(self.f_albedo_blend2_color))
             for i in range(len(self.f_albedo_blend2_color)):
                 pass
 
-            if (len(self.f_detail_normal_u_v_scale) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_detail_normal_u_v_scale", len(self.f_detail_normal_u_v_scale), 2)
+            if len(self.f_detail_normal_u_v_scale) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_detail_normal_u_v_scale", 2, len(self.f_detail_normal_u_v_scale))
             for i in range(len(self.f_detail_normal_u_v_scale)):
                 pass
 
-            if (len(self.f_fresnel_legacy) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_fresnel_legacy", len(self.f_fresnel_legacy), 2)
+            if len(self.f_fresnel_legacy) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_fresnel_legacy", 2, len(self.f_fresnel_legacy))
             for i in range(len(self.f_fresnel_legacy)):
                 pass
 
-            if (len(self.f_normal_mask_pow0) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_normal_mask_pow0", len(self.f_normal_mask_pow0), 4)
+            if len(self.f_normal_mask_pow0) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_normal_mask_pow0", 4, len(self.f_normal_mask_pow0))
             for i in range(len(self.f_normal_mask_pow0)):
                 pass
 
-            if (len(self.f_normal_mask_pow1) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_normal_mask_pow1", len(self.f_normal_mask_pow1), 4)
+            if len(self.f_normal_mask_pow1) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_normal_mask_pow1", 4, len(self.f_normal_mask_pow1))
             for i in range(len(self.f_normal_mask_pow1)):
                 pass
 
-            if (len(self.f_normal_mask_pow2) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_normal_mask_pow2", len(self.f_normal_mask_pow2), 4)
+            if len(self.f_normal_mask_pow2) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_normal_mask_pow2", 4, len(self.f_normal_mask_pow2))
             for i in range(len(self.f_normal_mask_pow2)):
                 pass
 
-            if (len(self.f_texture_blend_rate) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_texture_blend_rate", len(self.f_texture_blend_rate), 4)
+            if len(self.f_texture_blend_rate) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_texture_blend_rate", 4, len(self.f_texture_blend_rate))
             for i in range(len(self.f_texture_blend_rate)):
                 pass
 
-            if (len(self.f_texture_blend_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_texture_blend_color", len(self.f_texture_blend_color), 4)
+            if len(self.f_texture_blend_color) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_texture_blend_color", 4, len(self.f_texture_blend_color))
             for i in range(len(self.f_texture_blend_color)):
                 pass
 
+            self._dirty = False
 
         @property
         def size_(self):
@@ -7749,375 +6847,1127 @@ class Mrl(ReadWriteKaitaiStruct):
         def _invalidate_size_(self):
             del self._m_size_
 
-    class Material(ReadWriteKaitaiStruct):
+    class CbGlobals3(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-            self._should_write_resources = False
-            self.resources__to_write = True
-            self._should_write_anims = False
-            self.anims__to_write = True
-
-        def _read(self):
-            self.type_hash = self._io.read_u4le()
-            self.name_hash_crcjam32 = self._io.read_u4le()
-            self.cmd_buffer_size = self._io.read_u4le()
-            self.blend_state_hash = self._io.read_u4le()
-            self.depth_stencil_state_hash = self._io.read_u4le()
-            self.rasterizer_state_hash = self._io.read_u4le()
-            self.num_resources = self._io.read_bits_int_le(12)
-            self.reserverd1 = self._io.read_bits_int_le(9)
-            self.id = self._io.read_bits_int_le(8)
-            self.fog = self._io.read_bits_int_le(1) != 0
-            self.tangent = self._io.read_bits_int_le(1) != 0
-            self.half_lambert = self._io.read_bits_int_le(1) != 0
-            self.stencil_ref = self._io.read_bits_int_le(8)
-            self.alphatest_ref = self._io.read_bits_int_le(8)
-            self.polygon_offset = self._io.read_bits_int_le(4)
-            self.alphatest = self._io.read_bits_int_le(1) != 0
-            self.alphatest_func = self._io.read_bits_int_le(3)
-            self.draw_pass = self._io.read_bits_int_le(5)
-            self.layer_id = self._io.read_bits_int_le(2)
-            self.deffered_lighting = self._io.read_bits_int_le(1) != 0
-            self.blend_factor = []
-            for i in range(4):
-                self.blend_factor.append(self._io.read_f4le())
-
-            self.anim_data_size = self._io.read_u4le()
-            self.ofs_cmd = self._io.read_u4le()
-            self.ofs_anim_data = self._io.read_u4le()
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.blend_factor)):
-                pass
-
-            _ = self.resources
-            for i in range(len(self._m_resources)):
-                pass
-                self.resources[i]._fetch_instances()
-
-            if (self.anim_data_size != 0):
-                pass
-                _ = self.anims
-                self.anims._fetch_instances()
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.Material, self)._write__seq(io)
-            self._should_write_resources = self.resources__to_write
-            self._should_write_anims = self.anims__to_write
-            self._io.write_u4le(self.type_hash)
-            self._io.write_u4le(self.name_hash_crcjam32)
-            self._io.write_u4le(self.cmd_buffer_size)
-            self._io.write_u4le(self.blend_state_hash)
-            self._io.write_u4le(self.depth_stencil_state_hash)
-            self._io.write_u4le(self.rasterizer_state_hash)
-            self._io.write_bits_int_le(12, self.num_resources)
-            self._io.write_bits_int_le(9, self.reserverd1)
-            self._io.write_bits_int_le(8, self.id)
-            self._io.write_bits_int_le(1, int(self.fog))
-            self._io.write_bits_int_le(1, int(self.tangent))
-            self._io.write_bits_int_le(1, int(self.half_lambert))
-            self._io.write_bits_int_le(8, self.stencil_ref)
-            self._io.write_bits_int_le(8, self.alphatest_ref)
-            self._io.write_bits_int_le(4, self.polygon_offset)
-            self._io.write_bits_int_le(1, int(self.alphatest))
-            self._io.write_bits_int_le(3, self.alphatest_func)
-            self._io.write_bits_int_le(5, self.draw_pass)
-            self._io.write_bits_int_le(2, self.layer_id)
-            self._io.write_bits_int_le(1, int(self.deffered_lighting))
-            for i in range(len(self.blend_factor)):
-                pass
-                self._io.write_f4le(self.blend_factor[i])
-
-            self._io.write_u4le(self.anim_data_size)
-            self._io.write_u4le(self.ofs_cmd)
-            self._io.write_u4le(self.ofs_anim_data)
-
-
-        def _check(self):
-            pass
-            if (len(self.blend_factor) != 4):
-                raise kaitaistruct.ConsistencyError(u"blend_factor", len(self.blend_factor), 4)
-            for i in range(len(self.blend_factor)):
-                pass
-
-
-        @property
-        def resources(self):
-            if self._should_write_resources:
-                self._write_resources()
-            if hasattr(self, '_m_resources'):
-                return self._m_resources
-
-            _pos = self._io.pos()
-            self._io.seek(self.ofs_cmd)
-            self._m_resources = []
-            for i in range(self.num_resources):
-                _t__m_resources = Mrl.ResourceBinding(self._io, self, self._root)
-                _t__m_resources._read()
-                self._m_resources.append(_t__m_resources)
-
-            self._io.seek(_pos)
-            return getattr(self, '_m_resources', None)
-
-        @resources.setter
-        def resources(self, v):
-            self._m_resources = v
-
-        def _write_resources(self):
-            self._should_write_resources = False
-            _pos = self._io.pos()
-            self._io.seek(self.ofs_cmd)
-            for i in range(len(self._m_resources)):
-                pass
-                self.resources[i]._write__seq(self._io)
-
-            self._io.seek(_pos)
-
-
-        def _check_resources(self):
-            pass
-            if (len(self.resources) != self.num_resources):
-                raise kaitaistruct.ConsistencyError(u"resources", len(self.resources), self.num_resources)
-            for i in range(len(self._m_resources)):
-                pass
-                if self.resources[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"resources", self.resources[i]._root, self._root)
-                if self.resources[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"resources", self.resources[i]._parent, self)
-
-
-        @property
-        def anims(self):
-            if self._should_write_anims:
-                self._write_anims()
-            if hasattr(self, '_m_anims'):
-                return self._m_anims
-
-            if (self.anim_data_size != 0):
-                pass
-                _pos = self._io.pos()
-                self._io.seek(self.ofs_anim_data)
-                self._m_anims = Mrl.AnimData(self._io, self, self._root)
-                self._m_anims._read()
-                self._io.seek(_pos)
-
-            return getattr(self, '_m_anims', None)
-
-        @anims.setter
-        def anims(self, v):
-            self._m_anims = v
-
-        def _write_anims(self):
-            self._should_write_anims = False
-            if (self.anim_data_size != 0):
-                pass
-                _pos = self._io.pos()
-                self._io.seek(self.ofs_anim_data)
-                self.anims._write__seq(self._io)
-                self._io.seek(_pos)
-
-
-
-        def _check_anims(self):
-            pass
-            if (self.anim_data_size != 0):
-                pass
-                if self.anims._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"anims", self.anims._root, self._root)
-                if self.anims._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"anims", self.anims._parent, self)
-
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 60
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
-
-    class AnimType1(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mrl.CbGlobals3, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
-            self.unk_00 = self._io.read_u4le()
-            self.unk_01 = []
-            for i in range(4):
-                self.unk_01.append(self._io.read_f4le())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.unk_01)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.AnimType1, self)._write__seq(io)
-            self._io.write_u4le(self.unk_00)
-            for i in range(len(self.unk_01)):
-                pass
-                self._io.write_f4le(self.unk_01[i])
-
-
-
-        def _check(self):
-            pass
-            if (len(self.unk_01) != 4):
-                raise kaitaistruct.ConsistencyError(u"unk_01", len(self.unk_01), 4)
-            for i in range(len(self.unk_01)):
-                pass
-
-
-
-    class CbAppClipPlane1(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.f_plane_normal = []
+            self.f_albedo_color = []
             for i in range(3):
-                self.f_plane_normal.append(self._io.read_f4le())
+                self.f_albedo_color.append(self._io.read_f4le())
 
             self.padding_1 = self._io.read_f4le()
-            self.f_plane_point = []
-            for i in range(3):
-                self.f_plane_point.append(self._io.read_f4le())
+            self.f_albedo_blend_color = []
+            for i in range(4):
+                self.f_albedo_blend_color.append(self._io.read_f4le())
 
-            self.padding_2 = self._io.read_f4le()
-            self.f_app_clip_mask = self._io.read_f4le()
+            self.f_detail_normal_power = self._io.read_f4le()
+            self.f_detail_normal_uv_scale = self._io.read_f4le()
+            self.f_detail_normal2_power = self._io.read_f4le()
+            self.f_detail_normal2_uv_scale = self._io.read_f4le()
+            self.f_primary_shift = self._io.read_f4le()
+            self.f_secondary_shift = self._io.read_f4le()
+            self.f_parallax_factor = self._io.read_f4le()
+            self.f_parallax_self_occlusion = self._io.read_f4le()
+            self.f_parallax_min_sample = self._io.read_f4le()
+            self.f_parallax_max_sample = self._io.read_f4le()
+            self.padding_2 = []
+            for i in range(2):
+                self.padding_2.append(self._io.read_f4le())
+
+            self.f_light_map_color = []
+            for i in range(3):
+                self.f_light_map_color.append(self._io.read_f4le())
+
             self.padding_3 = self._io.read_f4le()
+            self.f_thin_map_color = []
+            for i in range(3):
+                self.f_thin_map_color.append(self._io.read_f4le())
+
+            self.f_thin_scattering = self._io.read_f4le()
+            self.f_indirect_offset = []
+            for i in range(2):
+                self.f_indirect_offset.append(self._io.read_f4le())
+
+            self.f_indirect_scale = []
+            for i in range(2):
+                self.f_indirect_scale.append(self._io.read_f4le())
+
+            self.f_fresnel_schlick = self._io.read_f4le()
+            self.f_fresnel_schlick_rgb = []
+            for i in range(3):
+                self.f_fresnel_schlick_rgb.append(self._io.read_f4le())
+
+            self.f_specular_color = []
+            for i in range(3):
+                self.f_specular_color.append(self._io.read_f4le())
+
+            self.f_shininess = self._io.read_f4le()
+            self.f_emission_color = []
+            for i in range(3):
+                self.f_emission_color.append(self._io.read_f4le())
+
+            self.f_alpha_clip_threshold = self._io.read_f4le()
+            self.f_primary_expo = self._io.read_f4le()
+            self.f_secondary_expo = self._io.read_f4le()
+            self.padding_4 = []
+            for i in range(2):
+                self.padding_4.append(self._io.read_f4le())
+
+            self.f_primary_color = []
+            for i in range(3):
+                self.f_primary_color.append(self._io.read_f4le())
+
+            self.padding_5 = self._io.read_f4le()
+            self.f_secondary_color = []
+            for i in range(3):
+                self.f_secondary_color.append(self._io.read_f4le())
+
+            self.padding_6 = self._io.read_f4le()
+            self.f_albedo_color_2 = []
+            for i in range(3):
+                self.f_albedo_color_2.append(self._io.read_f4le())
+
+            self.padding_7 = self._io.read_f4le()
+            self.f_specular_color_2 = []
+            for i in range(3):
+                self.f_specular_color_2.append(self._io.read_f4le())
+
+            self.f_fresnel_schlick_2 = self._io.read_f4le()
+            self.f_shininess_2 = self._io.read_f4le()
+            self.padding_8 = []
+            for i in range(3):
+                self.padding_8.append(self._io.read_f4le())
+
+            self.f_transparency_clip_threshold = []
+            for i in range(4):
+                self.f_transparency_clip_threshold.append(self._io.read_f4le())
+
+            self.f_blend_uv = self._io.read_f4le()
+            self.padding_9 = []
+            for i in range(3):
+                self.padding_9.append(self._io.read_f4le())
+
+            self.f_albedo_blend2_color = []
+            for i in range(4):
+                self.f_albedo_blend2_color.append(self._io.read_f4le())
+
+            self.f_detail_normalu_vscale = []
+            for i in range(2):
+                self.f_detail_normalu_vscale.append(self._io.read_f4le())
+
+            self.padding_10 = []
+            for i in range(2):
+                self.padding_10.append(self._io.read_f4le())
+
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
-            for i in range(len(self.f_plane_normal)):
+            for i in range(len(self.f_albedo_color)):
                 pass
 
-            for i in range(len(self.f_plane_point)):
+            for i in range(len(self.f_albedo_blend_color)):
+                pass
+
+            for i in range(len(self.padding_2)):
+                pass
+
+            for i in range(len(self.f_light_map_color)):
+                pass
+
+            for i in range(len(self.f_thin_map_color)):
+                pass
+
+            for i in range(len(self.f_indirect_offset)):
+                pass
+
+            for i in range(len(self.f_indirect_scale)):
+                pass
+
+            for i in range(len(self.f_fresnel_schlick_rgb)):
+                pass
+
+            for i in range(len(self.f_specular_color)):
+                pass
+
+            for i in range(len(self.f_emission_color)):
+                pass
+
+            for i in range(len(self.padding_4)):
+                pass
+
+            for i in range(len(self.f_primary_color)):
+                pass
+
+            for i in range(len(self.f_secondary_color)):
+                pass
+
+            for i in range(len(self.f_albedo_color_2)):
+                pass
+
+            for i in range(len(self.f_specular_color_2)):
+                pass
+
+            for i in range(len(self.padding_8)):
+                pass
+
+            for i in range(len(self.f_transparency_clip_threshold)):
+                pass
+
+            for i in range(len(self.padding_9)):
+                pass
+
+            for i in range(len(self.f_albedo_blend2_color)):
+                pass
+
+            for i in range(len(self.f_detail_normalu_vscale)):
+                pass
+
+            for i in range(len(self.padding_10)):
                 pass
 
 
 
         def _write__seq(self, io=None):
-            super(Mrl.CbAppClipPlane1, self)._write__seq(io)
-            for i in range(len(self.f_plane_normal)):
+            super(Mrl.CbGlobals3, self)._write__seq(io)
+            for i in range(len(self.f_albedo_color)):
                 pass
-                self._io.write_f4le(self.f_plane_normal[i])
+                self._io.write_f4le(self.f_albedo_color[i])
 
             self._io.write_f4le(self.padding_1)
-            for i in range(len(self.f_plane_point)):
+            for i in range(len(self.f_albedo_blend_color)):
                 pass
-                self._io.write_f4le(self.f_plane_point[i])
+                self._io.write_f4le(self.f_albedo_blend_color[i])
 
-            self._io.write_f4le(self.padding_2)
-            self._io.write_f4le(self.f_app_clip_mask)
+            self._io.write_f4le(self.f_detail_normal_power)
+            self._io.write_f4le(self.f_detail_normal_uv_scale)
+            self._io.write_f4le(self.f_detail_normal2_power)
+            self._io.write_f4le(self.f_detail_normal2_uv_scale)
+            self._io.write_f4le(self.f_primary_shift)
+            self._io.write_f4le(self.f_secondary_shift)
+            self._io.write_f4le(self.f_parallax_factor)
+            self._io.write_f4le(self.f_parallax_self_occlusion)
+            self._io.write_f4le(self.f_parallax_min_sample)
+            self._io.write_f4le(self.f_parallax_max_sample)
+            for i in range(len(self.padding_2)):
+                pass
+                self._io.write_f4le(self.padding_2[i])
+
+            for i in range(len(self.f_light_map_color)):
+                pass
+                self._io.write_f4le(self.f_light_map_color[i])
+
             self._io.write_f4le(self.padding_3)
+            for i in range(len(self.f_thin_map_color)):
+                pass
+                self._io.write_f4le(self.f_thin_map_color[i])
+
+            self._io.write_f4le(self.f_thin_scattering)
+            for i in range(len(self.f_indirect_offset)):
+                pass
+                self._io.write_f4le(self.f_indirect_offset[i])
+
+            for i in range(len(self.f_indirect_scale)):
+                pass
+                self._io.write_f4le(self.f_indirect_scale[i])
+
+            self._io.write_f4le(self.f_fresnel_schlick)
+            for i in range(len(self.f_fresnel_schlick_rgb)):
+                pass
+                self._io.write_f4le(self.f_fresnel_schlick_rgb[i])
+
+            for i in range(len(self.f_specular_color)):
+                pass
+                self._io.write_f4le(self.f_specular_color[i])
+
+            self._io.write_f4le(self.f_shininess)
+            for i in range(len(self.f_emission_color)):
+                pass
+                self._io.write_f4le(self.f_emission_color[i])
+
+            self._io.write_f4le(self.f_alpha_clip_threshold)
+            self._io.write_f4le(self.f_primary_expo)
+            self._io.write_f4le(self.f_secondary_expo)
+            for i in range(len(self.padding_4)):
+                pass
+                self._io.write_f4le(self.padding_4[i])
+
+            for i in range(len(self.f_primary_color)):
+                pass
+                self._io.write_f4le(self.f_primary_color[i])
+
+            self._io.write_f4le(self.padding_5)
+            for i in range(len(self.f_secondary_color)):
+                pass
+                self._io.write_f4le(self.f_secondary_color[i])
+
+            self._io.write_f4le(self.padding_6)
+            for i in range(len(self.f_albedo_color_2)):
+                pass
+                self._io.write_f4le(self.f_albedo_color_2[i])
+
+            self._io.write_f4le(self.padding_7)
+            for i in range(len(self.f_specular_color_2)):
+                pass
+                self._io.write_f4le(self.f_specular_color_2[i])
+
+            self._io.write_f4le(self.f_fresnel_schlick_2)
+            self._io.write_f4le(self.f_shininess_2)
+            for i in range(len(self.padding_8)):
+                pass
+                self._io.write_f4le(self.padding_8[i])
+
+            for i in range(len(self.f_transparency_clip_threshold)):
+                pass
+                self._io.write_f4le(self.f_transparency_clip_threshold[i])
+
+            self._io.write_f4le(self.f_blend_uv)
+            for i in range(len(self.padding_9)):
+                pass
+                self._io.write_f4le(self.padding_9[i])
+
+            for i in range(len(self.f_albedo_blend2_color)):
+                pass
+                self._io.write_f4le(self.f_albedo_blend2_color[i])
+
+            for i in range(len(self.f_detail_normalu_vscale)):
+                pass
+                self._io.write_f4le(self.f_detail_normalu_vscale[i])
+
+            for i in range(len(self.padding_10)):
+                pass
+                self._io.write_f4le(self.padding_10[i])
+
 
 
         def _check(self):
-            pass
-            if (len(self.f_plane_normal) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_plane_normal", len(self.f_plane_normal), 3)
-            for i in range(len(self.f_plane_normal)):
+            if len(self.f_albedo_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_albedo_color", 3, len(self.f_albedo_color))
+            for i in range(len(self.f_albedo_color)):
                 pass
 
-            if (len(self.f_plane_point) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_plane_point", len(self.f_plane_point), 3)
-            for i in range(len(self.f_plane_point)):
+            if len(self.f_albedo_blend_color) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_albedo_blend_color", 4, len(self.f_albedo_blend_color))
+            for i in range(len(self.f_albedo_blend_color)):
                 pass
 
+            if len(self.padding_2) != 2:
+                raise kaitaistruct.ConsistencyError(u"padding_2", 2, len(self.padding_2))
+            for i in range(len(self.padding_2)):
+                pass
+
+            if len(self.f_light_map_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_light_map_color", 3, len(self.f_light_map_color))
+            for i in range(len(self.f_light_map_color)):
+                pass
+
+            if len(self.f_thin_map_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_thin_map_color", 3, len(self.f_thin_map_color))
+            for i in range(len(self.f_thin_map_color)):
+                pass
+
+            if len(self.f_indirect_offset) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_indirect_offset", 2, len(self.f_indirect_offset))
+            for i in range(len(self.f_indirect_offset)):
+                pass
+
+            if len(self.f_indirect_scale) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_indirect_scale", 2, len(self.f_indirect_scale))
+            for i in range(len(self.f_indirect_scale)):
+                pass
+
+            if len(self.f_fresnel_schlick_rgb) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_fresnel_schlick_rgb", 3, len(self.f_fresnel_schlick_rgb))
+            for i in range(len(self.f_fresnel_schlick_rgb)):
+                pass
+
+            if len(self.f_specular_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_specular_color", 3, len(self.f_specular_color))
+            for i in range(len(self.f_specular_color)):
+                pass
+
+            if len(self.f_emission_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_emission_color", 3, len(self.f_emission_color))
+            for i in range(len(self.f_emission_color)):
+                pass
+
+            if len(self.padding_4) != 2:
+                raise kaitaistruct.ConsistencyError(u"padding_4", 2, len(self.padding_4))
+            for i in range(len(self.padding_4)):
+                pass
+
+            if len(self.f_primary_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_primary_color", 3, len(self.f_primary_color))
+            for i in range(len(self.f_primary_color)):
+                pass
+
+            if len(self.f_secondary_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_secondary_color", 3, len(self.f_secondary_color))
+            for i in range(len(self.f_secondary_color)):
+                pass
+
+            if len(self.f_albedo_color_2) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_albedo_color_2", 3, len(self.f_albedo_color_2))
+            for i in range(len(self.f_albedo_color_2)):
+                pass
+
+            if len(self.f_specular_color_2) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_specular_color_2", 3, len(self.f_specular_color_2))
+            for i in range(len(self.f_specular_color_2)):
+                pass
+
+            if len(self.padding_8) != 3:
+                raise kaitaistruct.ConsistencyError(u"padding_8", 3, len(self.padding_8))
+            for i in range(len(self.padding_8)):
+                pass
+
+            if len(self.f_transparency_clip_threshold) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_transparency_clip_threshold", 4, len(self.f_transparency_clip_threshold))
+            for i in range(len(self.f_transparency_clip_threshold)):
+                pass
+
+            if len(self.padding_9) != 3:
+                raise kaitaistruct.ConsistencyError(u"padding_9", 3, len(self.padding_9))
+            for i in range(len(self.padding_9)):
+                pass
+
+            if len(self.f_albedo_blend2_color) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_albedo_blend2_color", 4, len(self.f_albedo_blend2_color))
+            for i in range(len(self.f_albedo_blend2_color)):
+                pass
+
+            if len(self.f_detail_normalu_vscale) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_detail_normalu_vscale", 2, len(self.f_detail_normalu_vscale))
+            for i in range(len(self.f_detail_normalu_vscale)):
+                pass
+
+            if len(self.padding_10) != 2:
+                raise kaitaistruct.ConsistencyError(u"padding_10", 2, len(self.padding_10))
+            for i in range(len(self.padding_10)):
+                pass
+
+            self._dirty = False
 
         @property
         def size_(self):
             if hasattr(self, '_m_size_'):
                 return self._m_size_
 
-            self._m_size_ = 48
+            self._m_size_ = 336
             return getattr(self, '_m_size_', None)
 
         def _invalidate_size_(self):
             del self._m_size_
 
-    class AnimSubEntry6(ReadWriteKaitaiStruct):
+    class CbGlobals4(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mrl.CbGlobals4, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
-            self.header = []
+            self.f_albedo_color = []
+            for i in range(3):
+                self.f_albedo_color.append(self._io.read_f4le())
+
+            self.padding_1 = self._io.read_f4le()
+            self.f_albedo_blend_color = []
             for i in range(4):
-                self.header.append(self._io.read_u1())
+                self.f_albedo_blend_color.append(self._io.read_f4le())
 
-            self.values = []
-            for i in range(self._parent.info.num_entry):
-                _t_values = Mrl.AnimType6(self._io, self, self._root)
-                _t_values._read()
-                self.values.append(_t_values)
+            self.f_detail_normal_power = self._io.read_f4le()
+            self.f_detail_normal_uv_scale = self._io.read_f4le()
+            self.f_detail_normal2_power = self._io.read_f4le()
+            self.f_detail_normal2_uv_scale = self._io.read_f4le()
+            self.f_primary_shift = self._io.read_f4le()
+            self.f_secondary_shift = self._io.read_f4le()
+            self.f_parallax_factor = self._io.read_f4le()
+            self.f_parallax_self_occlusion = self._io.read_f4le()
+            self.f_parallax_min_sample = self._io.read_f4le()
+            self.f_parallax_max_sample = self._io.read_f4le()
+            self.padding_2 = []
+            for i in range(2):
+                self.padding_2.append(self._io.read_f4le())
 
+            self.f_light_map_color = []
+            for i in range(3):
+                self.f_light_map_color.append(self._io.read_f4le())
+
+            self.padding_3 = self._io.read_f4le()
+            self.f_thin_map_color = []
+            for i in range(3):
+                self.f_thin_map_color.append(self._io.read_f4le())
+
+            self.f_thin_scattering = self._io.read_f4le()
+            self.f_indirect_offset = []
+            for i in range(2):
+                self.f_indirect_offset.append(self._io.read_f4le())
+
+            self.f_indirect_scale = []
+            for i in range(2):
+                self.f_indirect_scale.append(self._io.read_f4le())
+
+            self.f_fresnel_schlick = self._io.read_f4le()
+            self.f_fresnel_schlick_rgb = []
+            for i in range(3):
+                self.f_fresnel_schlick_rgb.append(self._io.read_f4le())
+
+            self.f_specular_color = []
+            for i in range(3):
+                self.f_specular_color.append(self._io.read_f4le())
+
+            self.f_shininess = self._io.read_f4le()
+            self.f_emission_color = []
+            for i in range(3):
+                self.f_emission_color.append(self._io.read_f4le())
+
+            self.f_alpha_clip_threshold = self._io.read_f4le()
+            self.f_roughness = self._io.read_f4le()
+            self.f_roughness_rgb = []
+            for i in range(3):
+                self.f_roughness_rgb.append(self._io.read_f4le())
+
+            self.f_anisotoropic_direction = []
+            for i in range(3):
+                self.f_anisotoropic_direction.append(self._io.read_f4le())
+
+            self.f_smoothness = self._io.read_f4le()
+            self.f_anistropic_uv = []
+            for i in range(2):
+                self.f_anistropic_uv.append(self._io.read_f4le())
+
+            self.f_primary_expo = self._io.read_f4le()
+            self.f_secondary_expo = self._io.read_f4le()
+            self.f_primary_color = []
+            for i in range(3):
+                self.f_primary_color.append(self._io.read_f4le())
+
+            self.padding_4 = self._io.read_f4le()
+            self.f_secondary_color = []
+            for i in range(3):
+                self.f_secondary_color.append(self._io.read_f4le())
+
+            self.padding_5 = self._io.read_f4le()
+            self.xyzw_sepalate = []
+            for i in range(16):
+                self.xyzw_sepalate.append(self._io.read_f4le())
+
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
-            for i in range(len(self.header)):
+            for i in range(len(self.f_albedo_color)):
                 pass
 
-            for i in range(len(self.values)):
+            for i in range(len(self.f_albedo_blend_color)):
                 pass
-                self.values[i]._fetch_instances()
+
+            for i in range(len(self.padding_2)):
+                pass
+
+            for i in range(len(self.f_light_map_color)):
+                pass
+
+            for i in range(len(self.f_thin_map_color)):
+                pass
+
+            for i in range(len(self.f_indirect_offset)):
+                pass
+
+            for i in range(len(self.f_indirect_scale)):
+                pass
+
+            for i in range(len(self.f_fresnel_schlick_rgb)):
+                pass
+
+            for i in range(len(self.f_specular_color)):
+                pass
+
+            for i in range(len(self.f_emission_color)):
+                pass
+
+            for i in range(len(self.f_roughness_rgb)):
+                pass
+
+            for i in range(len(self.f_anisotoropic_direction)):
+                pass
+
+            for i in range(len(self.f_anistropic_uv)):
+                pass
+
+            for i in range(len(self.f_primary_color)):
+                pass
+
+            for i in range(len(self.f_secondary_color)):
+                pass
+
+            for i in range(len(self.xyzw_sepalate)):
+                pass
 
 
 
         def _write__seq(self, io=None):
-            super(Mrl.AnimSubEntry6, self)._write__seq(io)
-            for i in range(len(self.header)):
+            super(Mrl.CbGlobals4, self)._write__seq(io)
+            for i in range(len(self.f_albedo_color)):
                 pass
-                self._io.write_u1(self.header[i])
+                self._io.write_f4le(self.f_albedo_color[i])
 
-            for i in range(len(self.values)):
+            self._io.write_f4le(self.padding_1)
+            for i in range(len(self.f_albedo_blend_color)):
                 pass
-                self.values[i]._write__seq(self._io)
+                self._io.write_f4le(self.f_albedo_blend_color[i])
+
+            self._io.write_f4le(self.f_detail_normal_power)
+            self._io.write_f4le(self.f_detail_normal_uv_scale)
+            self._io.write_f4le(self.f_detail_normal2_power)
+            self._io.write_f4le(self.f_detail_normal2_uv_scale)
+            self._io.write_f4le(self.f_primary_shift)
+            self._io.write_f4le(self.f_secondary_shift)
+            self._io.write_f4le(self.f_parallax_factor)
+            self._io.write_f4le(self.f_parallax_self_occlusion)
+            self._io.write_f4le(self.f_parallax_min_sample)
+            self._io.write_f4le(self.f_parallax_max_sample)
+            for i in range(len(self.padding_2)):
+                pass
+                self._io.write_f4le(self.padding_2[i])
+
+            for i in range(len(self.f_light_map_color)):
+                pass
+                self._io.write_f4le(self.f_light_map_color[i])
+
+            self._io.write_f4le(self.padding_3)
+            for i in range(len(self.f_thin_map_color)):
+                pass
+                self._io.write_f4le(self.f_thin_map_color[i])
+
+            self._io.write_f4le(self.f_thin_scattering)
+            for i in range(len(self.f_indirect_offset)):
+                pass
+                self._io.write_f4le(self.f_indirect_offset[i])
+
+            for i in range(len(self.f_indirect_scale)):
+                pass
+                self._io.write_f4le(self.f_indirect_scale[i])
+
+            self._io.write_f4le(self.f_fresnel_schlick)
+            for i in range(len(self.f_fresnel_schlick_rgb)):
+                pass
+                self._io.write_f4le(self.f_fresnel_schlick_rgb[i])
+
+            for i in range(len(self.f_specular_color)):
+                pass
+                self._io.write_f4le(self.f_specular_color[i])
+
+            self._io.write_f4le(self.f_shininess)
+            for i in range(len(self.f_emission_color)):
+                pass
+                self._io.write_f4le(self.f_emission_color[i])
+
+            self._io.write_f4le(self.f_alpha_clip_threshold)
+            self._io.write_f4le(self.f_roughness)
+            for i in range(len(self.f_roughness_rgb)):
+                pass
+                self._io.write_f4le(self.f_roughness_rgb[i])
+
+            for i in range(len(self.f_anisotoropic_direction)):
+                pass
+                self._io.write_f4le(self.f_anisotoropic_direction[i])
+
+            self._io.write_f4le(self.f_smoothness)
+            for i in range(len(self.f_anistropic_uv)):
+                pass
+                self._io.write_f4le(self.f_anistropic_uv[i])
+
+            self._io.write_f4le(self.f_primary_expo)
+            self._io.write_f4le(self.f_secondary_expo)
+            for i in range(len(self.f_primary_color)):
+                pass
+                self._io.write_f4le(self.f_primary_color[i])
+
+            self._io.write_f4le(self.padding_4)
+            for i in range(len(self.f_secondary_color)):
+                pass
+                self._io.write_f4le(self.f_secondary_color[i])
+
+            self._io.write_f4le(self.padding_5)
+            for i in range(len(self.xyzw_sepalate)):
+                pass
+                self._io.write_f4le(self.xyzw_sepalate[i])
 
 
 
         def _check(self):
+            if len(self.f_albedo_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_albedo_color", 3, len(self.f_albedo_color))
+            for i in range(len(self.f_albedo_color)):
+                pass
+
+            if len(self.f_albedo_blend_color) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_albedo_blend_color", 4, len(self.f_albedo_blend_color))
+            for i in range(len(self.f_albedo_blend_color)):
+                pass
+
+            if len(self.padding_2) != 2:
+                raise kaitaistruct.ConsistencyError(u"padding_2", 2, len(self.padding_2))
+            for i in range(len(self.padding_2)):
+                pass
+
+            if len(self.f_light_map_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_light_map_color", 3, len(self.f_light_map_color))
+            for i in range(len(self.f_light_map_color)):
+                pass
+
+            if len(self.f_thin_map_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_thin_map_color", 3, len(self.f_thin_map_color))
+            for i in range(len(self.f_thin_map_color)):
+                pass
+
+            if len(self.f_indirect_offset) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_indirect_offset", 2, len(self.f_indirect_offset))
+            for i in range(len(self.f_indirect_offset)):
+                pass
+
+            if len(self.f_indirect_scale) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_indirect_scale", 2, len(self.f_indirect_scale))
+            for i in range(len(self.f_indirect_scale)):
+                pass
+
+            if len(self.f_fresnel_schlick_rgb) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_fresnel_schlick_rgb", 3, len(self.f_fresnel_schlick_rgb))
+            for i in range(len(self.f_fresnel_schlick_rgb)):
+                pass
+
+            if len(self.f_specular_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_specular_color", 3, len(self.f_specular_color))
+            for i in range(len(self.f_specular_color)):
+                pass
+
+            if len(self.f_emission_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_emission_color", 3, len(self.f_emission_color))
+            for i in range(len(self.f_emission_color)):
+                pass
+
+            if len(self.f_roughness_rgb) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_roughness_rgb", 3, len(self.f_roughness_rgb))
+            for i in range(len(self.f_roughness_rgb)):
+                pass
+
+            if len(self.f_anisotoropic_direction) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_anisotoropic_direction", 3, len(self.f_anisotoropic_direction))
+            for i in range(len(self.f_anisotoropic_direction)):
+                pass
+
+            if len(self.f_anistropic_uv) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_anistropic_uv", 2, len(self.f_anistropic_uv))
+            for i in range(len(self.f_anistropic_uv)):
+                pass
+
+            if len(self.f_primary_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_primary_color", 3, len(self.f_primary_color))
+            for i in range(len(self.f_primary_color)):
+                pass
+
+            if len(self.f_secondary_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_secondary_color", 3, len(self.f_secondary_color))
+            for i in range(len(self.f_secondary_color)):
+                pass
+
+            if len(self.xyzw_sepalate) != 16:
+                raise kaitaistruct.ConsistencyError(u"xyzw_sepalate", 16, len(self.xyzw_sepalate))
+            for i in range(len(self.xyzw_sepalate)):
+                pass
+
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 320
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class CbMaterial(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbMaterial, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_app_specific = False
+            self.app_specific__enabled = True
+
+        def _read(self):
             pass
-            if (len(self.header) != 4):
-                raise kaitaistruct.ConsistencyError(u"header", len(self.header), 4)
-            for i in range(len(self.header)):
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.app_specific
+            if hasattr(self, '_m_app_specific'):
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                elif _on == u"re0":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                elif _on == u"re1":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                elif _on == u"rev1":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                elif _on == u"rev2":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                else:
+                    pass
+                    self._m_app_specific._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbMaterial, self)._write__seq(io)
+            self._should_write_app_specific = self.app_specific__enabled
+
+
+        def _check(self):
+            if self.app_specific__enabled:
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                elif _on == u"re0":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                elif _on == u"re1":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                elif _on == u"rev1":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                elif _on == u"rev2":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                else:
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+
+            self._dirty = False
+
+        @property
+        def app_specific(self):
+            if self._should_write_app_specific:
+                self._write_app_specific()
+            if hasattr(self, '_m_app_specific'):
+                return self._m_app_specific
+
+            if not self.app_specific__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific = Mrl.CbMaterial1(self._io, self, self._root)
+                self._m_app_specific._read()
+            elif _on == u"re0":
+                pass
+                self._m_app_specific = Mrl.CbMaterial1(self._io, self, self._root)
+                self._m_app_specific._read()
+            elif _on == u"re1":
+                pass
+                self._m_app_specific = Mrl.CbMaterial1(self._io, self, self._root)
+                self._m_app_specific._read()
+            elif _on == u"rev1":
+                pass
+                self._m_app_specific = Mrl.CbMaterial1(self._io, self, self._root)
+                self._m_app_specific._read()
+            elif _on == u"rev2":
+                pass
+                self._m_app_specific = Mrl.CbMaterial1(self._io, self, self._root)
+                self._m_app_specific._read()
+            else:
+                pass
+                self._m_app_specific = Mrl.CbMaterial1(self._io, self, self._root)
+                self._m_app_specific._read()
+            self._io.seek(_pos)
+            return getattr(self, '_m_app_specific', None)
+
+        @app_specific.setter
+        def app_specific(self, v):
+            self._dirty = True
+            self._m_app_specific = v
+
+        def _write_app_specific(self):
+            self._should_write_app_specific = False
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            elif _on == u"re0":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            elif _on == u"re1":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            elif _on == u"rev1":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            elif _on == u"rev2":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            else:
+                pass
+                self._m_app_specific._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    class CbMaterial1(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbMaterial1, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.f_diffuse_color = []
+            for i in range(3):
+                self.f_diffuse_color.append(self._io.read_f4le())
+
+            self.f_transparency = self._io.read_f4le()
+            self.f_reflective_color = []
+            for i in range(3):
+                self.f_reflective_color.append(self._io.read_f4le())
+
+            self.f_transparency_volume = self._io.read_f4le()
+            self.f_uv_transform = []
+            for i in range(8):
+                self.f_uv_transform.append(self._io.read_f4le())
+
+            self.f_uv_transform2 = []
+            for i in range(8):
+                self.f_uv_transform2.append(self._io.read_f4le())
+
+            self.f_uv_transform3 = []
+            for i in range(8):
+                self.f_uv_transform3.append(self._io.read_f4le())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.f_diffuse_color)):
                 pass
 
-            if (len(self.values) != self._parent.info.num_entry):
-                raise kaitaistruct.ConsistencyError(u"values", len(self.values), self._parent.info.num_entry)
-            for i in range(len(self.values)):
+            for i in range(len(self.f_reflective_color)):
                 pass
-                if self.values[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"values", self.values[i]._root, self._root)
-                if self.values[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"values", self.values[i]._parent, self)
 
+            for i in range(len(self.f_uv_transform)):
+                pass
+
+            for i in range(len(self.f_uv_transform2)):
+                pass
+
+            for i in range(len(self.f_uv_transform3)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbMaterial1, self)._write__seq(io)
+            for i in range(len(self.f_diffuse_color)):
+                pass
+                self._io.write_f4le(self.f_diffuse_color[i])
+
+            self._io.write_f4le(self.f_transparency)
+            for i in range(len(self.f_reflective_color)):
+                pass
+                self._io.write_f4le(self.f_reflective_color[i])
+
+            self._io.write_f4le(self.f_transparency_volume)
+            for i in range(len(self.f_uv_transform)):
+                pass
+                self._io.write_f4le(self.f_uv_transform[i])
+
+            for i in range(len(self.f_uv_transform2)):
+                pass
+                self._io.write_f4le(self.f_uv_transform2[i])
+
+            for i in range(len(self.f_uv_transform3)):
+                pass
+                self._io.write_f4le(self.f_uv_transform3[i])
+
+
+
+        def _check(self):
+            if len(self.f_diffuse_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_diffuse_color", 3, len(self.f_diffuse_color))
+            for i in range(len(self.f_diffuse_color)):
+                pass
+
+            if len(self.f_reflective_color) != 3:
+                raise kaitaistruct.ConsistencyError(u"f_reflective_color", 3, len(self.f_reflective_color))
+            for i in range(len(self.f_reflective_color)):
+                pass
+
+            if len(self.f_uv_transform) != 8:
+                raise kaitaistruct.ConsistencyError(u"f_uv_transform", 8, len(self.f_uv_transform))
+            for i in range(len(self.f_uv_transform)):
+                pass
+
+            if len(self.f_uv_transform2) != 8:
+                raise kaitaistruct.ConsistencyError(u"f_uv_transform2", 8, len(self.f_uv_transform2))
+            for i in range(len(self.f_uv_transform2)):
+                pass
+
+            if len(self.f_uv_transform3) != 8:
+                raise kaitaistruct.ConsistencyError(u"f_uv_transform3", 8, len(self.f_uv_transform3))
+            for i in range(len(self.f_uv_transform3)):
+                pass
+
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 128
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class CbOutlineEx(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbOutlineEx, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_app_specific = False
+            self.app_specific__enabled = True
+
+        def _read(self):
+            pass
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.app_specific
+            if hasattr(self, '_m_app_specific'):
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                else:
+                    pass
+                    self._m_app_specific._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbOutlineEx, self)._write__seq(io)
+            self._should_write_app_specific = self.app_specific__enabled
+
+
+        def _check(self):
+            if self.app_specific__enabled:
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                else:
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+
+            self._dirty = False
+
+        @property
+        def app_specific(self):
+            if self._should_write_app_specific:
+                self._write_app_specific()
+            if hasattr(self, '_m_app_specific'):
+                return self._m_app_specific
+
+            if not self.app_specific__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific = Mrl.CbOutlineEx1(self._io, self, self._root)
+                self._m_app_specific._read()
+            else:
+                pass
+                self._m_app_specific = Mrl.CbOutlineEx1(self._io, self, self._root)
+                self._m_app_specific._read()
+            self._io.seek(_pos)
+            return getattr(self, '_m_app_specific', None)
+
+        @app_specific.setter
+        def app_specific(self, v):
+            self._dirty = True
+            self._m_app_specific = v
+
+        def _write_app_specific(self):
+            self._should_write_app_specific = False
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            else:
+                pass
+                self._m_app_specific._write__seq(self._io)
+            self._io.seek(_pos)
 
 
     class CbOutlineEx1(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mrl.CbOutlineEx1, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -8138,6 +7988,7 @@ class Mrl(ReadWriteKaitaiStruct):
             for i in range(4):
                 self.f_outline_blend_mask.append(self._io.read_f4le())
 
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -8174,22 +8025,22 @@ class Mrl(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
-            if (len(self.f_outline_outer_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_outline_outer_color", len(self.f_outline_outer_color), 4)
+            if len(self.f_outline_outer_color) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_outline_outer_color", 4, len(self.f_outline_outer_color))
             for i in range(len(self.f_outline_outer_color)):
                 pass
 
-            if (len(self.f_outline_inner_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_outline_inner_color", len(self.f_outline_inner_color), 4)
+            if len(self.f_outline_inner_color) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_outline_inner_color", 4, len(self.f_outline_inner_color))
             for i in range(len(self.f_outline_inner_color)):
                 pass
 
-            if (len(self.f_outline_blend_mask) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_outline_blend_mask", len(self.f_outline_blend_mask), 4)
+            if len(self.f_outline_blend_mask) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_outline_blend_mask", 4, len(self.f_outline_blend_mask))
             for i in range(len(self.f_outline_blend_mask)):
                 pass
 
+            self._dirty = False
 
         @property
         def size_(self):
@@ -8202,63 +8053,316 @@ class Mrl(ReadWriteKaitaiStruct):
         def _invalidate_size_(self):
             del self._m_size_
 
-    class CbBurnEmission1(ReadWriteKaitaiStruct):
+    class CbSpecularBlend(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mrl.CbSpecularBlend, self).__init__(_io)
             self._parent = _parent
             self._root = _root
+            self._should_write_app_specific = False
+            self.app_specific__enabled = True
 
         def _read(self):
-            self.f_b_emission_factor = self._io.read_f4le()
-            self.f_b_emission_alpha_band = self._io.read_f4le()
-            self.padding_1 = []
-            for i in range(2):
-                self.padding_1.append(self._io.read_f4le())
-
-            self.f_burn_emission_color = []
-            for i in range(3):
-                self.f_burn_emission_color.append(self._io.read_f4le())
-
-            self.padding_2 = self._io.read_f4le()
+            pass
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
-            for i in range(len(self.padding_1)):
+            _ = self.app_specific
+            if hasattr(self, '_m_app_specific'):
                 pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                else:
+                    pass
+                    self._m_app_specific._fetch_instances()
 
-            for i in range(len(self.f_burn_emission_color)):
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbSpecularBlend, self)._write__seq(io)
+            self._should_write_app_specific = self.app_specific__enabled
+
+
+        def _check(self):
+            if self.app_specific__enabled:
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                else:
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+
+            self._dirty = False
+
+        @property
+        def app_specific(self):
+            if self._should_write_app_specific:
+                self._write_app_specific()
+            if hasattr(self, '_m_app_specific'):
+                return self._m_app_specific
+
+            if not self.app_specific__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific = Mrl.CbSpecularBlend1(self._io, self, self._root)
+                self._m_app_specific._read()
+            else:
+                pass
+                self._m_app_specific = Mrl.CbSpecularBlend1(self._io, self, self._root)
+                self._m_app_specific._read()
+            self._io.seek(_pos)
+            return getattr(self, '_m_app_specific', None)
+
+        @app_specific.setter
+        def app_specific(self, v):
+            self._dirty = True
+            self._m_app_specific = v
+
+        def _write_app_specific(self):
+            self._should_write_app_specific = False
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            else:
+                pass
+                self._m_app_specific._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    class CbSpecularBlend1(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbSpecularBlend1, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.f_specular_blend_color = []
+            for i in range(4):
+                self.f_specular_blend_color.append(self._io.read_f4le())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.f_specular_blend_color)):
                 pass
 
 
 
         def _write__seq(self, io=None):
-            super(Mrl.CbBurnEmission1, self)._write__seq(io)
-            self._io.write_f4le(self.f_b_emission_factor)
-            self._io.write_f4le(self.f_b_emission_alpha_band)
-            for i in range(len(self.padding_1)):
+            super(Mrl.CbSpecularBlend1, self)._write__seq(io)
+            for i in range(len(self.f_specular_blend_color)):
                 pass
-                self._io.write_f4le(self.padding_1[i])
+                self._io.write_f4le(self.f_specular_blend_color[i])
 
-            for i in range(len(self.f_burn_emission_color)):
-                pass
-                self._io.write_f4le(self.f_burn_emission_color[i])
-
-            self._io.write_f4le(self.padding_2)
 
 
         def _check(self):
+            if len(self.f_specular_blend_color) != 4:
+                raise kaitaistruct.ConsistencyError(u"f_specular_blend_color", 4, len(self.f_specular_blend_color))
+            for i in range(len(self.f_specular_blend_color)):
+                pass
+
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 16
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class CbUvRotationOffset(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbUvRotationOffset, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_app_specific = False
+            self.app_specific__enabled = True
+
+        def _read(self):
             pass
-            if (len(self.padding_1) != 2):
-                raise kaitaistruct.ConsistencyError(u"padding_1", len(self.padding_1), 2)
-            for i in range(len(self.padding_1)):
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.app_specific
+            if hasattr(self, '_m_app_specific'):
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                else:
+                    pass
+                    self._m_app_specific._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbUvRotationOffset, self)._write__seq(io)
+            self._should_write_app_specific = self.app_specific__enabled
+
+
+        def _check(self):
+            if self.app_specific__enabled:
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                else:
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+
+            self._dirty = False
+
+        @property
+        def app_specific(self):
+            if self._should_write_app_specific:
+                self._write_app_specific()
+            if hasattr(self, '_m_app_specific'):
+                return self._m_app_specific
+
+            if not self.app_specific__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific = Mrl.CbUvRotationOffset1(self._io, self, self._root)
+                self._m_app_specific._read()
+            else:
+                pass
+                self._m_app_specific = Mrl.CbUvRotationOffset1(self._io, self, self._root)
+                self._m_app_specific._read()
+            self._io.seek(_pos)
+            return getattr(self, '_m_app_specific', None)
+
+        @app_specific.setter
+        def app_specific(self, v):
+            self._dirty = True
+            self._m_app_specific = v
+
+        def _write_app_specific(self):
+            self._should_write_app_specific = False
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            else:
+                pass
+                self._m_app_specific._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    class CbUvRotationOffset1(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbUvRotationOffset1, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.f_uv_rotation_center = []
+            for i in range(2):
+                self.f_uv_rotation_center.append(self._io.read_f4le())
+
+            self.f_uv_rotation_angle = self._io.read_f4le()
+            self.padding = self._io.read_f4le()
+            self.f_uv_rotation_offset = []
+            for i in range(2):
+                self.f_uv_rotation_offset.append(self._io.read_f4le())
+
+            self.f_uv_rotation_scale = []
+            for i in range(2):
+                self.f_uv_rotation_scale.append(self._io.read_f4le())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.f_uv_rotation_center)):
                 pass
 
-            if (len(self.f_burn_emission_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_burn_emission_color", len(self.f_burn_emission_color), 3)
-            for i in range(len(self.f_burn_emission_color)):
+            for i in range(len(self.f_uv_rotation_offset)):
                 pass
 
+            for i in range(len(self.f_uv_rotation_scale)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbUvRotationOffset1, self)._write__seq(io)
+            for i in range(len(self.f_uv_rotation_center)):
+                pass
+                self._io.write_f4le(self.f_uv_rotation_center[i])
+
+            self._io.write_f4le(self.f_uv_rotation_angle)
+            self._io.write_f4le(self.padding)
+            for i in range(len(self.f_uv_rotation_offset)):
+                pass
+                self._io.write_f4le(self.f_uv_rotation_offset[i])
+
+            for i in range(len(self.f_uv_rotation_scale)):
+                pass
+                self._io.write_f4le(self.f_uv_rotation_scale[i])
+
+
+
+        def _check(self):
+            if len(self.f_uv_rotation_center) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_uv_rotation_center", 2, len(self.f_uv_rotation_center))
+            for i in range(len(self.f_uv_rotation_center)):
+                pass
+
+            if len(self.f_uv_rotation_offset) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_uv_rotation_offset", 2, len(self.f_uv_rotation_offset))
+            for i in range(len(self.f_uv_rotation_offset)):
+                pass
+
+            if len(self.f_uv_rotation_scale) != 2:
+                raise kaitaistruct.ConsistencyError(u"f_uv_rotation_scale", 2, len(self.f_uv_rotation_scale))
+            for i in range(len(self.f_uv_rotation_scale)):
+                pass
+
+            self._dirty = False
 
         @property
         def size_(self):
@@ -8271,131 +8375,102 @@ class Mrl(ReadWriteKaitaiStruct):
         def _invalidate_size_(self):
             del self._m_size_
 
-    class AnimData(ReadWriteKaitaiStruct):
+    class CbVertexDisplacement(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.entry_count = self._io.read_u4le()
-            self.ofs_to_info = []
-            for i in range(self.entry_count):
-                _t_ofs_to_info = Mrl.AnimOfs(self._io, self, self._root)
-                _t_ofs_to_info._read()
-                self.ofs_to_info.append(_t_ofs_to_info)
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.ofs_to_info)):
-                pass
-                self.ofs_to_info[i]._fetch_instances()
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.AnimData, self)._write__seq(io)
-            self._io.write_u4le(self.entry_count)
-            for i in range(len(self.ofs_to_info)):
-                pass
-                self.ofs_to_info[i]._write__seq(self._io)
-
-
-
-        def _check(self):
-            pass
-            if (len(self.ofs_to_info) != self.entry_count):
-                raise kaitaistruct.ConsistencyError(u"ofs_to_info", len(self.ofs_to_info), self.entry_count)
-            for i in range(len(self.ofs_to_info)):
-                pass
-                if self.ofs_to_info[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"ofs_to_info", self.ofs_to_info[i]._root, self._root)
-                if self.ofs_to_info[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"ofs_to_info", self.ofs_to_info[i]._parent, self)
-
-
-        @property
-        def ofs_base(self):
-            if hasattr(self, '_m_ofs_base'):
-                return self._m_ofs_base
-
-            self._m_ofs_base = self._parent.ofs_anim_data
-            return getattr(self, '_m_ofs_base', None)
-
-        def _invalidate_ofs_base(self):
-            del self._m_ofs_base
-
-    class OfsBuff(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.ofs_const_buff = self._io.read_u4le()
-
-
-        def _fetch_instances(self):
-            pass
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.OfsBuff, self)._write__seq(io)
-            self._io.write_u4le(self.ofs_const_buff)
-
-
-        def _check(self):
-            pass
-
-
-    class CbVertexDisplacement2(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mrl.CbVertexDisplacement, self).__init__(_io)
             self._parent = _parent
             self._root = _root
             self._should_write_app_specific = False
-            self.app_specific__to_write = True
+            self.app_specific__enabled = True
 
         def _read(self):
             pass
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
             _ = self.app_specific
-            _on = self._root.app_id
-            if _on == u"re1":
+            if hasattr(self, '_m_app_specific'):
                 pass
-                self.app_specific._fetch_instances()
-            elif _on == u"rev1":
-                pass
-                self.app_specific._fetch_instances()
-            elif _on == u"re6":
-                pass
-                self.app_specific._fetch_instances()
-            elif _on == u"re0":
-                pass
-                self.app_specific._fetch_instances()
-            elif _on == u"dd":
-                pass
-                self.app_specific._fetch_instances()
-            elif _on == u"rev2":
-                pass
-                self.app_specific._fetch_instances()
-            else:
-                pass
-                self.app_specific._fetch_instances()
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                elif _on == u"re0":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                elif _on == u"re1":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                elif _on == u"re6":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                elif _on == u"rev1":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                elif _on == u"rev2":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                else:
+                    pass
+                    self._m_app_specific._fetch_instances()
+
 
 
         def _write__seq(self, io=None):
-            super(Mrl.CbVertexDisplacement2, self)._write__seq(io)
-            self._should_write_app_specific = self.app_specific__to_write
+            super(Mrl.CbVertexDisplacement, self)._write__seq(io)
+            self._should_write_app_specific = self.app_specific__enabled
 
 
         def _check(self):
-            pass
+            if self.app_specific__enabled:
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                elif _on == u"re0":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                elif _on == u"re1":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                elif _on == u"re6":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                elif _on == u"rev1":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                elif _on == u"rev2":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                else:
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+
+            self._dirty = False
 
         @property
         def app_specific(self):
@@ -8404,18 +8479,188 @@ class Mrl(ReadWriteKaitaiStruct):
             if hasattr(self, '_m_app_specific'):
                 return self._m_app_specific
 
+            if not self.app_specific__enabled:
+                return None
+
             _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
             _on = self._root.app_id
-            if _on == u"re1":
+            if _on == u"dd":
                 pass
-                self._m_app_specific = Mrl.CbVertexDisplacement21(self._io, self, self._root)
+                self._m_app_specific = Mrl.CbVertexDisplacement1(self._io, self, self._root)
+                self._m_app_specific._read()
+            elif _on == u"re0":
+                pass
+                self._m_app_specific = Mrl.CbVertexDisplacement1(self._io, self, self._root)
+                self._m_app_specific._read()
+            elif _on == u"re1":
+                pass
+                self._m_app_specific = Mrl.CbVertexDisplacement1(self._io, self, self._root)
+                self._m_app_specific._read()
+            elif _on == u"re6":
+                pass
+                self._m_app_specific = Mrl.CbVertexDisplacement1(self._io, self, self._root)
                 self._m_app_specific._read()
             elif _on == u"rev1":
                 pass
-                self._m_app_specific = Mrl.CbVertexDisplacement21(self._io, self, self._root)
+                self._m_app_specific = Mrl.CbVertexDisplacement1(self._io, self, self._root)
                 self._m_app_specific._read()
+            elif _on == u"rev2":
+                pass
+                self._m_app_specific = Mrl.CbVertexDisplacement1(self._io, self, self._root)
+                self._m_app_specific._read()
+            else:
+                pass
+                self._m_app_specific = Mrl.CbVertexDisplacement1(self._io, self, self._root)
+                self._m_app_specific._read()
+            self._io.seek(_pos)
+            return getattr(self, '_m_app_specific', None)
+
+        @app_specific.setter
+        def app_specific(self, v):
+            self._dirty = True
+            self._m_app_specific = v
+
+        def _write_app_specific(self):
+            self._should_write_app_specific = False
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            elif _on == u"re0":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            elif _on == u"re1":
+                pass
+                self._m_app_specific._write__seq(self._io)
             elif _on == u"re6":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            elif _on == u"rev1":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            elif _on == u"rev2":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            else:
+                pass
+                self._m_app_specific._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    class CbVertexDisplacement2(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CbVertexDisplacement2, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_app_specific = False
+            self.app_specific__enabled = True
+
+        def _read(self):
+            pass
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.app_specific
+            if hasattr(self, '_m_app_specific'):
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                elif _on == u"re0":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                elif _on == u"re1":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                elif _on == u"re6":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                elif _on == u"rev1":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                elif _on == u"rev2":
+                    pass
+                    self._m_app_specific._fetch_instances()
+                else:
+                    pass
+                    self._m_app_specific._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CbVertexDisplacement2, self)._write__seq(io)
+            self._should_write_app_specific = self.app_specific__enabled
+
+
+        def _check(self):
+            if self.app_specific__enabled:
+                pass
+                _on = self._root.app_id
+                if _on == u"dd":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                elif _on == u"re0":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                elif _on == u"re1":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                elif _on == u"re6":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                elif _on == u"rev1":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                elif _on == u"rev2":
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+                else:
+                    pass
+                    if self._m_app_specific._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self._root, self._m_app_specific._root)
+                    if self._m_app_specific._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"app_specific", self, self._m_app_specific._parent)
+
+            self._dirty = False
+
+        @property
+        def app_specific(self):
+            if self._should_write_app_specific:
+                self._write_app_specific()
+            if hasattr(self, '_m_app_specific'):
+                return self._m_app_specific
+
+            if not self.app_specific__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
+            _on = self._root.app_id
+            if _on == u"dd":
                 pass
                 self._m_app_specific = Mrl.CbVertexDisplacement21(self._io, self, self._root)
                 self._m_app_specific._read()
@@ -8423,7 +8668,15 @@ class Mrl(ReadWriteKaitaiStruct):
                 pass
                 self._m_app_specific = Mrl.CbVertexDisplacement21(self._io, self, self._root)
                 self._m_app_specific._read()
-            elif _on == u"dd":
+            elif _on == u"re1":
+                pass
+                self._m_app_specific = Mrl.CbVertexDisplacement21(self._io, self, self._root)
+                self._m_app_specific._read()
+            elif _on == u"re6":
+                pass
+                self._m_app_specific = Mrl.CbVertexDisplacement21(self._io, self, self._root)
+                self._m_app_specific._read()
+            elif _on == u"rev1":
                 pass
                 self._m_app_specific = Mrl.CbVertexDisplacement21(self._io, self, self._root)
                 self._m_app_specific._read()
@@ -8440,92 +8693,50 @@ class Mrl(ReadWriteKaitaiStruct):
 
         @app_specific.setter
         def app_specific(self, v):
+            self._dirty = True
             self._m_app_specific = v
 
         def _write_app_specific(self):
             self._should_write_app_specific = False
             _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
+            self._io.seek(self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff)
             _on = self._root.app_id
-            if _on == u"re1":
+            if _on == u"dd":
                 pass
-                self.app_specific._write__seq(self._io)
-            elif _on == u"rev1":
-                pass
-                self.app_specific._write__seq(self._io)
-            elif _on == u"re6":
-                pass
-                self.app_specific._write__seq(self._io)
+                self._m_app_specific._write__seq(self._io)
             elif _on == u"re0":
                 pass
-                self.app_specific._write__seq(self._io)
-            elif _on == u"dd":
+                self._m_app_specific._write__seq(self._io)
+            elif _on == u"re1":
                 pass
-                self.app_specific._write__seq(self._io)
+                self._m_app_specific._write__seq(self._io)
+            elif _on == u"re6":
+                pass
+                self._m_app_specific._write__seq(self._io)
+            elif _on == u"rev1":
+                pass
+                self._m_app_specific._write__seq(self._io)
             elif _on == u"rev2":
                 pass
-                self.app_specific._write__seq(self._io)
+                self._m_app_specific._write__seq(self._io)
             else:
                 pass
-                self.app_specific._write__seq(self._io)
+                self._m_app_specific._write__seq(self._io)
             self._io.seek(_pos)
 
 
-        def _check_app_specific(self):
-            pass
-            _on = self._root.app_id
-            if _on == u"re1":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            elif _on == u"rev1":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            elif _on == u"re6":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            elif _on == u"re0":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            elif _on == u"dd":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            elif _on == u"rev2":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            else:
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-
-
-    class TexOffset(ReadWriteKaitaiStruct):
+    class CbVertexDisplacement21(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mrl.CbVertexDisplacement21, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
-            self.texture_id = self._io.read_u4le()
+            self.f_vtx_disp_start2 = self._io.read_f4le()
+            self.f_vtx_disp_scale2 = self._io.read_f4le()
+            self.f_vtx_disp_inv_area2 = self._io.read_f4le()
+            self.f_vtx_disp_rcn2 = self._io.read_f4le()
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -8533,297 +8744,387 @@ class Mrl(ReadWriteKaitaiStruct):
 
 
         def _write__seq(self, io=None):
-            super(Mrl.TexOffset, self)._write__seq(io)
-            self._io.write_u4le(self.texture_id)
+            super(Mrl.CbVertexDisplacement21, self)._write__seq(io)
+            self._io.write_f4le(self.f_vtx_disp_start2)
+            self._io.write_f4le(self.f_vtx_disp_scale2)
+            self._io.write_f4le(self.f_vtx_disp_inv_area2)
+            self._io.write_f4le(self.f_vtx_disp_rcn2)
 
 
         def _check(self):
-            pass
-
-
-    class CbDdMaterialParam1(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.f_dd_material_blend_color = []
-            for i in range(4):
-                self.f_dd_material_blend_color.append(self._io.read_f4le())
-
-            self.f_dd_material_color_blend_rate = []
-            for i in range(2):
-                self.f_dd_material_color_blend_rate.append(self._io.read_f4le())
-
-            self.f_dd_material_area_mask = []
-            for i in range(2):
-                self.f_dd_material_area_mask.append(self._io.read_f4le())
-
-            self.f_dd_material_border_blend_mask = []
-            for i in range(4):
-                self.f_dd_material_border_blend_mask.append(self._io.read_f4le())
-
-            self.f_dd_material_border_shade_band = self._io.read_f4le()
-            self.f_dd_material_base_power = self._io.read_f4le()
-            self.f_dd_material_normal_blend_rate = self._io.read_f4le()
-            self.f_dd_material_reflect_blend_color = self._io.read_f4le()
-            self.f_dd_material_specular_factor = self._io.read_f4le()
-            self.f_dd_material_specular_map_factor = self._io.read_f4le()
-            self.f_dd_material_env_map_blend_color = self._io.read_f4le()
-            self.f_dd_material_area_alpha = self._io.read_f4le()
-            self.f_dd_material_area_pos = []
-            for i in range(4):
-                self.f_dd_material_area_pos.append(self._io.read_f4le())
-
-            self.f_dd_material_albedo_uv_scale = self._io.read_f4le()
-            self.f_dd_material_normal_uv_scale = self._io.read_f4le()
-            self.f_dd_material_normal_power = self._io.read_f4le()
-            self.f_dd_material_base_env_map_power = self._io.read_f4le()
-            self.f_dd_material_lantern_color = []
-            for i in range(3):
-                self.f_dd_material_lantern_color.append(self._io.read_f4le())
-
-            self.padding_1 = self._io.read_f4le()
-            self.f_dd_material_lantern_pos = []
-            for i in range(3):
-                self.f_dd_material_lantern_pos.append(self._io.read_f4le())
-
-            self.padding_2 = self._io.read_f4le()
-            self.f_dd_material_lantern_param = []
-            for i in range(3):
-                self.f_dd_material_lantern_param.append(self._io.read_f4le())
-
-            self.padding_3 = self._io.read_f4le()
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.f_dd_material_blend_color)):
-                pass
-
-            for i in range(len(self.f_dd_material_color_blend_rate)):
-                pass
-
-            for i in range(len(self.f_dd_material_area_mask)):
-                pass
-
-            for i in range(len(self.f_dd_material_border_blend_mask)):
-                pass
-
-            for i in range(len(self.f_dd_material_area_pos)):
-                pass
-
-            for i in range(len(self.f_dd_material_lantern_color)):
-                pass
-
-            for i in range(len(self.f_dd_material_lantern_pos)):
-                pass
-
-            for i in range(len(self.f_dd_material_lantern_param)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbDdMaterialParam1, self)._write__seq(io)
-            for i in range(len(self.f_dd_material_blend_color)):
-                pass
-                self._io.write_f4le(self.f_dd_material_blend_color[i])
-
-            for i in range(len(self.f_dd_material_color_blend_rate)):
-                pass
-                self._io.write_f4le(self.f_dd_material_color_blend_rate[i])
-
-            for i in range(len(self.f_dd_material_area_mask)):
-                pass
-                self._io.write_f4le(self.f_dd_material_area_mask[i])
-
-            for i in range(len(self.f_dd_material_border_blend_mask)):
-                pass
-                self._io.write_f4le(self.f_dd_material_border_blend_mask[i])
-
-            self._io.write_f4le(self.f_dd_material_border_shade_band)
-            self._io.write_f4le(self.f_dd_material_base_power)
-            self._io.write_f4le(self.f_dd_material_normal_blend_rate)
-            self._io.write_f4le(self.f_dd_material_reflect_blend_color)
-            self._io.write_f4le(self.f_dd_material_specular_factor)
-            self._io.write_f4le(self.f_dd_material_specular_map_factor)
-            self._io.write_f4le(self.f_dd_material_env_map_blend_color)
-            self._io.write_f4le(self.f_dd_material_area_alpha)
-            for i in range(len(self.f_dd_material_area_pos)):
-                pass
-                self._io.write_f4le(self.f_dd_material_area_pos[i])
-
-            self._io.write_f4le(self.f_dd_material_albedo_uv_scale)
-            self._io.write_f4le(self.f_dd_material_normal_uv_scale)
-            self._io.write_f4le(self.f_dd_material_normal_power)
-            self._io.write_f4le(self.f_dd_material_base_env_map_power)
-            for i in range(len(self.f_dd_material_lantern_color)):
-                pass
-                self._io.write_f4le(self.f_dd_material_lantern_color[i])
-
-            self._io.write_f4le(self.padding_1)
-            for i in range(len(self.f_dd_material_lantern_pos)):
-                pass
-                self._io.write_f4le(self.f_dd_material_lantern_pos[i])
-
-            self._io.write_f4le(self.padding_2)
-            for i in range(len(self.f_dd_material_lantern_param)):
-                pass
-                self._io.write_f4le(self.f_dd_material_lantern_param[i])
-
-            self._io.write_f4le(self.padding_3)
-
-
-        def _check(self):
-            pass
-            if (len(self.f_dd_material_blend_color) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_dd_material_blend_color", len(self.f_dd_material_blend_color), 4)
-            for i in range(len(self.f_dd_material_blend_color)):
-                pass
-
-            if (len(self.f_dd_material_color_blend_rate) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_dd_material_color_blend_rate", len(self.f_dd_material_color_blend_rate), 2)
-            for i in range(len(self.f_dd_material_color_blend_rate)):
-                pass
-
-            if (len(self.f_dd_material_area_mask) != 2):
-                raise kaitaistruct.ConsistencyError(u"f_dd_material_area_mask", len(self.f_dd_material_area_mask), 2)
-            for i in range(len(self.f_dd_material_area_mask)):
-                pass
-
-            if (len(self.f_dd_material_border_blend_mask) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_dd_material_border_blend_mask", len(self.f_dd_material_border_blend_mask), 4)
-            for i in range(len(self.f_dd_material_border_blend_mask)):
-                pass
-
-            if (len(self.f_dd_material_area_pos) != 4):
-                raise kaitaistruct.ConsistencyError(u"f_dd_material_area_pos", len(self.f_dd_material_area_pos), 4)
-            for i in range(len(self.f_dd_material_area_pos)):
-                pass
-
-            if (len(self.f_dd_material_lantern_color) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_dd_material_lantern_color", len(self.f_dd_material_lantern_color), 3)
-            for i in range(len(self.f_dd_material_lantern_color)):
-                pass
-
-            if (len(self.f_dd_material_lantern_pos) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_dd_material_lantern_pos", len(self.f_dd_material_lantern_pos), 3)
-            for i in range(len(self.f_dd_material_lantern_pos)):
-                pass
-
-            if (len(self.f_dd_material_lantern_param) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_dd_material_lantern_param", len(self.f_dd_material_lantern_param), 3)
-            for i in range(len(self.f_dd_material_lantern_param)):
-                pass
-
+            self._dirty = False
 
         @property
         def size_(self):
             if hasattr(self, '_m_size_'):
                 return self._m_size_
 
-            self._m_size_ = 160
+            self._m_size_ = 16
             return getattr(self, '_m_size_', None)
 
         def _invalidate_size_(self):
             del self._m_size_
 
-    class AnimEntry(ReadWriteKaitaiStruct):
+    class CbVertexDisplacement1(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mrl.CbVertexDisplacement1, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
-            self.unk_00 = self._io.read_u4le()
-            self.info = Mrl.AnimInfo(self._io, self, self._root)
-            self.info._read()
-            self.ofs_list_entry1 = self._io.read_u4le()
-            self.unk_hash = self._io.read_u4le()
-            self.ofs_entry2 = []
-            for i in range(self.info.num_entry2):
-                _t_ofs_entry2 = Mrl.BlockOffset(self._io, self, self._root)
-                _t_ofs_entry2._read()
-                self.ofs_entry2.append(_t_ofs_entry2)
+            self.f_vtx_disp_start = self._io.read_f4le()
+            self.f_vtx_disp_scale = self._io.read_f4le()
+            self.f_vtx_disp_inv_area = self._io.read_f4le()
+            self.f_vtx_disp_rcn = self._io.read_f4le()
+            self.f_vtx_disp_tilt_u = self._io.read_f4le()
+            self.f_vtx_disp_tilt_v = self._io.read_f4le()
+            self.filler = []
+            for i in range(2):
+                self.filler.append(self._io.read_f4le())
 
-            self.set_buff_hash = []
-            for i in range(self.info.num_entry1):
-                self.set_buff_hash.append(self._io.read_u4le())
-
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
-            self.info._fetch_instances()
-            for i in range(len(self.ofs_entry2)):
-                pass
-                self.ofs_entry2[i]._fetch_instances()
-
-            for i in range(len(self.set_buff_hash)):
+            for i in range(len(self.filler)):
                 pass
 
 
 
         def _write__seq(self, io=None):
-            super(Mrl.AnimEntry, self)._write__seq(io)
-            self._io.write_u4le(self.unk_00)
-            self.info._write__seq(self._io)
-            self._io.write_u4le(self.ofs_list_entry1)
-            self._io.write_u4le(self.unk_hash)
-            for i in range(len(self.ofs_entry2)):
+            super(Mrl.CbVertexDisplacement1, self)._write__seq(io)
+            self._io.write_f4le(self.f_vtx_disp_start)
+            self._io.write_f4le(self.f_vtx_disp_scale)
+            self._io.write_f4le(self.f_vtx_disp_inv_area)
+            self._io.write_f4le(self.f_vtx_disp_rcn)
+            self._io.write_f4le(self.f_vtx_disp_tilt_u)
+            self._io.write_f4le(self.f_vtx_disp_tilt_v)
+            for i in range(len(self.filler)):
                 pass
-                self.ofs_entry2[i]._write__seq(self._io)
-
-            for i in range(len(self.set_buff_hash)):
-                pass
-                self._io.write_u4le(self.set_buff_hash[i])
+                self._io.write_f4le(self.filler[i])
 
 
 
         def _check(self):
+            if len(self.filler) != 2:
+                raise kaitaistruct.ConsistencyError(u"filler", 2, len(self.filler))
+            for i in range(len(self.filler)):
+                pass
+
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 32
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class CmdOfsBuffer(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CmdOfsBuffer, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.ofs_float_buff = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
             pass
-            if self.info._root != self._root:
-                raise kaitaistruct.ConsistencyError(u"info", self.info._root, self._root)
-            if self.info._parent != self:
-                raise kaitaistruct.ConsistencyError(u"info", self.info._parent, self)
-            if (len(self.ofs_entry2) != self.info.num_entry2):
-                raise kaitaistruct.ConsistencyError(u"ofs_entry2", len(self.ofs_entry2), self.info.num_entry2)
-            for i in range(len(self.ofs_entry2)):
-                pass
-                if self.ofs_entry2[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"ofs_entry2", self.ofs_entry2[i]._root, self._root)
-                if self.ofs_entry2[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"ofs_entry2", self.ofs_entry2[i]._parent, self)
 
-            if (len(self.set_buff_hash) != self.info.num_entry1):
-                raise kaitaistruct.ConsistencyError(u"set_buff_hash", len(self.set_buff_hash), self.info.num_entry1)
-            for i in range(len(self.set_buff_hash)):
+
+        def _write__seq(self, io=None):
+            super(Mrl.CmdOfsBuffer, self)._write__seq(io)
+            self._io.write_u4le(self.ofs_float_buff)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class CmdTexIdx(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.CmdTexIdx, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.tex_idx = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.CmdTexIdx, self)._write__seq(io)
+            self._io.write_u4le(self.tex_idx)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Material(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.Material, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_anims = False
+            self.anims__enabled = True
+            self._should_write_resources = False
+            self.resources__enabled = True
+
+        def _read(self):
+            self.type_hash = self._io.read_u4le()
+            self.name_hash_crcjam32 = self._io.read_u4le()
+            self.cmd_buffer_size = self._io.read_u4le()
+            self.blend_state_hash = self._io.read_u4le()
+            self.depth_stencil_state_hash = self._io.read_u4le()
+            self.rasterizer_state_hash = self._io.read_u4le()
+            self.num_resources = self._io.read_bits_int_le(12)
+            self.reserverd1 = self._io.read_bits_int_le(9)
+            self.id = self._io.read_bits_int_le(8)
+            self.fog = self._io.read_bits_int_le(1) != 0
+            self.tangent = self._io.read_bits_int_le(1) != 0
+            self.half_lambert = self._io.read_bits_int_le(1) != 0
+            self.stencil_ref = self._io.read_bits_int_le(8)
+            self.alphatest_ref = self._io.read_bits_int_le(8)
+            self.polygon_offset = self._io.read_bits_int_le(4)
+            self.alphatest = self._io.read_bits_int_le(1) != 0
+            self.alphatest_func = self._io.read_bits_int_le(3)
+            self.draw_pass = self._io.read_bits_int_le(5)
+            self.layer_id = self._io.read_bits_int_le(2)
+            self.deffered_lighting = self._io.read_bits_int_le(1) != 0
+            self.blend_factor = []
+            for i in range(4):
+                self.blend_factor.append(self._io.read_f4le())
+
+            self.anim_data_size = self._io.read_u4le()
+            self.ofs_cmd = self._io.read_u4le()
+            self.ofs_anim_data = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.blend_factor)):
                 pass
 
+            _ = self.anims
+            if hasattr(self, '_m_anims'):
+                pass
+                self._m_anims._fetch_instances()
+
+            _ = self.resources
+            if hasattr(self, '_m_resources'):
+                pass
+                for i in range(len(self._m_resources)):
+                    pass
+                    self._m_resources[i]._fetch_instances()
+
+
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.Material, self)._write__seq(io)
+            self._should_write_anims = self.anims__enabled
+            self._should_write_resources = self.resources__enabled
+            self._io.write_u4le(self.type_hash)
+            self._io.write_u4le(self.name_hash_crcjam32)
+            self._io.write_u4le(self.cmd_buffer_size)
+            self._io.write_u4le(self.blend_state_hash)
+            self._io.write_u4le(self.depth_stencil_state_hash)
+            self._io.write_u4le(self.rasterizer_state_hash)
+            self._io.write_bits_int_le(12, self.num_resources)
+            self._io.write_bits_int_le(9, self.reserverd1)
+            self._io.write_bits_int_le(8, self.id)
+            self._io.write_bits_int_le(1, int(self.fog))
+            self._io.write_bits_int_le(1, int(self.tangent))
+            self._io.write_bits_int_le(1, int(self.half_lambert))
+            self._io.write_bits_int_le(8, self.stencil_ref)
+            self._io.write_bits_int_le(8, self.alphatest_ref)
+            self._io.write_bits_int_le(4, self.polygon_offset)
+            self._io.write_bits_int_le(1, int(self.alphatest))
+            self._io.write_bits_int_le(3, self.alphatest_func)
+            self._io.write_bits_int_le(5, self.draw_pass)
+            self._io.write_bits_int_le(2, self.layer_id)
+            self._io.write_bits_int_le(1, int(self.deffered_lighting))
+            for i in range(len(self.blend_factor)):
+                pass
+                self._io.write_f4le(self.blend_factor[i])
+
+            self._io.write_u4le(self.anim_data_size)
+            self._io.write_u4le(self.ofs_cmd)
+            self._io.write_u4le(self.ofs_anim_data)
+
+
+        def _check(self):
+            if len(self.blend_factor) != 4:
+                raise kaitaistruct.ConsistencyError(u"blend_factor", 4, len(self.blend_factor))
+            for i in range(len(self.blend_factor)):
+                pass
+
+            if self.anims__enabled:
+                pass
+                if self.anim_data_size != 0:
+                    pass
+                    if self._m_anims._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"anims", self._root, self._m_anims._root)
+                    if self._m_anims._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"anims", self, self._m_anims._parent)
+
+
+            if self.resources__enabled:
+                pass
+                if len(self._m_resources) != self.num_resources:
+                    raise kaitaistruct.ConsistencyError(u"resources", self.num_resources, len(self._m_resources))
+                for i in range(len(self._m_resources)):
+                    pass
+                    if self._m_resources[i]._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"resources", self._root, self._m_resources[i]._root)
+                    if self._m_resources[i]._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"resources", self, self._m_resources[i]._parent)
+
+
+            self._dirty = False
+
+        @property
+        def anims(self):
+            if self._should_write_anims:
+                self._write_anims()
+            if hasattr(self, '_m_anims'):
+                return self._m_anims
+
+            if not self.anims__enabled:
+                return None
+
+            if self.anim_data_size != 0:
+                pass
+                _pos = self._io.pos()
+                self._io.seek(self.ofs_anim_data)
+                self._m_anims = Mrl.AnimData(self._io, self, self._root)
+                self._m_anims._read()
+                self._io.seek(_pos)
+
+            return getattr(self, '_m_anims', None)
+
+        @anims.setter
+        def anims(self, v):
+            self._dirty = True
+            self._m_anims = v
+
+        def _write_anims(self):
+            self._should_write_anims = False
+            if self.anim_data_size != 0:
+                pass
+                _pos = self._io.pos()
+                self._io.seek(self.ofs_anim_data)
+                self._m_anims._write__seq(self._io)
+                self._io.seek(_pos)
+
+
+        @property
+        def resources(self):
+            if self._should_write_resources:
+                self._write_resources()
+            if hasattr(self, '_m_resources'):
+                return self._m_resources
+
+            if not self.resources__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_cmd)
+            self._m_resources = []
+            for i in range(self.num_resources):
+                _t__m_resources = Mrl.ResourceBinding(self._io, self, self._root)
+                try:
+                    _t__m_resources._read()
+                finally:
+                    self._m_resources.append(_t__m_resources)
+
+            self._io.seek(_pos)
+            return getattr(self, '_m_resources', None)
+
+        @resources.setter
+        def resources(self, v):
+            self._dirty = True
+            self._m_resources = v
+
+        def _write_resources(self):
+            self._should_write_resources = False
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_cmd)
+            for i in range(len(self._m_resources)):
+                pass
+                self._m_resources[i]._write__seq(self._io)
+
+            self._io.seek(_pos)
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 60
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
+
+    class OfsBuff(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.OfsBuff, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.ofs_const_buff = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.OfsBuff, self)._write__seq(io)
+            self._io.write_u4le(self.ofs_const_buff)
+
+
+        def _check(self):
+            self._dirty = False
 
 
     class ResourceBinding(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mrl.ResourceBinding, self).__init__(_io)
             self._parent = _parent
             self._root = _root
             self._should_write_float_buffer = False
-            self.float_buffer__to_write = True
+            self.float_buffer__enabled = True
 
         def _read(self):
             self.cmd_type = KaitaiStream.resolve_enum(Mrl.CmdType, self._io.read_bits_int_le(4))
             self.unused = self._io.read_bits_int_le(16)
             self.shader_obj_idx = self._io.read_bits_int_le(12)
             _on = self.cmd_type
-            if _on == Mrl.CmdType.set_flag:
-                pass
-                self.value_cmd = Mrl.ShaderObject(self._io, self, self._root)
-                self.value_cmd._read()
-            elif _on == Mrl.CmdType.set_constant_buffer:
+            if _on == Mrl.CmdType.set_constant_buffer:
                 pass
                 self.value_cmd = Mrl.CmdOfsBuffer(self._io, self, self._root)
+                self.value_cmd._read()
+            elif _on == Mrl.CmdType.set_flag:
+                pass
+                self.value_cmd = Mrl.ShaderObject(self._io, self, self._root)
                 self.value_cmd._read()
             elif _on == Mrl.CmdType.set_sampler_state:
                 pass
@@ -8838,15 +9139,16 @@ class Mrl(ReadWriteKaitaiStruct):
                 self.value_cmd = Mrl.ShaderObject(self._io, self, self._root)
                 self.value_cmd._read()
             self.shader_object_id = self._io.read_u4le()
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
             _on = self.cmd_type
-            if _on == Mrl.CmdType.set_flag:
+            if _on == Mrl.CmdType.set_constant_buffer:
                 pass
                 self.value_cmd._fetch_instances()
-            elif _on == Mrl.CmdType.set_constant_buffer:
+            elif _on == Mrl.CmdType.set_flag:
                 pass
                 self.value_cmd._fetch_instances()
             elif _on == Mrl.CmdType.set_sampler_state:
@@ -8858,72 +9160,72 @@ class Mrl(ReadWriteKaitaiStruct):
             elif _on == Mrl.CmdType.set_unk:
                 pass
                 self.value_cmd._fetch_instances()
-            if (self.cmd_type == Mrl.CmdType.set_constant_buffer):
+            _ = self.float_buffer
+            if hasattr(self, '_m_float_buffer'):
                 pass
-                _ = self.float_buffer
                 _on = self.shader_object_hash
-                if _on == Mrl.ShaderObjectHash.cbuvrotationoffset:
+                if _on == Mrl.ShaderObjectHash.cbappclipplane:
                     pass
-                    self.float_buffer._fetch_instances()
-                elif _on == Mrl.ShaderObjectHash.cbvertexdisplacement:
-                    pass
-                    self.float_buffer._fetch_instances()
-                elif _on == Mrl.ShaderObjectHash.cbcolormask:
-                    pass
-                    self.float_buffer._fetch_instances()
-                elif _on == Mrl.ShaderObjectHash.cbspecularblend:
-                    pass
-                    self.float_buffer._fetch_instances()
-                elif _on == Mrl.ShaderObjectHash.cbddmaterialparam:
-                    pass
-                    self.float_buffer._fetch_instances()
-                elif _on == Mrl.ShaderObjectHash.cbdistortion:
-                    pass
-                    self.float_buffer._fetch_instances()
-                elif _on == Mrl.ShaderObjectHash.cbappreflectshadowlight:
-                    pass
-                    self.float_buffer._fetch_instances()
-                elif _on == Mrl.ShaderObjectHash.cbddmaterialparaminnercorrect:
-                    pass
-                    self.float_buffer._fetch_instances()
-                elif _on == Mrl.ShaderObjectHash.cbmaterial:
-                    pass
-                    self.float_buffer._fetch_instances()
-                elif _on == Mrl.ShaderObjectHash.cboutlineex:
-                    pass
-                    self.float_buffer._fetch_instances()
-                elif _on == Mrl.ShaderObjectHash.globals:
-                    pass
-                    self.float_buffer._fetch_instances()
-                elif _on == Mrl.ShaderObjectHash.cbburnemission:
-                    pass
-                    self.float_buffer._fetch_instances()
+                    self._m_float_buffer._fetch_instances()
                 elif _on == Mrl.ShaderObjectHash.cbappreflect:
                     pass
-                    self.float_buffer._fetch_instances()
-                elif _on == Mrl.ShaderObjectHash.cbappclipplane:
+                    self._m_float_buffer._fetch_instances()
+                elif _on == Mrl.ShaderObjectHash.cbappreflectshadowlight:
                     pass
-                    self.float_buffer._fetch_instances()
+                    self._m_float_buffer._fetch_instances()
                 elif _on == Mrl.ShaderObjectHash.cbburncommon:
                     pass
-                    self.float_buffer._fetch_instances()
+                    self._m_float_buffer._fetch_instances()
+                elif _on == Mrl.ShaderObjectHash.cbburnemission:
+                    pass
+                    self._m_float_buffer._fetch_instances()
+                elif _on == Mrl.ShaderObjectHash.cbcolormask:
+                    pass
+                    self._m_float_buffer._fetch_instances()
+                elif _on == Mrl.ShaderObjectHash.cbddmaterialparam:
+                    pass
+                    self._m_float_buffer._fetch_instances()
+                elif _on == Mrl.ShaderObjectHash.cbddmaterialparaminnercorrect:
+                    pass
+                    self._m_float_buffer._fetch_instances()
+                elif _on == Mrl.ShaderObjectHash.cbdistortion:
+                    pass
+                    self._m_float_buffer._fetch_instances()
+                elif _on == Mrl.ShaderObjectHash.cbmaterial:
+                    pass
+                    self._m_float_buffer._fetch_instances()
+                elif _on == Mrl.ShaderObjectHash.cboutlineex:
+                    pass
+                    self._m_float_buffer._fetch_instances()
+                elif _on == Mrl.ShaderObjectHash.cbspecularblend:
+                    pass
+                    self._m_float_buffer._fetch_instances()
+                elif _on == Mrl.ShaderObjectHash.cbuvrotationoffset:
+                    pass
+                    self._m_float_buffer._fetch_instances()
+                elif _on == Mrl.ShaderObjectHash.cbvertexdisplacement:
+                    pass
+                    self._m_float_buffer._fetch_instances()
                 elif _on == Mrl.ShaderObjectHash.cbvertexdisplacement2:
                     pass
-                    self.float_buffer._fetch_instances()
+                    self._m_float_buffer._fetch_instances()
+                elif _on == Mrl.ShaderObjectHash.globals:
+                    pass
+                    self._m_float_buffer._fetch_instances()
 
 
 
         def _write__seq(self, io=None):
             super(Mrl.ResourceBinding, self)._write__seq(io)
-            self._should_write_float_buffer = self.float_buffer__to_write
+            self._should_write_float_buffer = self.float_buffer__enabled
             self._io.write_bits_int_le(4, int(self.cmd_type))
             self._io.write_bits_int_le(16, self.unused)
             self._io.write_bits_int_le(12, self.shader_obj_idx)
             _on = self.cmd_type
-            if _on == Mrl.CmdType.set_flag:
+            if _on == Mrl.CmdType.set_constant_buffer:
                 pass
                 self.value_cmd._write__seq(self._io)
-            elif _on == Mrl.CmdType.set_constant_buffer:
+            elif _on == Mrl.CmdType.set_flag:
                 pass
                 self.value_cmd._write__seq(self._io)
             elif _on == Mrl.CmdType.set_sampler_state:
@@ -8939,39 +9241,298 @@ class Mrl(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
             _on = self.cmd_type
-            if _on == Mrl.CmdType.set_flag:
+            if _on == Mrl.CmdType.set_constant_buffer:
                 pass
                 if self.value_cmd._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"value_cmd", self.value_cmd._root, self._root)
+                    raise kaitaistruct.ConsistencyError(u"value_cmd", self._root, self.value_cmd._root)
                 if self.value_cmd._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"value_cmd", self.value_cmd._parent, self)
-            elif _on == Mrl.CmdType.set_constant_buffer:
+                    raise kaitaistruct.ConsistencyError(u"value_cmd", self, self.value_cmd._parent)
+            elif _on == Mrl.CmdType.set_flag:
                 pass
                 if self.value_cmd._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"value_cmd", self.value_cmd._root, self._root)
+                    raise kaitaistruct.ConsistencyError(u"value_cmd", self._root, self.value_cmd._root)
                 if self.value_cmd._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"value_cmd", self.value_cmd._parent, self)
+                    raise kaitaistruct.ConsistencyError(u"value_cmd", self, self.value_cmd._parent)
             elif _on == Mrl.CmdType.set_sampler_state:
                 pass
                 if self.value_cmd._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"value_cmd", self.value_cmd._root, self._root)
+                    raise kaitaistruct.ConsistencyError(u"value_cmd", self._root, self.value_cmd._root)
                 if self.value_cmd._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"value_cmd", self.value_cmd._parent, self)
+                    raise kaitaistruct.ConsistencyError(u"value_cmd", self, self.value_cmd._parent)
             elif _on == Mrl.CmdType.set_texture:
                 pass
                 if self.value_cmd._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"value_cmd", self.value_cmd._root, self._root)
+                    raise kaitaistruct.ConsistencyError(u"value_cmd", self._root, self.value_cmd._root)
                 if self.value_cmd._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"value_cmd", self.value_cmd._parent, self)
+                    raise kaitaistruct.ConsistencyError(u"value_cmd", self, self.value_cmd._parent)
             elif _on == Mrl.CmdType.set_unk:
                 pass
                 if self.value_cmd._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"value_cmd", self.value_cmd._root, self._root)
+                    raise kaitaistruct.ConsistencyError(u"value_cmd", self._root, self.value_cmd._root)
                 if self.value_cmd._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"value_cmd", self.value_cmd._parent, self)
+                    raise kaitaistruct.ConsistencyError(u"value_cmd", self, self.value_cmd._parent)
+            if self.float_buffer__enabled:
+                pass
+                if self.cmd_type == Mrl.CmdType.set_constant_buffer:
+                    pass
+                    _on = self.shader_object_hash
+                    if _on == Mrl.ShaderObjectHash.cbappclipplane:
+                        pass
+                        if self._m_float_buffer._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self._root, self._m_float_buffer._root)
+                        if self._m_float_buffer._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self, self._m_float_buffer._parent)
+                    elif _on == Mrl.ShaderObjectHash.cbappreflect:
+                        pass
+                        if self._m_float_buffer._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self._root, self._m_float_buffer._root)
+                        if self._m_float_buffer._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self, self._m_float_buffer._parent)
+                    elif _on == Mrl.ShaderObjectHash.cbappreflectshadowlight:
+                        pass
+                        if self._m_float_buffer._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self._root, self._m_float_buffer._root)
+                        if self._m_float_buffer._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self, self._m_float_buffer._parent)
+                    elif _on == Mrl.ShaderObjectHash.cbburncommon:
+                        pass
+                        if self._m_float_buffer._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self._root, self._m_float_buffer._root)
+                        if self._m_float_buffer._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self, self._m_float_buffer._parent)
+                    elif _on == Mrl.ShaderObjectHash.cbburnemission:
+                        pass
+                        if self._m_float_buffer._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self._root, self._m_float_buffer._root)
+                        if self._m_float_buffer._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self, self._m_float_buffer._parent)
+                    elif _on == Mrl.ShaderObjectHash.cbcolormask:
+                        pass
+                        if self._m_float_buffer._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self._root, self._m_float_buffer._root)
+                        if self._m_float_buffer._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self, self._m_float_buffer._parent)
+                    elif _on == Mrl.ShaderObjectHash.cbddmaterialparam:
+                        pass
+                        if self._m_float_buffer._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self._root, self._m_float_buffer._root)
+                        if self._m_float_buffer._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self, self._m_float_buffer._parent)
+                    elif _on == Mrl.ShaderObjectHash.cbddmaterialparaminnercorrect:
+                        pass
+                        if self._m_float_buffer._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self._root, self._m_float_buffer._root)
+                        if self._m_float_buffer._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self, self._m_float_buffer._parent)
+                    elif _on == Mrl.ShaderObjectHash.cbdistortion:
+                        pass
+                        if self._m_float_buffer._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self._root, self._m_float_buffer._root)
+                        if self._m_float_buffer._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self, self._m_float_buffer._parent)
+                    elif _on == Mrl.ShaderObjectHash.cbmaterial:
+                        pass
+                        if self._m_float_buffer._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self._root, self._m_float_buffer._root)
+                        if self._m_float_buffer._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self, self._m_float_buffer._parent)
+                    elif _on == Mrl.ShaderObjectHash.cboutlineex:
+                        pass
+                        if self._m_float_buffer._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self._root, self._m_float_buffer._root)
+                        if self._m_float_buffer._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self, self._m_float_buffer._parent)
+                    elif _on == Mrl.ShaderObjectHash.cbspecularblend:
+                        pass
+                        if self._m_float_buffer._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self._root, self._m_float_buffer._root)
+                        if self._m_float_buffer._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self, self._m_float_buffer._parent)
+                    elif _on == Mrl.ShaderObjectHash.cbuvrotationoffset:
+                        pass
+                        if self._m_float_buffer._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self._root, self._m_float_buffer._root)
+                        if self._m_float_buffer._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self, self._m_float_buffer._parent)
+                    elif _on == Mrl.ShaderObjectHash.cbvertexdisplacement:
+                        pass
+                        if self._m_float_buffer._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self._root, self._m_float_buffer._root)
+                        if self._m_float_buffer._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self, self._m_float_buffer._parent)
+                    elif _on == Mrl.ShaderObjectHash.cbvertexdisplacement2:
+                        pass
+                        if self._m_float_buffer._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self._root, self._m_float_buffer._root)
+                        if self._m_float_buffer._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self, self._m_float_buffer._parent)
+                    elif _on == Mrl.ShaderObjectHash.globals:
+                        pass
+                        if self._m_float_buffer._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self._root, self._m_float_buffer._root)
+                        if self._m_float_buffer._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"float_buffer", self, self._m_float_buffer._parent)
 
+
+            self._dirty = False
+
+        @property
+        def float_buffer(self):
+            if self._should_write_float_buffer:
+                self._write_float_buffer()
+            if hasattr(self, '_m_float_buffer'):
+                return self._m_float_buffer
+
+            if not self.float_buffer__enabled:
+                return None
+
+            if self.cmd_type == Mrl.CmdType.set_constant_buffer:
+                pass
+                _pos = self._io.pos()
+                self._io.seek(self._parent.ofs_cmd + self.value_cmd.ofs_float_buff)
+                _on = self.shader_object_hash
+                if _on == Mrl.ShaderObjectHash.cbappclipplane:
+                    pass
+                    self._m_float_buffer = Mrl.CbAppClipPlane(self._io, self, self._root)
+                    self._m_float_buffer._read()
+                elif _on == Mrl.ShaderObjectHash.cbappreflect:
+                    pass
+                    self._m_float_buffer = Mrl.CbAppReflect(self._io, self, self._root)
+                    self._m_float_buffer._read()
+                elif _on == Mrl.ShaderObjectHash.cbappreflectshadowlight:
+                    pass
+                    self._m_float_buffer = Mrl.CbAppReflectShadowLight(self._io, self, self._root)
+                    self._m_float_buffer._read()
+                elif _on == Mrl.ShaderObjectHash.cbburncommon:
+                    pass
+                    self._m_float_buffer = Mrl.CbBurnCommon(self._io, self, self._root)
+                    self._m_float_buffer._read()
+                elif _on == Mrl.ShaderObjectHash.cbburnemission:
+                    pass
+                    self._m_float_buffer = Mrl.CbBurnEmission(self._io, self, self._root)
+                    self._m_float_buffer._read()
+                elif _on == Mrl.ShaderObjectHash.cbcolormask:
+                    pass
+                    self._m_float_buffer = Mrl.CbColorMask(self._io, self, self._root)
+                    self._m_float_buffer._read()
+                elif _on == Mrl.ShaderObjectHash.cbddmaterialparam:
+                    pass
+                    self._m_float_buffer = Mrl.CbDdMaterialParam(self._io, self, self._root)
+                    self._m_float_buffer._read()
+                elif _on == Mrl.ShaderObjectHash.cbddmaterialparaminnercorrect:
+                    pass
+                    self._m_float_buffer = Mrl.CbDdMaterialParamInnerCorrect(self._io, self, self._root)
+                    self._m_float_buffer._read()
+                elif _on == Mrl.ShaderObjectHash.cbdistortion:
+                    pass
+                    self._m_float_buffer = Mrl.CbDistortion(self._io, self, self._root)
+                    self._m_float_buffer._read()
+                elif _on == Mrl.ShaderObjectHash.cbmaterial:
+                    pass
+                    self._m_float_buffer = Mrl.CbMaterial(self._io, self, self._root)
+                    self._m_float_buffer._read()
+                elif _on == Mrl.ShaderObjectHash.cboutlineex:
+                    pass
+                    self._m_float_buffer = Mrl.CbOutlineEx(self._io, self, self._root)
+                    self._m_float_buffer._read()
+                elif _on == Mrl.ShaderObjectHash.cbspecularblend:
+                    pass
+                    self._m_float_buffer = Mrl.CbSpecularBlend(self._io, self, self._root)
+                    self._m_float_buffer._read()
+                elif _on == Mrl.ShaderObjectHash.cbuvrotationoffset:
+                    pass
+                    self._m_float_buffer = Mrl.CbUvRotationOffset(self._io, self, self._root)
+                    self._m_float_buffer._read()
+                elif _on == Mrl.ShaderObjectHash.cbvertexdisplacement:
+                    pass
+                    self._m_float_buffer = Mrl.CbVertexDisplacement(self._io, self, self._root)
+                    self._m_float_buffer._read()
+                elif _on == Mrl.ShaderObjectHash.cbvertexdisplacement2:
+                    pass
+                    self._m_float_buffer = Mrl.CbVertexDisplacement2(self._io, self, self._root)
+                    self._m_float_buffer._read()
+                elif _on == Mrl.ShaderObjectHash.globals:
+                    pass
+                    self._m_float_buffer = Mrl.CbGlobals(self._io, self, self._root)
+                    self._m_float_buffer._read()
+                self._io.seek(_pos)
+
+            return getattr(self, '_m_float_buffer', None)
+
+        @float_buffer.setter
+        def float_buffer(self, v):
+            self._dirty = True
+            self._m_float_buffer = v
+
+        def _write_float_buffer(self):
+            self._should_write_float_buffer = False
+            if self.cmd_type == Mrl.CmdType.set_constant_buffer:
+                pass
+                _pos = self._io.pos()
+                self._io.seek(self._parent.ofs_cmd + self.value_cmd.ofs_float_buff)
+                _on = self.shader_object_hash
+                if _on == Mrl.ShaderObjectHash.cbappclipplane:
+                    pass
+                    self._m_float_buffer._write__seq(self._io)
+                elif _on == Mrl.ShaderObjectHash.cbappreflect:
+                    pass
+                    self._m_float_buffer._write__seq(self._io)
+                elif _on == Mrl.ShaderObjectHash.cbappreflectshadowlight:
+                    pass
+                    self._m_float_buffer._write__seq(self._io)
+                elif _on == Mrl.ShaderObjectHash.cbburncommon:
+                    pass
+                    self._m_float_buffer._write__seq(self._io)
+                elif _on == Mrl.ShaderObjectHash.cbburnemission:
+                    pass
+                    self._m_float_buffer._write__seq(self._io)
+                elif _on == Mrl.ShaderObjectHash.cbcolormask:
+                    pass
+                    self._m_float_buffer._write__seq(self._io)
+                elif _on == Mrl.ShaderObjectHash.cbddmaterialparam:
+                    pass
+                    self._m_float_buffer._write__seq(self._io)
+                elif _on == Mrl.ShaderObjectHash.cbddmaterialparaminnercorrect:
+                    pass
+                    self._m_float_buffer._write__seq(self._io)
+                elif _on == Mrl.ShaderObjectHash.cbdistortion:
+                    pass
+                    self._m_float_buffer._write__seq(self._io)
+                elif _on == Mrl.ShaderObjectHash.cbmaterial:
+                    pass
+                    self._m_float_buffer._write__seq(self._io)
+                elif _on == Mrl.ShaderObjectHash.cboutlineex:
+                    pass
+                    self._m_float_buffer._write__seq(self._io)
+                elif _on == Mrl.ShaderObjectHash.cbspecularblend:
+                    pass
+                    self._m_float_buffer._write__seq(self._io)
+                elif _on == Mrl.ShaderObjectHash.cbuvrotationoffset:
+                    pass
+                    self._m_float_buffer._write__seq(self._io)
+                elif _on == Mrl.ShaderObjectHash.cbvertexdisplacement:
+                    pass
+                    self._m_float_buffer._write__seq(self._io)
+                elif _on == Mrl.ShaderObjectHash.cbvertexdisplacement2:
+                    pass
+                    self._m_float_buffer._write__seq(self._io)
+                elif _on == Mrl.ShaderObjectHash.globals:
+                    pass
+                    self._m_float_buffer._write__seq(self._io)
+                self._io.seek(_pos)
+
+
+        @property
+        def shader_object_hash(self):
+            if hasattr(self, '_m_shader_object_hash'):
+                return self._m_shader_object_hash
+
+            self._m_shader_object_hash = KaitaiStream.resolve_enum(Mrl.ShaderObjectHash, self.shader_object_id >> 12)
+            return getattr(self, '_m_shader_object_hash', None)
+
+        def _invalidate_shader_object_hash(self):
+            del self._m_shader_object_hash
         @property
         def size_(self):
             if hasattr(self, '_m_size_'):
@@ -8982,506 +9543,170 @@ class Mrl(ReadWriteKaitaiStruct):
 
         def _invalidate_size_(self):
             del self._m_size_
-        @property
-        def shader_object_hash(self):
-            if hasattr(self, '_m_shader_object_hash'):
-                return self._m_shader_object_hash
 
-            self._m_shader_object_hash = KaitaiStream.resolve_enum(Mrl.ShaderObjectHash, (self.shader_object_id >> 12))
-            return getattr(self, '_m_shader_object_hash', None)
-
-        def _invalidate_shader_object_hash(self):
-            del self._m_shader_object_hash
-        @property
-        def float_buffer(self):
-            if self._should_write_float_buffer:
-                self._write_float_buffer()
-            if hasattr(self, '_m_float_buffer'):
-                return self._m_float_buffer
-
-            if (self.cmd_type == Mrl.CmdType.set_constant_buffer):
-                pass
-                _pos = self._io.pos()
-                self._io.seek((self._parent.ofs_cmd + self.value_cmd.ofs_float_buff))
-                _on = self.shader_object_hash
-                if _on == Mrl.ShaderObjectHash.cbuvrotationoffset:
-                    pass
-                    self._m_float_buffer = Mrl.CbUvRotationOffset(self._io, self, self._root)
-                    self._m_float_buffer._read()
-                elif _on == Mrl.ShaderObjectHash.cbvertexdisplacement:
-                    pass
-                    self._m_float_buffer = Mrl.CbVertexDisplacement(self._io, self, self._root)
-                    self._m_float_buffer._read()
-                elif _on == Mrl.ShaderObjectHash.cbcolormask:
-                    pass
-                    self._m_float_buffer = Mrl.CbColorMask(self._io, self, self._root)
-                    self._m_float_buffer._read()
-                elif _on == Mrl.ShaderObjectHash.cbspecularblend:
-                    pass
-                    self._m_float_buffer = Mrl.CbSpecularBlend(self._io, self, self._root)
-                    self._m_float_buffer._read()
-                elif _on == Mrl.ShaderObjectHash.cbddmaterialparam:
-                    pass
-                    self._m_float_buffer = Mrl.CbDdMaterialParam(self._io, self, self._root)
-                    self._m_float_buffer._read()
-                elif _on == Mrl.ShaderObjectHash.cbdistortion:
-                    pass
-                    self._m_float_buffer = Mrl.CbDistortion(self._io, self, self._root)
-                    self._m_float_buffer._read()
-                elif _on == Mrl.ShaderObjectHash.cbappreflectshadowlight:
-                    pass
-                    self._m_float_buffer = Mrl.CbAppReflectShadowLight(self._io, self, self._root)
-                    self._m_float_buffer._read()
-                elif _on == Mrl.ShaderObjectHash.cbddmaterialparaminnercorrect:
-                    pass
-                    self._m_float_buffer = Mrl.CbDdMaterialParamInnerCorrect(self._io, self, self._root)
-                    self._m_float_buffer._read()
-                elif _on == Mrl.ShaderObjectHash.cbmaterial:
-                    pass
-                    self._m_float_buffer = Mrl.CbMaterial(self._io, self, self._root)
-                    self._m_float_buffer._read()
-                elif _on == Mrl.ShaderObjectHash.cboutlineex:
-                    pass
-                    self._m_float_buffer = Mrl.CbOutlineEx(self._io, self, self._root)
-                    self._m_float_buffer._read()
-                elif _on == Mrl.ShaderObjectHash.globals:
-                    pass
-                    self._m_float_buffer = Mrl.CbGlobals(self._io, self, self._root)
-                    self._m_float_buffer._read()
-                elif _on == Mrl.ShaderObjectHash.cbburnemission:
-                    pass
-                    self._m_float_buffer = Mrl.CbBurnEmission(self._io, self, self._root)
-                    self._m_float_buffer._read()
-                elif _on == Mrl.ShaderObjectHash.cbappreflect:
-                    pass
-                    self._m_float_buffer = Mrl.CbAppReflect(self._io, self, self._root)
-                    self._m_float_buffer._read()
-                elif _on == Mrl.ShaderObjectHash.cbappclipplane:
-                    pass
-                    self._m_float_buffer = Mrl.CbAppClipPlane(self._io, self, self._root)
-                    self._m_float_buffer._read()
-                elif _on == Mrl.ShaderObjectHash.cbburncommon:
-                    pass
-                    self._m_float_buffer = Mrl.CbBurnCommon(self._io, self, self._root)
-                    self._m_float_buffer._read()
-                elif _on == Mrl.ShaderObjectHash.cbvertexdisplacement2:
-                    pass
-                    self._m_float_buffer = Mrl.CbVertexDisplacement2(self._io, self, self._root)
-                    self._m_float_buffer._read()
-                self._io.seek(_pos)
-
-            return getattr(self, '_m_float_buffer', None)
-
-        @float_buffer.setter
-        def float_buffer(self, v):
-            self._m_float_buffer = v
-
-        def _write_float_buffer(self):
-            self._should_write_float_buffer = False
-            if (self.cmd_type == Mrl.CmdType.set_constant_buffer):
-                pass
-                _pos = self._io.pos()
-                self._io.seek((self._parent.ofs_cmd + self.value_cmd.ofs_float_buff))
-                _on = self.shader_object_hash
-                if _on == Mrl.ShaderObjectHash.cbuvrotationoffset:
-                    pass
-                    self.float_buffer._write__seq(self._io)
-                elif _on == Mrl.ShaderObjectHash.cbvertexdisplacement:
-                    pass
-                    self.float_buffer._write__seq(self._io)
-                elif _on == Mrl.ShaderObjectHash.cbcolormask:
-                    pass
-                    self.float_buffer._write__seq(self._io)
-                elif _on == Mrl.ShaderObjectHash.cbspecularblend:
-                    pass
-                    self.float_buffer._write__seq(self._io)
-                elif _on == Mrl.ShaderObjectHash.cbddmaterialparam:
-                    pass
-                    self.float_buffer._write__seq(self._io)
-                elif _on == Mrl.ShaderObjectHash.cbdistortion:
-                    pass
-                    self.float_buffer._write__seq(self._io)
-                elif _on == Mrl.ShaderObjectHash.cbappreflectshadowlight:
-                    pass
-                    self.float_buffer._write__seq(self._io)
-                elif _on == Mrl.ShaderObjectHash.cbddmaterialparaminnercorrect:
-                    pass
-                    self.float_buffer._write__seq(self._io)
-                elif _on == Mrl.ShaderObjectHash.cbmaterial:
-                    pass
-                    self.float_buffer._write__seq(self._io)
-                elif _on == Mrl.ShaderObjectHash.cboutlineex:
-                    pass
-                    self.float_buffer._write__seq(self._io)
-                elif _on == Mrl.ShaderObjectHash.globals:
-                    pass
-                    self.float_buffer._write__seq(self._io)
-                elif _on == Mrl.ShaderObjectHash.cbburnemission:
-                    pass
-                    self.float_buffer._write__seq(self._io)
-                elif _on == Mrl.ShaderObjectHash.cbappreflect:
-                    pass
-                    self.float_buffer._write__seq(self._io)
-                elif _on == Mrl.ShaderObjectHash.cbappclipplane:
-                    pass
-                    self.float_buffer._write__seq(self._io)
-                elif _on == Mrl.ShaderObjectHash.cbburncommon:
-                    pass
-                    self.float_buffer._write__seq(self._io)
-                elif _on == Mrl.ShaderObjectHash.cbvertexdisplacement2:
-                    pass
-                    self.float_buffer._write__seq(self._io)
-                self._io.seek(_pos)
-
-
-
-        def _check_float_buffer(self):
-            pass
-            if (self.cmd_type == Mrl.CmdType.set_constant_buffer):
-                pass
-                _on = self.shader_object_hash
-                if _on == Mrl.ShaderObjectHash.cbuvrotationoffset:
-                    pass
-                    if self.float_buffer._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._root, self._root)
-                    if self.float_buffer._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._parent, self)
-                elif _on == Mrl.ShaderObjectHash.cbvertexdisplacement:
-                    pass
-                    if self.float_buffer._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._root, self._root)
-                    if self.float_buffer._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._parent, self)
-                elif _on == Mrl.ShaderObjectHash.cbcolormask:
-                    pass
-                    if self.float_buffer._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._root, self._root)
-                    if self.float_buffer._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._parent, self)
-                elif _on == Mrl.ShaderObjectHash.cbspecularblend:
-                    pass
-                    if self.float_buffer._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._root, self._root)
-                    if self.float_buffer._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._parent, self)
-                elif _on == Mrl.ShaderObjectHash.cbddmaterialparam:
-                    pass
-                    if self.float_buffer._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._root, self._root)
-                    if self.float_buffer._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._parent, self)
-                elif _on == Mrl.ShaderObjectHash.cbdistortion:
-                    pass
-                    if self.float_buffer._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._root, self._root)
-                    if self.float_buffer._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._parent, self)
-                elif _on == Mrl.ShaderObjectHash.cbappreflectshadowlight:
-                    pass
-                    if self.float_buffer._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._root, self._root)
-                    if self.float_buffer._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._parent, self)
-                elif _on == Mrl.ShaderObjectHash.cbddmaterialparaminnercorrect:
-                    pass
-                    if self.float_buffer._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._root, self._root)
-                    if self.float_buffer._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._parent, self)
-                elif _on == Mrl.ShaderObjectHash.cbmaterial:
-                    pass
-                    if self.float_buffer._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._root, self._root)
-                    if self.float_buffer._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._parent, self)
-                elif _on == Mrl.ShaderObjectHash.cboutlineex:
-                    pass
-                    if self.float_buffer._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._root, self._root)
-                    if self.float_buffer._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._parent, self)
-                elif _on == Mrl.ShaderObjectHash.globals:
-                    pass
-                    if self.float_buffer._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._root, self._root)
-                    if self.float_buffer._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._parent, self)
-                elif _on == Mrl.ShaderObjectHash.cbburnemission:
-                    pass
-                    if self.float_buffer._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._root, self._root)
-                    if self.float_buffer._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._parent, self)
-                elif _on == Mrl.ShaderObjectHash.cbappreflect:
-                    pass
-                    if self.float_buffer._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._root, self._root)
-                    if self.float_buffer._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._parent, self)
-                elif _on == Mrl.ShaderObjectHash.cbappclipplane:
-                    pass
-                    if self.float_buffer._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._root, self._root)
-                    if self.float_buffer._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._parent, self)
-                elif _on == Mrl.ShaderObjectHash.cbburncommon:
-                    pass
-                    if self.float_buffer._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._root, self._root)
-                    if self.float_buffer._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._parent, self)
-                elif _on == Mrl.ShaderObjectHash.cbvertexdisplacement2:
-                    pass
-                    if self.float_buffer._root != self._root:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._root, self._root)
-                    if self.float_buffer._parent != self:
-                        raise kaitaistruct.ConsistencyError(u"float_buffer", self.float_buffer._parent, self)
-
-
-
-    class CbAppReflectShadowLight1(ReadWriteKaitaiStruct):
+    class ShaderObject(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Mrl.ShaderObject, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
         def _read(self):
-            self.f_app_reflect_shadow_dir = []
-            for i in range(3):
-                self.f_app_reflect_shadow_dir.append(self._io.read_f4le())
-
-            self.padding = self._io.read_f4le()
+            self.index = self._io.read_bits_int_le(12)
+            self.name_hash = KaitaiStream.resolve_enum(Mrl.ShaderObjectHash, self._io.read_bits_int_le(20))
+            self._dirty = False
 
 
         def _fetch_instances(self):
             pass
-            for i in range(len(self.f_app_reflect_shadow_dir)):
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.ShaderObject, self)._write__seq(io)
+            self._io.write_bits_int_le(12, self.index)
+            self._io.write_bits_int_le(20, int(self.name_hash))
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class ShdHash(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.ShdHash, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.shader_hash = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.ShdHash, self)._write__seq(io)
+            self._io.write_u4le(self.shader_hash)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class TexOffset(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.TexOffset, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.texture_id = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Mrl.TexOffset, self)._write__seq(io)
+            self._io.write_u4le(self.texture_id)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class TextureSlot(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Mrl.TextureSlot, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.type_hash = KaitaiStream.resolve_enum(Mrl.TextureType, self._io.read_u4le())
+            self.unk_02 = self._io.read_u4le()
+            self.unk_03 = self._io.read_u4le()
+            self.texture_path = (self._io.read_bytes_term(0, False, True, True)).decode(u"ASCII")
+            self.filler = []
+            for i in range((64 - len(self.texture_path)) - 1):
+                self.filler.append(self._io.read_u1())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.filler)):
                 pass
 
 
 
         def _write__seq(self, io=None):
-            super(Mrl.CbAppReflectShadowLight1, self)._write__seq(io)
-            for i in range(len(self.f_app_reflect_shadow_dir)):
+            super(Mrl.TextureSlot, self)._write__seq(io)
+            self._io.write_u4le(int(self.type_hash))
+            self._io.write_u4le(self.unk_02)
+            self._io.write_u4le(self.unk_03)
+            self._io.write_bytes((self.texture_path).encode(u"ASCII"))
+            self._io.write_u1(0)
+            for i in range(len(self.filler)):
                 pass
-                self._io.write_f4le(self.f_app_reflect_shadow_dir[i])
+                self._io.write_u1(self.filler[i])
 
-            self._io.write_f4le(self.padding)
 
 
         def _check(self):
-            pass
-            if (len(self.f_app_reflect_shadow_dir) != 3):
-                raise kaitaistruct.ConsistencyError(u"f_app_reflect_shadow_dir", len(self.f_app_reflect_shadow_dir), 3)
-            for i in range(len(self.f_app_reflect_shadow_dir)):
+            if KaitaiStream.byte_array_index_of((self.texture_path).encode(u"ASCII"), 0) != -1:
+                raise kaitaistruct.ConsistencyError(u"texture_path", -1, KaitaiStream.byte_array_index_of((self.texture_path).encode(u"ASCII"), 0))
+            if len(self.filler) != (64 - len(self.texture_path)) - 1:
+                raise kaitaistruct.ConsistencyError(u"filler", (64 - len(self.texture_path)) - 1, len(self.filler))
+            for i in range(len(self.filler)):
                 pass
 
+            self._dirty = False
 
         @property
         def size_(self):
             if hasattr(self, '_m_size_'):
                 return self._m_size_
 
-            self._m_size_ = 16
+            self._m_size_ = 76
             return getattr(self, '_m_size_', None)
 
         def _invalidate_size_(self):
             del self._m_size_
 
-    class AnimSubEntry3(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
+    @property
+    def ofs_materials_calculated(self):
+        if hasattr(self, '_m_ofs_materials_calculated'):
+            return self._m_ofs_materials_calculated
 
-        def _read(self):
-            self.header = []
-            for i in range(24):
-                self.header.append(self._io.read_u1())
+        self._m_ofs_materials_calculated = self.ofs_textures_calculated + self.size_textures_
+        return getattr(self, '_m_ofs_materials_calculated', None)
 
-            self.values = []
-            for i in range((16 * (self._parent.info.num_entry - 1))):
-                self.values.append(self._io.read_u1())
+    def _invalidate_ofs_materials_calculated(self):
+        del self._m_ofs_materials_calculated
+    @property
+    def ofs_resources_calculated(self):
+        if hasattr(self, '_m_ofs_resources_calculated'):
+            return self._m_ofs_resources_calculated
 
+        self._m_ofs_resources_calculated = self.ofs_resources_calculated_no_padding + -(self.ofs_resources_calculated_no_padding) % 16
+        return getattr(self, '_m_ofs_resources_calculated', None)
 
+    def _invalidate_ofs_resources_calculated(self):
+        del self._m_ofs_resources_calculated
+    @property
+    def ofs_resources_calculated_no_padding(self):
+        if hasattr(self, '_m_ofs_resources_calculated_no_padding'):
+            return self._m_ofs_resources_calculated_no_padding
 
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.header)):
-                pass
+        self._m_ofs_resources_calculated_no_padding = (self.size_top_level_ + self.size_textures_) + self.size_materials_
+        return getattr(self, '_m_ofs_resources_calculated_no_padding', None)
 
-            for i in range(len(self.values)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.AnimSubEntry3, self)._write__seq(io)
-            for i in range(len(self.header)):
-                pass
-                self._io.write_u1(self.header[i])
-
-            for i in range(len(self.values)):
-                pass
-                self._io.write_u1(self.values[i])
-
-
-
-        def _check(self):
-            pass
-            if (len(self.header) != 24):
-                raise kaitaistruct.ConsistencyError(u"header", len(self.header), 24)
-            for i in range(len(self.header)):
-                pass
-
-            if (len(self.values) != (16 * (self._parent.info.num_entry - 1))):
-                raise kaitaistruct.ConsistencyError(u"values", len(self.values), (16 * (self._parent.info.num_entry - 1)))
-            for i in range(len(self.values)):
-                pass
-
-
-
-    class CbAppClipPlane(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-            self._should_write_app_specific = False
-            self.app_specific__to_write = True
-
-        def _read(self):
-            pass
-
-
-        def _fetch_instances(self):
-            pass
-            _ = self.app_specific
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self.app_specific._fetch_instances()
-            else:
-                pass
-                self.app_specific._fetch_instances()
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.CbAppClipPlane, self)._write__seq(io)
-            self._should_write_app_specific = self.app_specific__to_write
-
-
-        def _check(self):
-            pass
-
-        @property
-        def app_specific(self):
-            if self._should_write_app_specific:
-                self._write_app_specific()
-            if hasattr(self, '_m_app_specific'):
-                return self._m_app_specific
-
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self._m_app_specific = Mrl.CbAppClipPlane1(self._io, self, self._root)
-                self._m_app_specific._read()
-            else:
-                pass
-                self._m_app_specific = Mrl.CbAppClipPlane1(self._io, self, self._root)
-                self._m_app_specific._read()
-            self._io.seek(_pos)
-            return getattr(self, '_m_app_specific', None)
-
-        @app_specific.setter
-        def app_specific(self, v):
-            self._m_app_specific = v
-
-        def _write_app_specific(self):
-            self._should_write_app_specific = False
-            _pos = self._io.pos()
-            self._io.seek((self._parent._parent.ofs_cmd + self._parent.value_cmd.ofs_float_buff))
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                self.app_specific._write__seq(self._io)
-            else:
-                pass
-                self.app_specific._write__seq(self._io)
-            self._io.seek(_pos)
-
-
-        def _check_app_specific(self):
-            pass
-            _on = self._root.app_id
-            if _on == u"dd":
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-            else:
-                pass
-                if self.app_specific._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._root, self._root)
-                if self.app_specific._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"app_specific", self.app_specific._parent, self)
-
-
-    class AnimSubEntry2(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.header = []
-            for i in range(12):
-                self.header.append(self._io.read_u1())
-
-            self.values = []
-            for i in range((8 * self._parent.info.num_entry)):
-                self.values.append(self._io.read_u1())
-
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.header)):
-                pass
-
-            for i in range(len(self.values)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Mrl.AnimSubEntry2, self)._write__seq(io)
-            for i in range(len(self.header)):
-                pass
-                self._io.write_u1(self.header[i])
-
-            for i in range(len(self.values)):
-                pass
-                self._io.write_u1(self.values[i])
-
-
-
-        def _check(self):
-            pass
-            if (len(self.header) != 12):
-                raise kaitaistruct.ConsistencyError(u"header", len(self.header), 12)
-            for i in range(len(self.header)):
-                pass
-
-            if (len(self.values) != (8 * self._parent.info.num_entry)):
-                raise kaitaistruct.ConsistencyError(u"values", len(self.values), (8 * self._parent.info.num_entry))
-            for i in range(len(self.values)):
-                pass
-
-
-
+    def _invalidate_ofs_resources_calculated_no_padding(self):
+        del self._m_ofs_resources_calculated_no_padding
     @property
     def ofs_textures_calculated(self):
         if hasattr(self, '_m_ofs_textures_calculated'):
@@ -9493,45 +9718,35 @@ class Mrl(ReadWriteKaitaiStruct):
     def _invalidate_ofs_textures_calculated(self):
         del self._m_ofs_textures_calculated
     @property
-    def ofs_materials_calculated(self):
-        if hasattr(self, '_m_ofs_materials_calculated'):
-            return self._m_ofs_materials_calculated
+    def size_materials_(self):
+        if hasattr(self, '_m_size_materials_'):
+            return self._m_size_materials_
 
-        self._m_ofs_materials_calculated = (self.ofs_textures_calculated + self.size_textures_)
-        return getattr(self, '_m_ofs_materials_calculated', None)
+        self._m_size_materials_ = self.materials[0].size_ * self.num_materials
+        return getattr(self, '_m_size_materials_', None)
 
-    def _invalidate_ofs_materials_calculated(self):
-        del self._m_ofs_materials_calculated
-    @property
-    def ofs_resources_calculated_no_padding(self):
-        if hasattr(self, '_m_ofs_resources_calculated_no_padding'):
-            return self._m_ofs_resources_calculated_no_padding
-
-        self._m_ofs_resources_calculated_no_padding = ((self.size_top_level_ + self.size_textures_) + self.size_materials_)
-        return getattr(self, '_m_ofs_resources_calculated_no_padding', None)
-
-    def _invalidate_ofs_resources_calculated_no_padding(self):
-        del self._m_ofs_resources_calculated_no_padding
-    @property
-    def size_todo_(self):
-        if hasattr(self, '_m_size_todo_'):
-            return self._m_size_todo_
-
-        self._m_size_todo_ = ((self.size_top_level_ + self.size_textures_) + self.size_materials_)
-        return getattr(self, '_m_size_todo_', None)
-
-    def _invalidate_size_todo_(self):
-        del self._m_size_todo_
+    def _invalidate_size_materials_(self):
+        del self._m_size_materials_
     @property
     def size_textures_(self):
         if hasattr(self, '_m_size_textures_'):
             return self._m_size_textures_
 
-        self._m_size_textures_ = (self.textures[0].size_ * self.num_textures)
+        self._m_size_textures_ = self.textures[0].size_ * self.num_textures
         return getattr(self, '_m_size_textures_', None)
 
     def _invalidate_size_textures_(self):
         del self._m_size_textures_
+    @property
+    def size_todo_(self):
+        if hasattr(self, '_m_size_todo_'):
+            return self._m_size_todo_
+
+        self._m_size_todo_ = (self.size_top_level_ + self.size_textures_) + self.size_materials_
+        return getattr(self, '_m_size_todo_', None)
+
+    def _invalidate_size_todo_(self):
+        del self._m_size_todo_
     @property
     def size_top_level_(self):
         if hasattr(self, '_m_size_top_level_'):
@@ -9542,24 +9757,4 @@ class Mrl(ReadWriteKaitaiStruct):
 
     def _invalidate_size_top_level_(self):
         del self._m_size_top_level_
-    @property
-    def size_materials_(self):
-        if hasattr(self, '_m_size_materials_'):
-            return self._m_size_materials_
-
-        self._m_size_materials_ = (self.materials[0].size_ * self.num_materials)
-        return getattr(self, '_m_size_materials_', None)
-
-    def _invalidate_size_materials_(self):
-        del self._m_size_materials_
-    @property
-    def ofs_resources_calculated(self):
-        if hasattr(self, '_m_ofs_resources_calculated'):
-            return self._m_ofs_resources_calculated
-
-        self._m_ofs_resources_calculated = (self.ofs_resources_calculated_no_padding + (-(self.ofs_resources_calculated_no_padding) % 16))
-        return getattr(self, '_m_ofs_resources_calculated', None)
-
-    def _invalidate_ofs_resources_calculated(self):
-        del self._m_ofs_resources_calculated
 

--- a/albam/engines/mtfw/structs/nav-156.ksy
+++ b/albam/engines/mtfw/structs/nav-156.ksy
@@ -2,7 +2,7 @@ meta:
   id: nav_156
   file-extension: nav
   endian: le
-  ks-version: "0.11"
+  ks-version: '0.11'
   title: Resident Evil 5 navmesh
 
 seq:

--- a/albam/engines/mtfw/structs/rtex-112.ksy
+++ b/albam/engines/mtfw/structs/rtex-112.ksy
@@ -3,7 +3,7 @@ meta:
   bit-endian: le
   file-extension: rtex
   id: rtex_112
-  ks-version: 0.10
+  ks-version: '0.11'
   title: MTFramework texture format version 112
 
 seq:

--- a/albam/engines/mtfw/structs/rtex-157.ksy
+++ b/albam/engines/mtfw/structs/rtex-157.ksy
@@ -3,7 +3,7 @@ meta:
   bit-endian: le
   file-extension: rtex
   id: rtex_157
-  ks-version: 0.10
+  ks-version: '0.11'
   title: MTFramework texture render target format version 157
 
 seq:

--- a/albam/engines/mtfw/structs/rtex_112.py
+++ b/albam/engines/mtfw/structs/rtex_112.py
@@ -5,18 +5,18 @@ import kaitaistruct
 from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
 
 
-if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 11):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.11 or later is required, but you have %s" % (kaitaistruct.__version__))
 
 class Rtex112(ReadWriteKaitaiStruct):
     def __init__(self, _io=None, _parent=None, _root=None):
-        self._io = _io
+        super(Rtex112, self).__init__(_io)
         self._parent = _parent
-        self._root = _root if _root else self
+        self._root = _root or self
 
     def _read(self):
         self.id_magic = self._io.read_bytes(4)
-        if not (self.id_magic == b"\x52\x54\x58\x00"):
+        if not self.id_magic == b"\x52\x54\x58\x00":
             raise kaitaistruct.ValidationNotEqualError(b"\x52\x54\x58\x00", self.id_magic, self._io, u"/seq/0")
         self.version = self._io.read_u2le()
         self.texture_type = self._io.read_bits_int_le(4)
@@ -30,11 +30,12 @@ class Rtex112(ReadWriteKaitaiStruct):
         self.width = self._io.read_u2le()
         self.height = self._io.read_u2le()
         self.depth = self._io.read_u4le()
-        self.compression_format = (self._io.read_bytes(4)).decode("ASCII")
+        self.compression_format = (self._io.read_bytes(4)).decode(u"ASCII")
         self.red = self._io.read_f4le()
         self.green = self._io.read_f4le()
         self.blue = self._io.read_f4le()
         self.alpha = self._io.read_f4le()
+        self._dirty = False
 
 
     def _fetch_instances(self):
@@ -64,13 +65,13 @@ class Rtex112(ReadWriteKaitaiStruct):
 
 
     def _check(self):
-        pass
-        if (len(self.id_magic) != 4):
-            raise kaitaistruct.ConsistencyError(u"id_magic", len(self.id_magic), 4)
-        if not (self.id_magic == b"\x52\x54\x58\x00"):
+        if len(self.id_magic) != 4:
+            raise kaitaistruct.ConsistencyError(u"id_magic", 4, len(self.id_magic))
+        if not self.id_magic == b"\x52\x54\x58\x00":
             raise kaitaistruct.ValidationNotEqualError(b"\x52\x54\x58\x00", self.id_magic, None, u"/seq/0")
-        if (len((self.compression_format).encode(u"ASCII")) != 4):
-            raise kaitaistruct.ConsistencyError(u"compression_format", len((self.compression_format).encode(u"ASCII")), 4)
+        if len((self.compression_format).encode(u"ASCII")) != 4:
+            raise kaitaistruct.ConsistencyError(u"compression_format", 4, len((self.compression_format).encode(u"ASCII")))
+        self._dirty = False
 
     @property
     def size_before_data_(self):

--- a/albam/engines/mtfw/structs/rtex_157.py
+++ b/albam/engines/mtfw/structs/rtex_157.py
@@ -5,18 +5,18 @@ import kaitaistruct
 from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
 
 
-if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 11):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.11 or later is required, but you have %s" % (kaitaistruct.__version__))
 
 class Rtex157(ReadWriteKaitaiStruct):
     def __init__(self, _io=None, _parent=None, _root=None):
-        self._io = _io
+        super(Rtex157, self).__init__(_io)
         self._parent = _parent
-        self._root = _root if _root else self
+        self._root = _root or self
 
     def _read(self):
         self.id_magic = self._io.read_bytes(4)
-        if not (self.id_magic == b"\x52\x54\x58\x00"):
+        if not self.id_magic == b"\x52\x54\x58\x00":
             raise kaitaistruct.ValidationNotEqualError(b"\x52\x54\x58\x00", self.id_magic, self._io, u"/seq/0")
         self.version = self._io.read_bits_int_le(8)
         self.unk = self._io.read_bits_int_le(8)
@@ -32,6 +32,7 @@ class Rtex157(ReadWriteKaitaiStruct):
         self.auto_resize = self._io.read_bits_int_le(1) != 0
         self.render_target = self._io.read_bits_int_le(1) != 0
         self.use_vtf = self._io.read_bits_int_le(1) != 0
+        self._dirty = False
 
 
     def _fetch_instances(self):
@@ -58,11 +59,11 @@ class Rtex157(ReadWriteKaitaiStruct):
 
 
     def _check(self):
-        pass
-        if (len(self.id_magic) != 4):
-            raise kaitaistruct.ConsistencyError(u"id_magic", len(self.id_magic), 4)
-        if not (self.id_magic == b"\x52\x54\x58\x00"):
+        if len(self.id_magic) != 4:
+            raise kaitaistruct.ConsistencyError(u"id_magic", 4, len(self.id_magic))
+        if not self.id_magic == b"\x52\x54\x58\x00":
             raise kaitaistruct.ValidationNotEqualError(b"\x52\x54\x58\x00", self.id_magic, None, u"/seq/0")
+        self._dirty = False
 
     @property
     def size_before_data_(self):

--- a/albam/engines/mtfw/structs/sbc-156.ksy
+++ b/albam/engines/mtfw/structs/sbc-156.ksy
@@ -2,7 +2,7 @@ meta:
   endian: le
   file-extension: sbc
   id: sbc_156
-  ks-version: 0.11
+  ks-version: '0.11'
   title:  Resident Evil 5 (MTFramework) collision format
 
 seq:

--- a/albam/engines/mtfw/structs/sbc-21.ksy
+++ b/albam/engines/mtfw/structs/sbc-21.ksy
@@ -2,7 +2,7 @@ meta:
   endian: le
   file-extension: sbc
   id: sbc_21
-  ks-version: 0.11
+  ks-version: '0.11'
   title: MTFramework collision format version 210
   
 seq:

--- a/albam/engines/mtfw/structs/sbc-211.ksy
+++ b/albam/engines/mtfw/structs/sbc-211.ksy
@@ -2,7 +2,7 @@ meta:
   endian: le
   file-extension: sbc
   id: sbc_211
-  ks-version: 0.11
+  ks-version: '0.11'
   title: MTFramework collision format version 211
   
 seq:

--- a/albam/engines/mtfw/structs/tex-112.ksy
+++ b/albam/engines/mtfw/structs/tex-112.ksy
@@ -3,7 +3,7 @@ meta:
   bit-endian: le
   file-extension: tex
   id: tex_112
-  ks-version: 0.10
+  ks-version: '0.11'
   title: MTFramework texture format version 112
 
 seq:

--- a/albam/engines/mtfw/structs/tex-157.ksy
+++ b/albam/engines/mtfw/structs/tex-157.ksy
@@ -3,7 +3,7 @@ meta:
   bit-endian: le
   file-extension: tex
   id: tex_157
-  ks-version: 0.10
+  ks-version: '0.11'
   title: MTFramework texture format version 157
 
 seq:

--- a/albam/engines/mtfw/structs/tex_112.py
+++ b/albam/engines/mtfw/structs/tex_112.py
@@ -5,18 +5,18 @@ import kaitaistruct
 from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
 
 
-if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 11):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.11 or later is required, but you have %s" % (kaitaistruct.__version__))
 
 class Tex112(ReadWriteKaitaiStruct):
     def __init__(self, _io=None, _parent=None, _root=None):
-        self._io = _io
+        super(Tex112, self).__init__(_io)
         self._parent = _parent
-        self._root = _root if _root else self
+        self._root = _root or self
 
     def _read(self):
         self.id_magic = self._io.read_bytes(4)
-        if not (self.id_magic == b"\x54\x45\x58\x00"):
+        if not self.id_magic == b"\x54\x45\x58\x00":
             raise kaitaistruct.ValidationNotEqualError(b"\x54\x45\x58\x00", self.id_magic, self._io, u"/seq/0")
         self.version = self._io.read_u2le()
         self.texture_type = self._io.read_bits_int_le(4)
@@ -30,30 +30,33 @@ class Tex112(ReadWriteKaitaiStruct):
         self.width = self._io.read_u2le()
         self.height = self._io.read_u2le()
         self.depth = self._io.read_u4le()
-        self.compression_format = (self._io.read_bytes(4)).decode("ASCII")
+        self.compression_format = (self._io.read_bytes(4)).decode(u"ASCII")
         self.red = self._io.read_f4le()
         self.green = self._io.read_f4le()
         self.blue = self._io.read_f4le()
         self.alpha = self._io.read_f4le()
-        if (self.num_images == 6):
+        if self.num_images == 6:
             pass
             self.cube_faces = []
             for i in range(3):
                 _t_cube_faces = Tex112.CubeFace(self._io, self, self._root)
-                _t_cube_faces._read()
-                self.cube_faces.append(_t_cube_faces)
+                try:
+                    _t_cube_faces._read()
+                finally:
+                    self.cube_faces.append(_t_cube_faces)
 
 
         self.mipmap_offsets = []
-        for i in range((self.num_mipmaps_per_image * self.num_images)):
+        for i in range(self.num_mipmaps_per_image * self.num_images):
             self.mipmap_offsets.append(self._io.read_u4le())
 
         self.dds_data = self._io.read_bytes_full()
+        self._dirty = False
 
 
     def _fetch_instances(self):
         pass
-        if (self.num_images == 6):
+        if self.num_images == 6:
             pass
             for i in range(len(self.cube_faces)):
                 pass
@@ -85,7 +88,7 @@ class Tex112(ReadWriteKaitaiStruct):
         self._io.write_f4le(self.green)
         self._io.write_f4le(self.blue)
         self._io.write_f4le(self.alpha)
-        if (self.num_images == 6):
+        if self.num_images == 6:
             pass
             for i in range(len(self.cube_faces)):
                 pass
@@ -98,38 +101,38 @@ class Tex112(ReadWriteKaitaiStruct):
 
         self._io.write_bytes(self.dds_data)
         if not self._io.is_eof():
-            raise kaitaistruct.ConsistencyError(u"dds_data", self._io.size() - self._io.pos(), 0)
+            raise kaitaistruct.ConsistencyError(u"dds_data", 0, self._io.size() - self._io.pos())
 
 
     def _check(self):
-        pass
-        if (len(self.id_magic) != 4):
-            raise kaitaistruct.ConsistencyError(u"id_magic", len(self.id_magic), 4)
-        if not (self.id_magic == b"\x54\x45\x58\x00"):
+        if len(self.id_magic) != 4:
+            raise kaitaistruct.ConsistencyError(u"id_magic", 4, len(self.id_magic))
+        if not self.id_magic == b"\x54\x45\x58\x00":
             raise kaitaistruct.ValidationNotEqualError(b"\x54\x45\x58\x00", self.id_magic, None, u"/seq/0")
-        if (len((self.compression_format).encode(u"ASCII")) != 4):
-            raise kaitaistruct.ConsistencyError(u"compression_format", len((self.compression_format).encode(u"ASCII")), 4)
-        if (self.num_images == 6):
+        if len((self.compression_format).encode(u"ASCII")) != 4:
+            raise kaitaistruct.ConsistencyError(u"compression_format", 4, len((self.compression_format).encode(u"ASCII")))
+        if self.num_images == 6:
             pass
-            if (len(self.cube_faces) != 3):
-                raise kaitaistruct.ConsistencyError(u"cube_faces", len(self.cube_faces), 3)
+            if len(self.cube_faces) != 3:
+                raise kaitaistruct.ConsistencyError(u"cube_faces", 3, len(self.cube_faces))
             for i in range(len(self.cube_faces)):
                 pass
                 if self.cube_faces[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"cube_faces", self.cube_faces[i]._root, self._root)
+                    raise kaitaistruct.ConsistencyError(u"cube_faces", self._root, self.cube_faces[i]._root)
                 if self.cube_faces[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"cube_faces", self.cube_faces[i]._parent, self)
+                    raise kaitaistruct.ConsistencyError(u"cube_faces", self, self.cube_faces[i]._parent)
 
 
-        if (len(self.mipmap_offsets) != (self.num_mipmaps_per_image * self.num_images)):
-            raise kaitaistruct.ConsistencyError(u"mipmap_offsets", len(self.mipmap_offsets), (self.num_mipmaps_per_image * self.num_images))
+        if len(self.mipmap_offsets) != self.num_mipmaps_per_image * self.num_images:
+            raise kaitaistruct.ConsistencyError(u"mipmap_offsets", self.num_mipmaps_per_image * self.num_images, len(self.mipmap_offsets))
         for i in range(len(self.mipmap_offsets)):
             pass
 
+        self._dirty = False
 
     class CubeFace(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Tex112.CubeFace, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -147,6 +150,7 @@ class Tex112(ReadWriteKaitaiStruct):
             for i in range(2):
                 self.uv.append(self._io.read_f4le())
 
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -180,22 +184,22 @@ class Tex112(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
-            if (len(self.negative_co) != 3):
-                raise kaitaistruct.ConsistencyError(u"negative_co", len(self.negative_co), 3)
+            if len(self.negative_co) != 3:
+                raise kaitaistruct.ConsistencyError(u"negative_co", 3, len(self.negative_co))
             for i in range(len(self.negative_co)):
                 pass
 
-            if (len(self.positive_co) != 3):
-                raise kaitaistruct.ConsistencyError(u"positive_co", len(self.positive_co), 3)
+            if len(self.positive_co) != 3:
+                raise kaitaistruct.ConsistencyError(u"positive_co", 3, len(self.positive_co))
             for i in range(len(self.positive_co)):
                 pass
 
-            if (len(self.uv) != 2):
-                raise kaitaistruct.ConsistencyError(u"uv", len(self.uv), 2)
+            if len(self.uv) != 2:
+                raise kaitaistruct.ConsistencyError(u"uv", 2, len(self.uv))
             for i in range(len(self.uv)):
                 pass
 
+            self._dirty = False
 
         @property
         def size_(self):
@@ -213,7 +217,7 @@ class Tex112(ReadWriteKaitaiStruct):
         if hasattr(self, '_m_size_before_data_'):
             return self._m_size_before_data_
 
-        self._m_size_before_data_ = ((40 + ((4 * self.num_mipmaps_per_image) * self.num_images)) if (self.num_images == 1) else ((40 + ((4 * self.num_mipmaps_per_image) * self.num_images)) + 108))
+        self._m_size_before_data_ = (40 + (4 * self.num_mipmaps_per_image) * self.num_images if self.num_images == 1 else (40 + (4 * self.num_mipmaps_per_image) * self.num_images) + 108)
         return getattr(self, '_m_size_before_data_', None)
 
     def _invalidate_size_before_data_(self):

--- a/albam/engines/mtfw/structs/tex_157.py
+++ b/albam/engines/mtfw/structs/tex_157.py
@@ -5,18 +5,18 @@ import kaitaistruct
 from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
 
 
-if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 11):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.11 or later is required, but you have %s" % (kaitaistruct.__version__))
 
 class Tex157(ReadWriteKaitaiStruct):
     def __init__(self, _io=None, _parent=None, _root=None):
-        self._io = _io
+        super(Tex157, self).__init__(_io)
         self._parent = _parent
-        self._root = _root if _root else self
+        self._root = _root or self
 
     def _read(self):
         self.id_magic = self._io.read_bytes(4)
-        if not (self.id_magic == b"\x54\x45\x58\x00"):
+        if not self.id_magic == b"\x54\x45\x58\x00":
             raise kaitaistruct.ValidationNotEqualError(b"\x54\x45\x58\x00", self.id_magic, self._io, u"/seq/0")
         self.version = self._io.read_bits_int_le(8)
         self.unk = self._io.read_bits_int_le(8)
@@ -32,25 +32,28 @@ class Tex157(ReadWriteKaitaiStruct):
         self.auto_resize = self._io.read_bits_int_le(1) != 0
         self.render_target = self._io.read_bits_int_le(1) != 0
         self.use_vtf = self._io.read_bits_int_le(1) != 0
-        if (self.num_images == 6):
+        if self.num_images == 6:
             pass
             self.cube_faces = []
             for i in range(3):
                 _t_cube_faces = Tex157.CubeFace(self._io, self, self._root)
-                _t_cube_faces._read()
-                self.cube_faces.append(_t_cube_faces)
+                try:
+                    _t_cube_faces._read()
+                finally:
+                    self.cube_faces.append(_t_cube_faces)
 
 
         self.mipmap_offsets = []
-        for i in range((self.num_mipmaps_per_image * self.num_images)):
+        for i in range(self.num_mipmaps_per_image * self.num_images):
             self.mipmap_offsets.append(self._io.read_u4le())
 
         self.dds_data = self._io.read_bytes_full()
+        self._dirty = False
 
 
     def _fetch_instances(self):
         pass
-        if (self.num_images == 6):
+        if self.num_images == 6:
             pass
             for i in range(len(self.cube_faces)):
                 pass
@@ -79,7 +82,7 @@ class Tex157(ReadWriteKaitaiStruct):
         self._io.write_bits_int_le(1, int(self.auto_resize))
         self._io.write_bits_int_le(1, int(self.render_target))
         self._io.write_bits_int_le(1, int(self.use_vtf))
-        if (self.num_images == 6):
+        if self.num_images == 6:
             pass
             for i in range(len(self.cube_faces)):
                 pass
@@ -92,36 +95,36 @@ class Tex157(ReadWriteKaitaiStruct):
 
         self._io.write_bytes(self.dds_data)
         if not self._io.is_eof():
-            raise kaitaistruct.ConsistencyError(u"dds_data", self._io.size() - self._io.pos(), 0)
+            raise kaitaistruct.ConsistencyError(u"dds_data", 0, self._io.size() - self._io.pos())
 
 
     def _check(self):
-        pass
-        if (len(self.id_magic) != 4):
-            raise kaitaistruct.ConsistencyError(u"id_magic", len(self.id_magic), 4)
-        if not (self.id_magic == b"\x54\x45\x58\x00"):
+        if len(self.id_magic) != 4:
+            raise kaitaistruct.ConsistencyError(u"id_magic", 4, len(self.id_magic))
+        if not self.id_magic == b"\x54\x45\x58\x00":
             raise kaitaistruct.ValidationNotEqualError(b"\x54\x45\x58\x00", self.id_magic, None, u"/seq/0")
-        if (self.num_images == 6):
+        if self.num_images == 6:
             pass
-            if (len(self.cube_faces) != 3):
-                raise kaitaistruct.ConsistencyError(u"cube_faces", len(self.cube_faces), 3)
+            if len(self.cube_faces) != 3:
+                raise kaitaistruct.ConsistencyError(u"cube_faces", 3, len(self.cube_faces))
             for i in range(len(self.cube_faces)):
                 pass
                 if self.cube_faces[i]._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"cube_faces", self.cube_faces[i]._root, self._root)
+                    raise kaitaistruct.ConsistencyError(u"cube_faces", self._root, self.cube_faces[i]._root)
                 if self.cube_faces[i]._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"cube_faces", self.cube_faces[i]._parent, self)
+                    raise kaitaistruct.ConsistencyError(u"cube_faces", self, self.cube_faces[i]._parent)
 
 
-        if (len(self.mipmap_offsets) != (self.num_mipmaps_per_image * self.num_images)):
-            raise kaitaistruct.ConsistencyError(u"mipmap_offsets", len(self.mipmap_offsets), (self.num_mipmaps_per_image * self.num_images))
+        if len(self.mipmap_offsets) != self.num_mipmaps_per_image * self.num_images:
+            raise kaitaistruct.ConsistencyError(u"mipmap_offsets", self.num_mipmaps_per_image * self.num_images, len(self.mipmap_offsets))
         for i in range(len(self.mipmap_offsets)):
             pass
 
+        self._dirty = False
 
     class CubeFace(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
-            self._io = _io
+            super(Tex157.CubeFace, self).__init__(_io)
             self._parent = _parent
             self._root = _root
 
@@ -139,6 +142,7 @@ class Tex157(ReadWriteKaitaiStruct):
             for i in range(2):
                 self.uv.append(self._io.read_f4le())
 
+            self._dirty = False
 
 
         def _fetch_instances(self):
@@ -172,22 +176,22 @@ class Tex157(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            pass
-            if (len(self.negative_co) != 3):
-                raise kaitaistruct.ConsistencyError(u"negative_co", len(self.negative_co), 3)
+            if len(self.negative_co) != 3:
+                raise kaitaistruct.ConsistencyError(u"negative_co", 3, len(self.negative_co))
             for i in range(len(self.negative_co)):
                 pass
 
-            if (len(self.positive_co) != 3):
-                raise kaitaistruct.ConsistencyError(u"positive_co", len(self.positive_co), 3)
+            if len(self.positive_co) != 3:
+                raise kaitaistruct.ConsistencyError(u"positive_co", 3, len(self.positive_co))
             for i in range(len(self.positive_co)):
                 pass
 
-            if (len(self.uv) != 2):
-                raise kaitaistruct.ConsistencyError(u"uv", len(self.uv), 2)
+            if len(self.uv) != 2:
+                raise kaitaistruct.ConsistencyError(u"uv", 2, len(self.uv))
             for i in range(len(self.uv)):
                 pass
 
+            self._dirty = False
 
         @property
         def size_(self):
@@ -205,7 +209,7 @@ class Tex157(ReadWriteKaitaiStruct):
         if hasattr(self, '_m_size_before_data_'):
             return self._m_size_before_data_
 
-        self._m_size_before_data_ = ((16 + ((4 * self.num_mipmaps_per_image) * self.num_images)) if (self.num_images == 1) else ((16 + ((4 * self.num_mipmaps_per_image) * self.num_images)) + (36 * 3)))
+        self._m_size_before_data_ = (16 + (4 * self.num_mipmaps_per_image) * self.num_images if self.num_images == 1 else (16 + (4 * self.num_mipmaps_per_image) * self.num_images) + 36 * 3)
         return getattr(self, '_m_size_before_data_', None)
 
     def _invalidate_size_before_data_(self):

--- a/albam/engines/reng/material.py
+++ b/albam/engines/reng/material.py
@@ -29,6 +29,7 @@ def build_blender_materials(mesh_vfile, context):
     mdf_version = int(mdf_virtual_path.rpartition(".")[2])
 
     mdf = ReengineMdf(mdf_version, KaitaiStream(io.BytesIO(mdf_bytes)))
+    mdf._read()
     images_to_build = {texture_header for mat in mdf.materials for texture_header in mat.textures}
     blender_images = build_blender_images(app_id, images_to_build, context)
 

--- a/albam/engines/reng/mesh.py
+++ b/albam/engines/reng/mesh.py
@@ -25,6 +25,7 @@ def build_blender_model(file_list_item, context: bpy.types.Context) -> bpy.types
 
     mesh_bytes = file_list_item.get_bytes()
     re_mesh = ReengineMesh(KaitaiStream(io.BytesIO(mesh_bytes)))
+    re_mesh._read()
 
     bl_object_name = file_list_item.display_name
     skeleton = None if not re_mesh.header.offset_bones else build_blender_armature(re_mesh, bl_object_name)

--- a/albam/engines/reng/pak_fs.py
+++ b/albam/engines/reng/pak_fs.py
@@ -81,6 +81,7 @@ class PakFS(FS):
             f.seek(0)
             read_size = HEADER_SIZE + FILE_ENTRY_SIZE * num_file_entries
             parsed = Pak(KaitaiStream(io.BytesIO(f.read(read_size))))
+            parsed._read()
         finally:
             f.close()
 

--- a/albam/engines/reng/structs/mdf.ksy
+++ b/albam/engines/reng/structs/mdf.ksy
@@ -3,7 +3,7 @@ meta:
     endian: le
     title: RE Engine material info format
     license: CCO-1.0
-    ks-version: 0.8
+    ks-version: '0.11'
 
 params:
   - {id: mdf_version, type: u4}

--- a/albam/engines/reng/structs/mesh.ksy
+++ b/albam/engines/reng/structs/mesh.ksy
@@ -2,7 +2,7 @@ meta:
     id: reengine_mesh
     endian: le
     title: RE Engine mesh format
-    ks-version: 0.10
+    ks-version: '0.11'
 
 seq:
     - {id: id_magic, contents: [77, 69, 83, 72]}

--- a/albam/engines/reng/structs/pak.ksy
+++ b/albam/engines/reng/structs/pak.ksy
@@ -4,7 +4,7 @@ meta:
   title: RE Engine archive format
   file-extension: pak
   license: CC0-1.0
-  ks-version: 0.8
+  ks-version: '0.11'
 
 
 seq:

--- a/albam/engines/reng/structs/pak.py
+++ b/albam/engines/reng/structs/pak.py
@@ -1,18 +1,18 @@
 # This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
+# type: ignore
 
 import kaitaistruct
-from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
+from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
 
 
-if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 11):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.11 or later is required, but you have %s" % (kaitaistruct.__version__))
 
-class Pak(KaitaiStruct):
-    def __init__(self, _io, _parent=None, _root=None):
-        self._io = _io
+class Pak(ReadWriteKaitaiStruct):
+    def __init__(self, _io=None, _parent=None, _root=None):
+        super(Pak, self).__init__(_io)
         self._parent = _parent
-        self._root = _root if _root else self
-        self._read()
+        self._root = _root or self
 
     def _read(self):
         self.ident = self._io.read_bytes(4)
@@ -23,15 +23,56 @@ class Pak(KaitaiStruct):
         self.reserved = self._io.read_u4le()
         self.file_entries = []
         for i in range(self.num_file_entries):
-            self.file_entries.append(Pak.FileEntry(self._io, self, self._root))
+            _t_file_entries = Pak.FileEntry(self._io, self, self._root)
+            try:
+                _t_file_entries._read()
+            finally:
+                self.file_entries.append(_t_file_entries)
+
+        self._dirty = False
 
 
-    class FileEntry(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+    def _fetch_instances(self):
+        pass
+        for i in range(len(self.file_entries)):
+            pass
+            self.file_entries[i]._fetch_instances()
+
+
+
+    def _write__seq(self, io=None):
+        super(Pak, self)._write__seq(io)
+        self._io.write_bytes(self.ident)
+        self._io.write_u4le(self.version)
+        self._io.write_u4le(self.num_file_entries)
+        self._io.write_u4le(self.reserved)
+        for i in range(len(self.file_entries)):
+            pass
+            self.file_entries[i]._write__seq(self._io)
+
+
+
+    def _check(self):
+        if len(self.ident) != 4:
+            raise kaitaistruct.ConsistencyError(u"ident", 4, len(self.ident))
+        if not self.ident == b"\x4B\x50\x4B\x41":
+            raise kaitaistruct.ValidationNotEqualError(b"\x4B\x50\x4B\x41", self.ident, None, u"/seq/0")
+        if len(self.file_entries) != self.num_file_entries:
+            raise kaitaistruct.ConsistencyError(u"file_entries", self.num_file_entries, len(self.file_entries))
+        for i in range(len(self.file_entries)):
+            pass
+            if self.file_entries[i]._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"file_entries", self._root, self.file_entries[i]._root)
+            if self.file_entries[i]._parent != self:
+                raise kaitaistruct.ConsistencyError(u"file_entries", self, self.file_entries[i]._parent)
+
+        self._dirty = False
+
+    class FileEntry(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Pak.FileEntry, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
 
         def _read(self):
             self.file_path_hash_case_insensitive = self._io.read_u4le()
@@ -41,6 +82,26 @@ class Pak(KaitaiStruct):
             self.size = self._io.read_u8le()
             self.flags = self._io.read_u8le()
             self.unk_01 = self._io.read_u8le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(Pak.FileEntry, self)._write__seq(io)
+            self._io.write_u4le(self.file_path_hash_case_insensitive)
+            self._io.write_u4le(self.file_path_hash_case_sensitive)
+            self._io.write_u8le(self.offset)
+            self._io.write_u8le(self.zsize)
+            self._io.write_u8le(self.size)
+            self._io.write_u8le(self.flags)
+            self._io.write_u8le(self.unk_01)
+
+
+        def _check(self):
+            self._dirty = False
 
 
 

--- a/albam/engines/reng/structs/reengine_mdf.py
+++ b/albam/engines/reng/structs/reengine_mdf.py
@@ -1,19 +1,19 @@
 # This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
+# type: ignore
 
 import kaitaistruct
-from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
+from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
 
 
-if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 11):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.11 or later is required, but you have %s" % (kaitaistruct.__version__))
 
-class ReengineMdf(KaitaiStruct):
-    def __init__(self, mdf_version, _io, _parent=None, _root=None):
-        self._io = _io
+class ReengineMdf(ReadWriteKaitaiStruct):
+    def __init__(self, mdf_version, _io=None, _parent=None, _root=None):
+        super(ReengineMdf, self).__init__(_io)
         self._parent = _parent
-        self._root = _root if _root else self
+        self._root = _root or self
         self.mdf_version = mdf_version
-        self._read()
 
     def _read(self):
         self.id_magic = self._io.read_bytes(4)
@@ -25,206 +25,57 @@ class ReengineMdf(KaitaiStruct):
         self.unk_03 = self._io.read_u4le()
         self.materials = []
         for i in range(self.num_materials):
-            self.materials.append(ReengineMdf.Material(self._io, self, self._root))
+            _t_materials = ReengineMdf.Material(self._io, self, self._root)
+            try:
+                _t_materials._read()
+            finally:
+                self.materials.append(_t_materials)
+
+        self._dirty = False
 
 
-    class TextureHeader(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+    def _fetch_instances(self):
+        pass
+        for i in range(len(self.materials)):
+            pass
+            self.materials[i]._fetch_instances()
+
+
+
+    def _write__seq(self, io=None):
+        super(ReengineMdf, self)._write__seq(io)
+        self._io.write_bytes(self.id_magic)
+        self._io.write_u2le(self.unk_01)
+        self._io.write_u2le(self.num_materials)
+        self._io.write_u4le(self.unk_02)
+        self._io.write_u4le(self.unk_03)
+        for i in range(len(self.materials)):
+            pass
+            self.materials[i]._write__seq(self._io)
+
+
+
+    def _check(self):
+        if len(self.id_magic) != 4:
+            raise kaitaistruct.ConsistencyError(u"id_magic", 4, len(self.id_magic))
+        if not self.id_magic == b"\x4D\x44\x46\x00":
+            raise kaitaistruct.ValidationNotEqualError(b"\x4D\x44\x46\x00", self.id_magic, None, u"/seq/0")
+        if len(self.materials) != self.num_materials:
+            raise kaitaistruct.ConsistencyError(u"materials", self.num_materials, len(self.materials))
+        for i in range(len(self.materials)):
+            pass
+            if self.materials[i]._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"materials", self._root, self.materials[i]._root)
+            if self.materials[i]._parent != self:
+                raise kaitaistruct.ConsistencyError(u"materials", self, self.materials[i]._parent)
+
+        self._dirty = False
+
+    class AlphaFlags(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineMdf.AlphaFlags, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
-
-        def _read(self):
-            self.ofs_texture_type = self._io.read_u8le()
-            self.hash_utf16 = self._io.read_u4le()
-            self.hash_ascii = self._io.read_u4le()
-            self.ofs_texture_path = self._io.read_u8le()
-            if self._root.mdf_version >= 13:
-                self.unk_01 = self._io.read_u8le()
-
-
-        @property
-        def texture_type_raw(self):
-            if hasattr(self, '_m_texture_type_raw'):
-                return self._m_texture_type_raw
-
-            _pos = self._io.pos()
-            self._io.seek(self.ofs_texture_type)
-            self._m_texture_type_raw = []
-            i = 0
-            while True:
-                _ = self._io.read_u2le()
-                self._m_texture_type_raw.append(_)
-                if _ == 0:
-                    break
-                i += 1
-            self._io.seek(_pos)
-            return getattr(self, '_m_texture_type_raw', None)
-
-        @property
-        def texture_path_raw(self):
-            if hasattr(self, '_m_texture_path_raw'):
-                return self._m_texture_path_raw
-
-            _pos = self._io.pos()
-            self._io.seek(self.ofs_texture_path)
-            self._m_texture_path_raw = []
-            i = 0
-            while True:
-                _ = self._io.read_u2le()
-                self._m_texture_path_raw.append(_)
-                if _ == 0:
-                    break
-                i += 1
-            self._io.seek(_pos)
-            return getattr(self, '_m_texture_path_raw', None)
-
-        @property
-        def texture_type(self):
-            if hasattr(self, '_m_texture_type'):
-                return self._m_texture_type
-
-            _pos = self._io.pos()
-            self._io.seek(self.ofs_texture_type)
-            self._m_texture_type = (self._io.read_bytes(((len(self.texture_type_raw) * 2) - 2))).decode(u"utf-16")
-            self._io.seek(_pos)
-            return getattr(self, '_m_texture_type', None)
-
-        @property
-        def texture_path(self):
-            if hasattr(self, '_m_texture_path'):
-                return self._m_texture_path
-
-            _pos = self._io.pos()
-            self._io.seek(self.ofs_texture_path)
-            self._m_texture_path = (self._io.read_bytes(((len(self.texture_path_raw) * 2) - 2))).decode(u"utf-16")
-            self._io.seek(_pos)
-            return getattr(self, '_m_texture_path', None)
-
-
-    class PropertiesHeader10(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
-
-        def _read(self):
-            self.ofs_name = self._io.read_u8le()
-            self.name_hash_utf16 = self._io.read_u4le()
-            self.name_hash_ascii = self._io.read_u4le()
-            self.num_params = self._io.read_u4le()
-            self.ofs_prop = self._io.read_u4le()
-
-        @property
-        def name_raw(self):
-            if hasattr(self, '_m_name_raw'):
-                return self._m_name_raw
-
-            _pos = self._io.pos()
-            self._io.seek(self.ofs_name)
-            self._m_name_raw = []
-            i = 0
-            while True:
-                _ = self._io.read_u2le()
-                self._m_name_raw.append(_)
-                if _ == 0:
-                    break
-                i += 1
-            self._io.seek(_pos)
-            return getattr(self, '_m_name_raw', None)
-
-        @property
-        def params(self):
-            if hasattr(self, '_m_params'):
-                return self._m_params
-
-            _pos = self._io.pos()
-            self._io.seek((self._parent.ofs_properties + self.ofs_prop))
-            self._m_params = []
-            for i in range(self.num_params):
-                self._m_params.append(self._io.read_f4le())
-
-            self._io.seek(_pos)
-            return getattr(self, '_m_params', None)
-
-        @property
-        def name(self):
-            if hasattr(self, '_m_name'):
-                return self._m_name
-
-            _pos = self._io.pos()
-            self._io.seek(self.ofs_name)
-            self._m_name = (self._io.read_bytes(((len(self.name_raw) * 2) - 2))).decode(u"utf-16")
-            self._io.seek(_pos)
-            return getattr(self, '_m_name', None)
-
-
-    class PropertiesHeader13(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
-
-        def _read(self):
-            self.ofs_name = self._io.read_u8le()
-            self.name_hash_utf16 = self._io.read_u4le()
-            self.name_hash_ascii = self._io.read_u4le()
-            self.ofs_prop = self._io.read_u4le()
-            self.num_params = self._io.read_u4le()
-
-        @property
-        def name_raw(self):
-            if hasattr(self, '_m_name_raw'):
-                return self._m_name_raw
-
-            _pos = self._io.pos()
-            self._io.seek(self.ofs_name)
-            self._m_name_raw = []
-            i = 0
-            while True:
-                _ = self._io.read_u2le()
-                self._m_name_raw.append(_)
-                if _ == 0:
-                    break
-                i += 1
-            self._io.seek(_pos)
-            return getattr(self, '_m_name_raw', None)
-
-        @property
-        def params(self):
-            if hasattr(self, '_m_params'):
-                return self._m_params
-
-            _pos = self._io.pos()
-            self._io.seek((self._parent.ofs_properties + self.ofs_prop))
-            self._m_params = []
-            for i in range(self.num_params):
-                self._m_params.append(self._io.read_f4le())
-
-            self._io.seek(_pos)
-            return getattr(self, '_m_params', None)
-
-        @property
-        def name(self):
-            if hasattr(self, '_m_name'):
-                return self._m_name
-
-            _pos = self._io.pos()
-            self._io.seek(self.ofs_name)
-            self._m_name = (self._io.read_bytes(((len(self.name_raw) * 2) - 2))).decode(u"utf-16")
-            self._io.seek(_pos)
-            return getattr(self, '_m_name', None)
-
-
-    class AlphaFlags(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
 
         def _read(self):
             self.base_two_side_enable = self._io.read_bits_int_be(1) != 0
@@ -248,14 +99,59 @@ class ReengineMdf(KaitaiStruct):
             self.pixel_depth_offset_used = self._io.read_bits_int_be(1) != 0
             self.no_ray_tracing = self._io.read_bits_int_be(1) != 0
             self.unk_01 = self._io.read_bits_int_be(7)
+            self._dirty = False
 
 
-    class Material(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(ReengineMdf.AlphaFlags, self)._write__seq(io)
+            self._io.write_bits_int_be(1, int(self.base_two_side_enable))
+            self._io.write_bits_int_be(1, int(self.base_alpha_test_enable))
+            self._io.write_bits_int_be(1, int(self.shadow_cast_disable))
+            self._io.write_bits_int_be(1, int(self.vertex_shader_used))
+            self._io.write_bits_int_be(1, int(self.emissive_used))
+            self._io.write_bits_int_be(1, int(self.tessellation_enable))
+            self._io.write_bits_int_be(1, int(self.enable_ignore_depth))
+            self._io.write_bits_int_be(1, int(self.alpha_mask_used))
+            self._io.write_bits_int_be(1, int(self.forced_two_side_enable))
+            self._io.write_bits_int_be(1, int(self.two_side_enable))
+            self._io.write_bits_int_be(6, self.tess_factor)
+            self._io.write_bits_int_be(1, int(self.phong_factor))
+            self._io.write_bits_int_be(1, int(self.rough_transparent_enable))
+            self._io.write_bits_int_be(1, int(self.forced_alpha_test_enable))
+            self._io.write_bits_int_be(1, int(self.alpha_test_enable))
+            self._io.write_bits_int_be(1, int(self.sss_profile_used))
+            self._io.write_bits_int_be(1, int(self.enable_stencil_priority))
+            self._io.write_bits_int_be(1, int(self.require_dual_quaternion))
+            self._io.write_bits_int_be(1, int(self.pixel_depth_offset_used))
+            self._io.write_bits_int_be(1, int(self.no_ray_tracing))
+            self._io.write_bits_int_be(7, self.unk_01)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Material(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineMdf.Material, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
+            self._should_write_master_material_path = False
+            self.master_material_path__enabled = True
+            self._should_write_master_material_path_raw = False
+            self.master_material_path_raw__enabled = True
+            self._should_write_name = False
+            self.name__enabled = True
+            self._should_write_name_raw = False
+            self.name_raw__enabled = True
+            self._should_write_properties_headers = False
+            self.properties_headers__enabled = True
+            self._should_write_textures = False
+            self.textures__enabled = True
 
         def _read(self):
             self.ofs_material_name = self._io.read_u8le()
@@ -264,53 +160,229 @@ class ReengineMdf(KaitaiStruct):
             self.num_properties_headers = self._io.read_u4le()
             self.num_textures = self._io.read_u4le()
             if self._root.mdf_version >= 19:
+                pass
                 self.unk_01 = self._io.read_u8le()
 
             self.material_shading_type = self._io.read_u4le()
             self.alpha_flags = ReengineMdf.AlphaFlags(self._io, self, self._root)
+            self.alpha_flags._read()
             self.ofs_properties_headers = self._io.read_u8le()
             self.ofs_texture_headers = self._io.read_u8le()
             if self._root.mdf_version >= 19:
+                pass
                 self.ofs_first_material_name = self._io.read_u8le()
 
             self.ofs_properties = self._io.read_u8le()
             self.ofs_master_material_path = self._io.read_u8le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            if self._root.mdf_version >= 19:
+                pass
+
+            self.alpha_flags._fetch_instances()
+            if self._root.mdf_version >= 19:
+                pass
+
+            _ = self.master_material_path
+            if hasattr(self, '_m_master_material_path'):
+                pass
+
+            _ = self.master_material_path_raw
+            if hasattr(self, '_m_master_material_path_raw'):
+                pass
+                for i in range(len(self._m_master_material_path_raw)):
+                    pass
+
+
+            _ = self.name
+            if hasattr(self, '_m_name'):
+                pass
+
+            _ = self.name_raw
+            if hasattr(self, '_m_name_raw'):
+                pass
+                for i in range(len(self._m_name_raw)):
+                    pass
+
+
+            _ = self.properties_headers
+            if hasattr(self, '_m_properties_headers'):
+                pass
+                for i in range(len(self._m_properties_headers)):
+                    pass
+                    _on = self._root.mdf_version
+                    if _on == 10:
+                        pass
+                        self._m_properties_headers[i]._fetch_instances()
+                    elif _on == 13:
+                        pass
+                        self._m_properties_headers[i]._fetch_instances()
+                    elif _on == 21:
+                        pass
+                        self._m_properties_headers[i]._fetch_instances()
+
+
+            _ = self.textures
+            if hasattr(self, '_m_textures'):
+                pass
+                for i in range(len(self._m_textures)):
+                    pass
+                    self._m_textures[i]._fetch_instances()
+
+
+
+
+        def _write__seq(self, io=None):
+            super(ReengineMdf.Material, self)._write__seq(io)
+            self._should_write_master_material_path = self.master_material_path__enabled
+            self._should_write_master_material_path_raw = self.master_material_path_raw__enabled
+            self._should_write_name = self.name__enabled
+            self._should_write_name_raw = self.name_raw__enabled
+            self._should_write_properties_headers = self.properties_headers__enabled
+            self._should_write_textures = self.textures__enabled
+            self._io.write_u8le(self.ofs_material_name)
+            self._io.write_u4le(self.hash)
+            self._io.write_u4le(self.size_properties)
+            self._io.write_u4le(self.num_properties_headers)
+            self._io.write_u4le(self.num_textures)
+            if self._root.mdf_version >= 19:
+                pass
+                self._io.write_u8le(self.unk_01)
+
+            self._io.write_u4le(self.material_shading_type)
+            self.alpha_flags._write__seq(self._io)
+            self._io.write_u8le(self.ofs_properties_headers)
+            self._io.write_u8le(self.ofs_texture_headers)
+            if self._root.mdf_version >= 19:
+                pass
+                self._io.write_u8le(self.ofs_first_material_name)
+
+            self._io.write_u8le(self.ofs_properties)
+            self._io.write_u8le(self.ofs_master_material_path)
+
+
+        def _check(self):
+            if self._root.mdf_version >= 19:
+                pass
+
+            if self.alpha_flags._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"alpha_flags", self._root, self.alpha_flags._root)
+            if self.alpha_flags._parent != self:
+                raise kaitaistruct.ConsistencyError(u"alpha_flags", self, self.alpha_flags._parent)
+            if self._root.mdf_version >= 19:
+                pass
+
+            if self.master_material_path__enabled:
+                pass
+
+            if self.master_material_path_raw__enabled:
+                pass
+                if len(self._m_master_material_path_raw) == 0:
+                    raise kaitaistruct.ConsistencyError(u"master_material_path_raw", 0, len(self._m_master_material_path_raw))
+                for i in range(len(self._m_master_material_path_raw)):
+                    pass
+                    _ = self._m_master_material_path_raw[i]
+                    if (_ == 0) != (i == len(self._m_master_material_path_raw) - 1):
+                        raise kaitaistruct.ConsistencyError(u"master_material_path_raw", i == len(self._m_master_material_path_raw) - 1, _ == 0)
+
+
+            if self.name__enabled:
+                pass
+
+            if self.name_raw__enabled:
+                pass
+                if len(self._m_name_raw) == 0:
+                    raise kaitaistruct.ConsistencyError(u"name_raw", 0, len(self._m_name_raw))
+                for i in range(len(self._m_name_raw)):
+                    pass
+                    _ = self._m_name_raw[i]
+                    if (_ == 0) != (i == len(self._m_name_raw) - 1):
+                        raise kaitaistruct.ConsistencyError(u"name_raw", i == len(self._m_name_raw) - 1, _ == 0)
+
+
+            if self.properties_headers__enabled:
+                pass
+                if len(self._m_properties_headers) != self.num_properties_headers:
+                    raise kaitaistruct.ConsistencyError(u"properties_headers", self.num_properties_headers, len(self._m_properties_headers))
+                for i in range(len(self._m_properties_headers)):
+                    pass
+                    _on = self._root.mdf_version
+                    if _on == 10:
+                        pass
+                        if self._m_properties_headers[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"properties_headers", self._root, self._m_properties_headers[i]._root)
+                        if self._m_properties_headers[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"properties_headers", self, self._m_properties_headers[i]._parent)
+                    elif _on == 13:
+                        pass
+                        if self._m_properties_headers[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"properties_headers", self._root, self._m_properties_headers[i]._root)
+                        if self._m_properties_headers[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"properties_headers", self, self._m_properties_headers[i]._parent)
+                    elif _on == 21:
+                        pass
+                        if self._m_properties_headers[i]._root != self._root:
+                            raise kaitaistruct.ConsistencyError(u"properties_headers", self._root, self._m_properties_headers[i]._root)
+                        if self._m_properties_headers[i]._parent != self:
+                            raise kaitaistruct.ConsistencyError(u"properties_headers", self, self._m_properties_headers[i]._parent)
+
+
+            if self.textures__enabled:
+                pass
+                if len(self._m_textures) != self.num_textures:
+                    raise kaitaistruct.ConsistencyError(u"textures", self.num_textures, len(self._m_textures))
+                for i in range(len(self._m_textures)):
+                    pass
+                    if self._m_textures[i]._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"textures", self._root, self._m_textures[i]._root)
+                    if self._m_textures[i]._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"textures", self, self._m_textures[i]._parent)
+
+
+            self._dirty = False
 
         @property
         def master_material_path(self):
+            if self._should_write_master_material_path:
+                self._write_master_material_path()
             if hasattr(self, '_m_master_material_path'):
                 return self._m_master_material_path
 
+            if not self.master_material_path__enabled:
+                return None
+
             _pos = self._io.pos()
             self._io.seek(self.ofs_master_material_path)
-            self._m_master_material_path = (self._io.read_bytes(((len(self.master_material_path_raw) * 2) - 2))).decode(u"utf-16")
+            self._m_master_material_path = (self._io.read_bytes(len(self.master_material_path_raw) * 2 - 2)).decode(u"utf-16")
             self._io.seek(_pos)
             return getattr(self, '_m_master_material_path', None)
 
-        @property
-        def properties_headers(self):
-            if hasattr(self, '_m_properties_headers'):
-                return self._m_properties_headers
+        @master_material_path.setter
+        def master_material_path(self, v):
+            self._dirty = True
+            self._m_master_material_path = v
 
+        def _write_master_material_path(self):
+            self._should_write_master_material_path = False
             _pos = self._io.pos()
-            self._io.seek(self.ofs_properties_headers)
-            self._m_properties_headers = []
-            for i in range(self.num_properties_headers):
-                _on = self._root.mdf_version
-                if _on == 10:
-                    self._m_properties_headers.append(ReengineMdf.PropertiesHeader10(self._io, self, self._root))
-                elif _on == 13:
-                    self._m_properties_headers.append(ReengineMdf.PropertiesHeader13(self._io, self, self._root))
-                elif _on == 21:
-                    self._m_properties_headers.append(ReengineMdf.PropertiesHeader13(self._io, self, self._root))
-
+            self._io.seek(self.ofs_master_material_path)
+            if len((self._m_master_material_path).encode(u"utf-16")) != len(self.master_material_path_raw) * 2 - 2:
+                raise kaitaistruct.ConsistencyError(u"master_material_path", len(self.master_material_path_raw) * 2 - 2, len((self._m_master_material_path).encode(u"utf-16")))
+            self._io.write_bytes((self._m_master_material_path).encode(u"utf-16"))
             self._io.seek(_pos)
-            return getattr(self, '_m_properties_headers', None)
 
         @property
         def master_material_path_raw(self):
+            if self._should_write_master_material_path_raw:
+                self._write_master_material_path_raw()
             if hasattr(self, '_m_master_material_path_raw'):
                 return self._m_master_material_path_raw
+
+            if not self.master_material_path_raw__enabled:
+                return None
 
             _pos = self._io.pos()
             self._io.seek(self.ofs_master_material_path)
@@ -325,35 +397,60 @@ class ReengineMdf(KaitaiStruct):
             self._io.seek(_pos)
             return getattr(self, '_m_master_material_path_raw', None)
 
-        @property
-        def textures(self):
-            if hasattr(self, '_m_textures'):
-                return self._m_textures
+        @master_material_path_raw.setter
+        def master_material_path_raw(self, v):
+            self._dirty = True
+            self._m_master_material_path_raw = v
 
+        def _write_master_material_path_raw(self):
+            self._should_write_master_material_path_raw = False
             _pos = self._io.pos()
-            self._io.seek(self.ofs_texture_headers)
-            self._m_textures = []
-            for i in range(self.num_textures):
-                self._m_textures.append(ReengineMdf.TextureHeader(self._io, self, self._root))
+            self._io.seek(self.ofs_master_material_path)
+            for i in range(len(self._m_master_material_path_raw)):
+                pass
+                self._io.write_u2le(self._m_master_material_path_raw[i])
 
             self._io.seek(_pos)
-            return getattr(self, '_m_textures', None)
 
         @property
         def name(self):
+            if self._should_write_name:
+                self._write_name()
             if hasattr(self, '_m_name'):
                 return self._m_name
 
+            if not self.name__enabled:
+                return None
+
             _pos = self._io.pos()
             self._io.seek(self.ofs_material_name)
-            self._m_name = (self._io.read_bytes(((len(self.name_raw) * 2) - 2))).decode(u"utf-16")
+            self._m_name = (self._io.read_bytes(len(self.name_raw) * 2 - 2)).decode(u"utf-16")
             self._io.seek(_pos)
             return getattr(self, '_m_name', None)
 
+        @name.setter
+        def name(self, v):
+            self._dirty = True
+            self._m_name = v
+
+        def _write_name(self):
+            self._should_write_name = False
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_material_name)
+            if len((self._m_name).encode(u"utf-16")) != len(self.name_raw) * 2 - 2:
+                raise kaitaistruct.ConsistencyError(u"name", len(self.name_raw) * 2 - 2, len((self._m_name).encode(u"utf-16")))
+            self._io.write_bytes((self._m_name).encode(u"utf-16"))
+            self._io.seek(_pos)
+
         @property
         def name_raw(self):
+            if self._should_write_name_raw:
+                self._write_name_raw()
             if hasattr(self, '_m_name_raw'):
                 return self._m_name_raw
+
+            if not self.name_raw__enabled:
+                return None
 
             _pos = self._io.pos()
             self._io.seek(self.ofs_material_name)
@@ -367,6 +464,731 @@ class ReengineMdf(KaitaiStruct):
                 i += 1
             self._io.seek(_pos)
             return getattr(self, '_m_name_raw', None)
+
+        @name_raw.setter
+        def name_raw(self, v):
+            self._dirty = True
+            self._m_name_raw = v
+
+        def _write_name_raw(self):
+            self._should_write_name_raw = False
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_material_name)
+            for i in range(len(self._m_name_raw)):
+                pass
+                self._io.write_u2le(self._m_name_raw[i])
+
+            self._io.seek(_pos)
+
+        @property
+        def properties_headers(self):
+            if self._should_write_properties_headers:
+                self._write_properties_headers()
+            if hasattr(self, '_m_properties_headers'):
+                return self._m_properties_headers
+
+            if not self.properties_headers__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_properties_headers)
+            self._m_properties_headers = []
+            for i in range(self.num_properties_headers):
+                _on = self._root.mdf_version
+                if _on == 10:
+                    pass
+                    _t__m_properties_headers = ReengineMdf.PropertiesHeader10(self._io, self, self._root)
+                    try:
+                        _t__m_properties_headers._read()
+                    finally:
+                        self._m_properties_headers.append(_t__m_properties_headers)
+                elif _on == 13:
+                    pass
+                    _t__m_properties_headers = ReengineMdf.PropertiesHeader13(self._io, self, self._root)
+                    try:
+                        _t__m_properties_headers._read()
+                    finally:
+                        self._m_properties_headers.append(_t__m_properties_headers)
+                elif _on == 21:
+                    pass
+                    _t__m_properties_headers = ReengineMdf.PropertiesHeader13(self._io, self, self._root)
+                    try:
+                        _t__m_properties_headers._read()
+                    finally:
+                        self._m_properties_headers.append(_t__m_properties_headers)
+
+            self._io.seek(_pos)
+            return getattr(self, '_m_properties_headers', None)
+
+        @properties_headers.setter
+        def properties_headers(self, v):
+            self._dirty = True
+            self._m_properties_headers = v
+
+        def _write_properties_headers(self):
+            self._should_write_properties_headers = False
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_properties_headers)
+            for i in range(len(self._m_properties_headers)):
+                pass
+                _on = self._root.mdf_version
+                if _on == 10:
+                    pass
+                    self._m_properties_headers[i]._write__seq(self._io)
+                elif _on == 13:
+                    pass
+                    self._m_properties_headers[i]._write__seq(self._io)
+                elif _on == 21:
+                    pass
+                    self._m_properties_headers[i]._write__seq(self._io)
+
+            self._io.seek(_pos)
+
+        @property
+        def textures(self):
+            if self._should_write_textures:
+                self._write_textures()
+            if hasattr(self, '_m_textures'):
+                return self._m_textures
+
+            if not self.textures__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_texture_headers)
+            self._m_textures = []
+            for i in range(self.num_textures):
+                _t__m_textures = ReengineMdf.TextureHeader(self._io, self, self._root)
+                try:
+                    _t__m_textures._read()
+                finally:
+                    self._m_textures.append(_t__m_textures)
+
+            self._io.seek(_pos)
+            return getattr(self, '_m_textures', None)
+
+        @textures.setter
+        def textures(self, v):
+            self._dirty = True
+            self._m_textures = v
+
+        def _write_textures(self):
+            self._should_write_textures = False
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_texture_headers)
+            for i in range(len(self._m_textures)):
+                pass
+                self._m_textures[i]._write__seq(self._io)
+
+            self._io.seek(_pos)
+
+
+    class PropertiesHeader10(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineMdf.PropertiesHeader10, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_name = False
+            self.name__enabled = True
+            self._should_write_name_raw = False
+            self.name_raw__enabled = True
+            self._should_write_params = False
+            self.params__enabled = True
+
+        def _read(self):
+            self.ofs_name = self._io.read_u8le()
+            self.name_hash_utf16 = self._io.read_u4le()
+            self.name_hash_ascii = self._io.read_u4le()
+            self.num_params = self._io.read_u4le()
+            self.ofs_prop = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.name
+            if hasattr(self, '_m_name'):
+                pass
+
+            _ = self.name_raw
+            if hasattr(self, '_m_name_raw'):
+                pass
+                for i in range(len(self._m_name_raw)):
+                    pass
+
+
+            _ = self.params
+            if hasattr(self, '_m_params'):
+                pass
+                for i in range(len(self._m_params)):
+                    pass
+
+
+
+
+        def _write__seq(self, io=None):
+            super(ReengineMdf.PropertiesHeader10, self)._write__seq(io)
+            self._should_write_name = self.name__enabled
+            self._should_write_name_raw = self.name_raw__enabled
+            self._should_write_params = self.params__enabled
+            self._io.write_u8le(self.ofs_name)
+            self._io.write_u4le(self.name_hash_utf16)
+            self._io.write_u4le(self.name_hash_ascii)
+            self._io.write_u4le(self.num_params)
+            self._io.write_u4le(self.ofs_prop)
+
+
+        def _check(self):
+            if self.name__enabled:
+                pass
+
+            if self.name_raw__enabled:
+                pass
+                if len(self._m_name_raw) == 0:
+                    raise kaitaistruct.ConsistencyError(u"name_raw", 0, len(self._m_name_raw))
+                for i in range(len(self._m_name_raw)):
+                    pass
+                    _ = self._m_name_raw[i]
+                    if (_ == 0) != (i == len(self._m_name_raw) - 1):
+                        raise kaitaistruct.ConsistencyError(u"name_raw", i == len(self._m_name_raw) - 1, _ == 0)
+
+
+            if self.params__enabled:
+                pass
+                if len(self._m_params) != self.num_params:
+                    raise kaitaistruct.ConsistencyError(u"params", self.num_params, len(self._m_params))
+                for i in range(len(self._m_params)):
+                    pass
+
+
+            self._dirty = False
+
+        @property
+        def name(self):
+            if self._should_write_name:
+                self._write_name()
+            if hasattr(self, '_m_name'):
+                return self._m_name
+
+            if not self.name__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_name)
+            self._m_name = (self._io.read_bytes(len(self.name_raw) * 2 - 2)).decode(u"utf-16")
+            self._io.seek(_pos)
+            return getattr(self, '_m_name', None)
+
+        @name.setter
+        def name(self, v):
+            self._dirty = True
+            self._m_name = v
+
+        def _write_name(self):
+            self._should_write_name = False
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_name)
+            if len((self._m_name).encode(u"utf-16")) != len(self.name_raw) * 2 - 2:
+                raise kaitaistruct.ConsistencyError(u"name", len(self.name_raw) * 2 - 2, len((self._m_name).encode(u"utf-16")))
+            self._io.write_bytes((self._m_name).encode(u"utf-16"))
+            self._io.seek(_pos)
+
+        @property
+        def name_raw(self):
+            if self._should_write_name_raw:
+                self._write_name_raw()
+            if hasattr(self, '_m_name_raw'):
+                return self._m_name_raw
+
+            if not self.name_raw__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_name)
+            self._m_name_raw = []
+            i = 0
+            while True:
+                _ = self._io.read_u2le()
+                self._m_name_raw.append(_)
+                if _ == 0:
+                    break
+                i += 1
+            self._io.seek(_pos)
+            return getattr(self, '_m_name_raw', None)
+
+        @name_raw.setter
+        def name_raw(self, v):
+            self._dirty = True
+            self._m_name_raw = v
+
+        def _write_name_raw(self):
+            self._should_write_name_raw = False
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_name)
+            for i in range(len(self._m_name_raw)):
+                pass
+                self._io.write_u2le(self._m_name_raw[i])
+
+            self._io.seek(_pos)
+
+        @property
+        def params(self):
+            if self._should_write_params:
+                self._write_params()
+            if hasattr(self, '_m_params'):
+                return self._m_params
+
+            if not self.params__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self._parent.ofs_properties + self.ofs_prop)
+            self._m_params = []
+            for i in range(self.num_params):
+                self._m_params.append(self._io.read_f4le())
+
+            self._io.seek(_pos)
+            return getattr(self, '_m_params', None)
+
+        @params.setter
+        def params(self, v):
+            self._dirty = True
+            self._m_params = v
+
+        def _write_params(self):
+            self._should_write_params = False
+            _pos = self._io.pos()
+            self._io.seek(self._parent.ofs_properties + self.ofs_prop)
+            for i in range(len(self._m_params)):
+                pass
+                self._io.write_f4le(self._m_params[i])
+
+            self._io.seek(_pos)
+
+
+    class PropertiesHeader13(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineMdf.PropertiesHeader13, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_name = False
+            self.name__enabled = True
+            self._should_write_name_raw = False
+            self.name_raw__enabled = True
+            self._should_write_params = False
+            self.params__enabled = True
+
+        def _read(self):
+            self.ofs_name = self._io.read_u8le()
+            self.name_hash_utf16 = self._io.read_u4le()
+            self.name_hash_ascii = self._io.read_u4le()
+            self.ofs_prop = self._io.read_u4le()
+            self.num_params = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.name
+            if hasattr(self, '_m_name'):
+                pass
+
+            _ = self.name_raw
+            if hasattr(self, '_m_name_raw'):
+                pass
+                for i in range(len(self._m_name_raw)):
+                    pass
+
+
+            _ = self.params
+            if hasattr(self, '_m_params'):
+                pass
+                for i in range(len(self._m_params)):
+                    pass
+
+
+
+
+        def _write__seq(self, io=None):
+            super(ReengineMdf.PropertiesHeader13, self)._write__seq(io)
+            self._should_write_name = self.name__enabled
+            self._should_write_name_raw = self.name_raw__enabled
+            self._should_write_params = self.params__enabled
+            self._io.write_u8le(self.ofs_name)
+            self._io.write_u4le(self.name_hash_utf16)
+            self._io.write_u4le(self.name_hash_ascii)
+            self._io.write_u4le(self.ofs_prop)
+            self._io.write_u4le(self.num_params)
+
+
+        def _check(self):
+            if self.name__enabled:
+                pass
+
+            if self.name_raw__enabled:
+                pass
+                if len(self._m_name_raw) == 0:
+                    raise kaitaistruct.ConsistencyError(u"name_raw", 0, len(self._m_name_raw))
+                for i in range(len(self._m_name_raw)):
+                    pass
+                    _ = self._m_name_raw[i]
+                    if (_ == 0) != (i == len(self._m_name_raw) - 1):
+                        raise kaitaistruct.ConsistencyError(u"name_raw", i == len(self._m_name_raw) - 1, _ == 0)
+
+
+            if self.params__enabled:
+                pass
+                if len(self._m_params) != self.num_params:
+                    raise kaitaistruct.ConsistencyError(u"params", self.num_params, len(self._m_params))
+                for i in range(len(self._m_params)):
+                    pass
+
+
+            self._dirty = False
+
+        @property
+        def name(self):
+            if self._should_write_name:
+                self._write_name()
+            if hasattr(self, '_m_name'):
+                return self._m_name
+
+            if not self.name__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_name)
+            self._m_name = (self._io.read_bytes(len(self.name_raw) * 2 - 2)).decode(u"utf-16")
+            self._io.seek(_pos)
+            return getattr(self, '_m_name', None)
+
+        @name.setter
+        def name(self, v):
+            self._dirty = True
+            self._m_name = v
+
+        def _write_name(self):
+            self._should_write_name = False
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_name)
+            if len((self._m_name).encode(u"utf-16")) != len(self.name_raw) * 2 - 2:
+                raise kaitaistruct.ConsistencyError(u"name", len(self.name_raw) * 2 - 2, len((self._m_name).encode(u"utf-16")))
+            self._io.write_bytes((self._m_name).encode(u"utf-16"))
+            self._io.seek(_pos)
+
+        @property
+        def name_raw(self):
+            if self._should_write_name_raw:
+                self._write_name_raw()
+            if hasattr(self, '_m_name_raw'):
+                return self._m_name_raw
+
+            if not self.name_raw__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_name)
+            self._m_name_raw = []
+            i = 0
+            while True:
+                _ = self._io.read_u2le()
+                self._m_name_raw.append(_)
+                if _ == 0:
+                    break
+                i += 1
+            self._io.seek(_pos)
+            return getattr(self, '_m_name_raw', None)
+
+        @name_raw.setter
+        def name_raw(self, v):
+            self._dirty = True
+            self._m_name_raw = v
+
+        def _write_name_raw(self):
+            self._should_write_name_raw = False
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_name)
+            for i in range(len(self._m_name_raw)):
+                pass
+                self._io.write_u2le(self._m_name_raw[i])
+
+            self._io.seek(_pos)
+
+        @property
+        def params(self):
+            if self._should_write_params:
+                self._write_params()
+            if hasattr(self, '_m_params'):
+                return self._m_params
+
+            if not self.params__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self._parent.ofs_properties + self.ofs_prop)
+            self._m_params = []
+            for i in range(self.num_params):
+                self._m_params.append(self._io.read_f4le())
+
+            self._io.seek(_pos)
+            return getattr(self, '_m_params', None)
+
+        @params.setter
+        def params(self, v):
+            self._dirty = True
+            self._m_params = v
+
+        def _write_params(self):
+            self._should_write_params = False
+            _pos = self._io.pos()
+            self._io.seek(self._parent.ofs_properties + self.ofs_prop)
+            for i in range(len(self._m_params)):
+                pass
+                self._io.write_f4le(self._m_params[i])
+
+            self._io.seek(_pos)
+
+
+    class TextureHeader(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineMdf.TextureHeader, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_texture_path = False
+            self.texture_path__enabled = True
+            self._should_write_texture_path_raw = False
+            self.texture_path_raw__enabled = True
+            self._should_write_texture_type = False
+            self.texture_type__enabled = True
+            self._should_write_texture_type_raw = False
+            self.texture_type_raw__enabled = True
+
+        def _read(self):
+            self.ofs_texture_type = self._io.read_u8le()
+            self.hash_utf16 = self._io.read_u4le()
+            self.hash_ascii = self._io.read_u4le()
+            self.ofs_texture_path = self._io.read_u8le()
+            if self._root.mdf_version >= 13:
+                pass
+                self.unk_01 = self._io.read_u8le()
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            if self._root.mdf_version >= 13:
+                pass
+
+            _ = self.texture_path
+            if hasattr(self, '_m_texture_path'):
+                pass
+
+            _ = self.texture_path_raw
+            if hasattr(self, '_m_texture_path_raw'):
+                pass
+                for i in range(len(self._m_texture_path_raw)):
+                    pass
+
+
+            _ = self.texture_type
+            if hasattr(self, '_m_texture_type'):
+                pass
+
+            _ = self.texture_type_raw
+            if hasattr(self, '_m_texture_type_raw'):
+                pass
+                for i in range(len(self._m_texture_type_raw)):
+                    pass
+
+
+
+
+        def _write__seq(self, io=None):
+            super(ReengineMdf.TextureHeader, self)._write__seq(io)
+            self._should_write_texture_path = self.texture_path__enabled
+            self._should_write_texture_path_raw = self.texture_path_raw__enabled
+            self._should_write_texture_type = self.texture_type__enabled
+            self._should_write_texture_type_raw = self.texture_type_raw__enabled
+            self._io.write_u8le(self.ofs_texture_type)
+            self._io.write_u4le(self.hash_utf16)
+            self._io.write_u4le(self.hash_ascii)
+            self._io.write_u8le(self.ofs_texture_path)
+            if self._root.mdf_version >= 13:
+                pass
+                self._io.write_u8le(self.unk_01)
+
+
+
+        def _check(self):
+            if self._root.mdf_version >= 13:
+                pass
+
+            if self.texture_path__enabled:
+                pass
+
+            if self.texture_path_raw__enabled:
+                pass
+                if len(self._m_texture_path_raw) == 0:
+                    raise kaitaistruct.ConsistencyError(u"texture_path_raw", 0, len(self._m_texture_path_raw))
+                for i in range(len(self._m_texture_path_raw)):
+                    pass
+                    _ = self._m_texture_path_raw[i]
+                    if (_ == 0) != (i == len(self._m_texture_path_raw) - 1):
+                        raise kaitaistruct.ConsistencyError(u"texture_path_raw", i == len(self._m_texture_path_raw) - 1, _ == 0)
+
+
+            if self.texture_type__enabled:
+                pass
+
+            if self.texture_type_raw__enabled:
+                pass
+                if len(self._m_texture_type_raw) == 0:
+                    raise kaitaistruct.ConsistencyError(u"texture_type_raw", 0, len(self._m_texture_type_raw))
+                for i in range(len(self._m_texture_type_raw)):
+                    pass
+                    _ = self._m_texture_type_raw[i]
+                    if (_ == 0) != (i == len(self._m_texture_type_raw) - 1):
+                        raise kaitaistruct.ConsistencyError(u"texture_type_raw", i == len(self._m_texture_type_raw) - 1, _ == 0)
+
+
+            self._dirty = False
+
+        @property
+        def texture_path(self):
+            if self._should_write_texture_path:
+                self._write_texture_path()
+            if hasattr(self, '_m_texture_path'):
+                return self._m_texture_path
+
+            if not self.texture_path__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_texture_path)
+            self._m_texture_path = (self._io.read_bytes(len(self.texture_path_raw) * 2 - 2)).decode(u"utf-16")
+            self._io.seek(_pos)
+            return getattr(self, '_m_texture_path', None)
+
+        @texture_path.setter
+        def texture_path(self, v):
+            self._dirty = True
+            self._m_texture_path = v
+
+        def _write_texture_path(self):
+            self._should_write_texture_path = False
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_texture_path)
+            if len((self._m_texture_path).encode(u"utf-16")) != len(self.texture_path_raw) * 2 - 2:
+                raise kaitaistruct.ConsistencyError(u"texture_path", len(self.texture_path_raw) * 2 - 2, len((self._m_texture_path).encode(u"utf-16")))
+            self._io.write_bytes((self._m_texture_path).encode(u"utf-16"))
+            self._io.seek(_pos)
+
+        @property
+        def texture_path_raw(self):
+            if self._should_write_texture_path_raw:
+                self._write_texture_path_raw()
+            if hasattr(self, '_m_texture_path_raw'):
+                return self._m_texture_path_raw
+
+            if not self.texture_path_raw__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_texture_path)
+            self._m_texture_path_raw = []
+            i = 0
+            while True:
+                _ = self._io.read_u2le()
+                self._m_texture_path_raw.append(_)
+                if _ == 0:
+                    break
+                i += 1
+            self._io.seek(_pos)
+            return getattr(self, '_m_texture_path_raw', None)
+
+        @texture_path_raw.setter
+        def texture_path_raw(self, v):
+            self._dirty = True
+            self._m_texture_path_raw = v
+
+        def _write_texture_path_raw(self):
+            self._should_write_texture_path_raw = False
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_texture_path)
+            for i in range(len(self._m_texture_path_raw)):
+                pass
+                self._io.write_u2le(self._m_texture_path_raw[i])
+
+            self._io.seek(_pos)
+
+        @property
+        def texture_type(self):
+            if self._should_write_texture_type:
+                self._write_texture_type()
+            if hasattr(self, '_m_texture_type'):
+                return self._m_texture_type
+
+            if not self.texture_type__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_texture_type)
+            self._m_texture_type = (self._io.read_bytes(len(self.texture_type_raw) * 2 - 2)).decode(u"utf-16")
+            self._io.seek(_pos)
+            return getattr(self, '_m_texture_type', None)
+
+        @texture_type.setter
+        def texture_type(self, v):
+            self._dirty = True
+            self._m_texture_type = v
+
+        def _write_texture_type(self):
+            self._should_write_texture_type = False
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_texture_type)
+            if len((self._m_texture_type).encode(u"utf-16")) != len(self.texture_type_raw) * 2 - 2:
+                raise kaitaistruct.ConsistencyError(u"texture_type", len(self.texture_type_raw) * 2 - 2, len((self._m_texture_type).encode(u"utf-16")))
+            self._io.write_bytes((self._m_texture_type).encode(u"utf-16"))
+            self._io.seek(_pos)
+
+        @property
+        def texture_type_raw(self):
+            if self._should_write_texture_type_raw:
+                self._write_texture_type_raw()
+            if hasattr(self, '_m_texture_type_raw'):
+                return self._m_texture_type_raw
+
+            if not self.texture_type_raw__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_texture_type)
+            self._m_texture_type_raw = []
+            i = 0
+            while True:
+                _ = self._io.read_u2le()
+                self._m_texture_type_raw.append(_)
+                if _ == 0:
+                    break
+                i += 1
+            self._io.seek(_pos)
+            return getattr(self, '_m_texture_type_raw', None)
+
+        @texture_type_raw.setter
+        def texture_type_raw(self, v):
+            self._dirty = True
+            self._m_texture_type_raw = v
+
+        def _write_texture_type_raw(self):
+            self._should_write_texture_type_raw = False
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_texture_type)
+            for i in range(len(self._m_texture_type_raw)):
+                pass
+                self._io.write_u2le(self._m_texture_type_raw[i])
+
+            self._io.seek(_pos)
 
 
 

--- a/albam/engines/reng/structs/reengine_mesh.py
+++ b/albam/engines/reng/structs/reengine_mesh.py
@@ -1,18 +1,28 @@
 # This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
+# type: ignore
 
 import kaitaistruct
-from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
+from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
 
 
-if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 11):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.11 or later is required, but you have %s" % (kaitaistruct.__version__))
 
-class ReengineMesh(KaitaiStruct):
-    def __init__(self, _io, _parent=None, _root=None):
-        self._io = _io
+class ReengineMesh(ReadWriteKaitaiStruct):
+    def __init__(self, _io=None, _parent=None, _root=None):
+        super(ReengineMesh, self).__init__(_io)
         self._parent = _parent
-        self._root = _root if _root else self
-        self._read()
+        self._root = _root or self
+        self._should_write_bones_header = False
+        self.bones_header__enabled = True
+        self._should_write_buffers_data = False
+        self.buffers_data__enabled = True
+        self._should_write_id_to_names_remap = False
+        self.id_to_names_remap__enabled = True
+        self._should_write_model_info = False
+        self.model_info__enabled = True
+        self._should_write_named_nodes = False
+        self.named_nodes__enabled = True
 
     def _read(self):
         self.id_magic = self._io.read_bytes(4)
@@ -21,191 +31,164 @@ class ReengineMesh(KaitaiStruct):
         self.version = self._io.read_u4le()
         self.size_file = self._io.read_u8le()
         self.header = ReengineMesh.Header(self._io, self, self._root)
+        self.header._read()
+        self._dirty = False
 
-    class Vec4(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+
+    def _fetch_instances(self):
+        pass
+        self.header._fetch_instances()
+        _ = self.bones_header
+        if hasattr(self, '_m_bones_header'):
+            pass
+            self._m_bones_header._fetch_instances()
+
+        _ = self.buffers_data
+        if hasattr(self, '_m_buffers_data'):
+            pass
+            self._m_buffers_data._fetch_instances()
+
+        _ = self.id_to_names_remap
+        if hasattr(self, '_m_id_to_names_remap'):
+            pass
+            for i in range(len(self._m_id_to_names_remap)):
+                pass
+
+
+        _ = self.model_info
+        if hasattr(self, '_m_model_info'):
+            pass
+            self._m_model_info._fetch_instances()
+
+        _ = self.named_nodes
+        if hasattr(self, '_m_named_nodes'):
+            pass
+            for i in range(len(self._m_named_nodes)):
+                pass
+                self._m_named_nodes[i]._fetch_instances()
+
+
+
+
+    def _write__seq(self, io=None):
+        super(ReengineMesh, self)._write__seq(io)
+        self._should_write_bones_header = self.bones_header__enabled
+        self._should_write_buffers_data = self.buffers_data__enabled
+        self._should_write_id_to_names_remap = self.id_to_names_remap__enabled
+        self._should_write_model_info = self.model_info__enabled
+        self._should_write_named_nodes = self.named_nodes__enabled
+        self._io.write_bytes(self.id_magic)
+        self._io.write_u4le(self.version)
+        self._io.write_u8le(self.size_file)
+        self.header._write__seq(self._io)
+
+
+    def _check(self):
+        if len(self.id_magic) != 4:
+            raise kaitaistruct.ConsistencyError(u"id_magic", 4, len(self.id_magic))
+        if not self.id_magic == b"\x4D\x45\x53\x48":
+            raise kaitaistruct.ValidationNotEqualError(b"\x4D\x45\x53\x48", self.id_magic, None, u"/seq/0")
+        if self.header._root != self._root:
+            raise kaitaistruct.ConsistencyError(u"header", self._root, self.header._root)
+        if self.header._parent != self:
+            raise kaitaistruct.ConsistencyError(u"header", self, self.header._parent)
+        if self.bones_header__enabled:
+            pass
+            if self.header.offset_bones != 0:
+                pass
+                if self._m_bones_header._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"bones_header", self._root, self._m_bones_header._root)
+                if self._m_bones_header._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"bones_header", self, self._m_bones_header._parent)
+
+
+        if self.buffers_data__enabled:
+            pass
+            if self._m_buffers_data._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"buffers_data", self._root, self._m_buffers_data._root)
+            if self._m_buffers_data._parent != self:
+                raise kaitaistruct.ConsistencyError(u"buffers_data", self, self._m_buffers_data._parent)
+
+        if self.id_to_names_remap__enabled:
+            pass
+            if len(self._m_id_to_names_remap) != self.header.num_named_nodes:
+                raise kaitaistruct.ConsistencyError(u"id_to_names_remap", self.header.num_named_nodes, len(self._m_id_to_names_remap))
+            for i in range(len(self._m_id_to_names_remap)):
+                pass
+
+
+        if self.model_info__enabled:
+            pass
+            if self._m_model_info._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"model_info", self._root, self._m_model_info._root)
+            if self._m_model_info._parent != self:
+                raise kaitaistruct.ConsistencyError(u"model_info", self, self._m_model_info._parent)
+
+        if self.named_nodes__enabled:
+            pass
+            if len(self._m_named_nodes) != self.header.num_named_nodes:
+                raise kaitaistruct.ConsistencyError(u"named_nodes", self.header.num_named_nodes, len(self._m_named_nodes))
+            for i in range(len(self._m_named_nodes)):
+                pass
+                if self._m_named_nodes[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"named_nodes", self._root, self._m_named_nodes[i]._root)
+                if self._m_named_nodes[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"named_nodes", self, self._m_named_nodes[i]._parent)
+
+
+        self._dirty = False
+
+    class Bone(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineMesh.Bone, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
 
         def _read(self):
-            self.x = self._io.read_f4le()
-            self.y = self._io.read_f4le()
-            self.z = self._io.read_f4le()
-            self.w = self._io.read_f4le()
+            self.idx = self._io.read_u2le()
+            self.parent_idx = self._io.read_u2le()
+            self.unk_02 = []
+            for i in range(6):
+                self.unk_02.append(self._io.read_u2le())
+
+            self._dirty = False
 
 
-    class MeshGroupTest(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.unk_02)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(ReengineMesh.Bone, self)._write__seq(io)
+            self._io.write_u2le(self.idx)
+            self._io.write_u2le(self.parent_idx)
+            for i in range(len(self.unk_02)):
+                pass
+                self._io.write_u2le(self.unk_02[i])
+
+
+
+        def _check(self):
+            if len(self.unk_02) != 6:
+                raise kaitaistruct.ConsistencyError(u"unk_02", 6, len(self.unk_02))
+            for i in range(len(self.unk_02)):
+                pass
+
+            self._dirty = False
+
+
+    class BoneHeader(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineMesh.BoneHeader, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
-
-        def _read(self):
-            self.offset = self._io.read_u8le()
-
-        @property
-        def mesh_group(self):
-            if hasattr(self, '_m_mesh_group'):
-                return self._m_mesh_group
-
-            _pos = self._io.pos()
-            self._io.seek(self.offset)
-            self._m_mesh_group = ReengineMesh.MeshGroup(self._io, self, self._root)
-            self._io.seek(_pos)
-            return getattr(self, '_m_mesh_group', None)
-
-
-    class TestName(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
-
-        def _read(self):
-            self.offset = self._io.read_u8le()
-
-        @property
-        def value(self):
-            if hasattr(self, '_m_value'):
-                return self._m_value
-
-            _pos = self._io.pos()
-            self._io.seek(self.offset)
-            self._m_value = (self._io.read_bytes_term(0, False, True, True)).decode(u"ascii")
-            self._io.seek(_pos)
-            return getattr(self, '_m_value', None)
-
-
-    class Model(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
-
-        def _read(self):
-            self.num_mesh_groups = self._io.read_u4le()
-            self.unk = self._io.read_u4le()
-            self.offset_main_mesh_header = self._io.read_u8le()
-            self.mesh_groups = []
-            for i in range(self.num_mesh_groups):
-                self.mesh_groups.append(ReengineMesh.MeshGroupTest(self._io, self, self._root))
-
-            self.padding = self._io.read_u8le()
-
-
-    class Matrix4x4(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
-
-        def _read(self):
-            self.row_1 = ReengineMesh.Vec4(self._io, self, self._root)
-            self.row_2 = ReengineMesh.Vec4(self._io, self, self._root)
-            self.row_3 = ReengineMesh.Vec4(self._io, self, self._root)
-            self.row_4 = ReengineMesh.Vec4(self._io, self, self._root)
-
-
-    class ModelOffset(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
-
-        def _read(self):
-            self.offset = self._io.read_u8le()
-
-        @property
-        def model(self):
-            if hasattr(self, '_m_model'):
-                return self._m_model
-
-            _pos = self._io.pos()
-            self._io.seek(self.offset)
-            self._m_model = ReengineMesh.Model(self._io, self, self._root)
-            self._io.seek(_pos)
-            return getattr(self, '_m_model', None)
-
-
-    class BuffersHeader(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
-
-        def _read(self):
-            self.offset_primitive_accessors = self._io.read_u8le()
-            self.offset_vertex_buffer = self._io.read_u8le()
-            self.offset_index_buffer = self._io.read_u8le()
-            if self._root.version == 21041600:
-                self.unk_00 = self._io.read_u8le()
-
-            self.size_vertex_buffer = self._io.read_u4le()
-            self.size_index_buffer = self._io.read_u4le()
-            self.num_unk = self._io.read_u2le()
-            self.num_primitive_accessors = self._io.read_u2le()
-            self.unk_01 = self._io.read_u4le()
-            self.reserved_01 = self._io.read_u4le()
-            self.unk_2 = self._io.read_u2le()
-            self.unk_3 = self._io.read_u2le()
-            if  ((self._root.version == 21041600) and (self.unk_00 == 0)) :
-                self.unk_00_a = self._io.read_u4le()
-
-            if  ((self._root.version == 21041600) and (self.unk_00 == 0)) :
-                self.unk_00_b = self._io.read_u4le()
-
-
-        @property
-        def vertex_buffer(self):
-            if hasattr(self, '_m_vertex_buffer'):
-                return self._m_vertex_buffer
-
-            _pos = self._io.pos()
-            self._io.seek(self.offset_vertex_buffer)
-            self._m_vertex_buffer = self._io.read_bytes(self.size_vertex_buffer)
-            self._io.seek(_pos)
-            return getattr(self, '_m_vertex_buffer', None)
-
-        @property
-        def index_buffer(self):
-            if hasattr(self, '_m_index_buffer'):
-                return self._m_index_buffer
-
-            _pos = self._io.pos()
-            self._io.seek(self.offset_index_buffer)
-            self._m_index_buffer = self._io.read_bytes(self.size_index_buffer)
-            self._io.seek(_pos)
-            return getattr(self, '_m_index_buffer', None)
-
-        @property
-        def primitive_accessors(self):
-            if hasattr(self, '_m_primitive_accessors'):
-                return self._m_primitive_accessors
-
-            _pos = self._io.pos()
-            self._io.seek(self.offset_primitive_accessors)
-            self._m_primitive_accessors = []
-            for i in range(self.num_primitive_accessors):
-                self._m_primitive_accessors.append(ReengineMesh.PrimitiveAccessor(self._io, self, self._root))
-
-            self._io.seek(_pos)
-            return getattr(self, '_m_primitive_accessors', None)
-
-
-    class BoneHeader(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
+            self._should_write_bones = False
+            self.bones__enabled = True
+            self._should_write_inverse_bind_matrices = False
+            self.inverse_bind_matrices__enabled = True
 
         def _read(self):
             self.num_bones = self._io.read_u4le()
@@ -220,160 +203,391 @@ class ReengineMesh(KaitaiStruct):
             for i in range(self.num_bone_maps):
                 self.bone_maps.append(self._io.read_u2le())
 
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.bone_maps)):
+                pass
+
+            _ = self.bones
+            if hasattr(self, '_m_bones'):
+                pass
+                for i in range(len(self._m_bones)):
+                    pass
+                    self._m_bones[i]._fetch_instances()
+
+
+            _ = self.inverse_bind_matrices
+            if hasattr(self, '_m_inverse_bind_matrices'):
+                pass
+                for i in range(len(self._m_inverse_bind_matrices)):
+                    pass
+                    self._m_inverse_bind_matrices[i]._fetch_instances()
+
+
+
+
+        def _write__seq(self, io=None):
+            super(ReengineMesh.BoneHeader, self)._write__seq(io)
+            self._should_write_bones = self.bones__enabled
+            self._should_write_inverse_bind_matrices = self.inverse_bind_matrices__enabled
+            self._io.write_u4le(self.num_bones)
+            self._io.write_u4le(self.num_bone_maps)
+            self._io.write_u4le(self.reserved_01)
+            self._io.write_u4le(self.reserved_02)
+            self._io.write_u8le(self.offset_parent_bone)
+            self._io.write_u8le(self.offset_matrix_1)
+            self._io.write_u8le(self.offset_matrix_2)
+            self._io.write_u8le(self.offset_inverse_bind_matrices)
+            for i in range(len(self.bone_maps)):
+                pass
+                self._io.write_u2le(self.bone_maps[i])
+
+
+
+        def _check(self):
+            if len(self.bone_maps) != self.num_bone_maps:
+                raise kaitaistruct.ConsistencyError(u"bone_maps", self.num_bone_maps, len(self.bone_maps))
+            for i in range(len(self.bone_maps)):
+                pass
+
+            if self.bones__enabled:
+                pass
+                if len(self._m_bones) != self.num_bones:
+                    raise kaitaistruct.ConsistencyError(u"bones", self.num_bones, len(self._m_bones))
+                for i in range(len(self._m_bones)):
+                    pass
+                    if self._m_bones[i]._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"bones", self._root, self._m_bones[i]._root)
+                    if self._m_bones[i]._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"bones", self, self._m_bones[i]._parent)
+
+
+            if self.inverse_bind_matrices__enabled:
+                pass
+                if len(self._m_inverse_bind_matrices) != self.num_bones:
+                    raise kaitaistruct.ConsistencyError(u"inverse_bind_matrices", self.num_bones, len(self._m_inverse_bind_matrices))
+                for i in range(len(self._m_inverse_bind_matrices)):
+                    pass
+                    if self._m_inverse_bind_matrices[i]._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"inverse_bind_matrices", self._root, self._m_inverse_bind_matrices[i]._root)
+                    if self._m_inverse_bind_matrices[i]._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"inverse_bind_matrices", self, self._m_inverse_bind_matrices[i]._parent)
+
+
+            self._dirty = False
 
         @property
         def bones(self):
+            if self._should_write_bones:
+                self._write_bones()
             if hasattr(self, '_m_bones'):
                 return self._m_bones
+
+            if not self.bones__enabled:
+                return None
 
             _pos = self._io.pos()
             self._io.seek(self.offset_parent_bone)
             self._m_bones = []
             for i in range(self.num_bones):
-                self._m_bones.append(ReengineMesh.Bone(self._io, self, self._root))
+                _t__m_bones = ReengineMesh.Bone(self._io, self, self._root)
+                try:
+                    _t__m_bones._read()
+                finally:
+                    self._m_bones.append(_t__m_bones)
 
             self._io.seek(_pos)
             return getattr(self, '_m_bones', None)
 
+        @bones.setter
+        def bones(self, v):
+            self._dirty = True
+            self._m_bones = v
+
+        def _write_bones(self):
+            self._should_write_bones = False
+            _pos = self._io.pos()
+            self._io.seek(self.offset_parent_bone)
+            for i in range(len(self._m_bones)):
+                pass
+                self._m_bones[i]._write__seq(self._io)
+
+            self._io.seek(_pos)
+
         @property
         def inverse_bind_matrices(self):
+            if self._should_write_inverse_bind_matrices:
+                self._write_inverse_bind_matrices()
             if hasattr(self, '_m_inverse_bind_matrices'):
                 return self._m_inverse_bind_matrices
+
+            if not self.inverse_bind_matrices__enabled:
+                return None
 
             _pos = self._io.pos()
             self._io.seek(self.offset_inverse_bind_matrices)
             self._m_inverse_bind_matrices = []
             for i in range(self.num_bones):
-                self._m_inverse_bind_matrices.append(ReengineMesh.Matrix4x4(self._io, self, self._root))
+                _t__m_inverse_bind_matrices = ReengineMesh.Matrix4x4(self._io, self, self._root)
+                try:
+                    _t__m_inverse_bind_matrices._read()
+                finally:
+                    self._m_inverse_bind_matrices.append(_t__m_inverse_bind_matrices)
 
             self._io.seek(_pos)
             return getattr(self, '_m_inverse_bind_matrices', None)
 
+        @inverse_bind_matrices.setter
+        def inverse_bind_matrices(self, v):
+            self._dirty = True
+            self._m_inverse_bind_matrices = v
 
-    class MeshGroup(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
-
-        def _read(self):
-            self.type = self._io.read_u1()
-            self.num_meshes = self._io.read_u1()
-            self.unk_01 = self._io.read_u2le()
-            self.unk_02 = self._io.read_u4le()
-            self.num_vertices = self._io.read_u4le()
-            self.num_indices = self._io.read_u4le()
-            self.meshes = []
-            for i in range(self.num_meshes):
-                self.meshes.append(ReengineMesh.Mesh(self._io, self, self._root))
-
-
-
-    class Bone(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
-
-        def _read(self):
-            self.idx = self._io.read_u2le()
-            self.parent_idx = self._io.read_u2le()
-            self.unk_02 = []
-            for i in range(6):
-                self.unk_02.append(self._io.read_u2le())
-
-
-
-    class ModelInfo(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
-
-        def _read(self):
-            self.len_offsets_models = self._io.read_u1()
-            self.num_materials = self._io.read_u1()
-            self.num_uv_layers = self._io.read_u1()
-            self.num_skin_weights = self._io.read_u1()
-            self.num_meshes = self._io.read_u4le()
-            if self._root.version == 386270720:
-                self.reserved_01 = self._io.read_u8le()
-
-            self.box = []
-            for i in range(12):
-                self.box.append(self._io.read_f4le())
-
-            self.offset_lod_info = self._io.read_u4le()
-            self.reserved_02 = self._io.read_u4le()
-
-        @property
-        def model_offsets(self):
-            if hasattr(self, '_m_model_offsets'):
-                return self._m_model_offsets
-
+        def _write_inverse_bind_matrices(self):
+            self._should_write_inverse_bind_matrices = False
             _pos = self._io.pos()
-            self._io.seek(self.offset_lod_info)
-            self._m_model_offsets = []
-            for i in range(self.len_offsets_models):
-                self._m_model_offsets.append(ReengineMesh.ModelOffset(self._io, self, self._root))
+            self._io.seek(self.offset_inverse_bind_matrices)
+            for i in range(len(self._m_inverse_bind_matrices)):
+                pass
+                self._m_inverse_bind_matrices[i]._write__seq(self._io)
 
             self._io.seek(_pos)
-            return getattr(self, '_m_model_offsets', None)
 
 
-    class Mesh(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+    class BuffersHeader(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineMesh.BuffersHeader, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
+            self._should_write_index_buffer = False
+            self.index_buffer__enabled = True
+            self._should_write_primitive_accessors = False
+            self.primitive_accessors__enabled = True
+            self._should_write_vertex_buffer = False
+            self.vertex_buffer__enabled = True
 
         def _read(self):
-            self.material_id = self._io.read_u4le()
-            self.num_indices = self._io.read_u4le()
-            self.pos_index_buffer = self._io.read_u4le()
-            self.pos_vertex_buffer = self._io.read_u4le()
-            if self._root.version != 386270720:
-                self.unk_01 = self._io.read_u8le()
+            self.offset_primitive_accessors = self._io.read_u8le()
+            self.offset_vertex_buffer = self._io.read_u8le()
+            self.offset_index_buffer = self._io.read_u8le()
+            if self._root.version == 21041600:
+                pass
+                self.unk_00 = self._io.read_u8le()
 
+            self.size_vertex_buffer = self._io.read_u4le()
+            self.size_index_buffer = self._io.read_u4le()
+            self.num_unk = self._io.read_u2le()
+            self.num_primitive_accessors = self._io.read_u2le()
+            self.unk_01 = self._io.read_u4le()
+            self.reserved_01 = self._io.read_u4le()
+            self.unk_2 = self._io.read_u2le()
+            self.unk_3 = self._io.read_u2le()
+            if  ((self._root.version == 21041600) and (self.unk_00 == 0)) :
+                pass
+                self.unk_00_a = self._io.read_u4le()
+
+            if  ((self._root.version == 21041600) and (self.unk_00 == 0)) :
+                pass
+                self.unk_00_b = self._io.read_u4le()
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            if self._root.version == 21041600:
+                pass
+
+            if  ((self._root.version == 21041600) and (self.unk_00 == 0)) :
+                pass
+
+            if  ((self._root.version == 21041600) and (self.unk_00 == 0)) :
+                pass
+
+            _ = self.index_buffer
+            if hasattr(self, '_m_index_buffer'):
+                pass
+
+            _ = self.primitive_accessors
+            if hasattr(self, '_m_primitive_accessors'):
+                pass
+                for i in range(len(self._m_primitive_accessors)):
+                    pass
+                    self._m_primitive_accessors[i]._fetch_instances()
+
+
+            _ = self.vertex_buffer
+            if hasattr(self, '_m_vertex_buffer'):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(ReengineMesh.BuffersHeader, self)._write__seq(io)
+            self._should_write_index_buffer = self.index_buffer__enabled
+            self._should_write_primitive_accessors = self.primitive_accessors__enabled
+            self._should_write_vertex_buffer = self.vertex_buffer__enabled
+            self._io.write_u8le(self.offset_primitive_accessors)
+            self._io.write_u8le(self.offset_vertex_buffer)
+            self._io.write_u8le(self.offset_index_buffer)
+            if self._root.version == 21041600:
+                pass
+                self._io.write_u8le(self.unk_00)
+
+            self._io.write_u4le(self.size_vertex_buffer)
+            self._io.write_u4le(self.size_index_buffer)
+            self._io.write_u2le(self.num_unk)
+            self._io.write_u2le(self.num_primitive_accessors)
+            self._io.write_u4le(self.unk_01)
+            self._io.write_u4le(self.reserved_01)
+            self._io.write_u2le(self.unk_2)
+            self._io.write_u2le(self.unk_3)
+            if  ((self._root.version == 21041600) and (self.unk_00 == 0)) :
+                pass
+                self._io.write_u4le(self.unk_00_a)
+
+            if  ((self._root.version == 21041600) and (self.unk_00 == 0)) :
+                pass
+                self._io.write_u4le(self.unk_00_b)
+
+
+
+        def _check(self):
+            if self._root.version == 21041600:
+                pass
+
+            if  ((self._root.version == 21041600) and (self.unk_00 == 0)) :
+                pass
+
+            if  ((self._root.version == 21041600) and (self.unk_00 == 0)) :
+                pass
+
+            if self.index_buffer__enabled:
+                pass
+                if len(self._m_index_buffer) != self.size_index_buffer:
+                    raise kaitaistruct.ConsistencyError(u"index_buffer", self.size_index_buffer, len(self._m_index_buffer))
+
+            if self.primitive_accessors__enabled:
+                pass
+                if len(self._m_primitive_accessors) != self.num_primitive_accessors:
+                    raise kaitaistruct.ConsistencyError(u"primitive_accessors", self.num_primitive_accessors, len(self._m_primitive_accessors))
+                for i in range(len(self._m_primitive_accessors)):
+                    pass
+                    if self._m_primitive_accessors[i]._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"primitive_accessors", self._root, self._m_primitive_accessors[i]._root)
+                    if self._m_primitive_accessors[i]._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"primitive_accessors", self, self._m_primitive_accessors[i]._parent)
+
+
+            if self.vertex_buffer__enabled:
+                pass
+                if len(self._m_vertex_buffer) != self.size_vertex_buffer:
+                    raise kaitaistruct.ConsistencyError(u"vertex_buffer", self.size_vertex_buffer, len(self._m_vertex_buffer))
+
+            self._dirty = False
 
         @property
-        def normals(self):
-            if hasattr(self, '_m_normals'):
-                return self._m_normals
+        def index_buffer(self):
+            if self._should_write_index_buffer:
+                self._write_index_buffer()
+            if hasattr(self, '_m_index_buffer'):
+                return self._m_index_buffer
+
+            if not self.index_buffer__enabled:
+                return None
 
             _pos = self._io.pos()
-            self._io.seek(((self._root.buffers_data.offset_vertex_buffer + self._root.buffers_data.primitive_accessors[1].offset) + (self._root.buffers_data.primitive_accessors[1].size * self.pos_vertex_buffer)))
-            self._m_normals = []
-            for i in range(100):
-                self._m_normals.append(self._io.read_s1())
+            self._io.seek(self.offset_index_buffer)
+            self._m_index_buffer = self._io.read_bytes(self.size_index_buffer)
+            self._io.seek(_pos)
+            return getattr(self, '_m_index_buffer', None)
+
+        @index_buffer.setter
+        def index_buffer(self, v):
+            self._dirty = True
+            self._m_index_buffer = v
+
+        def _write_index_buffer(self):
+            self._should_write_index_buffer = False
+            _pos = self._io.pos()
+            self._io.seek(self.offset_index_buffer)
+            self._io.write_bytes(self._m_index_buffer)
+            self._io.seek(_pos)
+
+        @property
+        def primitive_accessors(self):
+            if self._should_write_primitive_accessors:
+                self._write_primitive_accessors()
+            if hasattr(self, '_m_primitive_accessors'):
+                return self._m_primitive_accessors
+
+            if not self.primitive_accessors__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self.offset_primitive_accessors)
+            self._m_primitive_accessors = []
+            for i in range(self.num_primitive_accessors):
+                _t__m_primitive_accessors = ReengineMesh.PrimitiveAccessor(self._io, self, self._root)
+                try:
+                    _t__m_primitive_accessors._read()
+                finally:
+                    self._m_primitive_accessors.append(_t__m_primitive_accessors)
 
             self._io.seek(_pos)
-            return getattr(self, '_m_normals', None)
+            return getattr(self, '_m_primitive_accessors', None)
+
+        @primitive_accessors.setter
+        def primitive_accessors(self, v):
+            self._dirty = True
+            self._m_primitive_accessors = v
+
+        def _write_primitive_accessors(self):
+            self._should_write_primitive_accessors = False
+            _pos = self._io.pos()
+            self._io.seek(self.offset_primitive_accessors)
+            for i in range(len(self._m_primitive_accessors)):
+                pass
+                self._m_primitive_accessors[i]._write__seq(self._io)
+
+            self._io.seek(_pos)
+
+        @property
+        def vertex_buffer(self):
+            if self._should_write_vertex_buffer:
+                self._write_vertex_buffer()
+            if hasattr(self, '_m_vertex_buffer'):
+                return self._m_vertex_buffer
+
+            if not self.vertex_buffer__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self.offset_vertex_buffer)
+            self._m_vertex_buffer = self._io.read_bytes(self.size_vertex_buffer)
+            self._io.seek(_pos)
+            return getattr(self, '_m_vertex_buffer', None)
+
+        @vertex_buffer.setter
+        def vertex_buffer(self, v):
+            self._dirty = True
+            self._m_vertex_buffer = v
+
+        def _write_vertex_buffer(self):
+            self._should_write_vertex_buffer = False
+            _pos = self._io.pos()
+            self._io.seek(self.offset_vertex_buffer)
+            self._io.write_bytes(self._m_vertex_buffer)
+            self._io.seek(_pos)
 
 
-    class PrimitiveAccessor(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+    class Header(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineMesh.Header, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
-
-        def _read(self):
-            self.primitive_type = self._io.read_u2le()
-            self.size = self._io.read_u2le()
-            self.offset = self._io.read_u4le()
-
-
-    class Header(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
 
         def _read(self):
             self.unk1 = self._io.read_u2le()
@@ -392,83 +606,825 @@ class ReengineMesh(KaitaiStruct):
             self.offset_unk_8 = self._io.read_u8le()
             self.offset_unk_9 = self._io.read_u8le()
             self.offset_names = self._io.read_u8le()
+            self._dirty = False
 
 
-    class NameOffset(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(ReengineMesh.Header, self)._write__seq(io)
+            self._io.write_u2le(self.unk1)
+            self._io.write_u2le(self.num_named_nodes)
+            self._io.write_u4le(self.reserved_02)
+            self._io.write_u8le(self.offset_data)
+            self._io.write_u8le(self.offset_unk_1)
+            self._io.write_u8le(self.offset_unk_2)
+            self._io.write_u8le(self.offset_bones)
+            self._io.write_u8le(self.offset_unk_3)
+            self._io.write_u8le(self.offset_unk_4)
+            self._io.write_u8le(self.offset_unk_5)
+            self._io.write_u8le(self.offset_buffers_header)
+            self._io.write_u8le(self.offset_unk_6)
+            self._io.write_u8le(self.offset_test_remap)
+            self._io.write_u8le(self.offset_unk_8)
+            self._io.write_u8le(self.offset_unk_9)
+            self._io.write_u8le(self.offset_names)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class Matrix4x4(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineMesh.Matrix4x4, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
+
+        def _read(self):
+            self.row_1 = ReengineMesh.Vec4(self._io, self, self._root)
+            self.row_1._read()
+            self.row_2 = ReengineMesh.Vec4(self._io, self, self._root)
+            self.row_2._read()
+            self.row_3 = ReengineMesh.Vec4(self._io, self, self._root)
+            self.row_3._read()
+            self.row_4 = ReengineMesh.Vec4(self._io, self, self._root)
+            self.row_4._read()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            self.row_1._fetch_instances()
+            self.row_2._fetch_instances()
+            self.row_3._fetch_instances()
+            self.row_4._fetch_instances()
+
+
+        def _write__seq(self, io=None):
+            super(ReengineMesh.Matrix4x4, self)._write__seq(io)
+            self.row_1._write__seq(self._io)
+            self.row_2._write__seq(self._io)
+            self.row_3._write__seq(self._io)
+            self.row_4._write__seq(self._io)
+
+
+        def _check(self):
+            if self.row_1._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"row_1", self._root, self.row_1._root)
+            if self.row_1._parent != self:
+                raise kaitaistruct.ConsistencyError(u"row_1", self, self.row_1._parent)
+            if self.row_2._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"row_2", self._root, self.row_2._root)
+            if self.row_2._parent != self:
+                raise kaitaistruct.ConsistencyError(u"row_2", self, self.row_2._parent)
+            if self.row_3._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"row_3", self._root, self.row_3._root)
+            if self.row_3._parent != self:
+                raise kaitaistruct.ConsistencyError(u"row_3", self, self.row_3._parent)
+            if self.row_4._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"row_4", self._root, self.row_4._root)
+            if self.row_4._parent != self:
+                raise kaitaistruct.ConsistencyError(u"row_4", self, self.row_4._parent)
+            self._dirty = False
+
+
+    class Mesh(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineMesh.Mesh, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_normals = False
+            self.normals__enabled = True
+
+        def _read(self):
+            self.material_id = self._io.read_u4le()
+            self.num_indices = self._io.read_u4le()
+            self.pos_index_buffer = self._io.read_u4le()
+            self.pos_vertex_buffer = self._io.read_u4le()
+            if self._root.version != 386270720:
+                pass
+                self.unk_01 = self._io.read_u8le()
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            if self._root.version != 386270720:
+                pass
+
+            _ = self.normals
+            if hasattr(self, '_m_normals'):
+                pass
+                for i in range(len(self._m_normals)):
+                    pass
+
+
+
+
+        def _write__seq(self, io=None):
+            super(ReengineMesh.Mesh, self)._write__seq(io)
+            self._should_write_normals = self.normals__enabled
+            self._io.write_u4le(self.material_id)
+            self._io.write_u4le(self.num_indices)
+            self._io.write_u4le(self.pos_index_buffer)
+            self._io.write_u4le(self.pos_vertex_buffer)
+            if self._root.version != 386270720:
+                pass
+                self._io.write_u8le(self.unk_01)
+
+
+
+        def _check(self):
+            if self._root.version != 386270720:
+                pass
+
+            if self.normals__enabled:
+                pass
+                if len(self._m_normals) != 100:
+                    raise kaitaistruct.ConsistencyError(u"normals", 100, len(self._m_normals))
+                for i in range(len(self._m_normals)):
+                    pass
+
+
+            self._dirty = False
+
+        @property
+        def normals(self):
+            if self._should_write_normals:
+                self._write_normals()
+            if hasattr(self, '_m_normals'):
+                return self._m_normals
+
+            if not self.normals__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek((self._root.buffers_data.offset_vertex_buffer + self._root.buffers_data.primitive_accessors[1].offset) + self._root.buffers_data.primitive_accessors[1].size * self.pos_vertex_buffer)
+            self._m_normals = []
+            for i in range(100):
+                self._m_normals.append(self._io.read_s1())
+
+            self._io.seek(_pos)
+            return getattr(self, '_m_normals', None)
+
+        @normals.setter
+        def normals(self, v):
+            self._dirty = True
+            self._m_normals = v
+
+        def _write_normals(self):
+            self._should_write_normals = False
+            _pos = self._io.pos()
+            self._io.seek((self._root.buffers_data.offset_vertex_buffer + self._root.buffers_data.primitive_accessors[1].offset) + self._root.buffers_data.primitive_accessors[1].size * self.pos_vertex_buffer)
+            for i in range(len(self._m_normals)):
+                pass
+                self._io.write_s1(self._m_normals[i])
+
+            self._io.seek(_pos)
+
+
+    class MeshGroup(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineMesh.MeshGroup, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.type = self._io.read_u1()
+            self.num_meshes = self._io.read_u1()
+            self.unk_01 = self._io.read_u2le()
+            self.unk_02 = self._io.read_u4le()
+            self.num_vertices = self._io.read_u4le()
+            self.num_indices = self._io.read_u4le()
+            self.meshes = []
+            for i in range(self.num_meshes):
+                _t_meshes = ReengineMesh.Mesh(self._io, self, self._root)
+                try:
+                    _t_meshes._read()
+                finally:
+                    self.meshes.append(_t_meshes)
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.meshes)):
+                pass
+                self.meshes[i]._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(ReengineMesh.MeshGroup, self)._write__seq(io)
+            self._io.write_u1(self.type)
+            self._io.write_u1(self.num_meshes)
+            self._io.write_u2le(self.unk_01)
+            self._io.write_u4le(self.unk_02)
+            self._io.write_u4le(self.num_vertices)
+            self._io.write_u4le(self.num_indices)
+            for i in range(len(self.meshes)):
+                pass
+                self.meshes[i]._write__seq(self._io)
+
+
+
+        def _check(self):
+            if len(self.meshes) != self.num_meshes:
+                raise kaitaistruct.ConsistencyError(u"meshes", self.num_meshes, len(self.meshes))
+            for i in range(len(self.meshes)):
+                pass
+                if self.meshes[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"meshes", self._root, self.meshes[i]._root)
+                if self.meshes[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"meshes", self, self.meshes[i]._parent)
+
+            self._dirty = False
+
+
+    class MeshGroupTest(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineMesh.MeshGroupTest, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_mesh_group = False
+            self.mesh_group__enabled = True
 
         def _read(self):
             self.offset = self._io.read_u8le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.mesh_group
+            if hasattr(self, '_m_mesh_group'):
+                pass
+                self._m_mesh_group._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(ReengineMesh.MeshGroupTest, self)._write__seq(io)
+            self._should_write_mesh_group = self.mesh_group__enabled
+            self._io.write_u8le(self.offset)
+
+
+        def _check(self):
+            if self.mesh_group__enabled:
+                pass
+                if self._m_mesh_group._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"mesh_group", self._root, self._m_mesh_group._root)
+                if self._m_mesh_group._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"mesh_group", self, self._m_mesh_group._parent)
+
+            self._dirty = False
 
         @property
-        def name(self):
-            if hasattr(self, '_m_name'):
-                return self._m_name
+        def mesh_group(self):
+            if self._should_write_mesh_group:
+                self._write_mesh_group()
+            if hasattr(self, '_m_mesh_group'):
+                return self._m_mesh_group
+
+            if not self.mesh_group__enabled:
+                return None
 
             _pos = self._io.pos()
             self._io.seek(self.offset)
-            self._m_name = (self._io.read_bytes_term(0, False, True, True)).decode(u"ascii")
+            self._m_mesh_group = ReengineMesh.MeshGroup(self._io, self, self._root)
+            self._m_mesh_group._read()
+            self._io.seek(_pos)
+            return getattr(self, '_m_mesh_group', None)
+
+        @mesh_group.setter
+        def mesh_group(self, v):
+            self._dirty = True
+            self._m_mesh_group = v
+
+        def _write_mesh_group(self):
+            self._should_write_mesh_group = False
+            _pos = self._io.pos()
+            self._io.seek(self.offset)
+            self._m_mesh_group._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    class Model(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineMesh.Model, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.num_mesh_groups = self._io.read_u4le()
+            self.unk = self._io.read_u4le()
+            self.offset_main_mesh_header = self._io.read_u8le()
+            self.mesh_groups = []
+            for i in range(self.num_mesh_groups):
+                _t_mesh_groups = ReengineMesh.MeshGroupTest(self._io, self, self._root)
+                try:
+                    _t_mesh_groups._read()
+                finally:
+                    self.mesh_groups.append(_t_mesh_groups)
+
+            self.padding = self._io.read_u8le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.mesh_groups)):
+                pass
+                self.mesh_groups[i]._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(ReengineMesh.Model, self)._write__seq(io)
+            self._io.write_u4le(self.num_mesh_groups)
+            self._io.write_u4le(self.unk)
+            self._io.write_u8le(self.offset_main_mesh_header)
+            for i in range(len(self.mesh_groups)):
+                pass
+                self.mesh_groups[i]._write__seq(self._io)
+
+            self._io.write_u8le(self.padding)
+
+
+        def _check(self):
+            if len(self.mesh_groups) != self.num_mesh_groups:
+                raise kaitaistruct.ConsistencyError(u"mesh_groups", self.num_mesh_groups, len(self.mesh_groups))
+            for i in range(len(self.mesh_groups)):
+                pass
+                if self.mesh_groups[i]._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"mesh_groups", self._root, self.mesh_groups[i]._root)
+                if self.mesh_groups[i]._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"mesh_groups", self, self.mesh_groups[i]._parent)
+
+            self._dirty = False
+
+
+    class ModelInfo(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineMesh.ModelInfo, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_model_offsets = False
+            self.model_offsets__enabled = True
+
+        def _read(self):
+            self.len_offsets_models = self._io.read_u1()
+            self.num_materials = self._io.read_u1()
+            self.num_uv_layers = self._io.read_u1()
+            self.num_skin_weights = self._io.read_u1()
+            self.num_meshes = self._io.read_u4le()
+            if self._root.version == 386270720:
+                pass
+                self.reserved_01 = self._io.read_u8le()
+
+            self.box = []
+            for i in range(12):
+                self.box.append(self._io.read_f4le())
+
+            self.offset_lod_info = self._io.read_u4le()
+            self.reserved_02 = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            if self._root.version == 386270720:
+                pass
+
+            for i in range(len(self.box)):
+                pass
+
+            _ = self.model_offsets
+            if hasattr(self, '_m_model_offsets'):
+                pass
+                for i in range(len(self._m_model_offsets)):
+                    pass
+                    self._m_model_offsets[i]._fetch_instances()
+
+
+
+
+        def _write__seq(self, io=None):
+            super(ReengineMesh.ModelInfo, self)._write__seq(io)
+            self._should_write_model_offsets = self.model_offsets__enabled
+            self._io.write_u1(self.len_offsets_models)
+            self._io.write_u1(self.num_materials)
+            self._io.write_u1(self.num_uv_layers)
+            self._io.write_u1(self.num_skin_weights)
+            self._io.write_u4le(self.num_meshes)
+            if self._root.version == 386270720:
+                pass
+                self._io.write_u8le(self.reserved_01)
+
+            for i in range(len(self.box)):
+                pass
+                self._io.write_f4le(self.box[i])
+
+            self._io.write_u4le(self.offset_lod_info)
+            self._io.write_u4le(self.reserved_02)
+
+
+        def _check(self):
+            if self._root.version == 386270720:
+                pass
+
+            if len(self.box) != 12:
+                raise kaitaistruct.ConsistencyError(u"box", 12, len(self.box))
+            for i in range(len(self.box)):
+                pass
+
+            if self.model_offsets__enabled:
+                pass
+                if len(self._m_model_offsets) != self.len_offsets_models:
+                    raise kaitaistruct.ConsistencyError(u"model_offsets", self.len_offsets_models, len(self._m_model_offsets))
+                for i in range(len(self._m_model_offsets)):
+                    pass
+                    if self._m_model_offsets[i]._root != self._root:
+                        raise kaitaistruct.ConsistencyError(u"model_offsets", self._root, self._m_model_offsets[i]._root)
+                    if self._m_model_offsets[i]._parent != self:
+                        raise kaitaistruct.ConsistencyError(u"model_offsets", self, self._m_model_offsets[i]._parent)
+
+
+            self._dirty = False
+
+        @property
+        def model_offsets(self):
+            if self._should_write_model_offsets:
+                self._write_model_offsets()
+            if hasattr(self, '_m_model_offsets'):
+                return self._m_model_offsets
+
+            if not self.model_offsets__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self.offset_lod_info)
+            self._m_model_offsets = []
+            for i in range(self.len_offsets_models):
+                _t__m_model_offsets = ReengineMesh.ModelOffset(self._io, self, self._root)
+                try:
+                    _t__m_model_offsets._read()
+                finally:
+                    self._m_model_offsets.append(_t__m_model_offsets)
+
+            self._io.seek(_pos)
+            return getattr(self, '_m_model_offsets', None)
+
+        @model_offsets.setter
+        def model_offsets(self, v):
+            self._dirty = True
+            self._m_model_offsets = v
+
+        def _write_model_offsets(self):
+            self._should_write_model_offsets = False
+            _pos = self._io.pos()
+            self._io.seek(self.offset_lod_info)
+            for i in range(len(self._m_model_offsets)):
+                pass
+                self._m_model_offsets[i]._write__seq(self._io)
+
+            self._io.seek(_pos)
+
+
+    class ModelOffset(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineMesh.ModelOffset, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_model = False
+            self.model__enabled = True
+
+        def _read(self):
+            self.offset = self._io.read_u8le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.model
+            if hasattr(self, '_m_model'):
+                pass
+                self._m_model._fetch_instances()
+
+
+
+        def _write__seq(self, io=None):
+            super(ReengineMesh.ModelOffset, self)._write__seq(io)
+            self._should_write_model = self.model__enabled
+            self._io.write_u8le(self.offset)
+
+
+        def _check(self):
+            if self.model__enabled:
+                pass
+                if self._m_model._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"model", self._root, self._m_model._root)
+                if self._m_model._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"model", self, self._m_model._parent)
+
+            self._dirty = False
+
+        @property
+        def model(self):
+            if self._should_write_model:
+                self._write_model()
+            if hasattr(self, '_m_model'):
+                return self._m_model
+
+            if not self.model__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self.offset)
+            self._m_model = ReengineMesh.Model(self._io, self, self._root)
+            self._m_model._read()
+            self._io.seek(_pos)
+            return getattr(self, '_m_model', None)
+
+        @model.setter
+        def model(self, v):
+            self._dirty = True
+            self._m_model = v
+
+        def _write_model(self):
+            self._should_write_model = False
+            _pos = self._io.pos()
+            self._io.seek(self.offset)
+            self._m_model._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    class NameOffset(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineMesh.NameOffset, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_name = False
+            self.name__enabled = True
+
+        def _read(self):
+            self.offset = self._io.read_u8le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.name
+            if hasattr(self, '_m_name'):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(ReengineMesh.NameOffset, self)._write__seq(io)
+            self._should_write_name = self.name__enabled
+            self._io.write_u8le(self.offset)
+
+
+        def _check(self):
+            if self.name__enabled:
+                pass
+                if KaitaiStream.byte_array_index_of((self._m_name).encode(u"ASCII"), 0) != -1:
+                    raise kaitaistruct.ConsistencyError(u"name", -1, KaitaiStream.byte_array_index_of((self._m_name).encode(u"ASCII"), 0))
+
+            self._dirty = False
+
+        @property
+        def name(self):
+            if self._should_write_name:
+                self._write_name()
+            if hasattr(self, '_m_name'):
+                return self._m_name
+
+            if not self.name__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self.offset)
+            self._m_name = (self._io.read_bytes_term(0, False, True, True)).decode(u"ASCII")
             self._io.seek(_pos)
             return getattr(self, '_m_name', None)
 
+        @name.setter
+        def name(self, v):
+            self._dirty = True
+            self._m_name = v
 
-    @property
-    def buffers_data(self):
-        if hasattr(self, '_m_buffers_data'):
-            return self._m_buffers_data
+        def _write_name(self):
+            self._should_write_name = False
+            _pos = self._io.pos()
+            self._io.seek(self.offset)
+            self._io.write_bytes((self._m_name).encode(u"ASCII"))
+            self._io.write_u1(0)
+            self._io.seek(_pos)
 
-        _pos = self._io.pos()
-        self._io.seek(self.header.offset_buffers_header)
-        self._m_buffers_data = ReengineMesh.BuffersHeader(self._io, self, self._root)
-        self._io.seek(_pos)
-        return getattr(self, '_m_buffers_data', None)
 
-    @property
-    def named_nodes(self):
-        if hasattr(self, '_m_named_nodes'):
-            return self._m_named_nodes
+    class PrimitiveAccessor(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineMesh.PrimitiveAccessor, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
 
-        _pos = self._io.pos()
-        self._io.seek(self.header.offset_names)
-        self._m_named_nodes = []
-        for i in range(self.header.num_named_nodes):
-            self._m_named_nodes.append(ReengineMesh.TestName(self._io, self, self._root))
+        def _read(self):
+            self.primitive_type = self._io.read_u2le()
+            self.size = self._io.read_u2le()
+            self.offset = self._io.read_u4le()
+            self._dirty = False
 
-        self._io.seek(_pos)
-        return getattr(self, '_m_named_nodes', None)
 
-    @property
-    def model_info(self):
-        if hasattr(self, '_m_model_info'):
-            return self._m_model_info
+        def _fetch_instances(self):
+            pass
 
-        _pos = self._io.pos()
-        self._io.seek(self.header.offset_data)
-        self._m_model_info = ReengineMesh.ModelInfo(self._io, self, self._root)
-        self._io.seek(_pos)
-        return getattr(self, '_m_model_info', None)
+
+        def _write__seq(self, io=None):
+            super(ReengineMesh.PrimitiveAccessor, self)._write__seq(io)
+            self._io.write_u2le(self.primitive_type)
+            self._io.write_u2le(self.size)
+            self._io.write_u4le(self.offset)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class TestName(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineMesh.TestName, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+            self._should_write_value = False
+            self.value__enabled = True
+
+        def _read(self):
+            self.offset = self._io.read_u8le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.value
+            if hasattr(self, '_m_value'):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(ReengineMesh.TestName, self)._write__seq(io)
+            self._should_write_value = self.value__enabled
+            self._io.write_u8le(self.offset)
+
+
+        def _check(self):
+            if self.value__enabled:
+                pass
+                if KaitaiStream.byte_array_index_of((self._m_value).encode(u"ASCII"), 0) != -1:
+                    raise kaitaistruct.ConsistencyError(u"value", -1, KaitaiStream.byte_array_index_of((self._m_value).encode(u"ASCII"), 0))
+
+            self._dirty = False
+
+        @property
+        def value(self):
+            if self._should_write_value:
+                self._write_value()
+            if hasattr(self, '_m_value'):
+                return self._m_value
+
+            if not self.value__enabled:
+                return None
+
+            _pos = self._io.pos()
+            self._io.seek(self.offset)
+            self._m_value = (self._io.read_bytes_term(0, False, True, True)).decode(u"ASCII")
+            self._io.seek(_pos)
+            return getattr(self, '_m_value', None)
+
+        @value.setter
+        def value(self, v):
+            self._dirty = True
+            self._m_value = v
+
+        def _write_value(self):
+            self._should_write_value = False
+            _pos = self._io.pos()
+            self._io.seek(self.offset)
+            self._io.write_bytes((self._m_value).encode(u"ASCII"))
+            self._io.write_u1(0)
+            self._io.seek(_pos)
+
+
+    class Vec4(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineMesh.Vec4, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.x = self._io.read_f4le()
+            self.y = self._io.read_f4le()
+            self.z = self._io.read_f4le()
+            self.w = self._io.read_f4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(ReengineMesh.Vec4, self)._write__seq(io)
+            self._io.write_f4le(self.x)
+            self._io.write_f4le(self.y)
+            self._io.write_f4le(self.z)
+            self._io.write_f4le(self.w)
+
+
+        def _check(self):
+            self._dirty = False
+
 
     @property
     def bones_header(self):
+        if self._should_write_bones_header:
+            self._write_bones_header()
         if hasattr(self, '_m_bones_header'):
             return self._m_bones_header
 
+        if not self.bones_header__enabled:
+            return None
+
         if self.header.offset_bones != 0:
+            pass
             _pos = self._io.pos()
             self._io.seek(self.header.offset_bones)
             self._m_bones_header = ReengineMesh.BoneHeader(self._io, self, self._root)
+            self._m_bones_header._read()
             self._io.seek(_pos)
 
         return getattr(self, '_m_bones_header', None)
 
+    @bones_header.setter
+    def bones_header(self, v):
+        self._dirty = True
+        self._m_bones_header = v
+
+    def _write_bones_header(self):
+        self._should_write_bones_header = False
+        if self.header.offset_bones != 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_bones)
+            self._m_bones_header._write__seq(self._io)
+            self._io.seek(_pos)
+
+
+    @property
+    def buffers_data(self):
+        if self._should_write_buffers_data:
+            self._write_buffers_data()
+        if hasattr(self, '_m_buffers_data'):
+            return self._m_buffers_data
+
+        if not self.buffers_data__enabled:
+            return None
+
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_buffers_header)
+        self._m_buffers_data = ReengineMesh.BuffersHeader(self._io, self, self._root)
+        self._m_buffers_data._read()
+        self._io.seek(_pos)
+        return getattr(self, '_m_buffers_data', None)
+
+    @buffers_data.setter
+    def buffers_data(self, v):
+        self._dirty = True
+        self._m_buffers_data = v
+
+    def _write_buffers_data(self):
+        self._should_write_buffers_data = False
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_buffers_header)
+        self._m_buffers_data._write__seq(self._io)
+        self._io.seek(_pos)
+
     @property
     def id_to_names_remap(self):
+        if self._should_write_id_to_names_remap:
+            self._write_id_to_names_remap()
         if hasattr(self, '_m_id_to_names_remap'):
             return self._m_id_to_names_remap
+
+        if not self.id_to_names_remap__enabled:
+            return None
 
         _pos = self._io.pos()
         self._io.seek(self.header.offset_test_remap)
@@ -478,5 +1434,87 @@ class ReengineMesh(KaitaiStruct):
 
         self._io.seek(_pos)
         return getattr(self, '_m_id_to_names_remap', None)
+
+    @id_to_names_remap.setter
+    def id_to_names_remap(self, v):
+        self._dirty = True
+        self._m_id_to_names_remap = v
+
+    def _write_id_to_names_remap(self):
+        self._should_write_id_to_names_remap = False
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_test_remap)
+        for i in range(len(self._m_id_to_names_remap)):
+            pass
+            self._io.write_u2le(self._m_id_to_names_remap[i])
+
+        self._io.seek(_pos)
+
+    @property
+    def model_info(self):
+        if self._should_write_model_info:
+            self._write_model_info()
+        if hasattr(self, '_m_model_info'):
+            return self._m_model_info
+
+        if not self.model_info__enabled:
+            return None
+
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_data)
+        self._m_model_info = ReengineMesh.ModelInfo(self._io, self, self._root)
+        self._m_model_info._read()
+        self._io.seek(_pos)
+        return getattr(self, '_m_model_info', None)
+
+    @model_info.setter
+    def model_info(self, v):
+        self._dirty = True
+        self._m_model_info = v
+
+    def _write_model_info(self):
+        self._should_write_model_info = False
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_data)
+        self._m_model_info._write__seq(self._io)
+        self._io.seek(_pos)
+
+    @property
+    def named_nodes(self):
+        if self._should_write_named_nodes:
+            self._write_named_nodes()
+        if hasattr(self, '_m_named_nodes'):
+            return self._m_named_nodes
+
+        if not self.named_nodes__enabled:
+            return None
+
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_names)
+        self._m_named_nodes = []
+        for i in range(self.header.num_named_nodes):
+            _t__m_named_nodes = ReengineMesh.TestName(self._io, self, self._root)
+            try:
+                _t__m_named_nodes._read()
+            finally:
+                self._m_named_nodes.append(_t__m_named_nodes)
+
+        self._io.seek(_pos)
+        return getattr(self, '_m_named_nodes', None)
+
+    @named_nodes.setter
+    def named_nodes(self, v):
+        self._dirty = True
+        self._m_named_nodes = v
+
+    def _write_named_nodes(self):
+        self._should_write_named_nodes = False
+        _pos = self._io.pos()
+        self._io.seek(self.header.offset_names)
+        for i in range(len(self._m_named_nodes)):
+            pass
+            self._m_named_nodes[i]._write__seq(self._io)
+
+        self._io.seek(_pos)
 
 

--- a/albam/engines/reng/structs/reengine_tex.py
+++ b/albam/engines/reng/structs/reengine_tex.py
@@ -1,18 +1,18 @@
 # This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
+# type: ignore
 
 import kaitaistruct
-from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
+from kaitaistruct import ReadWriteKaitaiStruct, KaitaiStream, BytesIO
 
 
-if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 11):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.11 or later is required, but you have %s" % (kaitaistruct.__version__))
 
-class ReengineTex(KaitaiStruct):
-    def __init__(self, _io, _parent=None, _root=None):
-        self._io = _io
+class ReengineTex(ReadWriteKaitaiStruct):
+    def __init__(self, _io=None, _parent=None, _root=None):
+        super(ReengineTex, self).__init__(_io)
         self._parent = _parent
-        self._root = _root if _root else self
-        self._read()
+        self._root = _root or self
 
     def _read(self):
         self.ident = self._io.read_bytes(4)
@@ -24,42 +24,192 @@ class ReengineTex(KaitaiStruct):
         self.unk_00 = self._io.read_u2le()
         _on = self.version
         if _on == 10:
+            pass
             self.mipmap_header = ReengineTex.MipmapHeader1(self._io, self, self._root)
+            self.mipmap_header._read()
         elif _on == 190820018:
+            pass
             self.mipmap_header = ReengineTex.MipmapHeader1(self._io, self, self._root)
+            self.mipmap_header._read()
         elif _on == 30:
+            pass
             self.mipmap_header = ReengineTex.MipmapHeader2(self._io, self, self._root)
+            self.mipmap_header._read()
         elif _on == 34:
+            pass
             self.mipmap_header = ReengineTex.MipmapHeader2(self._io, self, self._root)
+            self.mipmap_header._read()
         self.format = self._io.read_u4le()
         self.unk_02 = self._io.read_u4le()
         self.unk_03 = self._io.read_u4le()
         self.unk_04 = self._io.read_u4le()
         if  ((self.version == 30) or (self.version == 34)) :
+            pass
             self.unk_05 = self._io.read_u8le()
 
         self.mipmaps = []
         for i in range((self.mipmap_header.num_mipmaps if  ((self.version == 10) or (self.version == 190820018))  else self.mipmap_header.num_mipmaps)):
-            self.mipmaps.append(ReengineTex.MipmapData(self._io, self, self._root))
+            _t_mipmaps = ReengineTex.MipmapData(self._io, self, self._root)
+            try:
+                _t_mipmaps._read()
+            finally:
+                self.mipmaps.append(_t_mipmaps)
+
+        self._dirty = False
 
 
-    class MipmapData(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+    def _fetch_instances(self):
+        pass
+        _on = self.version
+        if _on == 10:
+            pass
+            self.mipmap_header._fetch_instances()
+        elif _on == 190820018:
+            pass
+            self.mipmap_header._fetch_instances()
+        elif _on == 30:
+            pass
+            self.mipmap_header._fetch_instances()
+        elif _on == 34:
+            pass
+            self.mipmap_header._fetch_instances()
+        if  ((self.version == 30) or (self.version == 34)) :
+            pass
+
+        for i in range(len(self.mipmaps)):
+            pass
+            self.mipmaps[i]._fetch_instances()
+
+
+
+    def _write__seq(self, io=None):
+        super(ReengineTex, self)._write__seq(io)
+        self._io.write_bytes(self.ident)
+        self._io.write_u4le(self.version)
+        self._io.write_u2le(self.width)
+        self._io.write_u2le(self.height)
+        self._io.write_u2le(self.unk_00)
+        _on = self.version
+        if _on == 10:
+            pass
+            self.mipmap_header._write__seq(self._io)
+        elif _on == 190820018:
+            pass
+            self.mipmap_header._write__seq(self._io)
+        elif _on == 30:
+            pass
+            self.mipmap_header._write__seq(self._io)
+        elif _on == 34:
+            pass
+            self.mipmap_header._write__seq(self._io)
+        self._io.write_u4le(self.format)
+        self._io.write_u4le(self.unk_02)
+        self._io.write_u4le(self.unk_03)
+        self._io.write_u4le(self.unk_04)
+        if  ((self.version == 30) or (self.version == 34)) :
+            pass
+            self._io.write_u8le(self.unk_05)
+
+        for i in range(len(self.mipmaps)):
+            pass
+            self.mipmaps[i]._write__seq(self._io)
+
+
+
+    def _check(self):
+        if len(self.ident) != 4:
+            raise kaitaistruct.ConsistencyError(u"ident", 4, len(self.ident))
+        if not self.ident == b"\x54\x45\x58\x00":
+            raise kaitaistruct.ValidationNotEqualError(b"\x54\x45\x58\x00", self.ident, None, u"/seq/0")
+        _on = self.version
+        if _on == 10:
+            pass
+            if self.mipmap_header._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"mipmap_header", self._root, self.mipmap_header._root)
+            if self.mipmap_header._parent != self:
+                raise kaitaistruct.ConsistencyError(u"mipmap_header", self, self.mipmap_header._parent)
+        elif _on == 190820018:
+            pass
+            if self.mipmap_header._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"mipmap_header", self._root, self.mipmap_header._root)
+            if self.mipmap_header._parent != self:
+                raise kaitaistruct.ConsistencyError(u"mipmap_header", self, self.mipmap_header._parent)
+        elif _on == 30:
+            pass
+            if self.mipmap_header._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"mipmap_header", self._root, self.mipmap_header._root)
+            if self.mipmap_header._parent != self:
+                raise kaitaistruct.ConsistencyError(u"mipmap_header", self, self.mipmap_header._parent)
+        elif _on == 34:
+            pass
+            if self.mipmap_header._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"mipmap_header", self._root, self.mipmap_header._root)
+            if self.mipmap_header._parent != self:
+                raise kaitaistruct.ConsistencyError(u"mipmap_header", self, self.mipmap_header._parent)
+        if  ((self.version == 30) or (self.version == 34)) :
+            pass
+
+        if len(self.mipmaps) != (self.mipmap_header.num_mipmaps if  ((self.version == 10) or (self.version == 190820018))  else self.mipmap_header.num_mipmaps):
+            raise kaitaistruct.ConsistencyError(u"mipmaps", (self.mipmap_header.num_mipmaps if  ((self.version == 10) or (self.version == 190820018))  else self.mipmap_header.num_mipmaps), len(self.mipmaps))
+        for i in range(len(self.mipmaps)):
+            pass
+            if self.mipmaps[i]._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"mipmaps", self._root, self.mipmaps[i]._root)
+            if self.mipmaps[i]._parent != self:
+                raise kaitaistruct.ConsistencyError(u"mipmaps", self, self.mipmaps[i]._parent)
+
+        self._dirty = False
+
+    class MipmapData(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineTex.MipmapData, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
+            self._should_write_dds_data = False
+            self.dds_data__enabled = True
 
         def _read(self):
             self.ofs_data = self._io.read_u4le()
             self.unk_01 = self._io.read_u4le()
             self.unk_02 = self._io.read_u4le()
             self.size_data = self._io.read_u4le()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            _ = self.dds_data
+            if hasattr(self, '_m_dds_data'):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(ReengineTex.MipmapData, self)._write__seq(io)
+            self._should_write_dds_data = self.dds_data__enabled
+            self._io.write_u4le(self.ofs_data)
+            self._io.write_u4le(self.unk_01)
+            self._io.write_u4le(self.unk_02)
+            self._io.write_u4le(self.size_data)
+
+
+        def _check(self):
+            if self.dds_data__enabled:
+                pass
+                if len(self._m_dds_data) != self.size_data:
+                    raise kaitaistruct.ConsistencyError(u"dds_data", self.size_data, len(self._m_dds_data))
+
+            self._dirty = False
 
         @property
         def dds_data(self):
+            if self._should_write_dds_data:
+                self._write_dds_data()
             if hasattr(self, '_m_dds_data'):
                 return self._m_dds_data
+
+            if not self.dds_data__enabled:
+                return None
 
             _pos = self._io.pos()
             self._io.seek(self.ofs_data)
@@ -67,29 +217,69 @@ class ReengineTex(KaitaiStruct):
             self._io.seek(_pos)
             return getattr(self, '_m_dds_data', None)
 
+        @dds_data.setter
+        def dds_data(self, v):
+            self._dirty = True
+            self._m_dds_data = v
 
-    class MipmapHeader1(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+        def _write_dds_data(self):
+            self._should_write_dds_data = False
+            _pos = self._io.pos()
+            self._io.seek(self.ofs_data)
+            self._io.write_bytes(self._m_dds_data)
+            self._io.seek(_pos)
+
+
+    class MipmapHeader1(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineTex.MipmapHeader1, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
 
         def _read(self):
             self.num_mipmaps = self._io.read_u1()
             self.num_images = self._io.read_u1()
+            self._dirty = False
 
 
-    class MipmapHeader2(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(ReengineTex.MipmapHeader1, self)._write__seq(io)
+            self._io.write_u1(self.num_mipmaps)
+            self._io.write_u1(self.num_images)
+
+
+        def _check(self):
+            self._dirty = False
+
+
+    class MipmapHeader2(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(ReengineTex.MipmapHeader2, self).__init__(_io)
             self._parent = _parent
-            self._root = _root if _root else self
-            self._read()
+            self._root = _root
 
         def _read(self):
             self.num_images = self._io.read_u1()
             self.size_mipmap_header = self._io.read_u1()
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(ReengineTex.MipmapHeader2, self)._write__seq(io)
+            self._io.write_u1(self.num_images)
+            self._io.write_u1(self.size_mipmap_header)
+
+
+        def _check(self):
+            self._dirty = False
 
         @property
         def num_mipmaps(self):
@@ -99,5 +289,7 @@ class ReengineTex(KaitaiStruct):
             self._m_num_mipmaps = self.size_mipmap_header // 16
             return getattr(self, '_m_num_mipmaps', None)
 
+        def _invalidate_num_mipmaps(self):
+            del self._m_num_mipmaps
 
 

--- a/albam/engines/reng/structs/tex.ksy
+++ b/albam/engines/reng/structs/tex.ksy
@@ -4,7 +4,7 @@ meta:
   title: RE Engine texture format
   file-extension: tex
   license: CC0-1.0
-  ks-version: 0.8
+  ks-version: '0.11'
 
 
 seq:

--- a/albam/engines/reng/texture.py
+++ b/albam/engines/reng/texture.py
@@ -31,6 +31,7 @@ def import_texture(file_list_item, context):
 
     tex_bytes = file_list_item.get_bytes()
     tex = ReengineTex(KaitaiStream(io.BytesIO(tex_bytes)))
+    tex._read()
 
     dds_data = tex.mipmaps[0].dds_data
     pixel_bytes = unpack_dds(io.BytesIO(dds_data), tex.width, tex.height, 'BC7', 0)
@@ -69,6 +70,7 @@ def build_blender_images(app_id, texture_headers, context):
         try:
             tex_bytes = tex_virtual_file.get_bytes()
             tex = ReengineTex(KaitaiStream(io.BytesIO(tex_bytes)))
+            tex._read()
 
             if tex.format == 98 or tex.format == 99:
                 tex_format = "BC7"

--- a/tests/mtfw/test_lmt_parsing.py
+++ b/tests/mtfw/test_lmt_parsing.py
@@ -44,7 +44,9 @@ def parsed_lmt(game_fs_root, local_lmt_path_hash):
     path = resolve_hashes(game_fs_root, {local_lmt_path_hash})[local_lmt_path_hash]
     src_bytes = game_fs_root.readbytes(path)
 
-    return Lmt.from_bytes(src_bytes)
+    lmt = Lmt.from_bytes(src_bytes)
+    lmt._read()
+    return lmt
 
 
 SUPPORTED_LMT_VERSIONS = (51, 67)

--- a/tests/reng/test_mesh_parsing.py
+++ b/tests/reng/test_mesh_parsing.py
@@ -47,6 +47,7 @@ def parsed_mesh(pak_fs_root, local_mesh_path_hash):
     src_bytes = pak_fs_root.readbytes(path)
 
     parsed = ReengineMesh(KaitaiStream(io.BytesIO(src_bytes)))
+    parsed._read()
     return parsed, src_bytes
 
 

--- a/tests/reng/test_pak_fs_s3.py
+++ b/tests/reng/test_pak_fs_s3.py
@@ -11,8 +11,9 @@ commit real game asset bytes, even small ones), a real .pak is tens of GB
 anyway, and this file is meant to stay fully self-contained/network-free -
 same rationale as tests/mtfw/test_arc_fs_s3.py, which this mirrors.
 
-Pak.FileEntry (structs/pak.py) has no generated _write() (unlike Arc), so
-the bytes are packed by hand via struct - the layout (see pak_fs.py's
+The bytes are packed by hand via struct rather than through Pak's own
+generated writer: building a fixture with the same parser the test is
+exercising would make it agree with itself. The layout (see pak_fs.py's
 HEADER_SIZE/FILE_ENTRY_SIZE) is simple enough that isn't a real burden.
 """
 import os

--- a/tests/test_generated_structs.py
+++ b/tests/test_generated_structs.py
@@ -1,0 +1,116 @@
+"""
+Guards on the Kaitai Struct toolchain itself, rather than on any one
+format: the .ksy sources have to keep compiling, and the generated code
+has to keep exposing the handful of names albam assigns to by hand.
+
+Both failures this protects against are silent. A .ksy that no longer
+compiles is only noticed by whoever next tries to regenerate it, and a
+renamed attribute on a generated class is not an error in Python at all -
+`mesh.vertices__enabled = False` against a class that has since renamed
+that attribute just creates a new one and writes the buffer anyway. That
+rename has already happened once, between the 0.11 pre-release and the
+0.11 release (`__to_write` -> `__enabled`).
+"""
+import os
+import shutil
+import subprocess
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ENGINES_DIR = os.path.join(REPO_ROOT, "albam", "engines")
+COMPILER = "kaitai-struct-compiler"
+
+# Names albam assigns to on a generated Mesh to keep a lazily-written
+# buffer from being serialized twice (albam/engines/mtfw/mesh.py). Listed
+# per app_id because they only exist for fields the format actually has -
+# mod 21 has no second vertex buffer, so nothing there defines
+# `vertices2__enabled`, and albam's unconditional assignment to it is a
+# no-op for that version.
+WRITE_CONTROL_ATTRS = {
+    "re5": ("indices__enabled", "vertices__enabled", "vertices2__enabled"),
+    "re1": ("indices__enabled", "vertices__enabled"),
+}
+
+# Every parser is generated with `-w`/`--read-write`, including the formats
+# albam only reads today, so there is one regeneration command rather than a
+# per-file split nothing in the .ksy records. The cost is that `-w` implies
+# `--no-auto-read`: constructing a parser no longer parses anything, and
+# every caller has to follow it with an explicit `_read()`.
+
+
+def _ksy_files():
+    found = []
+    for root, _, files in os.walk(ENGINES_DIR):
+        found.extend(os.path.join(root, f) for f in files if f.endswith(".ksy"))
+    return sorted(found)
+
+
+def test_ksy_files_are_found():
+    """Guards the two tests below against silently passing on an empty set
+    if the structs ever move."""
+    assert len(_ksy_files()) > 15
+
+
+@pytest.mark.skipif(shutil.which(COMPILER) is None, reason=f"{COMPILER} not installed")
+def test_every_ksy_file_compiles(tmp_path):
+    """`ks-version: 0.10` unquoted is read by YAML as the float 0.1, which
+    the compiler rejects as below its minimum supported version - so a
+    struct can stop compiling without anything in the repo changing. Quoted
+    versions avoid it; this keeps them that way.
+    """
+    result = subprocess.run(
+        [COMPILER, "--target", "python", "-w", "--outdir", str(tmp_path), *_ksy_files()],
+        capture_output=True,
+        text=True,
+    )
+    errors = [ln for ln in (result.stdout + result.stderr).splitlines() if "error" in ln.lower()]
+    assert not errors, "\n".join(errors)
+    assert result.returncode == 0
+
+
+@pytest.mark.parametrize("app_id", sorted(WRITE_CONTROL_ATTRS))
+def test_generated_meshes_keep_their_write_control_attributes(app_id):
+    """albam/engines/mtfw/mesh.py turns off lazy writing for buffers it
+    serializes itself by assigning to `<field>__enabled`. The compiler has
+    renamed these once already (`__to_write` before the 0.11 release), and
+    because assigning an unknown attribute is legal Python, a rename would
+    leave export running while silently writing those buffers twice. Fail
+    here instead.
+    """
+    from albam.engines.mtfw.mesh import APPID_CLASS_MAPPER
+    from kaitaistruct import BytesIO, KaitaiStream
+
+    mesh = APPID_CLASS_MAPPER[app_id].Mesh(KaitaiStream(BytesIO(b"")), None, None)
+    missing = [name for name in WRITE_CONTROL_ATTRS[app_id] if not hasattr(mesh, name)]
+    assert not missing, (
+        f"{APPID_CLASS_MAPPER[app_id].__name__}.Mesh no longer defines {missing}. If the structs "
+        f"were regenerated, update both these names and the assignments in mtfw/mesh.py together."
+    )
+
+
+def _generated_parsers():
+    found = []
+    for root, _, files in os.walk(ENGINES_DIR):
+        if os.path.basename(root) != "structs":
+            continue
+        for name in files:
+            if name.endswith(".py") and name != "__init__.py":
+                found.append(os.path.relpath(os.path.join(root, name), REPO_ROOT))
+    return sorted(found)
+
+
+def test_every_parser_is_generated_read_write():
+    """One regeneration command for the whole tree, so nothing depends on
+    remembering which formats albam happens to serialize today. A parser
+    regenerated without `-w` still imports and still reads - it just has no
+    `_write()`, so exporting that format breaks whenever someone adds it.
+    """
+    read_only = []
+    for parser in _generated_parsers():
+        with open(os.path.join(REPO_ROOT, parser)) as f:
+            if "_write__seq" not in f.read():
+                read_only.append(parser)
+    assert not read_only, (
+        "generated without -w/--read-write:\n  " + "\n  ".join(read_only)
+    )


### PR DESCRIPTION
## Summary

The generated Kaitai parsers had drifted from the `.ksy` sources they come from, in a way that made
regenerating any of them either impossible or quietly destructive. This regenerates all 19 with the
0.11 release compiler, uniformly, and pins the things that made it risky.

**The tree was a mix of two compilers.** `nav_156.py` and the three `sbc_*.py` were already 0.11
release output; everything else came from a 0.11 pre-release build. Recompiling `mod_156.ksy`
unchanged rewrote 3030 lines, almost all of it that difference rather than anything intended.

**Ten `.ksy` files could not be compiled at all.** `ks-version: 0.10` unquoted is read by YAML as
the float `0.1`:

```
mod-153.ksy: /meta/ks-version:
	error: minimum allowed version is 0.6, but got 0.1
```

Every `.ksy` now declares `ks-version: '0.11'`, quoted, matching the compiler that generates them.

## One command for the whole tree

Every parser is generated with `-w`/`--read-write`, including formats albam only reads today:

```
kaitai-struct-compiler --target python -w --outdir . <file>.ksy
```

The alternative was a per-file split - `-w` only where albam serializes - and it is a bad trade.
Nothing in a `.ksy` records which mode it wants, it depends on what albam happens to do with the
format that week, and getting it wrong is silent in both directions: without `-w` a format loses
`_write()` the moment someone adds exporting for it, and with `-w` a read-only parser stops parsing
at all, because it implies `--no-auto-read`:

```
AttributeError: 'Pak' object has no attribute 'file_entries'
```

So the ten call sites that were relying on auto-read - `lmt`, `mfx`, `pak` and the three `reng`
formats - now call `_read()` explicitly, which is what every already-read-write format was doing
anyway. That is the whole cost, and it makes the parse step visible at the call site instead of
implied by a compiler flag chosen somewhere else.

## The rename that would have been silent

The 0.11 release renames the lazy-write flags from `<field>__to_write` to `<field>__enabled`, and
`mtfw/mesh.py` assigns to those by hand to stop buffers it serializes itself from being written
twice. Assigning an attribute a class doesn't define raises nothing in Python, so left alone this
would have kept exporting running while double-writing the vertex and index buffers - which is why
this was worth doing deliberately rather than leaving for whoever regenerated next.

## Guards

`tests/test_generated_structs.py` turns each failure mode into a test failure:

- every `.ksy` still compiles (skipped where the compiler isn't installed, so CI stays green)
- every parser is generated read-write
- the generated `Mesh` classes keep the attribute names `mesh.py` assigns to

Each was verified to fail when it should, rather than assumed to work.

The README documents the single regeneration command and `--no-auto-read` as the one thing callers
have to know.

## Verification

- Full suite against local re5 + re1 installs: **105 passed, 0 failed** - the pre-regeneration
  baseline was 104 passed, the difference being this commit's own new test
- CI-safe subset: 63 passed
- `flake8` clean

## Notes

- The vendored runtime (`albam/albam_vendor/kaitaistruct.py`, `0.11.dev1`) is left alone: it reports
  `API_VERSION == (0, 11)` and satisfies the check the release-generated code makes, which the
  already-release-generated `sbc_*`/`nav_156` parsers had been demonstrating in production anyway.
- A comment in `tests/reng/test_pak_fs_s3.py` justified hand-packing its fixture by saying
  `Pak.FileEntry` has no generated `_write()`. It has one now, so the rationale is corrected to the
  real one: building a fixture with the parser under test would make it agree with itself.
- `mesh.py` sets `vertices2__enabled` unconditionally, but `Mod21.Mesh` has no such field - a silent
  no-op for that format version. Captured in a comment rather than changed.
