### PR TITLE
Frame character renders on geometry, and render them in parallel

### DIFF
--- a/tests/tools/render_characters.py
+++ b/tests/tools/render_characters.py
@@ -12,7 +12,7 @@ same interpreter pytest uses - not the real Blender application.
 Usage:
     python tests/tools/render_characters.py <app-id> <game-root> [--pattern REGEX]
                                       [--suffix NAME] [--limit N]
-                                      [--resolution WIDTHxHEIGHT]
+                                      [--resolution WIDTHxHEIGHT] [--jobs N]
 
 Example:
 
@@ -20,12 +20,17 @@ Example:
 
 Writes tests/data/<app-id>/<model>[_<suffix>].png. Pass --suffix to keep
 a before/after pair side by side while working on shading.
+
+Rendering is spread over --jobs worker processes. One process per worker is
+the only way to parallelise this: bpy drives a single global Blender session,
+so two characters cannot be in flight inside one interpreter.
 """
 import argparse
 import gc
 import math
 import os
 import re
+import subprocess
 import sys
 
 import bpy
@@ -167,6 +172,20 @@ def _model_name(path):
     return re.sub(r"[^A-Za-z0-9_-]+", "_", stem)
 
 
+def _run_workers(args):
+    """Re-run this script once per shard and wait for them all."""
+    base = [sys.executable, os.path.abspath(__file__), args.app_id, args.game_root,
+            "--pattern", args.pattern, "--resolution", args.resolution, "--jobs", "1"]
+    if args.suffix:
+        base += ["--suffix", args.suffix]
+    if args.limit:
+        base += ["--limit", str(args.limit)]
+
+    workers = [subprocess.Popen(base + ["--shard", f"{index}/{args.jobs}"])
+               for index in range(args.jobs)]
+    return max(worker.wait() for worker in workers)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -178,7 +197,13 @@ def main():
     parser.add_argument("--limit", type=int, default=None)
     parser.add_argument("--resolution", default="1024x1536",
                         help="WIDTHxHEIGHT, e.g. 640x960 for a quick low-res pass")
+    parser.add_argument("--jobs", type=int, default=4,
+                        help="worker processes to render with (default 4)")
+    parser.add_argument("--shard", default=None, help=argparse.SUPPRESS)
     args = parser.parse_args()
+
+    if args.shard is None and args.jobs > 1:
+        return _run_workers(args)
 
     import albam
     albam.register()
@@ -193,6 +218,12 @@ def main():
                    if p.lower().endswith(".mod") and rx.match(p))
     if args.limit:
         paths = paths[:args.limit]
+    if args.shard:
+        index, total = (int(n) for n in args.shard.split("/"))
+        # Round robin rather than contiguous blocks: neighbouring characters
+        # in a sorted listing tend to be alike in size, so a block hands one
+        # worker every heavy model and leaves another idle.
+        paths = paths[index::total]
     print(f"{len(paths)} models", file=sys.stderr)
 
     bpy.context.scene.albam.apps.app_selected = args.app_id

--- a/tests/tools/render_characters.py
+++ b/tests/tools/render_characters.py
@@ -12,6 +12,7 @@ same interpreter pytest uses - not the real Blender application.
 Usage:
     python tests/tools/render_characters.py <app-id> <game-root> [--pattern REGEX]
                                       [--suffix NAME] [--limit N]
+                                      [--resolution WIDTHxHEIGHT]
 
 Example:
 
@@ -52,18 +53,23 @@ def _clear_scene():
     gc.collect()
 
 
-def _bounding_box_world():
-    """World-space bounding box (min, max) across every mesh object."""
-    corners = []
+def _world_points(max_points=20000):
+    """World-space vertices of every mesh object, thinned to a bounded sample.
+
+    Framing on vertices rather than on each object's bounding box matters for
+    a character standing diagonally to the camera: the box corners stick out
+    into empty space and cost a good part of the frame."""
+    points = []
     for obj in bpy.data.objects:
         if obj.type != "MESH":
             continue
-        for corner in obj.bound_box:
-            corners.append(obj.matrix_world @ Vector(corner))
-    if not corners:
-        raise RuntimeError("no mesh objects to frame")
-    xs, ys, zs = zip(*corners)
-    return Vector((min(xs), min(ys), min(zs))), Vector((max(xs), max(ys), max(zs)))
+        vertices = obj.data.vertices
+        stride = max(1, len(vertices) // max_points)
+        matrix = obj.matrix_world
+        points.extend(matrix @ v.co for v in vertices[::stride])
+    if not points:
+        raise RuntimeError("no mesh geometry to frame")
+    return points
 
 
 def _setup_three_point_lighting(key=2.5, fill=0.9, rim=1.4):
@@ -90,32 +96,59 @@ def _setup_three_point_lighting(key=2.5, fill=0.9, rim=1.4):
         background.inputs["Strength"].default_value = 1.0
 
 
-def _setup_camera(bbox_min, bbox_max, fov_deg=40):
-    center = (bbox_min + bbox_max) / 2
-    dimensions = bbox_max - bbox_min
-    # Fit the bounding sphere, not the height: a model that is longer than
-    # it is tall (a quadruped, a vehicle) would otherwise run out of frame.
-    radius = (dimensions.length / 2) or 1.0
+def _setup_camera(points, resolution, fov_deg=40):
+    xs, ys, zs = zip(*points)
+    center = Vector((
+        (min(xs) + max(xs)) / 2, (min(ys) + max(ys)) / 2, (min(zs) + max(zs)) / 2))
 
     fov = math.radians(fov_deg)
-    distance = radius / math.sin(fov / 2) * 1.1  # a little headroom
+    # Blender's camera angle applies to the larger render dimension; the other
+    # axis follows from the aspect ratio.
+    width, height = resolution
+    if width >= height:
+        fov_x, fov_y = fov, 2 * math.atan(math.tan(fov / 2) * height / width)
+    else:
+        fov_y, fov_x = fov, 2 * math.atan(math.tan(fov / 2) * width / height)
 
     # Slightly elevated 3/4 front view - the usual character showcase angle.
     azimuth, elevation = math.radians(-25), math.radians(12)
-    cam_location = center + Vector((
+    direction = Vector((
         math.sin(azimuth) * math.cos(elevation),
         -math.cos(azimuth) * math.cos(elevation),
         math.sin(elevation),
-    )) * distance
+    ))
+    rotation = direction.to_track_quat("Z", "Y").to_matrix()
+    right, up = rotation.col[0], rotation.col[1]
+
+    # Centre on the silhouette as the camera sees it, not on the world-space
+    # box: an off-centre mid-point costs frame on one side and clips on the other.
+    local_x = [(p - center).dot(right) for p in points]
+    local_y = [(p - center).dot(up) for p in points]
+    center = center + right * ((min(local_x) + max(local_x)) / 2)
+    center = center + up * ((min(local_y) + max(local_y)) / 2)
+
+    # For a point at camera-space (x, y, z) the camera must stand at least
+    # z + |x| / tan(fov_x / 2) away for it to stay in frame (likewise for y),
+    # so take the furthest demand any point makes.
+    distance = 0.0
+    for point in points:
+        offset = point - center
+        local = Vector((offset.dot(right), offset.dot(up), offset.dot(direction)))
+        distance = max(
+            distance,
+            local.z + abs(local.x) / math.tan(fov_x / 2),
+            local.z + abs(local.y) / math.tan(fov_y / 2),
+        )
+    distance = (distance or 1.0) * 1.06  # a little headroom
 
     cam_data = bpy.data.cameras.new("RenderCamera")
     cam_data.lens_unit = "FOV"
     cam_data.angle = fov
     cam_obj = bpy.data.objects.new("RenderCamera", cam_data)
-    cam_obj.location = cam_location
+    cam_obj.location = center + direction * distance
     bpy.context.collection.objects.link(cam_obj)
     bpy.context.scene.camera = cam_obj
-    cam_obj.rotation_euler = (center - cam_location).to_track_quat("-Z", "Y").to_euler()
+    cam_obj.rotation_euler = (-direction).to_track_quat("-Z", "Y").to_euler()
 
 
 def _render(output_path, resolution=(1024, 1536)):
@@ -143,6 +176,8 @@ def main():
     parser.add_argument("--suffix", default=None,
                         help="appended to each filename, to keep runs side by side")
     parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--resolution", default="1024x1536",
+                        help="WIDTHxHEIGHT, e.g. 640x960 for a quick low-res pass")
     args = parser.parse_args()
 
     import albam
@@ -165,6 +200,8 @@ def main():
     vfs = bpy.context.scene.albam.vfs
     vfs.add_fs_root(args.app_id, game_fs, display_name=f"{args.app_id}-render")
 
+    resolution = tuple(int(n) for n in args.resolution.lower().split("x"))
+
     rendered, failed = [], []
     for i, path in enumerate(paths, 1):
         name = _model_name(path)
@@ -186,10 +223,10 @@ def main():
             # unculled that hull simply swallows the model.
             for bl_material in bpy.data.materials:
                 bl_material.use_backface_culling = True
-            bbox_min, bbox_max = _bounding_box_world()
+            points = _world_points()
             _setup_three_point_lighting()
-            _setup_camera(bbox_min, bbox_max)
-            _render(output_path)
+            _setup_camera(points, resolution)
+            _render(output_path, resolution=resolution)
             rendered.append(output_path)
         except Exception as e:
             failed.append((name, f"{type(e).__name__}: {e}"))


### PR DESCRIPTION
Two changes to `tests/tools/render_characters.py`, from a full umvc3 character sweep.

## Framing

The camera fitted the bounding sphere, which left a character at about half the frame height. Fitting per-object bounding boxes instead is no better: they include the default startup cube, and for a model standing diagonally to the camera the box corners sit out in empty space. The camera now fits the world-space vertices themselves and recentres on the silhouette as the camera sees it.

New `--resolution WIDTHxHEIGHT` (default unchanged). A T-pose is limited by its arm span, so a square frame fits it far better than the portrait default.

## Parallel workers

`bpy` drives a single global Blender session, so two characters cannot be in flight in one interpreter. New `--jobs N` (default 4) shards the model list and re-runs the script once per shard as a subprocess. Shards are round-robin rather than contiguous, since adjacent names in a sorted listing tend to be alike in size and a block hands one worker every heavy model.

## Verification

Full umvc3 character sweep at 768x768, mounting `nativePCx64/chr`: all characters rendered, no failures, **14m48s serial to 3m51s with `--jobs 4`**. Parallel output is pixel-identical to serial (max channel delta 0.0000 on spot-checked pairs; raw bytes differ only in PNG metadata).