### PR TITLE
Fix latest-main version counting the wrong number of commits

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -164,7 +164,7 @@ jobs:
         run: |
           set -e
           base_version="$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")"
-          last_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+          last_tag="$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true)"
           if [ -n "$last_tag" ]; then
             commit_count="$(git rev-list "${last_tag}..HEAD" --count)"
           else


### PR DESCRIPTION
The latest-main rolling release creates a real git tag on every push to main. Since git describe --tags --abbrev=0 has no filter, it picks up that tag as the last tag instead of the real version tag. That resets the commit count on every run instead of counting since the last real release.

Fix: match only real version tags (v[0-9]*) when finding the last tag, consistent with how the rest of the workflow already identifies releases.