### PR TITLE
ci: run on every branch push, once per commit, without touching the badge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,13 +1,39 @@
 name: Test
 on:
   push:
-    branches: [ "main" ]
+    # Every branch, not just main: a branch used to get no CI at all until a
+    # PR was opened for it. The duplicate runs this would normally cause on
+    # an open PR are suppressed by the tests job's own condition below.
+    branches: [ "**" ]
     tags: [ "v*" ]
   pull_request:
     branches: [ "main" ]
+  # Re-run on demand without pushing anything, e.g. to retry a flaky job:
+  # `gh workflow run tests.yml --ref <branch>`. Only offered once this file
+  # is on the default branch - GitHub reads the trigger list from there.
+  workflow_dispatch:
+
+# A burst of pushes to one branch used to leave every intermediate commit
+# running both matrix legs to completion; only the newest is worth the
+# runner. main and tags are excluded: publish-latest-main and publish-release
+# hang off this workflow, so cancelling a superseded run there would skip a
+# release build.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: >-
+    ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
   tests:
+    # A branch in this repo is already covered by the push trigger above, so
+    # its PR would otherwise run the whole matrix a second time on the same
+    # commit. A fork's branch produces no push event here, so fork PRs - the
+    # only ones this skips for - still need the pull_request trigger. A
+    # skipped job satisfies a required status check, so this stays usable
+    # with branch protection.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -121,6 +147,12 @@ jobs:
       - name: "Coverage report"
         run: coverage report --sort cover
       - name: "Make badge"
+        # The badge is public and reads as "albam's coverage", so only main
+        # may write it - the steps above still run everywhere, so a PR (or a
+        # workflow_dispatch run on a branch) keeps its coverage report and
+        # step summary. Without this the job had no branch condition at all,
+        # and a branch run would overwrite the badge with that branch's number.
+        if: github.ref == 'refs/heads/main'
         uses: schneegans/dynamic-badges-action@v1.4.0
         with:
           # GIST_TOKEN is a GitHub personal access token with scope "gist".


### PR DESCRIPTION
A branch got no CI until a PR was opened for it. The push trigger now covers every branch, and the `tests` job skips the `pull_request` event for branches in this repo, so a commit on an open PR runs **once** rather than twice — `push` and `pull_request` land in different concurrency groups and would not otherwise deduplicate. A fork's branch produces no push event here, so fork PRs still run via `pull_request`, which is the only case that condition skips for.

### Tradeoff

A same-repo PR is now tested at its branch tip rather than merged with main, so a change that breaks against a moved main is caught by main's own run just after the merge instead of just before it. That is acceptable here: main pushes run the full suite, and `publish-latest-main` has `needs: tests`, so a break fails the run and publishes nothing. Rebasing before merge is the cheap guard; requiring up-to-date branches or a merge queue is more process than this repo's merge rate justifies.

### Also in here

- **Superseded runs are cancelled.** Nothing cancelled them before, so a burst of pushes left every intermediate commit running both matrix legs to completion — one branch did five runs inside an hour, four already obsolete. `main` and tags are excluded, since `publish-latest-main` and `publish-release` hang off this workflow and cancelling one would skip a release build.
- **The coverage badge is gated to main.** The badge step had no branch condition at all, and it publishes to a public gist that reads as "albam's coverage" — any branch run, routine now, would have overwritten it with that branch's number. The gate sits on the step rather than the job, so the coverage report and step summary still run everywhere, which is what makes them useful on a PR.
- **`workflow_dispatch`** for on-demand re-runs, e.g. retrying a flaky job without pushing an empty commit. Note it only becomes available once this is on the default branch — GitHub reads the trigger list from there.

### Verification

`publish-latest-main` (`push` + `refs/heads/main`) and `publish-release` (`refs/tags/v`) are both ref-gated, so the broadened `push` trigger cannot reach a publish job from a feature branch. The `if:` expressions are only evaluated by GitHub at run time, so this PR's own runs are the first real check of them.
