### PR TITLE
Fix exporting a model that has no armature

### DIFF
--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -857,7 +857,14 @@ def export_mod(bl_obj):
     _init_mod_header(bl_obj, src_mod, dst_mod)
 
     bone_palettes = _create_bone_palettes(src_mod, bl_obj, bl_meshes)
-    dst_mod.bones_data = _serialize_bones_data(bl_obj, bl_meshes, src_mod, dst_mod, bone_palettes)
+    bones_data = _serialize_bones_data(bl_obj, bl_meshes, src_mod, dst_mod, bone_palettes)
+    if bones_data is not None:
+        # Only assign when there is one. Assigning None still *creates* the
+        # attribute, and the generated _fetch_instances() guards optional
+        # instances with hasattr(), which is true for an attribute holding
+        # None - so a model with no armature would crash on write instead of
+        # skipping the section it doesn't have.
+        dst_mod.bones_data = bones_data
     dst_mod.groups = _serialize_groups(src_mod, dst_mod)
     materials_map, mrl, vtextures = serialize_materials_data(asset, bl_meshes, src_mod, dst_mod)
 


### PR DESCRIPTION
## Summary

Exporting a model with no armature - stage geometry rather than a character - crashes:

```
File "albam/engines/mtfw/structs/mod_156.py", line 96, in _fetch_instances
  self._m_bones_data._fetch_instances()
AttributeError: 'NoneType' object has no attribute '_fetch_instances'
```

`_serialize_bones_data` returns `None` when the exported object isn't an armature, and albam
assigned that straight onto `dst_mod.bones_data`. Assigning `None` still *creates* the attribute,
and the generated `_fetch_instances()` guards optional instances with `hasattr()` - true for an
attribute holding `None` - so writing the file dereferenced it.

The fix is to assign only when there is something to assign, so the section stays absent the way
the format expects.

`bones_data` is the only conditional instance albam can hand a `None`: `groups` is unconditional
and `_serialize_groups` always returns a list, and `meshes_data` and the three buffers always come
back from `_serialize_meshes_data` as real objects. Checked rather than assumed.

## How it got in

Two PRs that were each green on their own branch:

- **#226** added the first model with no armature to the serialization dataset.
- **#227** regenerated the parsers, whose `_fetch_instances()` is where the `hasattr()` guard lives.

#227 branched off `main` before #226's dataset entry existed, so it never ran against a boneless
model, and #226 predates the regenerated parsers. Neither branch could have caught this; only the
merged result exhibits it. Requiring branches to be up to date with `main` before merging is what
prevents this class of thing, and is worth turning on given how fast the suite runs.

## Test results

Full suite against local re5 + re1 installs: **110 passed, 19 skipped, 352 xfailed, 3 xpassed, 0
failures, 0 errors**. Before this fix the same run gave 8 errors, all on the boneless model, with
the 5 dependent tests never running - which is why the passed/xfailed counts go up rather than just
the errors going down.

No new test: #226's dataset entry already covers this. Those 8 errors on `main` are that test
failing exactly as it should.
