### PR TITLE
Ask how many UV layers a mesh has instead of probing past the end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   for that animation id, dropping the id from an exported `.lmt`
 - A second animation file imported onto the same skeleton leaving its limb
   chains solving towards goals none of its blocks move
+- Spurious "Array iterator out of range" messages printed on every export of a mesh with fewer UV layers than the vertex format allows
 
 ### Changed
 

--- a/albam/lib/blender.py
+++ b/albam/lib/blender.py
@@ -178,12 +178,20 @@ def get_uvs_per_loop(blender_mesh_object, layer_index):
     Return {loop_index: (uv_x, uv_y)}, one entry per mesh corner (as opposed
     to per vertex): a shared vertex can be part of more than one UV island,
     so its corners can legitimately have different UVs.
+
+    Callers ask for a fixed number of layers because that is what the vertex
+    formats allow, so a mesh with fewer is the normal case, not an error.
+    Asking how many there are rather than indexing and catching the failure
+    keeps Blender from printing "Array iterator out of range" to stdout: it
+    writes that before raising, so catching the exception does not suppress
+    it, and once per missing layer per mesh it reads like a real error in
+    the middle of an export log.
     """
     loops = {}
-    try:
-        uv_layer = blender_mesh_object.data.uv_layers[layer_index]
-    except IndexError:
+    uv_layers = blender_mesh_object.data.uv_layers
+    if layer_index >= len(uv_layers):
         return loops
+    uv_layer = uv_layers[layer_index]
     uvs_per_loop = uv_layer.data
     if not uvs_per_loop:
         return loops


### PR DESCRIPTION
Exporting a mesh prints a line like this to stdout, once per UV layer the mesh does not have:

```
Array iterator out of range: Mesh_uv_layers_lookup_int (index 2)
Array iterator out of range: Mesh_uv_layers_lookup_int (index 3)
```

It is not an error. `_build_export_vertex_table` probes four UV layers because that is what the vertex formats allow, so a mesh with two real layers is asked for indices 2 and 3 as a matter of course. `get_uvs_per_loop` indexed the collection and caught the `IndexError`:

```python
try:
    uv_layer = blender_mesh_object.data.uv_layers[layer_index]
except IndexError:
    return loops
```

That handles the case correctly but not quietly. Blender's RNA layer writes the message straight to stdout *before* raising, so catching the exception in Python does not suppress it. Comparing against the length first means the failing lookup never happens.

Worth fixing because it is noise that reads like a real error: an export of a scene fills the log with it, and anyone debugging an actual export problem has to work out that these lines are meaningless first.

No test: the change swaps an index-and-catch for a length check with identical return values either way, and the only observable difference is a line of Blender's own stdout that nothing contracts to keep.
