### PR TITLE
Fix VFS export re-registration returning stale bytes on re-export

### DIFF
--- a/albam/vfs.py
+++ b/albam/vfs.py
@@ -226,12 +226,34 @@ class VirtualFileSystemBase:
         read-only archive/game-folder roots, sharing the same tree-building
         and get_bytes() machinery instead of duplicating bytes into
         data_bytes.
+
+        A child file's node id is `app_id::<relative path parts>` (see
+        select_vfile()/get_vfile()) and isn't scoped by which root added it -
+        each root here gets its own unique display_name (see
+        ALBAM_OT_Export._execute()), but re-exporting the same
+        (app_id, relative_path) still produces a second file_list entry with
+        an identical id. Blender's CollectionProperty name lookup
+        (file_list[id]/file_list.find(id)) returns the *first* match, so
+        without this, select_vfile() on that identity would keep returning
+        the previous export's bytes forever after, silently - purge every
+        earlier entry for each identity this export is about to add, so the
+        new one (added below via add_fs_root()) is the one found. Scoped to
+        the export root only - add_fs_root()'s read-only archive/game-folder
+        mount path has its own separate "mounting the same folder twice"
+        sharp edge (see game_fs_root()'s docstring), left alone here.
         """
         mem_fs = MemoryFS()
         for vfile_data in vfiles_data:
             path = "/" + str(vfile_data.relative_path).replace("\\", "/")
             mem_fs.makedirs(dirname(path), recreate=True)
             mem_fs.writebytes(path, vfile_data.data_bytes or b"")
+
+            file_id = self.SEPARATOR.join(
+                (app_id,) + PureWindowsPath(vfile_data.relative_path).parts)
+            stale_index = self.file_list.find(file_id)
+            while stale_index != -1:
+                self.file_list.remove(stale_index)
+                stale_index = self.file_list.find(file_id)
 
         return self.add_fs_root(app_id, mem_fs, display_name=display_name)
 

--- a/tests/test_vfs_fs_backed.py
+++ b/tests/test_vfs_fs_backed.py
@@ -105,6 +105,34 @@ def test_add_export_root_writes_and_reads_bytes():
     assert vfile_mrl.get_bytes() == b"exported-mrl"
 
 
+def test_add_export_root_second_export_replaces_stale_entry():
+    """
+    A child file's node id is app_id::relative_path, not scoped by which
+    root added it. Exporting the same identity twice in one session used to
+    leave both the old and new file_list entries around with an identical
+    id - Blender's CollectionProperty name lookup (file_list[id]/.find(id))
+    returns the *first* match, so select_vfile()/get_vfile() kept silently
+    returning the first export's bytes forever after, no matter how many
+    times the same asset was re-exported (#239).
+    """
+    exported = bpy.context.scene.albam.exported
+    path = "model/pl/pl00/pl00.mod"
+
+    exported.add_export_root("re5", "export-root-first", [
+        VirtualFileData("re5", path, data_bytes=b"first-export"),
+    ])
+    exported.add_export_root("re5", "export-root-second", [
+        VirtualFileData("re5", path, data_bytes=b"second-export"),
+    ])
+
+    assert exported.select_vfile("re5", path).get_bytes() == b"second-export"
+    assert exported.get_vfile("re5", path).get_bytes() == b"second-export"
+
+    file_id = "re5::model::pl::pl00::pl00.mod"
+    matches = [vf for vf in exported.file_list if vf.name == file_id]
+    assert len(matches) == 1
+
+
 def test_add_export_root_defaults_missing_bytes_to_empty():
     exported = bpy.context.scene.albam.exported
     exported.add_export_root(


### PR DESCRIPTION
## Summary
- Fixes #239: `add_export_root()` never de-duplicated child file entries, so re-exporting the same `(app_id, relative_path)` in one session left a stale entry ahead of the fresh one in `file_list`. Blender's `CollectionProperty` name lookup returns the *first* match, so `select_vfile()`/`get_vfile()` on that identity kept silently returning the first export's bytes forever after, no matter how many times the asset was re-exported.
- `add_export_root()` now purges any existing `file_list` entries for each identity it's about to add before staging the fresh ones, so the latest export always wins. Scoped to the export path only, per the issue's own fix-direction notes — `add_fs_root()`'s read-only archive/game-folder mount path has a separate "mounting the same folder twice" sharp edge that's left alone here.
- Found as the true root cause of a `test_export_anim_block[re5]` failure on PR #180 that had been masked by an unrelated crash until that crash was fixed there.

## Test plan
- [x] New regression test `test_add_export_root_second_export_replaces_stale_entry` in `tests/test_vfs_fs_backed.py`, confirmed to fail without the fix and pass with it.
- [x] Full `tests/test_vfs_fs_backed.py` suite passes (9/9).
- [x] `flake8 .` clean.
- [x] Full CI-safe `pytest` subset passes (46 passed, 83 skipped, 1 xfailed; one unrelated pre-existing error from a missing optional `pymmh3` dependency in this venv, unrelated to this change).