### PR TITLE
Mount VFS roots again on demand, not just on file load

### DIFF
--- a/albam/blender_ui/export_panel.py
+++ b/albam/blender_ui/export_panel.py
@@ -2,7 +2,6 @@ import time
 import os
 import bpy
 
-from ..lib import fs_registry
 from .error_handling import handle_operator_exception
 from ..registry import blender_registry
 from ..vfs import (
@@ -10,6 +9,7 @@ from ..vfs import (
     ALBAM_OT_VirtualFileSystemCollapseToggleBase,
     ALBAM_OT_VirtualFileSystemRemoveRootVFileBase,
     VirtualFileSystemBase,
+    root_fs,
 )
 from .import_panel import ALBAM_UL_VirtualFileSystemUIBase
 
@@ -378,7 +378,7 @@ class ALBAM_OT_Pack(bpy.types.Operator):
                 # ArcFS-wrapped .arc (always returns that arc's own path) or
                 # a whole MTFW_FS game-folder root (resolves the specific
                 # .arc this path actually came from) - see origin_arc_path.
-                path_i = origin_arc_path(fs_registry.get(item_i.fs_key), item_i.fs_path)
+                path_i = origin_arc_path(root_fs(item_i), item_i.fs_path)
                 if path_i is None:
                     self.report({'ERROR'}, "Selected archive isn't backed by a packed .arc file")
                     return

--- a/albam/vfs.py
+++ b/albam/vfs.py
@@ -96,7 +96,7 @@ class VirtualFile(bpy.types.PropertyGroup):
     def get_bytes(self):
         root = self.root_vfile
         if root and root.fs_key:
-            return fs_registry.get(root.fs_key).readbytes(self.fs_path)
+            return root_fs(root).readbytes(self.fs_path)
         accessor = self.get_accessor()
         return accessor(self, bpy.context)
 
@@ -105,7 +105,7 @@ class VirtualFile(bpy.types.PropertyGroup):
             return self.real_file_accessor
         if self.data_bytes:
             return lambda vfile, context: self.data_bytes
-        vfs = getattr(bpy.context.scene.albam, self.vfs_id)
+        vfs = self.get_vfs()
         root = vfs.file_list[self.tree_node.root_id]
         accessor_func = blender_registry.archive_accessor_registry.get(
             (self.app_id, root.extension)
@@ -121,7 +121,14 @@ class VirtualFile(bpy.types.PropertyGroup):
             return f.read()
 
     def get_vfs(self):
-        return getattr(bpy.context.scene.albam, self.vfs_id)
+        """The vfs collection this file actually belongs to - resolved
+        through the scene owning it (`id_data`), not through
+        bpy.context.scene: a file lives in one specific scene's albam data,
+        and looking it up in whichever scene happens to be active resolves
+        roots (and therefore bytes) from the wrong file list entirely.
+        """
+        scene = self.id_data
+        return getattr(scene.albam, self.vfs_id)
 
     def _get_relative_path_windows(self, include_extension=True):
         p = PureWindowsPath(self.relative_path)
@@ -323,37 +330,91 @@ class VirtualFileSystemBase:
         return vfile
 
 
+def _fs_root_loader(vf):
+    """The registered fs_root_loader able to rebuild root `vf`'s FS: keyed by
+    the root's own extension for an archive root ("Add Files"), falling back
+    to the whole-folder loader ("Add Folder"), same as add_real_file().
+    """
+    return (blender_registry.fs_root_loader_registry.get((vf.app_id, vf.extension)) or
+            blender_registry.fs_root_loader_registry.get((vf.app_id, None)))
+
+
+def reconnect_fs_root(vf):
+    """
+    Rebuild the fs_registry entry backing root `vf` - under the `fs_key` it
+    already carries, not a fresh one - and return the live FS instance.
+
+    fs_registry is plain in-process state (see its module docstring): it
+    isn't part of the .blend file, and it's also dropped mid-session
+    whenever the add-on is re-registered (Reload Scripts, an extension
+    update, a disable/enable cycle - unregister() calls fs_registry.clear()).
+    A root's `fs_key`/`absolute_path` are real bpy.props that outlive both,
+    so the entry can be recreated the same way add_real_file() created it
+    the first time.
+    """
+    if not vf.absolute_path:
+        raise RuntimeError(
+            f"VFS root {vf.display_name!r} has no path on disk to mount again - it only "
+            f"ever existed in memory (e.g. an export root), so it's gone for this session"
+        )
+    fs_loader = _fs_root_loader(vf)
+    if not fs_loader:
+        raise RuntimeError(
+            f"VFS root {vf.display_name!r} has no fs_root_loader registered for "
+            f"app_id={vf.app_id!r} to mount it again with"
+        )
+    fs_instance = fs_loader(vf.absolute_path)
+    fs_registry.reconnect(vf.fs_key, fs_instance)
+    return fs_instance
+
+
+def root_fs(root_vf):
+    """
+    The live FS instance backing root `root_vf`, mounting it again on demand
+    if this process's fs_registry doesn't have it (any more) - see
+    reconnect_fs_root(). Going through here instead of straight to
+    fs_registry.get() keeps a root readable in every case the load_post
+    handler below can't cover: the add-on being re-registered mid-session,
+    roots living in a scene that wasn't the active one when the file loaded,
+    or a file loaded before the add-on was enabled at all. Otherwise the
+    first read of such a root raises a bare KeyError on a uuid, from
+    wherever an importer happened to ask for bytes.
+    """
+    try:
+        return fs_registry.get(root_vf.fs_key)
+    except KeyError:
+        print(f"albam: mounting VFS root {root_vf.display_name!r} again "
+              f"from {root_vf.absolute_path!r}")
+        return reconnect_fs_root(root_vf)
+
+
 @persistent
 def reconnect_fs_roots(dummy):
     """
-    fs_registry is plain in-process state (see its module docstring) - it
-    isn't part of the .blend file and comes up empty in a fresh Blender
-    session, while a root VirtualFile's `fs_key`/`absolute_path` (real
-    bpy.props, restored from the file) still point at the FS instance that
-    used to back it. Without this, VirtualFile.get_bytes() on any such root
-    - i.e. every "Add Folder"/"Add Files" root re-added by loading a saved
-    .blend - raises KeyError the first time it's read (e.g. on import).
-    Rebuilds the registry entry the same way add_real_file() built it the
-    first time, so existing fs_key values keep pointing at something live.
-    Roots with no `absolute_path` (add_export_root()'s in-memory FS) can't
-    be recreated this way and are left as-is - they're transient, run-only
-    state to begin with.
+    Mount every FS-backed root in the freshly-loaded file again, so the
+    `fs_key` values restored from it keep pointing at something live (see
+    reconnect_fs_root() for what drops them). Doing it up front here keeps
+    the first read of a root predictable - a whole game folder can take a
+    while to mount - while get_bytes() still falls back to mounting lazily
+    for any root this misses. Roots with no `absolute_path`
+    (add_export_root()'s in-memory FS) can't be recreated this way and are
+    left as-is - they're transient, run-only state to begin with.
     """
-    for vfs_id in ("vfs", "exported"):
-        vfs = getattr(bpy.context.scene.albam, vfs_id, None)
-        if vfs is None:
+    for scene in bpy.data.scenes:
+        albam_data = getattr(scene, "albam", None)
+        if albam_data is None:
             continue
-        for vf in vfs.file_list:
-            if not (vf.is_root and vf.fs_key and vf.absolute_path):
+        for vfs_id in ("vfs", "exported"):
+            vfs = getattr(albam_data, vfs_id, None)
+            if vfs is None:
                 continue
-            fs_loader = (blender_registry.fs_root_loader_registry.get((vf.app_id, vf.extension)) or
-                         blender_registry.fs_root_loader_registry.get((vf.app_id, None)))
-            if not fs_loader:
-                continue
-            try:
-                fs_registry.reconnect(vf.fs_key, fs_loader(vf.absolute_path))
-            except Exception as err:
-                print(f"albam: could not reconnect VFS root {vf.display_name!r}: {err}")
+            for vf in vfs.file_list:
+                if not (vf.is_root and vf.fs_key and vf.absolute_path):
+                    continue
+                try:
+                    reconnect_fs_root(vf)
+                except Exception as err:
+                    print(f"albam: could not reconnect VFS root {vf.display_name!r}: {err}")
 
 
 @blender_registry.register_blender_prop_albam(name="vfs")

--- a/tests/test_vfs_fs_backed.py
+++ b/tests/test_vfs_fs_backed.py
@@ -177,6 +177,71 @@ def test_reload_blend_file_reconnects_fs_roots(tmp_path):
     assert vfile.get_bytes() == b"mod-bytes"
 
 
+def test_get_bytes_remounts_a_root_the_registry_lost(tmp_path):
+    """
+    fs_registry is also emptied *without* a file load: unregister() clears
+    it, so Reload Scripts, an extension update or a disable/enable cycle
+    leaves every already-added root pointing at a key that's gone, with no
+    load_post to rebuild it. Reading bytes must mount the root again on
+    demand instead of raising a bare KeyError on a uuid.
+    """
+    game_root = tmp_path / "game_root"
+    (game_root / "model").mkdir(parents=True)
+    (game_root / "model" / "pl00.mod").write_bytes(b"mod-bytes")
+
+    vfs = bpy.context.scene.albam.vfs
+    vfs.add_real_file("re5", str(game_root))
+    vfile = vfs.select_vfile("re5", "model/pl00.mod")
+    assert vfile.get_bytes() == b"mod-bytes"
+
+    fs_registry.clear()
+
+    assert vfile.get_bytes() == b"mod-bytes"
+    # Mounted again under the key the root already carried, not a new one.
+    assert fs_registry.get(vfile.root_vfile.fs_key) is not None
+
+
+def test_get_bytes_on_an_unmountable_root_says_why():
+    """An export root's MemoryFS only ever existed in this process - there's
+    no path to mount it again from, so the error naming it must say that
+    rather than surfacing the internal registry key.
+    """
+    exported = bpy.context.scene.albam.exported
+    exported.add_export_root(
+        "re5", "export-root", [VirtualFileData("re5", "a.mod", data_bytes=b"bytes")]
+    )
+    vfile = exported.select_vfile("re5", "a.mod")
+
+    fs_registry.clear()
+
+    with pytest.raises(RuntimeError, match="export-root"):
+        vfile.get_bytes()
+
+
+def test_reload_blend_file_reconnects_roots_in_every_scene(tmp_path):
+    """The load_post handler used to walk bpy.context.scene only, leaving a
+    root added in any other scene of the same file unmounted.
+    """
+    game_root = tmp_path / "game_root"
+    (game_root / "model").mkdir(parents=True)
+    (game_root / "model" / "pl00.mod").write_bytes(b"mod-bytes")
+
+    extra_scene = bpy.data.scenes.new("extra")
+    extra_scene.albam.vfs.add_real_file("re5", str(game_root))
+
+    blend_path = str(tmp_path / "save.blend")
+    bpy.ops.wm.save_as_mainfile(filepath=blend_path)
+    fs_registry.clear()
+    bpy.ops.wm.open_mainfile(filepath=blend_path)
+
+    extra_scene = bpy.data.scenes["extra"]
+    vfile = extra_scene.albam.vfs.select_vfile("re5", "model/pl00.mod")
+    assert vfile.get_bytes() == b"mod-bytes"
+
+    extra_scene.albam.vfs.file_list.clear()
+    bpy.data.scenes.remove(extra_scene)
+
+
 def test_remove_root_unregisters_fs():
     from albam.vfs import ALBAM_OT_VirtualFileSystemRemoveRootVFile
 


### PR DESCRIPTION
Reported as a `KeyError: '<uuid>'` on import from a saved .blend, from `fs_registry.get(root.fs_key)`:

```
File ".../engines/hexn/material.py", line 51, in build_blender_materials
  matb_bytes = matb_vfile.get_bytes()
File ".../vfs.py", line 99, in get_bytes
  return fs_registry.get(root.fs_key).readbytes(self.fs_path)
File ".../lib/fs_registry.py", line 32, in get
  return _REGISTRY[key]
KeyError: '7806ca0b7fc84d9684a4bd91f82606d7'
```

`fs_registry` is process-lifetime state that isn't part of the .blend, while a root's `fs_key` is a real bpy.prop restored from it. #235's `load_post` handler covers one way that pair goes out of sync - reopening a saved file - and not the others:

- `unregister()` calls `fs_registry.clear()`, so Reload Scripts, an extension update or a disable/enable cycle leaves every already-added root pointing at a key that's gone, with no file load to rebuild it. Reproduced against a real install: mount a game folder, save, reopen, `unregister()`/`register()`, read any file -> the KeyError above.
- The handler walked `bpy.context.scene` only, so a root added in any other scene of the file was never reconnected.
- `VirtualFile.get_vfs()` resolved its file list through `bpy.context.scene` too, so a file in a non-active scene looked its root up in the wrong list entirely.

## What changed

- Reads go through a new `root_fs(root)`, which mounts a root again on demand under the `fs_key` it already carries, so a root stays readable in every case the handler can't cover - including ones neither of us has enumerated.
- When a root genuinely can't be mounted again (an export root's in-memory FS has no path on disk), the error names the root and says why, instead of surfacing an internal uuid from wherever an importer happened to ask for bytes.
- The `load_post` handler walks every scene and shares the same `reconnect_fs_root()` helper. Doing it up front is still worth keeping: mounting a whole game folder takes a while, and the lazy path would charge that to the first import instead.
- `get_vfs()` resolves through the scene owning the file (`id_data`).
- `export_panel`'s `origin_arc_path` call had the same raw `fs_registry.get`, and now uses `root_fs` too.

## Tests

Three new tests in `tests/test_vfs_fs_backed.py`: reading after the registry is cleared mid-session, the error message for a root that can't be mounted again, and the handler reconnecting a root that lives in a non-active scene.

- `pytest tests/` (CI-safe): 70 passed
- `pytest tests/ --game-dir=re1::<install>`: 82 passed, 1601 subtests
- On the branch this came from (hexn/orc), the same commit passes `pytest tests/ --game-dir=reorc::<install>`: 256 passed, and the reported import succeeds after a reload.