### PR TITLE
Reconnect fs_registry entries for VFS roots after reopening a .blend

### DIFF
--- a/albam/__init__.py
+++ b/albam/__init__.py
@@ -64,6 +64,11 @@ def register():
     # Load data from user's config files
     bpy.app.handlers.load_post.append(populate_albam_data)
 
+    # Rebuild fs_registry's process-lifetime entries for VFS roots restored
+    # from the loaded .blend file - see albam.vfs.reconnect_fs_roots.
+    from .vfs import reconnect_fs_roots
+    bpy.app.handlers.load_post.append(reconnect_fs_roots)
+
 
 def unregister():
     fs_registry.clear()

--- a/albam/lib/fs_registry.py
+++ b/albam/lib/fs_registry.py
@@ -19,6 +19,15 @@ def register(fs_instance):
     return key
 
 
+def reconnect(key, fs_instance):
+    """Store `fs_instance` under an existing `key` (one a `VirtualFile.fs_key`
+    already carries, restored from a .blend file), instead of minting a new
+    one. Used to rebuild this process-lifetime registry after it comes up
+    empty in a fresh Blender session - see albam/vfs.py's load_post handler.
+    """
+    _REGISTRY[key] = fs_instance
+
+
 def get(key):
     return _REGISTRY[key]
 

--- a/albam/vfs.py
+++ b/albam/vfs.py
@@ -3,6 +3,7 @@ import os
 from pathlib import PureWindowsPath, Path
 
 import bpy
+from bpy.app.handlers import persistent
 from fs.memoryfs import MemoryFS
 from fs.path import dirname
 
@@ -298,6 +299,39 @@ class VirtualFileSystemBase:
         if not vfile.is_root and vfile.is_expandable:
             return None
         return vfile
+
+
+@persistent
+def reconnect_fs_roots(dummy):
+    """
+    fs_registry is plain in-process state (see its module docstring) - it
+    isn't part of the .blend file and comes up empty in a fresh Blender
+    session, while a root VirtualFile's `fs_key`/`absolute_path` (real
+    bpy.props, restored from the file) still point at the FS instance that
+    used to back it. Without this, VirtualFile.get_bytes() on any such root
+    - i.e. every "Add Folder"/"Add Files" root re-added by loading a saved
+    .blend - raises KeyError the first time it's read (e.g. on import).
+    Rebuilds the registry entry the same way add_real_file() built it the
+    first time, so existing fs_key values keep pointing at something live.
+    Roots with no `absolute_path` (add_export_root()'s in-memory FS) can't
+    be recreated this way and are left as-is - they're transient, run-only
+    state to begin with.
+    """
+    for vfs_id in ("vfs", "exported"):
+        vfs = getattr(bpy.context.scene.albam, vfs_id, None)
+        if vfs is None:
+            continue
+        for vf in vfs.file_list:
+            if not (vf.is_root and vf.fs_key and vf.absolute_path):
+                continue
+            fs_loader = (blender_registry.fs_root_loader_registry.get((vf.app_id, vf.extension)) or
+                         blender_registry.fs_root_loader_registry.get((vf.app_id, None)))
+            if not fs_loader:
+                continue
+            try:
+                fs_registry.reconnect(vf.fs_key, fs_loader(vf.absolute_path))
+            except Exception as err:
+                print(f"albam: could not reconnect VFS root {vf.display_name!r}: {err}")
 
 
 @blender_registry.register_blender_prop_albam(name="vfs")

--- a/tests/test_vfs_fs_backed.py
+++ b/tests/test_vfs_fs_backed.py
@@ -115,6 +115,40 @@ def test_add_export_root_defaults_missing_bytes_to_empty():
     assert vfile.get_bytes() == b""
 
 
+def test_reload_blend_file_reconnects_fs_roots(tmp_path):
+    """
+    add_fs_root() stashes the live FS instance in fs_registry - a plain
+    in-process dict (see its module docstring) - and only a string key on
+    the persisted VirtualFile.fs_key. That dict isn't part of the .blend
+    file and doesn't survive a real restart: a fresh Blender process starts
+    with fs_registry empty again, while VirtualFile.fs_key (restored from
+    the file) still points at an entry that no longer exists. Reproduces
+    the KeyError a user hits importing after reopening a saved .blend that
+    had a folder/archive added to the VFS.
+    """
+    game_root = tmp_path / "game_root"
+    (game_root / "model" / "pl" / "pl00").mkdir(parents=True)
+    (game_root / "model" / "pl" / "pl00" / "pl00.mod").write_bytes(b"mod-bytes")
+
+    vfs = bpy.context.scene.albam.vfs
+    vfs.add_real_file("re5", str(game_root))
+    vfile = vfs.select_vfile("re5", "model/pl/pl00/pl00.mod")
+    assert vfile.get_bytes() == b"mod-bytes"
+
+    blend_path = str(tmp_path / "save.blend")
+    bpy.ops.wm.save_as_mainfile(filepath=blend_path)
+
+    # Simulate closing and reopening Blender: fs_registry is plain-Python,
+    # in-process state that a fresh process starts up without, unlike
+    # bpy.data (including VirtualFile.fs_key), which is restored from disk.
+    fs_registry.clear()
+    bpy.ops.wm.open_mainfile(filepath=blend_path)
+
+    vfs = bpy.context.scene.albam.vfs
+    vfile = vfs.select_vfile("re5", "model/pl/pl00/pl00.mod")
+    assert vfile.get_bytes() == b"mod-bytes"
+
+
 def test_remove_root_unregisters_fs():
     from albam.vfs import ALBAM_OT_VirtualFileSystemRemoveRootVFile
 


### PR DESCRIPTION
## Summary
- `albam/lib/fs_registry.py` is a plain in-process dict mapping a `VirtualFile.fs_key` to a live `fs.base.FS` instance; it's never part of the saved `.blend` file, only the key is.
- Reproduced: add a folder/archive to the VFS, save, close Blender, reopen, try to import → `KeyError` in `VirtualFile.get_bytes()`, since the root's persisted `fs_key` now points at nothing.
- Fix: a new `load_post` handler (`albam.vfs.reconnect_fs_roots`) rebuilds each root's live FS instance from its stored `absolute_path`, using the same `fs_root_loader` dispatch `add_real_file` used originally, and re-registers it under the existing key via a new `fs_registry.reconnect()`.
- Roots with no `absolute_path` (in-memory export roots from `add_export_root`) can't be rebuilt this way and are left alone — they're transient, run-only state to begin with.

## Test plan
- [x] `pytest tests/test_vfs_fs_backed.py -v` — added `test_reload_blend_file_reconnects_fs_roots`, which reproduces the exact `KeyError` pre-fix (via a real save → `fs_registry.clear()` → `bpy.ops.wm.open_mainfile` round trip) and passes post-fix.
- [x] Full CI-safe suite (`pytest`, with `.[tests,reen]` installed): 45 passed, 81 skipped, 1 xfailed, no regressions.
- [x] `flake8 .` clean.