### PR TITLE
Move the workflow's actions off Node 20

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,9 +42,9 @@ jobs:
               {"bpy-version": "5.2.0", "python-version": "3.13"}
              ]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.bpy.python-version }} with bpy ${{ matrix.bpy-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.bpy.python-version }}
         # No `cache: pip` - uv caches instead, below. setup-python's pip cache
@@ -52,9 +52,9 @@ jobs:
         # requirements.txt), so the key never changed and the cache only ever
         # grew: 946MB for 3.11 against 461MB for 3.13, same dependencies.
     - name: Set up uv
-      # v6 is the newest floating major tag astral-sh publishes; 10.x exists
-      # but only as exact versions (there is no v10 tag to track).
-      uses: astral-sh/setup-uv@v6
+      # v7 is the newest floating major tag astral-sh publishes; later
+      # majors exist but only as exact versions, with no tag to track.
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         # Both files pin what gets installed - pyproject.toml for these jobs,
@@ -109,7 +109,7 @@ jobs:
         fi
         exit "$exitcode"
     - name: "Upload coverage data"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: .coverage.${{ matrix.bpy.bpy-version }}
         path: .coverage.${{ matrix.bpy.bpy-version }}
@@ -121,9 +121,9 @@ jobs:
     needs: tests
     steps:
       - name: "Check out the repo"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v5"
       - name: "Set up Python"
-        uses: "actions/setup-python@v5"
+        uses: "actions/setup-python@v6"
         with:
           python-version: "3.12"
           # No pip cache here: this job installs one small package, and the
@@ -132,7 +132,7 @@ jobs:
         run: |
           python -m pip install coverage
       - name: "Download coverage data"
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v6
         with:
           path: .covdata
           pattern: .coverage.*
@@ -177,13 +177,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # `git describe`/`rev-list --count` below need full history and
           # tags to compute the commit-count-since-last-release suffix -
           # actions/checkout defaults to a shallow, tag-less clone.
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
           cache: 'pip'
@@ -235,8 +235,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
           cache: 'pip'


### PR DESCRIPTION
Every run currently ends with:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v3, actions/setup-python@v5, actions/upload-artifact@v4, astral-sh/setup-uv@v6

| action | from | to |
| --- | --- | --- |
| `actions/checkout` | v3, v4 | v5 |
| `actions/setup-python` | v5 | v6 |
| `actions/upload-artifact` | v4 | v5 |
| `actions/download-artifact` | v4.1.7 | v6 |
| `astral-sh/setup-uv` | v6 | v7 |

These are the **first major of each that runs Node 24 outright**, not the newest available (checkout is on v7, download-artifact on v8). That is what the deprecation actually requires, and it keeps the version jump small enough to reason about. Bumping to the newest can be a separate, deliberate decision.

### Breaking changes checked, none reach this workflow

- **`download-artifact` v5** changed the output path for single artifact downloads *by id*. The coverage job downloads by `pattern` with `merge-multiple`, so it is unaffected.
- **`setup-python` v7** removes the `pip-install` input. Not used here, and this only bumps to v6 anyway.
- **`setup-uv` v7** removes the deprecated `server-url` input. Not used here.
- The rest of each jump is the Node 20 to Node 24 runtime change, which needs runner v2.327.1 or newer. GitHub-hosted runners are well past that.

### Also

The comment above `setup-uv` said v6 was the newest floating major tag astral-sh publishes. That is no longer true, so it is updated: v7 exists as a tracked tag, while the later majors are still exact versions only.

`schneegans/dynamic-badges-action@v1.4.0` is left alone. It was not in the deprecation list, and it is the one third-party action here that is not maintained by GitHub or Astral, so it is worth bumping on its own merits rather than as part of this.

CI passing on this PR is itself the test.
