### PR TITLE
Stop swallowing failures, in operators and in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,10 +47,18 @@ jobs:
       run: |
         set +e
           R2_BUCKET_NAME="${R2_BUCKET_NAME//$'\n'/}"
+          export ALBAM_PYTEST_EXIT_STATUS_FILE="$RUNNER_TEMP/pytest-exit-status"
+          rm -f "$ALBAM_PYTEST_EXIT_STATUS_FILE"
           coverage run --data-file=.coverage.${{ matrix.bpy.bpy-version }} -m pytest --game-dir=re5::r2://"$R2_BUCKET_NAME"/re5 --game-dir=re1::r2://"$R2_BUCKET_NAME"/re1
         exitcode="$?"
-        # Ignore segfault in bpy==4.1.0; there's no way around it yet.
-        if  [ $exitcode == 139 ];then exitcode=0;
+        # bpy segfaults during interpreter finalization, so a 139 here says
+        # nothing about whether the run passed - it is what this job sees on
+        # every run, failing or not. Fall back to the status pytest recorded
+        # itself before that happened (tests/conftest.py). Discounting 139
+        # outright, which this used to do, reported 8 errors as a green build.
+        # No file means pytest died before finishing: keep 139 as a failure.
+        if [ "$exitcode" == 139 ]; then
+          exitcode="$(cat "$ALBAM_PYTEST_EXIT_STATUS_FILE" 2>/dev/null || echo 139)"
         fi
         exit "$exitcode"
     - name: "Upload coverage data"

--- a/albam/blender_ui/error_handling.py
+++ b/albam/blender_ui/error_handling.py
@@ -1,3 +1,4 @@
+import os
 from platform import platform
 import traceback
 from pathlib import Path
@@ -8,6 +9,8 @@ import bpy
 from ..exceptions import AlbamCheckFailure
 from ..registry import blender_registry
 from ..__version__ import __version__ as albam_version
+
+RERAISE_ERRORS_ENV_VAR = "ALBAM_RERAISE_ERRORS"
 
 ERROR_TEMPLATE = """
 ==================
@@ -22,6 +25,51 @@ Traceback:
 {traceback_str}
 =================
 """
+
+
+def format_error_report(type_err, err, tb):
+    """The full report - versions, OS, redacted traceback - as a string.
+
+    Module level, and taking the exception explicitly, so callers outside a
+    popup can use it: the operator error handlers print it from their own
+    `except` blocks, which is the only way it reaches a console when Blender
+    runs in background mode (`INVOKE_DEFAULT` falls back to `execute()`
+    there, so the popup's `invoke()` never runs and its print never happens).
+    """
+    stack_summary = traceback.extract_tb(tb)
+    traceback_str = "".join(stack_summary.format())
+    traceback_str_home_redacted = traceback_str.replace(str(Path.home()), "******")
+    return ERROR_TEMPLATE.format(
+        blender_version=".".join(map(str, bpy.app.version)),
+        albam_version=albam_version,
+        operating_system=platform(),
+        error=f"{type_err.__name__}: {str(err)}",
+        traceback_str=traceback_str_home_redacted,
+    )
+
+
+def handle_operator_exception(operator, message):
+    """Shared tail for every operator `except` block: print the report, then
+    surface it to the user.
+
+    Call from inside the `except`, which is where sys.exc_info() is live.
+    Printing here rather than from the popup means the traceback survives
+    headless Blender and CI, where the popup never opens - the popup itself
+    tells users to "provide the error shown in the console", which until now
+    was empty for exactly those users.
+
+    With ALBAM_RERAISE_ERRORS set the exception is re-raised instead of being
+    turned into an operator report. Blender converts an {'ERROR'} report into
+    a bare RuntimeError carrying only `message`, which loses the traceback
+    and the exception type - fine for a user staring at a dialog, useless for
+    a test asserting on a failure. The test suite sets it (tests/conftest.py).
+    """
+    type_err, err, tb = sys.exc_info()
+    print(format_error_report(type_err, err, tb))
+    if os.environ.get(RERAISE_ERRORS_ENV_VAR):
+        raise err
+    operator.report({"ERROR"}, f"{message}: {type_err.__name__}: {err}")
+    bpy.ops.albam.error_handler_popup("INVOKE_DEFAULT")
 
 
 @blender_registry.register_blender_type
@@ -85,19 +133,7 @@ class ALBAM_OT_ErrorHandler(bpy.types.Operator):
 
     @staticmethod
     def _generate_error_report(type_err, err, tb):
-        type_err, err, tb = sys.exc_info()
-        stack_summary = traceback.extract_tb(tb)
-        traceback_str = "".join(stack_summary.format())
-        traceback_str_home_redacted = traceback_str.replace(str(Path.home()), "******")
-        error = ERROR_TEMPLATE.format(
-            blender_version=".".join(map(str, bpy.app.version)),
-            albam_version=albam_version,
-            operating_system=platform(),
-            error=f"{type_err.__name__}: {str(err)}",
-            traceback_str=traceback_str_home_redacted,
-        )
-
-        return error
+        return format_error_report(type_err, err, tb)
 
     def _calculate_popup_width(self):
         using_space = (

--- a/albam/blender_ui/export_panel.py
+++ b/albam/blender_ui/export_panel.py
@@ -3,6 +3,7 @@ import os
 import bpy
 
 from ..lib import fs_registry
+from .error_handling import handle_operator_exception
 from ..registry import blender_registry
 from ..vfs import (
     ALBAM_OT_VirtualFileSystemSaveFileBase,
@@ -286,8 +287,7 @@ class ALBAM_OT_Export(bpy.types.Operator):
         try:
             self._execute(context, item)
         except Exception:
-            self.report({'ERROR'}, 'Import failed')
-            bpy.ops.albam.error_handler_popup("INVOKE_DEFAULT")
+            handle_operator_exception(self, "Export failed")
             return {"CANCELLED"}
         self.report({'INFO'}, 'Export successful')
         return {"FINISHED"}
@@ -359,7 +359,8 @@ class ALBAM_OT_Pack(bpy.types.Operator):
         try:
             self._execute(context)
         except Exception:
-            bpy.ops.albam.error_handler_popup("INVOKE_DEFAULT")
+            handle_operator_exception(self, "Pack failed")
+            return {"CANCELLED"}
         return {"FINISHED"}
 
     def _execute(self, context):  # pragma: no cover
@@ -451,7 +452,8 @@ class ALBAM_OT_Patch(bpy.types.Operator):
         try:
             self._execute(context)
         except Exception:
-            bpy.ops.albam.error_handler_popup("INVOKE_DEFAULT")
+            handle_operator_exception(self, "Patch failed")
+            return {"CANCELLED"}
         return {"FINISHED"}
 
     def _execute(self, context):

--- a/albam/blender_ui/import_panel.py
+++ b/albam/blender_ui/import_panel.py
@@ -1,6 +1,7 @@
 import bpy
 
 from ..apps import APPS, REENGINE_APPS
+from .error_handling import handle_operator_exception
 from ..registry import blender_registry
 from ..vfs import ALBAM_OT_VirtualFileSystemCollapseToggle, VirtualFile
 from ..data_loading import AppsUserDataConfigManager
@@ -96,8 +97,7 @@ class ALBAM_OT_Import(bpy.types.Operator):
                 self._make_exportable(vfile, bl_object, context)
 
         except Exception:
-            self.report({'ERROR'}, 'Import failed')
-            bpy.ops.albam.error_handler_popup("INVOKE_DEFAULT")
+            handle_operator_exception(self, "Import failed")
             return {"CANCELLED"}
         self.report({'INFO'}, 'Import successful')
         return {"FINISHED"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,11 @@ from albam import register, unregister
 from albam.blender_ui.error_handling import RERAISE_ERRORS_ENV_VAR
 
 
+# Written by pytest_sessionfinish so CI can recover the real exit status when
+# the interpreter segfaults on the way out - see the comment there.
+EXIT_STATUS_FILE_ENV_VAR = "ALBAM_PYTEST_EXIT_STATUS_FILE"
+
+
 def pytest_sessionstart():
     # Operator error handlers turn any exception into an {'ERROR'} report,
     # which Blender re-raises as a bare RuntimeError carrying only the
@@ -18,7 +23,8 @@ def pytest_sessionstart():
     register()
 
 
-def pytest_sessionfinish():
+def pytest_sessionfinish(exitstatus):
+    _record_exit_status(exitstatus)
     unregister()
 
     # bpy (the pip package, not the full Blender application) segfaults
@@ -34,6 +40,29 @@ def pytest_sessionfinish():
     # existing handling (discounting exit code 139 - see
     # .github/workflows/tests.yml) is the right place to deal with the exit
     # code, not here.
+
+
+def _record_exit_status(exitstatus):
+    """Write pytest's own exit status to $ALBAM_PYTEST_EXIT_STATUS_FILE, if
+    set, before anything else in teardown runs.
+
+    bpy segfaults during interpreter finalization (see pytest_sessionfinish
+    above), so the shell that ran pytest sees 139 whether the run passed or
+    failed, and CI cannot tell the two apart from the exit code alone.
+    Discounting 139 outright - which is what the workflow used to do - turns
+    every real failure on an affected bpy version into a green build; it hid
+    8 errors on one half of the matrix. Recording the status here, while the
+    interpreter is still alive and pytest has already decided the outcome,
+    gives CI something trustworthy to fall back on.
+    """
+    path = os.environ.get(EXIT_STATUS_FILE_ENV_VAR)
+    if not path:
+        return
+    try:
+        with open(path, "w") as f:
+            f.write(str(int(exitstatus)))
+    except OSError as err:  # never let bookkeeping fail the run
+        print(f"Could not write {path!r}: {err}")
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,20 @@
+import os
+
 import pytest
 
 from albam import register, unregister
+from albam.blender_ui.error_handling import RERAISE_ERRORS_ENV_VAR
 
 
 def pytest_sessionstart():
+    # Operator error handlers turn any exception into an {'ERROR'} report,
+    # which Blender re-raises as a bare RuntimeError carrying only the
+    # handler's own message - no traceback, no exception type. Useless for a
+    # test: a broken export reported as "RuntimeError: Export failed"
+    # pointing at conftest says nothing about what actually broke. With this
+    # set, the handlers re-raise instead, so failures land on the line that
+    # caused them (see albam/blender_ui/error_handling.py).
+    os.environ[RERAISE_ERRORS_ENV_VAR] = "1"
     register()
 
 


### PR DESCRIPTION
## Summary

Two ways failures were being hidden, one in the addon and one in CI. Neither is about a specific
bug; both are about not being able to see one.

## 1. Operators swallowed the real exception

Every albam operator wraps its work in `except Exception`, reports an `{'ERROR'}` to Blender and
opens the error popup. Blender turns that report into a bare `RuntimeError` carrying only the
handler's own message, so the exception type, its message and its traceback are gone by the time
anyone - a user, a test, CI - sees anything. `tests/mtfw/conftest.py` has carried a
`# FIXME: won't capture failures` about exactly this.

Three things were wrong at once:

- **The export operator reported `'Import failed'`**, copy-pasted from the importer. That one wrong
  word sends readers into the wrong subsystem; it cost me a real detour.
- **The traceback only ever printed from the popup's `invoke()`**, which never runs in background
  mode: `INVOKE_DEFAULT` falls back to `execute()`, and the popup's `execute()` is
  `return {"FINISHED"}`. So the console the popup tells users to check - *"Please provide the error
  shown in the console"* - was empty for precisely the headless users who have nowhere else to
  look. Confirmed: zero occurrences of "Albam error report" in any headless run.
- **`ALBAM_OT_Pack` and `ALBAM_OT_Patch` caught the exception and returned `{"FINISHED"}`**,
  reporting success on failure.

`format_error_report()` moves to module level - and stops discarding the arguments it was handed,
which it overwrote with `sys.exc_info()` on its first line. All four handlers share
`handle_operator_exception()`, which prints the report *before* anything else, so it survives
headless Blender and CI. `ALBAM_RERAISE_ERRORS` (set by `tests/conftest.py`, off by default so GUI
behavior is unchanged) re-raises instead of flattening the exception. Pack and Patch return
`{"CANCELLED"}`.

### Verified before/after

Against a failure that exists on `main` right now, `test_export_header[re5-dd278c4da3cc1635]`.

Before - the entire output, with no mention of `mesh.py`, `_fetch_instances`, or any report:

```
E       RuntimeError: Error: Import failed
tests/mtfw/conftest.py:98: RuntimeError
```

After - the failure lands on the line that broke:

```
E         File ".../albam/engines/mtfw/structs/mod_156.py", line 96, in _fetch_instances
E           self._m_bones_data._fetch_instances()
E       AttributeError: 'NoneType' object has no attribute '_fetch_instances'
```

...and the console gets the report it was always meant to, `$HOME` redacted:

```
Albam error report
Blender version: 5.2.0
Albam version: 0.5.0
Error: AttributeError: 'NoneType' object has no attribute '_fetch_instances'
Traceback:
  File "******/albam/engines/mtfw/mesh.py", line 908, in export_mod
    dst_mod._write(stream)
```

## 2. CI reported failed runs as green

`bpy` segfaults during interpreter finalization on some versions, long after pytest has decided the
outcome, so the shell sees exit code 139 whether the run passed or failed. The workflow discounted
139 outright, which meant that on any affected bpy version, **no test failure could ever turn the
build red**.

It had already happened. Run
[32447003627](https://github.com/Brachi/albam/actions/runs/32447003627) on `main` logged this on
the 4.5/3.11 job:

```
= 104 passed, 17 skipped, 2 xfailed, 2 xpassed, 4 warnings, 8 errors in 225.22s =
```

...and GitHub marked it **success**, while 5.2/3.13 failed on the same 8 errors. Half the matrix had
been reporting nothing but its own segfault.

`pytest_sessionfinish` now records pytest's own exit status to `$ALBAM_PYTEST_EXIT_STATUS_FILE`
while the interpreter is still alive, and the workflow consults that file when - and only when - it
sees 139. A missing file still fails the job: pytest dying before it finished is not something to
paper over either. Verified by running the suite both ways with the variable set: a passing run
records `0`, a failing one records `1`, and nothing is written when it is unset, so local runs are
unaffected.

## Expect this PR's own CI to be red

That is the fix working. `main` currently has a real bug - exporting a model with no armature
raises `AttributeError` in `_fetch_instances` - and it produces those 8 errors. Before this PR, one
matrix job hid them. Now both jobs report them. The one-line fix for that bug is on a separate
branch and should land first; this PR is what makes its failure legible in the meantime.

## Test results

Full suite against local re5 + re1 installs: **105 passed, 16 skipped, 289 xfailed, 2 xpassed, 8
errors, 0 failures** - identical to `main`'s baseline, with the 8 errors being that same bug.
CI-safe subset: 63 passed. `flake8` clean.

## Note

`ALBAM_OT_Pack` and `ALBAM_OT_Patch` returning `{"CANCELLED"}` is a behavior change rather than
pure error reporting: Blender pushes an undo step for `{"FINISHED"}`, and a script calling
`bpy.ops.albam.pack()` used to get `{'FINISHED'}` back from a failed pack and carry on. Same defect
class as the rest of this PR - reporting success on failure - so it stays here.
