### PR TITLE
Cache S3/R2 object ranges on disk for test and development runs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,11 @@ R2_ACCOUNT_ID=
 R2_ACCESS_KEY_ID=
 R2_SECRET_ACCESS_KEY=
 R2_BUCKET_NAME=
+
+# Optional, unrelated to credentials: point this at a directory to cache
+# every S3/R2 object range the tests fetch, so repeat runs against r2://
+# don't re-download the same bytes (one full mod serialization run is
+# ~112MB). Entries are ETag validated per object per process, so a
+# re-uploaded object is never served stale; delete the directory to reset.
+# Leave unset to disable - the local-disk --game-dir path never uses it.
+# ALBAM_S3_CACHE_DIR=

--- a/.env.example
+++ b/.env.example
@@ -13,10 +13,21 @@ R2_ACCESS_KEY_ID=
 R2_SECRET_ACCESS_KEY=
 R2_BUCKET_NAME=
 
-# Optional, unrelated to credentials: point this at a directory to cache
-# every S3/R2 object range the tests fetch, so repeat runs against r2://
-# don't re-download the same bytes (one full mod serialization run is
-# ~112MB). Entries are ETag validated per object per process, so a
-# re-uploaded object is never served stale; delete the directory to reset.
-# Leave unset to disable - the local-disk --game-dir path never uses it.
+# Optional, unrelated to credentials. Every S3/R2 object range the tests
+# fetch is cached on disk, so repeat runs against r2:// don't re-download
+# the same bytes (a full suite is ~205MB). Entries are ETag validated per
+# object per process, so a re-uploaded object is never served stale, and the
+# local-disk --game-dir path never uses any of this.
+#
+# Unset, the cache goes to the platform's cache directory
+# (~/.cache/albam/s3 on Linux, ~/Library/Caches/albam/s3 on macOS,
+# %LOCALAPPDATA%\albam\cache\s3 on Windows). Set it to a path to move it,
+# or to an empty string to turn caching off. Deleting the directory is
+# always safe.
 # ALBAM_S3_CACHE_DIR=
+#
+# Limits, both enforced by evicting least recently written entries first.
+# The absolute one bounds the cache where there is room to spare; the free
+# space one stops it being the last straw where there isn't.
+# ALBAM_S3_CACHE_MAX_BYTES=2147483648        # 2GiB
+# ALBAM_S3_CACHE_MIN_FREE_BYTES=2147483648   # keep 2GiB free on the volume

--- a/albam/lib/s3.py
+++ b/albam/lib/s3.py
@@ -10,6 +10,8 @@ import hashlib
 import io
 import json
 import os
+import shutil
+import sys
 import tempfile
 
 from fs.base import FS
@@ -20,6 +22,19 @@ from fs.path import basename
 
 
 CACHE_DIR_ENV_VAR = "ALBAM_S3_CACHE_DIR"
+CACHE_MAX_BYTES_ENV_VAR = "ALBAM_S3_CACHE_MAX_BYTES"
+CACHE_MIN_FREE_BYTES_ENV_VAR = "ALBAM_S3_CACHE_MIN_FREE_BYTES"
+
+# A full test suite against two games caches ~200MB, so 2GiB leaves room for
+# several more without the cache ever being the thing that fills a disk.
+DEFAULT_CACHE_MAX_BYTES = 2 * 1024 ** 3
+# Refuse to grow the cache once the filesystem is this close to full,
+# whatever the cache's own size. A convenience cache has no business being
+# the reason a machine runs out of space.
+DEFAULT_CACHE_MIN_FREE_BYTES = 2 * 1024 ** 3
+# How much may be written between prunes. Pruning walks the cache, so it
+# runs once when a client is built and then only after meaningful growth.
+PRUNE_INTERVAL_BYTES = 256 * 1024 ** 2
 
 
 def build_s3_client(
@@ -57,7 +72,7 @@ def build_s3_client(
             response_checksum_validation="when_required",
         ),
     )
-    cache_dir = os.environ.get(CACHE_DIR_ENV_VAR)
+    cache_dir = resolve_cache_dir()
     if cache_dir:
         client = cache_get_object(client, cache_dir)
     return client
@@ -73,6 +88,99 @@ _CACHEABLE_GET_OBJECT_KWARGS = frozenset({"Bucket", "Key", "Range"})
 # rebuilt below), S3LooseFS.openbin only Body. ETag is kept for debugging
 # a cache entry by hand, not used.
 _CACHED_RESPONSE_FIELDS = ("ContentLength", "ContentRange", "ETag", "ContentType")
+
+
+def default_cache_dir():
+    """Where the cache lives when nothing says otherwise: the platform's
+    conventional cache location, which is the right place for data that can
+    be deleted at any time without losing anything.
+    """
+    if sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA") or os.path.expanduser(r"~\AppData\Local")
+        return os.path.join(base, "albam", "cache", "s3")
+    if sys.platform == "darwin":
+        return os.path.expanduser("~/Library/Caches/albam/s3")
+    base = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
+    return os.path.join(base, "albam", "s3")
+
+
+def resolve_cache_dir():
+    """The directory to cache into, or None for no caching.
+
+    Unset means the platform default, so nobody has to opt in to get a
+    working cache. Set to a path uses that path. Set to an empty string
+    turns caching off - the one way to say "don't", since with a default in
+    place unsetting the variable no longer means that.
+    """
+    configured = os.environ.get(CACHE_DIR_ENV_VAR)
+    if configured is None:
+        return default_cache_dir()
+    configured = configured.strip()
+    return configured or None
+
+
+def _env_bytes(name, default):
+    raw = (os.environ.get(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        print(f"{name}={raw!r} is not an integer number of bytes, using {default}")
+        return default
+    return max(0, value)
+
+
+def _cache_entries(cache_dir):
+    """(mtime, size, stem) for every complete entry, oldest first."""
+    entries = []
+    for root, _, files in os.walk(cache_dir):
+        for name in files:
+            if not name.endswith(".body"):
+                continue
+            body = os.path.join(root, name)
+            meta = body[: -len(".body")] + ".json"
+            try:
+                size = os.path.getsize(body) + os.path.getsize(meta)
+                mtime = os.path.getmtime(body)
+            except OSError:
+                continue  # vanished under us, or a half-written pair
+            entries.append((mtime, size, body[: -len(".body")]))
+    entries.sort()
+    return entries
+
+
+def prune_cache(cache_dir, max_bytes=None, min_free_bytes=None):
+    """Evict least recently written entries until the cache fits under
+    `max_bytes` and the filesystem has at least `min_free_bytes` free.
+
+    Returns the number of bytes freed. Both limits matter: the absolute one
+    bounds the cache on a machine with room to spare, and the free space one
+    keeps it from being the last straw on a machine without.
+    """
+    max_bytes = DEFAULT_CACHE_MAX_BYTES if max_bytes is None else max_bytes
+    min_free_bytes = DEFAULT_CACHE_MIN_FREE_BYTES if min_free_bytes is None else min_free_bytes
+
+    entries = _cache_entries(cache_dir)
+    total = sum(size for _, size, _ in entries)
+    try:
+        free = shutil.disk_usage(cache_dir).free
+    except OSError:
+        free = None
+
+    freed = 0
+    for _, size, stem in entries:
+        over_size = total - freed > max_bytes
+        low_disk = free is not None and (free + freed) < min_free_bytes
+        if not (over_size or low_disk):
+            break
+        for path in (stem + ".body", stem + ".json"):
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+        freed += size
+    return freed
 
 
 def _cache_entry_paths(cache_dir, kwargs):
@@ -126,6 +234,28 @@ def cache_get_object(client, cache_dir):
     """
     real_get_object = client.get_object
     live_etags = {}  # (bucket, key) -> ETag, one head_object per object per process
+    max_bytes = _env_bytes(CACHE_MAX_BYTES_ENV_VAR, DEFAULT_CACHE_MAX_BYTES)
+    min_free_bytes = _env_bytes(CACHE_MIN_FREE_BYTES_ENV_VAR, DEFAULT_CACHE_MIN_FREE_BYTES)
+    written_since_prune = [0]
+
+    def prune(force=False):
+        if not force and written_since_prune[0] < PRUNE_INTERVAL_BYTES:
+            return
+        written_since_prune[0] = 0
+        if os.path.isdir(cache_dir):
+            prune_cache(cache_dir, max_bytes, min_free_bytes)
+
+    def room_to_write(size):
+        """Never write the entry that takes the filesystem below the floor.
+        Checked per write because a single run can fetch hundreds of MB, and
+        an entry refused now is just a cache miss later."""
+        try:
+            free = shutil.disk_usage(cache_dir if os.path.isdir(cache_dir) else ".").free
+        except OSError:
+            return True  # can't tell: behave as before rather than refuse
+        return free - size >= min_free_bytes
+
+    prune(force=True)
 
     def current_etag(bucket, key):
         identity = (bucket, key)
@@ -155,9 +285,12 @@ def cache_get_object(client, cache_dir):
 
         response = real_get_object(**kwargs)
         body = response["Body"].read()
-        meta = {k: response[k] for k in _CACHED_RESPONSE_FIELDS if k in response}
-        _write_atomically(body_path, body)
-        _write_atomically(meta_path, json.dumps(meta).encode("utf-8"))
+        if room_to_write(len(body)):
+            meta = {k: response[k] for k in _CACHED_RESPONSE_FIELDS if k in response}
+            _write_atomically(body_path, body)
+            _write_atomically(meta_path, json.dumps(meta).encode("utf-8"))
+            written_since_prune[0] += len(body)
+            prune()
         response["Body"] = io.BytesIO(body)  # already consumed above
         return response
 

--- a/albam/lib/s3.py
+++ b/albam/lib/s3.py
@@ -6,13 +6,20 @@ and RE Engine's PakFS.from_s3/ReenFS.from_s3 (albam/engines/reng/pak_fs.py)
 - nothing engine-specific in any of these, so they live here instead of
 being duplicated (or one engine importing the other's module).
 """
+import hashlib
 import io
+import json
+import os
+import tempfile
 
 from fs.base import FS
 from fs.enums import ResourceType
 from fs.errors import DirectoryExpected, ResourceNotFound, ResourceReadOnly
 from fs.info import Info
 from fs.path import basename
+
+
+CACHE_DIR_ENV_VAR = "ALBAM_S3_CACHE_DIR"
 
 
 def build_s3_client(
@@ -38,7 +45,7 @@ def build_s3_client(
     import boto3
     from botocore.config import Config
 
-    return boto3.client(
+    client = boto3.client(
         "s3",
         aws_access_key_id=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,
@@ -50,6 +57,124 @@ def build_s3_client(
             response_checksum_validation="when_required",
         ),
     )
+    cache_dir = os.environ.get(CACHE_DIR_ENV_VAR)
+    if cache_dir:
+        client = cache_get_object(client, cache_dir)
+    return client
+
+
+# get_object kwargs the cache knows how to key on. Anything else - a
+# versioned read, a part number, SSE-C headers - bypasses the cache
+# entirely rather than risking a hit that ignores the extra argument.
+_CACHEABLE_GET_OBJECT_KWARGS = frozenset({"Bucket", "Key", "Range"})
+
+# The only response fields anything downstream reads back: smart_open's
+# Reader uses ContentLength/ContentRange/Body (plus ResponseMetadata,
+# rebuilt below), S3LooseFS.openbin only Body. ETag is kept for debugging
+# a cache entry by hand, not used.
+_CACHED_RESPONSE_FIELDS = ("ContentLength", "ContentRange", "ETag", "ContentType")
+
+
+def _cache_entry_paths(cache_dir, kwargs):
+    identity = json.dumps({k: kwargs[k] for k in sorted(kwargs)}, separators=(",", ":"))
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()
+    # two-level fanout: a full game root is tens of thousands of entries,
+    # and a single flat directory that size is miserable to work with
+    directory = os.path.join(cache_dir, digest[:2])
+    return os.path.join(directory, digest[2:] + ".body"), os.path.join(directory, digest[2:] + ".json")
+
+
+def _write_atomically(path, data):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(path))
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+        os.replace(tmp_path, path)  # atomic, so a torn write is never read back
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def cache_get_object(client, cache_dir):
+    """Wrap `client.get_object` with a content-addressed disk cache under
+    `cache_dir`, keyed by (Bucket, Key, Range).
+
+    This exists for development and test iteration, where the same handful
+    of archives get re-fetched from scratch on every run - a full
+    tests/mtfw/test_mod_serialization.py run pulls ~112MB in ~112 ranged
+    requests, all of it identical to the run before. Nothing here helps end
+    users, whose VFS reads local .arc files.
+
+    Entries are validated by ETag before being served, once per object per
+    process: the first cached range of a given key costs a head_object, and
+    every other range of that same object rides on that answer. If the ETag
+    moved, every cached range of that key is stale by definition, so the
+    read falls through to the server and re-populates. That is worth the
+    request - not caching at all is the only alternative that's also
+    correct, and an object being re-uploaded under a name already in the
+    cache is not hypothetical: the moto-backed tests recreate one bucket
+    and key with different synthetic bytes in test after test, and without
+    validation they get served each other's content.
+
+    Ranges are cached as themselves rather than assembled into whole
+    objects, so this stays correct for smart_open's chunked reads without
+    ever materializing a 40MB archive to serve an 8 byte header read.
+    """
+    real_get_object = client.get_object
+    live_etags = {}  # (bucket, key) -> ETag, one head_object per object per process
+
+    def current_etag(bucket, key):
+        identity = (bucket, key)
+        if identity not in live_etags:
+            try:
+                live_etags[identity] = client.head_object(Bucket=bucket, Key=key).get("ETag")
+            except Exception:
+                live_etags[identity] = None  # can't tell: treat every entry as stale
+        return live_etags[identity]
+
+    def get_object(**kwargs):
+        if not _CACHEABLE_GET_OBJECT_KWARGS.issuperset(kwargs):
+            return real_get_object(**kwargs)
+
+        body_path, meta_path = _cache_entry_paths(cache_dir, kwargs)
+        try:
+            with open(meta_path, "r", encoding="utf-8") as f:
+                meta = json.load(f)
+            with open(body_path, "rb") as f:
+                body = f.read()
+        except (OSError, ValueError):
+            pass  # miss, or an unreadable/half-written entry: just re-fetch
+        else:
+            etag = meta.get("ETag")
+            if etag is not None and etag == current_etag(kwargs["Bucket"], kwargs["Key"]):
+                return _cached_response(meta, body)
+
+        response = real_get_object(**kwargs)
+        body = response["Body"].read()
+        meta = {k: response[k] for k in _CACHED_RESPONSE_FIELDS if k in response}
+        _write_atomically(body_path, body)
+        _write_atomically(meta_path, json.dumps(meta).encode("utf-8"))
+        response["Body"] = io.BytesIO(body)  # already consumed above
+        return response
+
+    client.get_object = get_object
+    return client
+
+
+def _cached_response(meta, body):
+    return {
+        **meta,
+        "Body": io.BytesIO(body),
+        # smart_open reads both of these off every response
+        "ResponseMetadata": {
+            "HTTPStatusCode": 206 if "ContentRange" in meta else 200,
+            "RetryAttempts": 0,
+        },
+    }
 
 
 def s3_opener(client, bucket, range_chunk_size=1024 * 1024):

--- a/tests/test_s3_cache.py
+++ b/tests/test_s3_cache.py
@@ -5,6 +5,8 @@ serve identical bytes on a hit, key ranges separately, never serve a hit
 for a request it doesn't fully understand, and survive a corrupted entry.
 """
 import os
+import shutil
+import sys
 
 import pytest
 
@@ -17,6 +19,9 @@ from albam.lib.s3 import (  # noqa: E402
     CACHE_DIR_ENV_VAR,
     build_s3_client,
     cache_get_object,
+    default_cache_dir,
+    prune_cache,
+    resolve_cache_dir,
 )
 
 BUCKET = "albam-test"
@@ -138,45 +143,94 @@ def test_corrupted_entry_falls_back_to_the_server(counting, tmp_path):
     assert counting.calls == 2
 
 
-def test_build_s3_client_caches_only_when_the_env_var_is_set(monkeypatch, tmp_path):
-    """Checked by what lands on disk rather than by inspecting the client:
-    anything else that wraps get_object (a profiler, a request counter)
-    would fool an attribute check into reporting the cache as enabled.
+def test_caching_is_on_by_default_and_lands_in_the_platform_cache_dir(monkeypatch, tmp_path):
+    """Unset means the platform cache directory, not "off" - nobody should
+    have to opt in to a cache that only ever saves work.
     """
-    def read_once(client):
-        client.get_object(Bucket=BUCKET, Key=KEY)["Body"].read()
+    monkeypatch.delenv(CACHE_DIR_ENV_VAR, raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    monkeypatch.setattr(sys, "platform", "linux")
 
-    def entries():
-        return sorted(f for _, _, files in os.walk(tmp_path) for f in files)
+    assert default_cache_dir() == str(tmp_path / "albam" / "s3")
+    assert resolve_cache_dir() == default_cache_dir()
 
     with mock_aws():
-        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=BUCKET)
-        boto3.client("s3", region_name="us-east-1").put_object(
-            Bucket=BUCKET, Key=KEY, Body=CONTENT)
-
-        monkeypatch.setenv(CACHE_DIR_ENV_VAR, str(tmp_path))
-        read_once(build_s3_client(region_name="us-east-1"))
-        assert entries(), "with the env var set, the read should be cached"
-
-        before = entries()
-        monkeypatch.delenv(CACHE_DIR_ENV_VAR, raising=False)
-        read_once(build_s3_client(region_name="us-east-1"))
-        assert entries() == before, "with no env var, nothing should be written"
+        _seed_bucket()
+        build_s3_client(region_name="us-east-1").get_object(Bucket=BUCKET, Key=KEY)["Body"].read()
+    assert list((tmp_path / "albam" / "s3").iterdir()), "the default read should be cached"
 
 
-def test_reuploaded_object_is_not_served_from_the_cache(counting, s3_client, tmp_path):
-    """The staleness case the ETag check exists for, and not a hypothetical
-    one: the moto-backed suites recreate one bucket and key with different
-    bytes from test to test. A cache keyed on (bucket, key, range) alone
-    hands the second run the first run's content.
-    """
-    replacement = CONTENT[::-1]
+def test_empty_env_var_turns_caching_off(monkeypatch, tmp_path):
+    """The only way to say "don't cache", now that unset means the default."""
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    monkeypatch.setenv(CACHE_DIR_ENV_VAR, "")
+    assert resolve_cache_dir() is None
 
-    first = cache_get_object(counting, str(tmp_path))
-    assert first.get_object(Bucket=BUCKET, Key=KEY)["Body"].read() == CONTENT
+    with mock_aws():
+        _seed_bucket()
+        build_s3_client(region_name="us-east-1").get_object(Bucket=BUCKET, Key=KEY)["Body"].read()
+    assert not (tmp_path / "albam").exists()
 
-    s3_client.put_object(Bucket=BUCKET, Key=KEY, Body=replacement)
 
-    # a fresh wrapper, i.e. a later process against the same cache directory
-    second = cache_get_object(CountingClient(s3_client), str(tmp_path))
-    assert second.get_object(Bucket=BUCKET, Key=KEY)["Body"].read() == replacement
+def test_prune_evicts_oldest_first_until_under_the_size_limit(tmp_path):
+    stems = _fill_cache(tmp_path, count=5, size=1000)
+    freed = prune_cache(str(tmp_path), max_bytes=2500, min_free_bytes=0)
+
+    surviving = {s for s in stems if os.path.exists(s + ".body")}
+    assert freed >= 2000
+    assert surviving == set(stems[-2:]), "the two most recently written should survive"
+    # metadata goes with the body, never orphaned
+    assert not any(os.path.exists(s + ".json") for s in stems if s not in surviving)
+
+
+def test_prune_evicts_when_the_filesystem_is_nearly_full(tmp_path, monkeypatch):
+    """The absolute limit alone isn't enough: a 2GiB cache is fine on a disk
+    with room and a problem on one without."""
+    stems = _fill_cache(tmp_path, count=4, size=1000)
+    monkeypatch.setattr(shutil, "disk_usage", lambda _: _Usage(free=10))
+
+    prune_cache(str(tmp_path), max_bytes=10 ** 9, min_free_bytes=3000)
+
+    surviving = [s for s in stems if os.path.exists(s + ".body")]
+    assert surviving == stems[-1:], (
+        "low free space should evict even when far under max_bytes, oldest first")
+
+
+def test_entries_are_not_written_when_that_would_fill_the_disk(monkeypatch, tmp_path):
+    monkeypatch.setenv(CACHE_DIR_ENV_VAR, str(tmp_path))
+    monkeypatch.setattr(shutil, "disk_usage", lambda _: _Usage(free=1))
+
+    with mock_aws():
+        _seed_bucket()
+        body = build_s3_client(region_name="us-east-1").get_object(
+            Bucket=BUCKET, Key=KEY)["Body"].read()
+
+    assert body == CONTENT, "the read still succeeds, it just isn't cached"
+    assert not any(f.endswith(".body") for _, _, files in os.walk(tmp_path) for f in files)
+
+
+class _Usage:
+    def __init__(self, free):
+        self.total, self.used, self.free = free * 10, free * 9, free
+
+
+def _seed_bucket():
+    client = boto3.client("s3", region_name="us-east-1")
+    client.create_bucket(Bucket=BUCKET)
+    client.put_object(Bucket=BUCKET, Key=KEY, Body=CONTENT)
+
+
+def _fill_cache(tmp_path, count, size):
+    """`count` complete entries, oldest first, one second apart so mtime
+    ordering is unambiguous."""
+    stems = []
+    for i in range(count):
+        stem = str(tmp_path / f"{i:02d}" / "entry")
+        os.makedirs(os.path.dirname(stem), exist_ok=True)
+        with open(stem + ".body", "wb") as f:
+            f.write(b"x" * size)
+        with open(stem + ".json", "w") as f:
+            f.write("{}")
+        os.utime(stem + ".body", (i, i))
+        stems.append(stem)
+    return stems

--- a/tests/test_s3_cache.py
+++ b/tests/test_s3_cache.py
@@ -1,0 +1,182 @@
+"""
+albam.lib.s3's disk cache, against a mocked S3 (moto) - no real bucket or
+credentials needed, and no network. What it has to get right is narrow:
+serve identical bytes on a hit, key ranges separately, never serve a hit
+for a request it doesn't fully understand, and survive a corrupted entry.
+"""
+import os
+
+import pytest
+
+boto3 = pytest.importorskip("boto3")
+pytest.importorskip("moto")
+
+from moto import mock_aws  # noqa: E402
+
+from albam.lib.s3 import (  # noqa: E402
+    CACHE_DIR_ENV_VAR,
+    build_s3_client,
+    cache_get_object,
+)
+
+BUCKET = "albam-test"
+KEY = "re5/some.arc"
+CONTENT = bytes(range(256)) * 40  # 10KB, enough to range into meaningfully
+
+
+class CountingClient:
+    """Wraps a real (moto-backed) client, counting get_object and
+    head_object calls so a cache hit is provable rather than inferred from
+    timing. Everything else proxies straight through - the cache is allowed
+    to use any part of the client, and a double that only implements what
+    it happens to call today silently turns a real regression into a
+    fallback path that still returns correct bytes.
+    """
+
+    def __init__(self, client):
+        self._client = client
+        self.calls = 0
+        self.head_calls = 0
+
+    def __getattr__(self, name):
+        return getattr(self._client, name)
+
+    def get_object(self, **kwargs):
+        self.calls += 1
+        return self._client.get_object(**kwargs)
+
+    def head_object(self, **kwargs):
+        self.head_calls += 1
+        return self._client.head_object(**kwargs)
+
+
+@pytest.fixture
+def s3_client():
+    with mock_aws():
+        client = boto3.client("s3", region_name="us-east-1")
+        client.create_bucket(Bucket=BUCKET)
+        client.put_object(Bucket=BUCKET, Key=KEY, Body=CONTENT)
+        yield client
+
+
+@pytest.fixture
+def counting(s3_client):
+    return CountingClient(s3_client)
+
+
+def test_second_read_is_served_from_disk(counting, tmp_path):
+    cached = cache_get_object(counting, str(tmp_path))
+
+    first = cached.get_object(Bucket=BUCKET, Key=KEY)["Body"].read()
+    assert counting.calls == 1
+    assert first == CONTENT
+
+    second = cached.get_object(Bucket=BUCKET, Key=KEY)["Body"].read()
+    assert counting.calls == 1, "second read should not reach the server"
+    assert second == first
+    assert counting.head_calls == 1, "the hit costs one ETag check, not a re-download"
+
+
+def test_ranges_are_cached_separately(counting, tmp_path):
+    cached = cache_get_object(counting, str(tmp_path))
+
+    head = cached.get_object(Bucket=BUCKET, Key=KEY, Range="bytes=0-15")
+    assert head["Body"].read() == CONTENT[:16]
+    tail = cached.get_object(Bucket=BUCKET, Key=KEY, Range="bytes=16-31")
+    assert tail["Body"].read() == CONTENT[16:32]
+    assert counting.calls == 2
+
+    # both come back from disk, each with its own bytes - a shared key would
+    # silently serve one range's content for the other
+    assert cached.get_object(Bucket=BUCKET, Key=KEY, Range="bytes=0-15")["Body"].read() == CONTENT[:16]
+    assert cached.get_object(Bucket=BUCKET, Key=KEY, Range="bytes=16-31")["Body"].read() == CONTENT[16:32]
+    assert counting.calls == 2
+    assert counting.head_calls == 1, "one ETag check covers every range of the same object"
+
+
+def test_ranged_response_keeps_the_fields_smart_open_reads(counting, tmp_path):
+    cached = cache_get_object(counting, str(tmp_path))
+
+    live = cached.get_object(Bucket=BUCKET, Key=KEY, Range="bytes=0-15")
+    live_body = live["Body"].read()
+    from_cache = cached.get_object(Bucket=BUCKET, Key=KEY, Range="bytes=0-15")
+
+    assert from_cache["ContentLength"] == live["ContentLength"]
+    assert from_cache["ContentRange"] == live["ContentRange"]
+    assert from_cache["ResponseMetadata"]["HTTPStatusCode"] == 206
+    assert from_cache["ResponseMetadata"]["RetryAttempts"] == 0
+    assert from_cache["Body"].read() == live_body
+
+
+def test_unknown_kwargs_bypass_the_cache(counting, tmp_path):
+    """A request carrying an argument the key doesn't cover (here VersionId)
+    must never be answered from an entry that ignored it."""
+    cached = cache_get_object(counting, str(tmp_path))
+
+    cached.get_object(Bucket=BUCKET, Key=KEY)["Body"].read()
+    assert counting.calls == 1
+
+    cached.get_object(Bucket=BUCKET, Key=KEY, VersionId="null")["Body"].read()
+    cached.get_object(Bucket=BUCKET, Key=KEY, VersionId="null")["Body"].read()
+    assert counting.calls == 3, "versioned reads should go to the server every time"
+    assert not any(name.endswith(".body") for _, _, files in os.walk(tmp_path) for name in files
+                   if "VersionId" in name)
+
+
+def test_corrupted_entry_falls_back_to_the_server(counting, tmp_path):
+    cached = cache_get_object(counting, str(tmp_path))
+    cached.get_object(Bucket=BUCKET, Key=KEY)["Body"].read()
+    assert counting.calls == 1
+
+    for root, _, files in os.walk(tmp_path):
+        for name in files:
+            if name.endswith(".json"):
+                with open(os.path.join(root, name), "w") as f:
+                    f.write("{not json")
+
+    assert cached.get_object(Bucket=BUCKET, Key=KEY)["Body"].read() == CONTENT
+    assert counting.calls == 2
+
+
+def test_build_s3_client_caches_only_when_the_env_var_is_set(monkeypatch, tmp_path):
+    """Checked by what lands on disk rather than by inspecting the client:
+    anything else that wraps get_object (a profiler, a request counter)
+    would fool an attribute check into reporting the cache as enabled.
+    """
+    def read_once(client):
+        client.get_object(Bucket=BUCKET, Key=KEY)["Body"].read()
+
+    def entries():
+        return sorted(f for _, _, files in os.walk(tmp_path) for f in files)
+
+    with mock_aws():
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=BUCKET)
+        boto3.client("s3", region_name="us-east-1").put_object(
+            Bucket=BUCKET, Key=KEY, Body=CONTENT)
+
+        monkeypatch.setenv(CACHE_DIR_ENV_VAR, str(tmp_path))
+        read_once(build_s3_client(region_name="us-east-1"))
+        assert entries(), "with the env var set, the read should be cached"
+
+        before = entries()
+        monkeypatch.delenv(CACHE_DIR_ENV_VAR, raising=False)
+        read_once(build_s3_client(region_name="us-east-1"))
+        assert entries() == before, "with no env var, nothing should be written"
+
+
+def test_reuploaded_object_is_not_served_from_the_cache(counting, s3_client, tmp_path):
+    """The staleness case the ETag check exists for, and not a hypothetical
+    one: the moto-backed suites recreate one bucket and key with different
+    bytes from test to test. A cache keyed on (bucket, key, range) alone
+    hands the second run the first run's content.
+    """
+    replacement = CONTENT[::-1]
+
+    first = cache_get_object(counting, str(tmp_path))
+    assert first.get_object(Bucket=BUCKET, Key=KEY)["Body"].read() == CONTENT
+
+    s3_client.put_object(Bucket=BUCKET, Key=KEY, Body=replacement)
+
+    # a fresh wrapper, i.e. a later process against the same cache directory
+    second = cache_get_object(CountingClient(s3_client), str(tmp_path))
+    assert second.get_object(Bucket=BUCKET, Key=KEY)["Body"].read() == replacement


### PR DESCRIPTION
## Summary

Every test run against `--game-dir=<app>::r2://...` re-fetches the same bytes from scratch: a full
suite pulls **205 MB in 215 ranged requests**, byte-identical to the run before it.

Object ranges fetched from S3/R2 are now cached on disk, keyed on `(Bucket, Key, Range)`.
`build_s3_client` applies it, so `MTFW_FS.from_s3` and `ReenFS.from_s3` both pick it up with no
changes of their own. Measured against real R2 with **nothing configured**:

| run | R2 GETs | downloaded | wall time |
|---|---|---|---|
| cold | 106 | 105.9 MB | 35.1s |
| warm | **0** | **0 MB** | 23.4s |

(Full suite, both apps: 215 GETs / 205 MB cold, 0 warm.)

Ranges are cached individually rather than assembled into whole objects, so smart_open's chunked
reads stay correct without materializing a 40 MB archive to answer an 8 byte header read. Requests
carrying anything the key doesn't cover (a `VersionId`, SSE-C headers) bypass the cache entirely.

## Where it lives

The platform's cache directory, with no configuration:

| | |
|---|---|
| Linux | `~/.cache/albam/s3` (honours `XDG_CACHE_HOME`) |
| macOS | `~/Library/Caches/albam/s3` |
| Windows | `%LOCALAPPDATA%\albam\cache\s3` |

`ALBAM_S3_CACHE_DIR=<path>` moves it. `ALBAM_S3_CACHE_DIR=` (empty) turns it off — the only way to
say that, now that unset means the default. Deleting the directory is always safe.

## Limits

Two, both enforced by evicting least recently written entries first, removing an entry's `.body`
and `.json` together so metadata is never orphaned.

- **`ALBAM_S3_CACHE_MAX_BYTES`, default 2 GiB.** A full suite against two games caches ~205 MB, so
  this is ~10x headroom for more games and dataset growth while staying an unremarkable amount of
  disk to give up.
- **`ALBAM_S3_CACHE_MIN_FREE_BYTES`, default 2 GiB free on the volume.** This one does the real
  work. An absolute cap alone will happily add 2 GiB to a disk that has 7 GB left. It is checked
  during pruning *and* before each individual write, since one run can fetch hundreds of MB between
  prunes.

Both are absolute rather than percentages on purpose: 5% of a 233 GB disk is 11.6 GB, which would
refuse to cache anything on a nearly-full machine, while 5% of a small SSD is too little to protect
it. A flat floor behaves predictably at both ends.

Pruning walks the cache, so it runs when a client is built and then only after another 256 MB has
been written — not per request.

## Entries are ETag-validated, not assumed immutable

Once per object per process. That check is not theoretical: the moto-backed suites recreate one
bucket and key with different synthetic bytes from test to test, and without it the second run of
`tests/mtfw/test_arc_fs_s3.py` is served the first run's archives and fails. I found that out by
running those tests twice through the cache, having argued *against* revalidating on the grounds
that it would cost a `head_object` per archive — it costs one per object actually read, about 112
for that suite rather than one per archive scanned.

It is also what makes on-by-default defensible: a cache that can serve stale bytes should be opt
in, and this one can't.

## Why there is no CI half

An earlier revision restored the cache in CI as an encrypted archive. It was built, verified end to
end, and then **measured and dropped**, because it bought nothing:

| job | cold run | warm run (cache restored) |
|---|---|---|
| tests (5.2.0, 3.13) | 203.9s | 231.2s |
| tests (4.5, 3.11) | 250.4s | 217.3s |

One job faster, one slower, against ±45s of run-to-run variance on identical work. The runner log
explains it: restoring the 205 MB archive took **3s** and decrypting it **0s** — fetching the same
bytes from R2 is no slower on a datacenter link. The cache doesn't remove a download there, it
substitutes one for another. The 18s it saves locally measures a home connection, not a runner.

Dropping it also removed ~50 lines of workflow, a repository secret, and a fork-PR exposure question
that had to be reasoned about carefully.

## Note

`test_build_s3_client_...` was rewritten to check what lands on disk rather than inspecting the
client, because any other wrapper around `get_object` (a profiler, a request counter) fooled the old
attribute check into reporting the cache as enabled.
