### PR TITLE
Write num_edges on export for the triangle-list versions

### DIFF
--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -902,6 +902,21 @@ def export_mod(bl_obj):
     dst_mod.header.size_vertex_buffer_2 = len(vertex_buffer_2)
     # TODO: revise, name accordingly
     dst_mod.header.num_faces = (len(index_buffer) // 2) + 1
+    if dst_mod.header.version not in VERSIONS_USE_TRISTRIPS:
+        # num_edges was initialised to 0 and never assigned, so every export
+        # wrote 0 for it. On a version that indexes triangles as a plain
+        # list, the two fields are one relation apart - measured across
+        # every model in the serialization dataset, num_faces equals the
+        # summed mesh index count and num_edges is exactly a third of it,
+        # which is what the TODO above is pointing at: these are the index
+        # count and the triangle count. Deriving it keeps the header
+        # self-consistent whatever num_faces ends up being.
+        #
+        # Left alone on the tristrip versions: there the index count is not
+        # three per triangle, num_edges has no such relation to num_faces in
+        # a real file, and recovering the triangle count needs the strip
+        # decomposition rather than arithmetic.
+        dst_mod.header.num_edges = dst_mod.header.num_faces // 3
     if app_id not in ["re5", "dd"]:
         index_buffer.extend((0, 0))
 


### PR DESCRIPTION
`num_edges` is initialised to `0` in the export header (`mesh.py:943`) and never assigned again, so **every `.mod` albam has ever written carries 0 for it**, regardless of app or version.

### What the field actually holds

Measured across every model in the serialization dataset:

| app | version | `num_faces` | `num_edges` | relation |
|---|---|---|---|---|
| umvc3 | 211 (triangle lists) | 117729 / 42846 / 204, equal to the summed mesh index count | 39243 / 14282 / 68 | exactly `num_faces / 3`, all three |
| re5 | 156 (tristrips) | 53234 / 54344 / 22588 | 29800 / 31609 / 7940 | none |

On a triangle-list version these are the index count and the triangle count, misnamed — which is what the `# TODO: revise, name accordingly` immediately above the line is pointing at.

### The change

Derives `num_edges` from `num_faces` on the non-tristrip versions. Deriving rather than recomputing keeps the header self-consistent if `num_faces` is later corrected — it is separately wrong, and both are covered by the same xfail.

The tristrip versions (153, 156, 212) are left writing 0: the index count is not three per triangle there, a real file shows no such relation, and recovering the triangle count needs the strip decomposition rather than arithmetic.

### Verification

main has no triangle-list models in its dataset (re5 is 156), so this path is not exercised by CI here. Verified by applying the change on the umvc3 branch and running the round-trip against a real install:

- two of three models: `num_edges` now **matches the source exactly**, and the failure moves on to `num_faces`
- the third: 39243 vs 38674, still off because `num_faces` is wrong for that model — the derived value inherits that error, as intended

So `num_edges` goes from wrong on 3 of 3 to correct on 2 of 3, the remainder blocked by the separate `num_faces` defect.

Stacks cleanly with #250; independent of it.

### How urgent is this?

Not very — this is correctness rather than a fix for broken output.

`num_edges` is declared in `mod-21.ksy`, `mod-156.ksy` and `mod-153.ksy` and referenced by none of them, unlike `num_faces`, which sizes the index buffer in all three (`size: header.num_faces * 2`). And albam has written `0` for it on every export it has ever produced, without that surfacing as a problem in-game — a broader test than anything runnable here. So the field looks not load-bearing at runtime, plausibly an authoring-time statistic.

Confirming that properly means finding the header parser in the game binary and checking whether the field's offset is ever read, which was not worth the time. Merging anyway because writing the true value costs one line, keeps the header self-consistent, and stops albam's output differing from Capcom's for no reason.
