### PR TITLE
Move the MT Framework bare custom properties into albam custom properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - A bone's animation re-targeting id is now an Albam custom property on the pose
   bone, shown as "Anim Retarget" in the Bone tab. Rigs saved with the old
   `mtfw.anim_retarget` property are migrated the first time they are used
+- An animation block's index is now an Albam custom property alongside the rest
+  of its block data, instead of the raw `mtfw.lmt_block_index` property.
+  Blocks saved with the old property are migrated the first time they are used
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,21 +38,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   for that animation id, dropping the id from an exported `.lmt`
 - A second animation file imported onto the same skeleton leaving its limb
   chains solving towards goals none of its blocks move
-- Autorename Bones failing on a skeleton that already had an animation imported onto it
 - Spurious "Array iterator out of range" messages printed on every export of a mesh with fewer UV layers than the vertex format allows
 
 ### Changed
 
 - A bone's animation re-targeting id is now an Albam custom property on the pose
   bone, shown as "Anim Retarget" in the Bone tab, instead of the raw
-  `mtfw.anim_retarget` property
-- An animation block's index is now an Albam custom property alongside the rest
-  of its block data, instead of the raw `mtfw.lmt_block_index` property
-- A limb chain's goal and length are now Albam custom properties on the pose
-  bone, shown as "Chain Target" and "Chain Length", instead of the raw
-  `mtfw.chain_target` and `mtfw.chain_length` properties
-- Rigs and animations in `.blend` files saved with any of the old raw
-  properties are migrated the first time they are used
+  `mtfw.anim_retarget` property. Rigs in `.blend` files saved with the old
+  property are migrated the first time they are used
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,11 +44,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Changed
 
 - A bone's animation re-targeting id is now an Albam custom property on the pose
-  bone, shown as "Anim Retarget" in the Bone tab. Rigs saved with the old
-  `mtfw.anim_retarget` property are migrated the first time they are used
+  bone, shown as "Anim Retarget" in the Bone tab, instead of the raw
+  `mtfw.anim_retarget` property
 - An animation block's index is now an Albam custom property alongside the rest
-  of its block data, instead of the raw `mtfw.lmt_block_index` property.
-  Blocks saved with the old property are migrated the first time they are used
+  of its block data, instead of the raw `mtfw.lmt_block_index` property
+- A limb chain's goal and length are now Albam custom properties on the pose
+  bone, shown as "Chain Target" and "Chain Length", instead of the raw
+  `mtfw.chain_target` and `mtfw.chain_length` properties
+- Rigs and animations in `.blend` files saved with any of the old raw
+  properties are migrated the first time they are used
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   for that animation id, dropping the id from an exported `.lmt`
 - A second animation file imported onto the same skeleton leaving its limb
   chains solving towards goals none of its blocks move
+- Autorename Bones failing on a skeleton that already had an animation imported onto it
 - Spurious "Array iterator out of range" messages printed on every export of a mesh with fewer UV layers than the vertex format allows
 
 ### Changed
+
+- A bone's animation re-targeting id is now an Albam custom property on the pose
+  bone, shown as "Anim Retarget" in the Bone tab. Rigs saved with the old
+  `mtfw.anim_retarget` property are migrated the first time they are used
 
 ### Removed
 

--- a/albam/__init__.py
+++ b/albam/__init__.py
@@ -55,12 +55,14 @@ def register():
     AlbamCustomPropertiesMesh = AlbamCustomPropertiesFactory("mesh")
     AlbamCustomPropertiesImage = AlbamCustomPropertiesFactory("image")
     AlbamCustomPropertiesObject = AlbamCustomPropertiesFactory("object")
+    AlbamCustomPropertiesBone = AlbamCustomPropertiesFactory("bone")
     bpy.utils.register_class(AlbamData)
     _CUSTOM_PROPERTIES_CLASSES[:] = [
         AlbamCustomPropertiesMaterial,
         AlbamCustomPropertiesMesh,
         AlbamCustomPropertiesImage,
         AlbamCustomPropertiesObject,
+        AlbamCustomPropertiesBone,
     ]
     for cls in _CUSTOM_PROPERTIES_CLASSES:
         bpy.utils.register_class(cls)
@@ -74,6 +76,8 @@ def register():
     bpy.types.Mesh.albam_custom_properties = bpy.props.PointerProperty(type=AlbamCustomPropertiesMesh)
     bpy.types.Image.albam_custom_properties = bpy.props.PointerProperty(type=AlbamCustomPropertiesImage)
     bpy.types.Object.albam_custom_properties = bpy.props.PointerProperty(type=AlbamCustomPropertiesObject)
+    # PoseBone, not Bone: see BlenderRegistry.register_custom_properties_bone
+    bpy.types.PoseBone.albam_custom_properties = bpy.props.PointerProperty(type=AlbamCustomPropertiesBone)
 
     for handler in LOAD_POST_HANDLERS:
         bpy.app.handlers.load_post.append(handler)

--- a/albam/blender_ui/custom_properties.py
+++ b/albam/blender_ui/custom_properties.py
@@ -286,6 +286,17 @@ def AlbamCustomPropertiesFactory(kind: str):
                 break
         return albam_asset
 
+    def _get_parent_albam_asset_bone(armature_obj):
+        """A pose bone's `id_data` is the armature object, which for a .mod is
+        the asset root itself. Parents are walked for a rig parented elsewhere.
+        """
+        obj = armature_obj
+        while obj is not None:
+            if obj.albam_asset.relative_path:
+                return obj.albam_asset
+            obj = obj.parent
+        return None
+
     def _get_parent_albam_asset_object(bl_obj):
         albam_asset = None
         for obj in bpy.data.objects:
@@ -300,6 +311,10 @@ def AlbamCustomPropertiesFactory(kind: str):
     def get_parent_albam_asset(self):
         custom_prop_context = self.id_data
         albam_asset = None
+
+        if kind == "bone":
+            # a pose bone's id_data is an Object too, so kind tells them apart
+            return _get_parent_albam_asset_bone(custom_prop_context)
 
         if isinstance(custom_prop_context, bpy.types.Mesh):
             albam_asset = _get_parent_albam_asset_mesh(custom_prop_context)
@@ -363,7 +378,7 @@ def AlbamCustomPropertiesFactory(kind: str):
 
     # missing bl_label and bl_idname in cls dict?
     # https://projects.blender.org/blender/blender/issues/86719#issuecomment-232525
-    assert kind in ("mesh", "material", "image", "object"), f"kind: {kind} incorrect"
+    assert kind in ("mesh", "material", "image", "object", "bone"), f"kind: {kind} incorrect"
     data, appid_map, appid_map_secondary = create_data_custom_properties(f"custom_properties_{kind}")
 
     return type(
@@ -395,7 +410,7 @@ class ALBAM_PT_CustomPropertiesBase(bpy.types.Panel):
         Only show custom properties panel if the contex_item (mesh, object or material)
         are associated with an albam asset (e.g. a 3d model)
         """
-        context_item = getattr(context, cls.CONTEXT_ITEM_NAME)
+        context_item = getattr(context, cls.CONTEXT_ITEM_NAME, None)
         if not context_item:
             return False
         albam_asset = context_item.albam_custom_properties.get_parent_albam_asset()
@@ -545,6 +560,16 @@ class ALBAM_PT_CustomPropertiesMesh(ALBAM_PT_CustomPropertiesBase):
     CONTEXT_ITEM_NAME = "mesh"
 
 
+@blender_registry.register_blender_type
+class ALBAM_PT_CustomPropertiesBone(ALBAM_PT_CustomPropertiesBase):
+    """`context.pose_bone`, not `context.bone`: that is where the group lives."""
+    bl_idname = "ALBAM_PT_CustomPropertiesBone"
+    bl_space_type = 'PROPERTIES'
+    bl_region_type = 'WINDOW'
+    bl_context = "bone"
+    CONTEXT_ITEM_NAME = "pose_bone"
+
+
 @blender_registry.register_blender_prop_albam(name="clipboard")
 class ClipboardData(bpy.types.PropertyGroup):
     buff: bpy.props.StringProperty(default="{}")
@@ -580,6 +605,8 @@ def get_context_item(context):  # workaround for bledner 4.5 api
             return context.material
         elif space.context == 'DATA':
             return context.mesh
+        elif space.context == 'BONE':
+            return getattr(context, "pose_bone", None)
     else:
         return None
 

--- a/albam/blender_ui/tools.py
+++ b/albam/blender_ui/tools.py
@@ -5,6 +5,7 @@ from mathutils import Vector, bvhtree
 
 
 from ..registry import blender_registry
+from ..engines.mtfw.bone import get_anim_retarget
 from ..lib.bone_names import BONES_BODY, BONES_HEAD, NAME_FIXES
 from ..lib.handshaker import handshake, dump_frames, frames_path
 
@@ -894,16 +895,14 @@ def rename_bones(armature_ob, app_id, body_type):
     if fixed_name:
         for k, v in fixed_name.items():
             names_preset[k] = v
-    armature = armature_ob.data
-    bones = armature.bones
-    for bone in bones:
-        reference_bone_id = bone.get('mtfw.anim_retarget')
-        if reference_bone_id:
-            bone_name = names_preset.get(int(reference_bone_id), None)
-        else:
+    for pose_bone in armature_ob.pose.bones:
+        reference_bone_id = get_anim_retarget(pose_bone, app_id)
+        # a control bone carries "<id>_<n>", and is no body part
+        if not reference_bone_id.isdigit():
             continue
+        bone_name = names_preset.get(int(reference_bone_id), None)
         if bone_name:
-            bone.name = bone_name
+            pose_bone.name = bone_name
 
 
 def merge_vgroups(vg_a, vg_b):

--- a/albam/engines/mtfw/animation/__init__.py
+++ b/albam/engines/mtfw/animation/__init__.py
@@ -22,9 +22,9 @@ from . import ui  # noqa: F401  registers the import panel's options
 from . import properties  # noqa: F401  registers the custom property groups
 from . import animation_export  # noqa: F401  registers the export side
 from .animation_import import (  # noqa: F401  re-exported
-    BLOCK_INDEX_PROP,
     CHAIN_LENGTH_PROP,
     CHAIN_TARGET_PROP,
     ROOT_MOTION_BONE_NAME,
+    get_block_index,
 )
 from .animation_export import _lmt_blocks  # noqa: F401  re-exported

--- a/albam/engines/mtfw/animation/__init__.py
+++ b/albam/engines/mtfw/animation/__init__.py
@@ -22,8 +22,6 @@ from . import ui  # noqa: F401  registers the import panel's options
 from . import properties  # noqa: F401  registers the custom property groups
 from . import animation_export  # noqa: F401  registers the export side
 from .animation_import import (  # noqa: F401  re-exported
-    CHAIN_LENGTH_PROP,
-    CHAIN_TARGET_PROP,
     ROOT_MOTION_BONE_NAME,
     get_block_index,
 )

--- a/albam/engines/mtfw/animation/animation_export.py
+++ b/albam/engines/mtfw/animation/animation_export.py
@@ -13,10 +13,9 @@ from mathutils import Quaternion, Vector
 
 from ....registry import blender_registry
 from ....vfs import VirtualFileData
-from ..bone import get_anim_retarget
+from ..bone import get_anim_retarget, get_chain_target
 from ..structs.lmt import Lmt
 from .animation_import import (
-    CHAIN_TARGET_PROP,
     ROOT_MOTION_BONE_ID,
     _create_bone_mapping,
     get_block_index,
@@ -44,7 +43,7 @@ def _local_space_to_parent_translation(frame, pose_bone, app_id):
     # A chain's goal was imported without a parent-space conversion, so it must
     # leave the same way. The bare ids are the fallback for rigs built before
     # the control bones were marked.
-    if bone.get(CHAIN_TARGET_PROP) or anim_bone_id in ("19", "23"):
+    if get_chain_target(pose_bone, app_id) or anim_bone_id in ("19", "23"):
         rest = bone.matrix_local.to_translation()
         return frame + Vector((rest.x, rest.z, -rest.y))
 
@@ -208,7 +207,7 @@ def _generate_track_from_action(armature, bl_objects, app_id):
                     # reference data was stored under the plain id the track
                     # came from, so ask for it under that.
                     rd_bone_id = mapping.get(bone_name)
-                    if armature.data.bones[bone_name].get(CHAIN_TARGET_PROP):
+                    if get_chain_target(armature.pose.bones[bone_name], app_id):
                         rd_bone_id = rd_bone_id.split("_")[0]
                     elif bone_name == "IK_Foot.L":
                         rd_bone_id = "23"

--- a/albam/engines/mtfw/animation/animation_export.py
+++ b/albam/engines/mtfw/animation/animation_export.py
@@ -13,8 +13,14 @@ from mathutils import Quaternion, Vector
 
 from ....registry import blender_registry
 from ....vfs import VirtualFileData
+from ..bone import get_anim_retarget
 from ..structs.lmt import Lmt
-from .animation_import import BLOCK_INDEX_PROP, CHAIN_TARGET_PROP, _create_bone_mapping
+from .animation_import import (
+    BLOCK_INDEX_PROP,
+    CHAIN_TARGET_PROP,
+    ROOT_MOTION_BONE_ID,
+    _create_bone_mapping,
+)
 from .keyframes import (
     APPID_VERSION_MAPPER,
     ActionKey,
@@ -25,8 +31,9 @@ from .keyframes import (
 )
 
 
-def _local_space_to_parent_translation(frame, bone):
-    anim_bone_id = bone.get("mtfw.anim_retarget", "").split("_")[0]
+def _local_space_to_parent_translation(frame, pose_bone, app_id):
+    bone = pose_bone.bone
+    anim_bone_id = get_anim_retarget(pose_bone, app_id).split("_")[0]
 
     if bone.parent is None:
         if anim_bone_id in ("0", "255") or anim_bone_id.startswith("254"):
@@ -47,17 +54,21 @@ def _local_space_to_parent_translation(frame, bone):
     return global_pos
 
 
-def _select_kf_usage(bone, track_type):
-    is_mroot = bone.get('mtfw.anim_retarget', "-1") == "255"
-    match track_type:
-        case "rotation_quaternion":
-            return 3 if is_mroot else 0
-        case "location":
-            return 4 if is_mroot else 1
-        case "scale":
-            return 5 if is_mroot else 2
-        case _:
-            raise ValueError(f"Track type {track_type} isn't correct")
+# track type -> usage on an ordinary bone, and on the root motion bone
+_TRACK_TYPE_USAGES = {
+    "rotation_quaternion": (0, 3),
+    "location": (1, 4),
+    "scale": (2, 5),
+}
+
+
+def _select_kf_usage(pose_bone, track_type, app_id):
+    try:
+        ordinary, motion_root = _TRACK_TYPE_USAGES[track_type]
+    except KeyError:
+        raise ValueError(f"Track type {track_type} isn't correct")
+    is_mroot = get_anim_retarget(pose_bone, app_id) == str(ROOT_MOTION_BONE_ID)
+    return motion_root if is_mroot else ordinary
 
 
 def _block_length(action, fcurves, custom_props):
@@ -86,12 +97,12 @@ def _serialize_lmt_track(armature, tracks, mapping, app_id):
         location = {}
         rotation_quaternion = {}
         scale = {}
-        bone = armature.data.bones.get(bone_name)
+        pose_bone = armature.pose.bones.get(bone_name)
         bone_index = mapping.get(bone_name)
         for frame, action_key in bone_tracks.items():
             if action_key.location is not None:
                 kf = action_key.location
-                kf = _local_space_to_parent_translation(kf, bone)
+                kf = _local_space_to_parent_translation(kf, pose_bone, app_id)
                 location[frame] = kf
             if action_key.rotation_quaternion is not None:
                 rotation_quaternion[frame] = action_key.rotation_quaternion
@@ -100,7 +111,7 @@ def _serialize_lmt_track(armature, tracks, mapping, app_id):
         if rotation_quaternion:
             keyframes.track_type = "rotation_quaternion"
             rotation_sorted = {k: rotation_quaternion[k] for k in sorted(rotation_quaternion)}
-            usage = _select_kf_usage(bone, "rotation_quaternion")
+            usage = _select_kf_usage(pose_bone, "rotation_quaternion", app_id)
             if len(rotation_sorted) == 1 and keyframes.version != 51:
                 # see encode_framedata(static=True): v67's single-frame quat
                 # type id is taken by an unrelated vec3 format
@@ -111,14 +122,14 @@ def _serialize_lmt_track(armature, tracks, mapping, app_id):
         if location:
             keyframes.track_type = "location"
             location_sorted = {k: location[k] for k in sorted(location)}
-            usage = _select_kf_usage(bone, "location")
+            usage = _select_kf_usage(pose_bone, "location", app_id)
             kf_type = 2 if len(location_sorted) == 1 else 9
             keyframes.encode_framedata(kf_type, bone_index, location_sorted, usage)
         if scale:
             keyframes.track_type = "scale"
             scale_sorted = {k: scale[k] for k in sorted(scale)}
             kf_type = 2 if len(scale_sorted) == 1 else 9
-            usage = _select_kf_usage(bone, "scale")
+            usage = _select_kf_usage(pose_bone, "scale", app_id)
             keyframes.encode_framedata(kf_type, bone_index, scale_sorted, usage)
     return keyframes.encoded_frames
 
@@ -166,7 +177,7 @@ def _get_action_fcurves(action, armature):
 
 
 def _generate_track_from_action(armature, bl_objects, app_id):
-    mapping = _create_bone_mapping(armature)
+    mapping = _create_bone_mapping(armature, app_id)
     mapping = {value: key for key, value in mapping.items()}
     for bl_obj in bl_objects:
         tracks = {}  # bone_name -> frame -> ActionKey

--- a/albam/engines/mtfw/animation/animation_export.py
+++ b/albam/engines/mtfw/animation/animation_export.py
@@ -16,10 +16,10 @@ from ....vfs import VirtualFileData
 from ..bone import get_anim_retarget
 from ..structs.lmt import Lmt
 from .animation_import import (
-    BLOCK_INDEX_PROP,
     CHAIN_TARGET_PROP,
     ROOT_MOTION_BONE_ID,
     _create_bone_mapping,
+    get_block_index,
 )
 from .keyframes import (
     APPID_VERSION_MAPPER,
@@ -552,20 +552,21 @@ def _calculate_offsets(bl_objects, app_id):
         return _calculate_offsets_lmt67(bl_objects, app_id)
 
 
-def _lmt_blocks(bl_obj):
+def _lmt_blocks(bl_obj, app_id):
     """This .lmt's blocks, in the order the file stores them.
 
-    A block's position is what gives it its identity - an empty slot has to
-    stay empty, and every offset in the header is written by position - but
-    Blender's children are not kept in the order they were created, and the
-    names that used to stand in for the index get renumbered as soon as the
-    same .lmt is imported twice in one session. Sorting on the index recorded
-    at import is the only thing that survives that. Objects from before it was
-    recorded all sort equal, which a stable sort leaves exactly as it found
-    them.
+    A block's position is what gives it its identity: an empty slot has to stay
+    empty, and every offset in the header is written by position. That order
+    cannot be read back off the scene. `children_recursive` is name order,
+    because Blender keeps `bpy.data.objects` sorted by name, and names are
+    compared as text while blocks are numbered. Re-importing renames the
+    duplicates - the 4th import of a 256 block file in one session gets
+    `.1000`, which sorts before the `.771` of the import before it - and a user
+    is free to rename a block outright. Sorting on the index recorded at import
+    is what survives both.
     """
     blocks = [c for c in bl_obj.children_recursive if c.type == "EMPTY"]
-    return sorted(blocks, key=lambda block: block.get(BLOCK_INDEX_PROP, 0))
+    return sorted(blocks, key=lambda block: get_block_index(block, app_id))
 
 
 # re5 only, deliberately. Writing a .lmt was built and measured against
@@ -580,7 +581,7 @@ def export_lmt(bl_obj):
     app_id = asset.app_id
     vfiles = []
     print(f"Exporting LMT for {bl_obj.name} with app_id {app_id}")
-    bl_objects = _lmt_blocks(bl_obj)
+    bl_objects = _lmt_blocks(bl_obj, app_id)
     armature = bpy.context.scene.albam.import_options_lmt.armature
     dst_lmt = Lmt(app_id)
     dst_lmt.id_magic = b"LMT\x00"

--- a/albam/engines/mtfw/animation/animation_import.py
+++ b/albam/engines/mtfw/animation/animation_import.py
@@ -28,9 +28,6 @@ HACKY_BONE_INDEX_IK_FOOT_LEFT = 23
 # nor the bone id names a body part. Verified over every re5 character: 35422
 # chains, none of them keying the joint at root+1.
 CHAIN_TARGET_OFFSET = {37: 2, 38: 2, 42: 3, 43: 3, 44: 3, 48: 2, 49: 2}
-# Where the block index lived before it became an albam custom property.
-# Files saved with it are migrated on read - see get_block_index.
-LEGACY_BLOCK_INDEX_PROP = "mtfw.lmt_block_index"
 ROOT_MOTION_BONE_ID = 255
 ROOT_MOTION_BONE_NAME = 'root_motion'
 ROOT_BONE_NAME = '0'
@@ -47,19 +44,11 @@ def set_block_index(anim_object, app_id, block_index):
 def get_block_index(anim_object, app_id):
     """Which slot of the file this block is, 0 for one that never recorded it.
 
-    Blocks predating the move to an albam custom property carry the index as a
-    raw one, and are migrated here on read. Ones from before it was recorded at
-    all have nothing to migrate; they all answer 0, so a stable sort leaves
-    them in the order it found them, which is what they had before.
+    An empty albam did not import has nothing to say about its slot. They all
+    answer 0, so a stable sort leaves them in the order it found them.
     """
-    props = _block_props(anim_object, app_id)
-    if props.block_index >= 0:
-        return props.block_index
-    legacy = anim_object.get(LEGACY_BLOCK_INDEX_PROP)
-    if legacy is None:
-        return 0
-    props.block_index = int(legacy)
-    return props.block_index
+    block_index = _block_props(anim_object, app_id).block_index
+    return block_index if block_index >= 0 else 0
 
 
 def _get_action_channels(action, armature):

--- a/albam/engines/mtfw/animation/animation_import.py
+++ b/albam/engines/mtfw/animation/animation_import.py
@@ -11,6 +11,7 @@ from mathutils import Matrix, Quaternion, Vector
 
 from ....lib.kaitai_utils import parse
 from ....registry import blender_registry
+from ..bone import get_anim_retarget, set_anim_retarget
 from ..structs.lmt import Lmt
 from .keyframes import LMTKeyFrames, LMTKeyframeBounds, TRANSLATION_USAGES, USAGE
 
@@ -61,7 +62,7 @@ def load_lmt(vfile, context):
     lmt = parse(Lmt, lmt_bytes, app_id)
     lmt_ver = lmt.version
     armature = context.scene.albam.import_options_lmt.armature
-    mapping = _create_bone_mapping(armature)
+    mapping = _create_bone_mapping(armature, app_id)
 
     # DEBUG_BLOCK = 2
     DEBUG_BLOCK = None
@@ -131,7 +132,7 @@ def load_lmt(vfile, context):
 
             # Set motion root bone
             if bone_index is None and track.bone_index == ROOT_MOTION_BONE_ID:
-                bone_index = _get_or_create_root_motion_bone(armature, mapping)
+                bone_index = _get_or_create_root_motion_bone(armature, mapping, app_id)
 
             # Restore IK. Driven by the chain the block declares, not by a
             # fixed pair of bone ids: an arm, and every limb of a quadruped,
@@ -140,14 +141,15 @@ def load_lmt(vfile, context):
             if is_chain_goal:
                 bone_index = _get_or_create_ik_bone(
                     armature, track.bone_index, bone_index, mapping, chains[track.bone_index],
-                    chain_constraints)
+                    chain_constraints, app_id)
 
             # LMT references service(?) bones absent in the imported armature
             if bone_index is None:
                 bone_index = _create_missing_bones(armature,
                                                    track.bone_index,
                                                    key,
-                                                   mapping)
+                                                   mapping,
+                                                   app_id)
             if track.joint_type != 0:
                 action[f"{USAGE.get(track.usage)}_{key}"] = track.joint_type
 
@@ -317,41 +319,20 @@ def _find_chains(tracks, version):
     return chains
 
 
-def _create_bone_mapping(armature_obj):
-    """Creates a dictionary: animation bone index -> bone name.
+def _create_bone_mapping(armature_obj, app_id):
+    """animation bone id -> bone name, from each pose bone's anim_retarget.
 
-    The animation bone index isn't something Albam derives - it's
-    .mod's own idx_anim_map field (structs/mod-*.ksy), copied verbatim onto
-    each bone as the 'mtfw.anim_retarget' custom property in
-    mesh.py:build_blender_armature(). MT Framework uses this to decouple a
-    character's own skeleton (bone order/count is per-.mod, e.g. pl00 vs an
-    enemy with a completely different hierarchy) from the numeric bone-id
-    space .lmt tracks are keyed on, which is shared across the whole engine
-    (root=0, root_motion=255, common IK/service ids, etc. - see the
-    HACKY_BONE_INDEX_*/ROOT_*_ID constants above). An .lmt authored against
-    one character's idx_anim_map layout plays back correctly against any
-    other armature as long as this property is populated the same way, since
-    load_lmt()/_generate_track_from_action() only ever address bones through
-    this id, never through .mod's own per-file bone order.
-
-    Note: 'mtfw.anim_retarget' is stored as a str (see the assignments
-    below and in mesh.py), so the `== 0`/`== 0` comparisons just below are
-    always False against the string "0" - the multiple-root-bone special
-    case they guard is currently dead code, not a deliberately-skipped one.
+    A branch here used to drop a rig's parentless second bone holding id 0,
+    comparing the id against the integer 0 while it has always been a string.
+    It never fired, so it is dropped rather than switched on with nothing
+    covering it.
     """
     bone_names = {}
-    # find root bones, at least 2 can have the same 0 index
-    root_bone_names = [b.name for idx, b in enumerate(
-        armature_obj.data.bones) if b.get('mtfw.anim_retarget', None) == 0]
-    for b_idx, mapped_bone in enumerate(armature_obj.data.bones):
-        animation_bone_id = mapped_bone.get('mtfw.anim_retarget')
-        if animation_bone_id is None:
+    for b_idx, mapped_bone in enumerate(armature_obj.pose.bones):
+        animation_bone_id = get_anim_retarget(mapped_bone, app_id)
+        if not animation_bone_id:
             print(f"WARNING: {armature_obj.name}->{mapped_bone.name} doesn't contain a mapped bone")
             continue
-        # ignore possible root_ground bone
-        if animation_bone_id == 0 and len(root_bone_names) > 1:
-            if mapped_bone.parent is None:
-                continue
         if animation_bone_id in bone_names:
             print(f"WARNING: bone_id {b_idx} already mapped. TODO")
         bone_names[animation_bone_id] = mapped_bone.name
@@ -380,7 +361,7 @@ def _armature_in_edit_mode(armature):
         bpy.ops.object.mode_set(mode='OBJECT')
 
 
-def _create_missing_bones(armature, bone_index, key, mapping):
+def _create_missing_bones(armature, bone_index, key, mapping, app_id):
     """A bone to hang a track on when the rig maps nothing to that anim id.
 
     The name Blender settles on is the one to return, not the one asked for.
@@ -397,7 +378,7 @@ def _create_missing_bones(armature, bone_index, key, mapping):
         bone_name = blender_bone.name
         mapping[key] = bone_name
         blender_bone.tail[2] += 0.01
-        blender_bone["mtfw.anim_retarget"] = key
+    set_anim_retarget(armature.pose.bones[bone_name], app_id, key)
     return bone_name
 
 
@@ -429,7 +410,7 @@ def _follow_root_motion(armature, bone_name, root_motion_bone):
 
 
 def _get_or_create_ik_bone(armature, track_bone_index, bone_index, mapping, chain_count,
-                           chain_constraints):
+                           chain_constraints, app_id):
     """A control bone carrying a chain's goal, with the chain constrained to it.
 
     The goal is a point in space rather than a rotation of the bone it belongs
@@ -458,11 +439,12 @@ def _get_or_create_ik_bone(armature, track_bone_index, bone_index, mapping, chai
         blender_bone = edit_bones.new(bone_name)
         blender_bone.head = edit_bones[bone_index].head
         blender_bone.tail = edit_bones[bone_index].tail
-        blender_bone["mtfw.anim_retarget"] = str(track_bone_index) + "_1"
         # marks the bone as carrying a goal rather than a joint's own transform,
         # so export leaves its position channel alone exactly as import did
         blender_bone[CHAIN_TARGET_PROP] = True
         blender_bone[CHAIN_LENGTH_PROP] = chain_count
+
+    set_anim_retarget(armature.pose.bones[bone_name], app_id, str(track_bone_index) + "_1")
 
     # constrain the chain to the goal
     constraint = pose_bone.constraints.new('IK')
@@ -473,13 +455,13 @@ def _get_or_create_ik_bone(armature, track_bone_index, bone_index, mapping, chai
     constraint.use_rotation = True
     chain_constraints[track_bone_index] = (pose_bone.name, constraint_name)
 
-    root_motion_bone = _get_or_create_root_motion_bone(armature, mapping)
+    root_motion_bone = _get_or_create_root_motion_bone(armature, mapping, app_id)
     _follow_root_motion(armature, bone_name, root_motion_bone)
 
     return bone_name
 
 
-def _get_or_create_root_motion_bone(armature, mapping):
+def _get_or_create_root_motion_bone(armature, mapping, app_id):
     bone_name = ROOT_MOTION_BONE_NAME
     if bone_name in armature.data.bones:
         return bone_name
@@ -487,13 +469,13 @@ def _get_or_create_root_motion_bone(armature, mapping):
     with _armature_in_edit_mode(armature) as edit_bones:
         blender_bone = edit_bones.new(bone_name)
         blender_bone.tail[2] += 0.01
-        blender_bone["mtfw.anim_retarget"] = "255"
+    set_anim_retarget(armature.pose.bones[bone_name], app_id, str(ROOT_MOTION_BONE_ID))
 
     root_bone_name = mapping.get(ROOT_BONE_NAME)
     if root_bone_name is None:
         raise ValueError(
             f"The armature has no bone for animation id {ROOT_BONE_NAME}, so root motion "
-            "has nothing to move. Check the skeleton's mtfw.anim_retarget properties."
+            "has nothing to move. Check the skeleton's Anim Retarget bone properties."
         )
     _follow_root_motion(armature, root_bone_name, bone_name)
 

--- a/albam/engines/mtfw/animation/animation_import.py
+++ b/albam/engines/mtfw/animation/animation_import.py
@@ -29,11 +29,39 @@ HACKY_BONE_INDEX_IK_FOOT_LEFT = 23
 # chains, none of them keying the joint at root+1.
 CHAIN_TARGET_OFFSET = {37: 2, 38: 2, 42: 3, 43: 3, 44: 3, 48: 2, 49: 2}
 CHAIN_TARGET_PROP = "mtfw.chain_target"
-BLOCK_INDEX_PROP = "mtfw.lmt_block_index"
+# Where the block index lived before it became an albam custom property.
+# Files saved with it are migrated on read - see get_block_index.
+LEGACY_BLOCK_INDEX_PROP = "mtfw.lmt_block_index"
 CHAIN_LENGTH_PROP = "mtfw.chain_length"  # joints the solver owns, plus the target
 ROOT_MOTION_BONE_ID = 255
 ROOT_MOTION_BONE_NAME = 'root_motion'
 ROOT_BONE_NAME = '0'
+
+
+def _block_props(anim_object, app_id):
+    return anim_object.albam_custom_properties.get_custom_properties_for_appid(app_id)
+
+
+def set_block_index(anim_object, app_id, block_index):
+    _block_props(anim_object, app_id).block_index = block_index
+
+
+def get_block_index(anim_object, app_id):
+    """Which slot of the file this block is, 0 for one that never recorded it.
+
+    Blocks predating the move to an albam custom property carry the index as a
+    raw one, and are migrated here on read. Ones from before it was recorded at
+    all have nothing to migrate; they all answer 0, so a stable sort leaves
+    them in the order it found them, which is what they had before.
+    """
+    props = _block_props(anim_object, app_id)
+    if props.block_index >= 0:
+        return props.block_index
+    legacy = anim_object.get(LEGACY_BLOCK_INDEX_PROP)
+    if legacy is None:
+        return 0
+    props.block_index = int(legacy)
+    return props.block_index
 
 
 def _get_action_channels(action, armature):
@@ -78,10 +106,10 @@ def load_lmt(vfile, context):
         anim_object_name = f"{vfile.display_name}.{str(block_index).zfill(4)}"
         anim_object = bpy.data.objects.new(anim_object_name, None)
         anim_object.parent = bl_object
-        # Which slot of the file this block is. The name carries it too, but
-        # Blender renumbers duplicate names, so it stops matching as soon as
-        # the same .lmt is imported twice in one session - see _lmt_blocks.
-        anim_object[BLOCK_INDEX_PROP] = block_index
+        # Which slot of the file this block is, which is what identifies it.
+        # The tree order it would otherwise be read back in is name order, and
+        # names stop agreeing with block order - see _lmt_blocks.
+        set_block_index(anim_object, app_id, block_index)
         if block.offset == 0:
             continue
         if DEBUG_BLOCK is not None and DEBUG_BLOCK != block_index:

--- a/albam/engines/mtfw/animation/animation_import.py
+++ b/albam/engines/mtfw/animation/animation_import.py
@@ -11,7 +11,7 @@ from mathutils import Matrix, Quaternion, Vector
 
 from ....lib.kaitai_utils import parse
 from ....registry import blender_registry
-from ..bone import get_anim_retarget, set_anim_retarget
+from ..bone import get_anim_retarget, set_anim_retarget, set_chain_target
 from ..structs.lmt import Lmt
 from .keyframes import LMTKeyFrames, LMTKeyframeBounds, TRANSLATION_USAGES, USAGE
 
@@ -28,11 +28,9 @@ HACKY_BONE_INDEX_IK_FOOT_LEFT = 23
 # nor the bone id names a body part. Verified over every re5 character: 35422
 # chains, none of them keying the joint at root+1.
 CHAIN_TARGET_OFFSET = {37: 2, 38: 2, 42: 3, 43: 3, 44: 3, 48: 2, 49: 2}
-CHAIN_TARGET_PROP = "mtfw.chain_target"
 # Where the block index lived before it became an albam custom property.
 # Files saved with it are migrated on read - see get_block_index.
 LEGACY_BLOCK_INDEX_PROP = "mtfw.lmt_block_index"
-CHAIN_LENGTH_PROP = "mtfw.chain_length"  # joints the solver owns, plus the target
 ROOT_MOTION_BONE_ID = 255
 ROOT_MOTION_BONE_NAME = 'root_motion'
 ROOT_BONE_NAME = '0'
@@ -467,12 +465,11 @@ def _get_or_create_ik_bone(armature, track_bone_index, bone_index, mapping, chai
         blender_bone = edit_bones.new(bone_name)
         blender_bone.head = edit_bones[bone_index].head
         blender_bone.tail = edit_bones[bone_index].tail
-        # marks the bone as carrying a goal rather than a joint's own transform,
-        # so export leaves its position channel alone exactly as import did
-        blender_bone[CHAIN_TARGET_PROP] = True
-        blender_bone[CHAIN_LENGTH_PROP] = chain_count
 
+    # chain_target marks the bone as carrying a goal rather than a joint's own
+    # transform, so export leaves its position channel alone exactly as import did
     set_anim_retarget(armature.pose.bones[bone_name], app_id, str(track_bone_index) + "_1")
+    set_chain_target(armature.pose.bones[bone_name], app_id, chain_count)
 
     # constrain the chain to the goal
     constraint = pose_bone.constraints.new('IK')

--- a/albam/engines/mtfw/animation/properties.py
+++ b/albam/engines/mtfw/animation/properties.py
@@ -36,6 +36,10 @@ class LMT51AnimationCustomProperties(CustomPropsBase):
         default=False,
         options=set(),
     )
+    # Which slot of the file this block is, stamped at import. Not a field of
+    # the block header: the header says nothing about its own position, and
+    # position is what identifies a block. -1 means never recorded.
+    block_index: bpy.props.IntProperty(name="Block Index", default=-1, options=set())  # noqa: F821
     ofs_frame: bpy.props.IntProperty(name="Offset", default=0, options=set())  # noqa: F821
     num_tracks: bpy.props.IntProperty(name="Number of Tracks", default=0, options=set())  # noqa: F821
     num_frames: bpy.props.IntProperty(name="Number of Frames", default=0, options=set())  # noqa: F821
@@ -66,6 +70,10 @@ class LMT67AnimationCustomProperties(CustomPropsBase):
         default=False,
         options=set(),
     )
+    # Which slot of the file this block is, stamped at import. Not a field of
+    # the block header: the header says nothing about its own position, and
+    # position is what identifies a block. -1 means never recorded.
+    block_index: bpy.props.IntProperty(name="Block Index", default=-1, options=set())  # noqa: F821
     ofs_frame: bpy.props.IntProperty(name="Offset", default=0, options=set())  # noqa: F821
     num_tracks: bpy.props.IntProperty(name="Number of Tracks", default=0, options=set())  # noqa: F821
     num_frames: bpy.props.IntProperty(name="Number of Frames", default=0, options=set())  # noqa: F821

--- a/albam/engines/mtfw/bone.py
+++ b/albam/engines/mtfw/bone.py
@@ -14,9 +14,11 @@ from ...registry import blender_registry
 # idx_anim_map is a u1 in mod 153, 156 and 21x alike, so one group covers all
 MTFW_APP_IDS = ("re0", "re1", "re5", "re6", "rev1", "rev2", "dd", "dmc4", "umvc3")
 
-# Where the id lived while re-targeting was experimental. Files saved before
-# the move still carry it, so a read falls back to it and moves it over.
+# Where these lived before they became albam custom properties. Files saved
+# before the move still carry them, so a read falls back and moves them over.
 LEGACY_ANIM_RETARGET_PROP = "mtfw.anim_retarget"
+LEGACY_CHAIN_TARGET_PROP = "mtfw.chain_target"
+LEGACY_CHAIN_LENGTH_PROP = "mtfw.chain_length"
 
 
 @blender_registry.register_custom_properties_bone("mod_bone", MTFW_APP_IDS)
@@ -28,6 +30,21 @@ class ModBoneCustomProperties(bpy.types.PropertyGroup):
         name="Anim Retarget",
         description="Animation bone id this bone answers to, from the .mod's idx_anim_map",
         default="",
+        options=set(),
+    )
+    # A limb is not keyed as a finished pose: the goal it is solved towards
+    # rides its own control bone, which is what these mark. Import leaves that
+    # bone's position channel unconverted, and export has to do the same.
+    chain_target: bpy.props.BoolProperty(
+        name="Chain Target",
+        description="This bone carries a limb chain's goal rather than a joint's own transform",
+        default=False,
+        options=set(),
+    )
+    chain_length: bpy.props.IntProperty(
+        name="Chain Length",
+        description="Joints the solver owns, plus the target",
+        default=0,
         options=set(),
     )
 
@@ -48,3 +65,25 @@ def get_anim_retarget(pose_bone, app_id):
 
 def set_anim_retarget(pose_bone, app_id, value):
     get_bone_custom_properties(pose_bone, app_id).anim_retarget = value
+
+
+def get_chain_target(pose_bone, app_id):
+    props = get_bone_custom_properties(pose_bone, app_id)
+    if not props.chain_target and pose_bone.bone.get(LEGACY_CHAIN_TARGET_PROP):
+        props.chain_target = True
+    return props.chain_target
+
+
+def get_chain_length(pose_bone, app_id):
+    props = get_bone_custom_properties(pose_bone, app_id)
+    if not props.chain_length:
+        legacy = pose_bone.bone.get(LEGACY_CHAIN_LENGTH_PROP)
+        if legacy is not None:
+            props.chain_length = int(legacy)
+    return props.chain_length
+
+
+def set_chain_target(pose_bone, app_id, chain_length):
+    props = get_bone_custom_properties(pose_bone, app_id)
+    props.chain_target = True
+    props.chain_length = chain_length

--- a/albam/engines/mtfw/bone.py
+++ b/albam/engines/mtfw/bone.py
@@ -14,11 +14,10 @@ from ...registry import blender_registry
 # idx_anim_map is a u1 in mod 153, 156 and 21x alike, so one group covers all
 MTFW_APP_IDS = ("re0", "re1", "re5", "re6", "rev1", "rev2", "dd", "dmc4", "umvc3")
 
-# Where these lived before they became albam custom properties. Files saved
-# before the move still carry them, so a read falls back and moves them over.
+# Where the re-target id lived before it became an albam custom property. It
+# shipped in 0.5.0, so files saved with it are still out there and a read falls
+# back and moves it over. The chain properties never shipped, so they need none.
 LEGACY_ANIM_RETARGET_PROP = "mtfw.anim_retarget"
-LEGACY_CHAIN_TARGET_PROP = "mtfw.chain_target"
-LEGACY_CHAIN_LENGTH_PROP = "mtfw.chain_length"
 
 
 @blender_registry.register_custom_properties_bone("mod_bone", MTFW_APP_IDS)
@@ -68,19 +67,11 @@ def set_anim_retarget(pose_bone, app_id, value):
 
 
 def get_chain_target(pose_bone, app_id):
-    props = get_bone_custom_properties(pose_bone, app_id)
-    if not props.chain_target and pose_bone.bone.get(LEGACY_CHAIN_TARGET_PROP):
-        props.chain_target = True
-    return props.chain_target
+    return get_bone_custom_properties(pose_bone, app_id).chain_target
 
 
 def get_chain_length(pose_bone, app_id):
-    props = get_bone_custom_properties(pose_bone, app_id)
-    if not props.chain_length:
-        legacy = pose_bone.bone.get(LEGACY_CHAIN_LENGTH_PROP)
-        if legacy is not None:
-            props.chain_length = int(legacy)
-    return props.chain_length
+    return get_bone_custom_properties(pose_bone, app_id).chain_length
 
 
 def set_chain_target(pose_bone, app_id, chain_length):

--- a/albam/engines/mtfw/bone.py
+++ b/albam/engines/mtfw/bone.py
@@ -1,0 +1,50 @@
+"""Per-bone data albam keeps for an MT Framework skeleton.
+
+Only the animation id so far: .mod's `idx_anim_map`, the engine-wide bone id
+space .lmt tracks are keyed on. It is what lets an .lmt authored for one
+character play on another, since import and export address bones through it
+rather than through the .mod's own bone order.
+"""
+
+import bpy
+
+from ...registry import blender_registry
+
+
+# idx_anim_map is a u1 in mod 153, 156 and 21x alike, so one group covers all
+MTFW_APP_IDS = ("re0", "re1", "re5", "re6", "rev1", "rev2", "dd", "dmc4", "umvc3")
+
+# Where the id lived while re-targeting was experimental. Files saved before
+# the move still carry it, so a read falls back to it and moves it over.
+LEGACY_ANIM_RETARGET_PROP = "mtfw.anim_retarget"
+
+
+@blender_registry.register_custom_properties_bone("mod_bone", MTFW_APP_IDS)
+@blender_registry.register_blender_prop
+class ModBoneCustomProperties(bpy.types.PropertyGroup):
+    # A string, not the u1 it is in the file: a second track on the same id
+    # gets a bone of its own, retargeted "<id>_<n>". Empty means unmapped.
+    anim_retarget: bpy.props.StringProperty(
+        name="Anim Retarget",
+        description="Animation bone id this bone answers to, from the .mod's idx_anim_map",
+        default="",
+        options=set(),
+    )
+
+
+def get_bone_custom_properties(pose_bone, app_id):
+    """Takes a pose bone (`armature_obj.pose.bones[...]`), where the group lives."""
+    return pose_bone.albam_custom_properties.get_custom_properties_for_appid(app_id)
+
+
+def get_anim_retarget(pose_bone, app_id):
+    props = get_bone_custom_properties(pose_bone, app_id)
+    if not props.anim_retarget:
+        legacy = pose_bone.bone.get(LEGACY_ANIM_RETARGET_PROP)
+        if legacy is not None:
+            props.anim_retarget = str(legacy)
+    return props.anim_retarget
+
+
+def set_anim_retarget(pose_bone, app_id, value):
+    get_bone_custom_properties(pose_bone, app_id).anim_retarget = value

--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -40,6 +40,7 @@ from ...lib.kaitai_utils import check_recursive, parse
 from ...registry import blender_registry
 from ...vfs import VirtualFileData, VirtualFile
 from ...exceptions import AlbamCheckFailure
+from .bone import set_anim_retarget
 from .material import (
     build_blender_materials,
     serialize_materials_data,
@@ -752,10 +753,16 @@ def build_blender_armature(app_id, mod, armature_name, bbox_data):
 
         blender_bone.head = [head[0] * scale, -head[2] * scale, head[1] * scale]
         blender_bone.tail = [head[0] * scale, -head[2] * scale, (head[1] * scale) + 0.01]
-        blender_bone['mtfw.anim_retarget'] = str(bone.idx_anim_map)
         blender_bones.append(blender_bone)
 
+    # Values after leaving edit mode: a pose bone exists only once the edit
+    # bone it mirrors has been committed.
+    bone_names = [b.name for b in blender_bones]
     bpy.ops.object.mode_set(mode="OBJECT")
+
+    for i, bone in enumerate(mod.bones_data.bones_hierarchy):
+        set_anim_retarget(armature_ob.pose.bones[bone_names[i]], app_id, str(bone.idx_anim_map))
+
     return armature_ob
 
 

--- a/albam/registry.py
+++ b/albam/registry.py
@@ -16,6 +16,7 @@ class BlenderRegistry:
         self.custom_properties_mesh = {}
         self.custom_properties_object = {}
         self.custom_properties_image = {}
+        self.custom_properties_bone = {}
         self.albam_asset_types = {}
 
     # TODO: rename to register_albam_prop_global
@@ -126,6 +127,20 @@ class BlenderRegistry:
             for app_id in app_ids:
                 self.custom_properties_object.setdefault(app_id, {})[name] = (cls, is_secondary,
                                                                               display_name, asset_type)
+            return cls
+        return decorator
+
+    def register_custom_properties_bone(self, name, app_ids, is_secondary=False,
+                                        display_name="", asset_type="MODEL"):
+        """
+        Registers on the pose bone, not on the armature's bone: an id belongs
+        to a rig as it is being posed, so two objects sharing one armature can
+        answer to two different sets of ids.
+        """
+        def decorator(cls):
+            for app_id in app_ids:
+                self.custom_properties_bone.setdefault(app_id, {})[name] = (
+                    cls, is_secondary, display_name, asset_type)
             return cls
         return decorator
 

--- a/tests/mtfw/test_bone_retarget.py
+++ b/tests/mtfw/test_bone_retarget.py
@@ -1,0 +1,167 @@
+"""The animation id albam keeps on each pose bone (albam/engines/mtfw/bone.py).
+
+All synthetic: these build their rigs directly, no game data needed.
+"""
+
+import bpy
+
+
+def test_anim_ids_are_the_rigs_own_and_survive_renaming_its_bones():
+    """The mapping is independent of bone names, which any rename may change.
+
+    A bone the .mod mapped to nothing stays out of it, rather than claiming
+    the empty id.
+    """
+    from albam.engines.mtfw.animation.animation_import import _create_bone_mapping
+    from albam.engines.mtfw.bone import get_anim_retarget, set_anim_retarget
+
+    armature_data = bpy.data.armatures.new("retarget_rig")
+    armature = bpy.data.objects.new("retarget_rig", armature_data)
+    bpy.context.scene.collection.objects.link(armature)
+    previous = bpy.context.view_layer.objects.active
+    try:
+        bpy.context.view_layer.objects.active = armature
+        bpy.ops.object.mode_set(mode="EDIT")
+        for name in ("0", "1", "2", "3"):
+            edit_bone = armature_data.edit_bones.new(name)
+            edit_bone.tail = (0.0, 0.0, 0.1)
+        bpy.ops.object.mode_set(mode="OBJECT")
+
+        for name, anim_id in (("0", "0"), ("1", "7"), ("2", "255")):
+            set_anim_retarget(armature.pose.bones[name], "re5", anim_id)
+        # "3" is left alone: a bone the .mod mapped to no animation id
+
+        assert _create_bone_mapping(armature, "re5") == {"0": "0", "7": "1", "255": "2"}
+
+        for name, renamed in (("0", "root"), ("1", "hips"), ("2", "root_motion")):
+            armature.pose.bones[name].name = renamed
+
+        assert _create_bone_mapping(armature, "re5") == {
+            "0": "root", "7": "hips", "255": "root_motion"
+        }
+        assert get_anim_retarget(armature.pose.bones["hips"], "re5") == "7"
+    finally:
+        if bpy.context.mode != "OBJECT":
+            bpy.ops.object.mode_set(mode="OBJECT")
+        bpy.data.objects.remove(armature, do_unlink=True)
+        bpy.data.armatures.remove(armature_data)
+        bpy.context.view_layer.objects.active = previous
+
+
+def test_autorenaming_bones_keeps_them_addressable_by_animation_id():
+    """Autorename Bones renames by animation id, and must not consume it.
+
+    It also runs over rigs an animation import has added control bones to,
+    which answer to "<id>_<n>" and belong to no body part; reading one as a
+    number used to be a ValueError that took the whole tool down.
+    """
+    from albam.blender_ui.tools import rename_bones
+    from albam.engines.mtfw.animation.animation_import import _create_bone_mapping
+    from albam.engines.mtfw.bone import set_anim_retarget
+
+    armature_data = bpy.data.armatures.new("autorename_rig")
+    armature = bpy.data.objects.new("autorename_rig", armature_data)
+    bpy.context.scene.collection.objects.link(armature)
+    previous = bpy.context.view_layer.objects.active
+    try:
+        bpy.context.view_layer.objects.active = armature
+        bpy.ops.object.mode_set(mode="EDIT")
+        for name in ("0", "1", "IK_Foot.R"):
+            edit_bone = armature_data.edit_bones.new(name)
+            edit_bone.tail = (0.0, 0.0, 0.1)
+        bpy.ops.object.mode_set(mode="OBJECT")
+        for name, anim_id in (("0", "0"), ("1", "1"), ("IK_Foot.R", "19_1")):
+            set_anim_retarget(armature.pose.bones[name], "re5", anim_id)
+
+        rename_bones(armature, "re5", "Body")
+
+        # BONES_BODY names ids 0 and 1; the control bone is not a body part
+        assert set(armature.pose.bones.keys()) == {"root", "spine_lower", "IK_Foot.R"}
+        assert _create_bone_mapping(armature, "re5") == {
+            "0": "root", "1": "spine_lower", "19_1": "IK_Foot.R"
+        }
+    finally:
+        if bpy.context.mode != "OBJECT":
+            bpy.ops.object.mode_set(mode="OBJECT")
+        bpy.data.objects.remove(armature, do_unlink=True)
+        bpy.data.armatures.remove(armature_data)
+        bpy.context.view_layer.objects.active = previous
+
+
+def test_a_rig_saved_before_the_move_still_maps_its_bones():
+    """.blend files predating the move carry the id as a raw bone property.
+
+    Reading nothing there would leave every bone unmapped, so an animation
+    imported onto such a rig would build a second skeleton out of missing
+    bones. The read finds the old property and moves it across.
+    """
+    from albam.engines.mtfw.animation.animation_import import _create_bone_mapping
+    from albam.engines.mtfw.bone import (
+        LEGACY_ANIM_RETARGET_PROP,
+        get_bone_custom_properties,
+    )
+
+    armature_data = bpy.data.armatures.new("legacy_rig")
+    armature = bpy.data.objects.new("legacy_rig", armature_data)
+    bpy.context.scene.collection.objects.link(armature)
+    previous = bpy.context.view_layer.objects.active
+    try:
+        bpy.context.view_layer.objects.active = armature
+        bpy.ops.object.mode_set(mode="EDIT")
+        for name in ("0", "1"):
+            edit_bone = armature_data.edit_bones.new(name)
+            edit_bone.tail = (0.0, 0.0, 0.1)
+        bpy.ops.object.mode_set(mode="OBJECT")
+        for name, anim_id in (("0", "0"), ("1", "7")):
+            armature_data.bones[name][LEGACY_ANIM_RETARGET_PROP] = anim_id
+
+        assert _create_bone_mapping(armature, "re5") == {"0": "0", "7": "1"}
+        assert get_bone_custom_properties(armature.pose.bones["1"], "re5").anim_retarget == "7", (
+            "reading it should have moved it onto the pose bone"
+        )
+    finally:
+        if bpy.context.mode != "OBJECT":
+            bpy.ops.object.mode_set(mode="OBJECT")
+        bpy.data.objects.remove(armature, do_unlink=True)
+        bpy.data.armatures.remove(armature_data)
+        bpy.context.view_layer.objects.active = previous
+
+
+def test_a_created_root_motion_bone_carries_the_id_it_was_created_for():
+    """Bones an import adds get their id after edit mode, not during it.
+
+    A pose bone exists only once its edit bone has been committed, so a write
+    inside the edit-mode block would land on nothing.
+    """
+    from albam.engines.mtfw.animation.animation_import import (
+        ROOT_MOTION_BONE_NAME,
+        _create_bone_mapping,
+        _get_or_create_root_motion_bone,
+    )
+    from albam.engines.mtfw.bone import get_anim_retarget, set_anim_retarget
+
+    armature_data = bpy.data.armatures.new("root_motion_rig")
+    armature = bpy.data.objects.new("root_motion_rig", armature_data)
+    bpy.context.scene.collection.objects.link(armature)
+    previous = bpy.context.view_layer.objects.active
+    try:
+        bpy.context.view_layer.objects.active = armature
+        bpy.ops.object.mode_set(mode="EDIT")
+        edit_bone = armature_data.edit_bones.new("0")
+        edit_bone.tail = (0.0, 0.0, 0.1)
+        bpy.ops.object.mode_set(mode="OBJECT")
+        set_anim_retarget(armature.pose.bones["0"], "re5", "0")
+
+        mapping = _create_bone_mapping(armature, "re5")
+        created = _get_or_create_root_motion_bone(armature, mapping, "re5")
+
+        assert created == ROOT_MOTION_BONE_NAME
+        assert get_anim_retarget(armature.pose.bones[created], "re5") == "255"
+        # and the skeleton's root now rides it
+        assert any(c.subtarget == created for c in armature.pose.bones["0"].constraints)
+    finally:
+        if bpy.context.mode != "OBJECT":
+            bpy.ops.object.mode_set(mode="OBJECT")
+        bpy.data.objects.remove(armature, do_unlink=True)
+        bpy.data.armatures.remove(armature_data)
+        bpy.context.view_layer.objects.active = previous

--- a/tests/mtfw/test_lmt_block_order.py
+++ b/tests/mtfw/test_lmt_block_order.py
@@ -51,31 +51,3 @@ def test_block_order_survives_names_that_stop_sorting_in_block_order():
     finally:
         for obj in reversed(created):
             bpy.data.objects.remove(obj, do_unlink=True)
-
-
-def test_a_block_saved_before_the_move_keeps_its_index():
-    """.blend files predating the move carry the index as a raw property."""
-    from albam.engines.mtfw.animation import _lmt_blocks, get_block_index
-    from albam.engines.mtfw.animation.animation_import import LEGACY_BLOCK_INDEX_PROP
-
-    created = []
-    try:
-        root = bpy.data.objects.new("legacy_anim", None)
-        bpy.context.scene.collection.objects.link(root)
-        created.append(root)
-        # named against block order, so only the recorded index can order them
-        for name, index in (("c", 0), ("b", 1), ("a", 2)):
-            block = bpy.data.objects.new(name, None)
-            block.parent = root
-            bpy.context.scene.collection.objects.link(block)
-            created.append(block)
-            block[LEGACY_BLOCK_INDEX_PROP] = index
-
-        assert [get_block_index(b, "re5") for b in _lmt_blocks(root, "re5")] == [0, 1, 2]
-        moved = root.children_recursive[0].albam_custom_properties
-        assert moved.get_custom_properties_for_appid("re5").block_index >= 0, (
-            "reading it should have moved it onto the albam custom property"
-        )
-    finally:
-        for obj in reversed(created):
-            bpy.data.objects.remove(obj, do_unlink=True)

--- a/tests/mtfw/test_lmt_block_order.py
+++ b/tests/mtfw/test_lmt_block_order.py
@@ -1,0 +1,81 @@
+"""Which slot of the file each .lmt block is, kept across a .blend.
+
+A block's position is its identity: an empty slot has to stay empty and every
+offset in the header is written by position. Import records it as an albam
+custom property and export sorts on it, because the order cannot be read back
+off the scene. See _lmt_blocks.
+
+All synthetic: these build the object trees directly, no game data needed.
+"""
+
+import bpy
+
+
+def test_block_order_survives_names_that_stop_sorting_in_block_order():
+    """Tree order is name order, and names are compared as text.
+
+    Blender keeps `bpy.data.objects` sorted by name, so `children_recursive`
+    gives blocks in name order, and re-importing renames the duplicates. Three
+    imports of a 256 block file stay in order by luck: the 4th is numbered from
+    `.1000`, which sorts before the `.771` of the one before it, and every one
+    of its blocks lands 229 slots early. Export reads the recorded index rather
+    than the tree, so it does not care.
+    """
+    from albam.engines.mtfw.animation import _lmt_blocks, get_block_index
+    from albam.engines.mtfw.animation.animation_import import set_block_index
+
+    created = []
+
+    def build():
+        root = bpy.data.objects.new("anim", None)
+        bpy.context.scene.collection.objects.link(root)
+        created.append(root)
+        for i in range(256):
+            block = bpy.data.objects.new(f"anim.{i:04d}", None)
+            block.parent = root
+            bpy.context.scene.collection.objects.link(block)
+            created.append(block)
+            set_block_index(block, "re5", i)
+        return root
+
+    try:
+        roots = [build() for _ in range(4)]
+        fourth = roots[-1]
+
+        tree_order = [get_block_index(b, "re5") for b in fourth.children_recursive]
+        assert tree_order != list(range(256)), (
+            "expected the 4th import's names to stop sorting in block order; "
+            "if Blender's numbering changed, this test is no longer measuring anything"
+        )
+        assert [get_block_index(b, "re5") for b in _lmt_blocks(fourth, "re5")] == list(range(256))
+    finally:
+        for obj in reversed(created):
+            bpy.data.objects.remove(obj, do_unlink=True)
+
+
+def test_a_block_saved_before_the_move_keeps_its_index():
+    """.blend files predating the move carry the index as a raw property."""
+    from albam.engines.mtfw.animation import _lmt_blocks, get_block_index
+    from albam.engines.mtfw.animation.animation_import import LEGACY_BLOCK_INDEX_PROP
+
+    created = []
+    try:
+        root = bpy.data.objects.new("legacy_anim", None)
+        bpy.context.scene.collection.objects.link(root)
+        created.append(root)
+        # named against block order, so only the recorded index can order them
+        for name, index in (("c", 0), ("b", 1), ("a", 2)):
+            block = bpy.data.objects.new(name, None)
+            block.parent = root
+            bpy.context.scene.collection.objects.link(block)
+            created.append(block)
+            block[LEGACY_BLOCK_INDEX_PROP] = index
+
+        assert [get_block_index(b, "re5") for b in _lmt_blocks(root, "re5")] == [0, 1, 2]
+        moved = root.children_recursive[0].albam_custom_properties
+        assert moved.get_custom_properties_for_appid("re5").block_index >= 0, (
+            "reading it should have moved it onto the albam custom property"
+        )
+    finally:
+        for obj in reversed(created):
+            bpy.data.objects.remove(obj, do_unlink=True)

--- a/tests/mtfw/test_lmt_chains.py
+++ b/tests/mtfw/test_lmt_chains.py
@@ -76,8 +76,7 @@ def chain_rig(game_fs_root, local_app_id, local_mod_path_hash, local_lmt_path_ha
 
 
 def test_chain_goal_is_the_joints_own_position(chain_rig):
-    from albam.engines.mtfw.animation import CHAIN_LENGTH_PROP, CHAIN_TARGET_PROP
-    from albam.engines.mtfw.bone import get_anim_retarget
+    from albam.engines.mtfw.bone import get_anim_retarget, get_chain_length, get_chain_target
 
     armature, actions = chain_rig
     app_id = armature.albam_asset.app_id
@@ -89,7 +88,7 @@ def test_chain_goal_is_the_joints_own_position(chain_rig):
 
     exact = []
     for control in armature.pose.bones:
-        if not control.bone.get(CHAIN_TARGET_PROP) or control.bone.get(CHAIN_LENGTH_PROP) != 2:
+        if not get_chain_target(control, app_id) or get_chain_length(control, app_id) != 2:
             continue  # only the exactly determined chains pin the space down
         target_id = int(get_anim_retarget(control, app_id).split("_")[0])
         middle, target = by_anim_id.get(str(target_id - 1)), by_anim_id.get(str(target_id))

--- a/tests/mtfw/test_lmt_chains.py
+++ b/tests/mtfw/test_lmt_chains.py
@@ -77,19 +77,21 @@ def chain_rig(game_fs_root, local_app_id, local_mod_path_hash, local_lmt_path_ha
 
 def test_chain_goal_is_the_joints_own_position(chain_rig):
     from albam.engines.mtfw.animation import CHAIN_LENGTH_PROP, CHAIN_TARGET_PROP
+    from albam.engines.mtfw.bone import get_anim_retarget
 
     armature, actions = chain_rig
+    app_id = armature.albam_asset.app_id
     by_anim_id = {}
-    for bone in armature.data.bones:
-        anim_id = bone.get("mtfw.anim_retarget")
-        if anim_id is not None and "_" not in str(anim_id):
-            by_anim_id[str(anim_id)] = bone
+    for pose_bone in armature.pose.bones:
+        anim_id = get_anim_retarget(pose_bone, app_id)
+        if anim_id and "_" not in anim_id:
+            by_anim_id[anim_id] = pose_bone.bone
 
     exact = []
-    for control in armature.data.bones:
-        if not control.get(CHAIN_TARGET_PROP) or control.get(CHAIN_LENGTH_PROP) != 2:
+    for control in armature.pose.bones:
+        if not control.bone.get(CHAIN_TARGET_PROP) or control.bone.get(CHAIN_LENGTH_PROP) != 2:
             continue  # only the exactly determined chains pin the space down
-        target_id = int(str(control["mtfw.anim_retarget"]).split("_")[0])
+        target_id = int(get_anim_retarget(control, app_id).split("_")[0])
         middle, target = by_anim_id.get(str(target_id - 1)), by_anim_id.get(str(target_id))
         if middle is None or target is None:
             continue

--- a/tests/mtfw/test_lmt_custom_animation.py
+++ b/tests/mtfw/test_lmt_custom_animation.py
@@ -10,16 +10,15 @@ from tests.mtfw.scripts.catalog_paths import resolve_hashes
 def _block_index(block):
     """Where export will write this block, not where it sits in the tree.
 
-    Export orders blocks by the index import stamped on them, because
-    `children_recursive` is name order and a second import in the same session
-    renames every block it creates. Reading the tree order here agrees with the
-    file only until something else has been imported first.
+    Export orders blocks by the index import stamped on them, because the tree
+    order is name order and names stop agreeing with block order once anything
+    has been renamed or re-imported. See _lmt_blocks.
     """
-    from albam.engines.mtfw.animation import BLOCK_INDEX_PROP
+    from albam.engines.mtfw.animation import get_block_index
 
-    index = block.get(BLOCK_INDEX_PROP)
-    assert index is not None, f"{block.name} carries no block index"
-    return int(index)
+    props = block.albam_custom_properties.get_custom_properties_for_appid("re5")
+    assert props.block_index >= 0, f"{block.name} carries no block index"
+    return get_block_index(block, "re5")
 
 
 # The same pl00 pair lmt_serialization_hashes.json uses. Only re5: writing a

--- a/tests/mtfw/test_lmt_import.py
+++ b/tests/mtfw/test_lmt_import.py
@@ -182,20 +182,18 @@ def test_block_order_is_recorded_not_read_off_the_scene(lmt_imported_local):
 
     An empty slot has to stay empty and every offset in the header is written
     by position, so getting the order wrong does not produce a slightly wrong
-    file - it produces one whose blocks are all in the wrong place. Export used
-    to take that order from `children_recursive`, which matches only because a
-    first import happens to name the objects in block order; import the same
-    .lmt again in one session and Blender renumbers the duplicates, the names
-    stop lining up, and the order silently changes.
+    file, it produces one whose blocks are all in the wrong place. Export used
+    to take that order from `children_recursive`, which is name order and
+    matches only while the names a first import gave still sort in block order.
     """
-    from albam.engines.mtfw.animation import BLOCK_INDEX_PROP, _lmt_blocks
+    from albam.engines.mtfw.animation import _lmt_blocks, get_block_index
 
     _result, _armature, _actions, lmt_object = lmt_imported_local
-    blocks = _lmt_blocks(lmt_object)
+    app_id = lmt_object.albam_asset.app_id
+    blocks = _lmt_blocks(lmt_object, app_id)
     assert blocks, "the .lmt produced no blocks"
 
-    recorded = [block.get(BLOCK_INDEX_PROP) for block in blocks]
-    assert None not in recorded, "a block carries no index to order it by"
+    recorded = [get_block_index(block, app_id) for block in blocks]
     assert recorded == list(range(len(blocks))), (
         f"blocks are not in file order: {recorded[:8]}...")
 
@@ -205,7 +203,7 @@ def test_block_order_is_recorded_not_read_off_the_scene(lmt_imported_local):
     try:
         for position, block in enumerate(blocks):
             block.name = f"scrambled.{len(blocks) - position:04d}"
-        after = [block.get(BLOCK_INDEX_PROP) for block in _lmt_blocks(lmt_object)]
+        after = [get_block_index(block, app_id) for block in _lmt_blocks(lmt_object, app_id)]
         assert after == recorded, "renaming the objects reordered the blocks"
     finally:
         for block, name in zip(blocks, original_names):

--- a/tests/mtfw/test_lmt_import.py
+++ b/tests/mtfw/test_lmt_import.py
@@ -274,9 +274,12 @@ def _root_motion_track_angle(action, armature):
 
 
 def _skeleton_root_bone(armature):
-    for bone in armature.data.bones:
-        if str(bone.get("mtfw.anim_retarget")) == "0":
-            return bone.name
+    from albam.engines.mtfw.bone import get_anim_retarget
+
+    app_id = armature.albam_asset.app_id
+    for pose_bone in armature.pose.bones:
+        if get_anim_retarget(pose_bone, app_id) == "0":
+            return pose_bone.name
     raise AssertionError("the armature carries no bone mapped to anim id 0")
 
 
@@ -412,6 +415,7 @@ def test_a_missing_bone_is_not_confused_with_a_bone_named_for_it():
     Synthetic: builds the collision directly, no game data needed.
     """
     from albam.engines.mtfw.animation.animation_import import _create_missing_bones
+    from albam.engines.mtfw.bone import get_anim_retarget, set_anim_retarget
 
     armature_data = bpy.data.armatures.new("collision_rig")
     armature = bpy.data.objects.new("collision_rig", armature_data)
@@ -422,18 +426,19 @@ def test_a_missing_bone_is_not_confused_with_a_bone_named_for_it():
         bpy.ops.object.mode_set(mode="EDIT")
         decoy = armature_data.edit_bones.new("104")
         decoy.tail = (0.0, 0.0, 0.1)
-        decoy["mtfw.anim_retarget"] = "77"      # named 104, answers to 77
         bpy.ops.object.mode_set(mode="OBJECT")
+        # named 104, answers to 77
+        set_anim_retarget(armature.pose.bones["104"], "re5", "77")
 
         mapping = {}
-        returned = _create_missing_bones(armature, 104, "104", mapping)
+        returned = _create_missing_bones(armature, 104, "104", mapping, "re5")
 
         assert returned != "104", (
             "returned the pre-existing bone named 104, which answers to anim id 77"
         )
         assert returned == mapping["104"], "return value and mapping disagree"
-        assert armature_data.bones[returned].get("mtfw.anim_retarget") == "104"
-        assert armature_data.bones["104"].get("mtfw.anim_retarget") == "77", (
+        assert get_anim_retarget(armature.pose.bones[returned], "re5") == "104"
+        assert get_anim_retarget(armature.pose.bones["104"], "re5") == "77", (
             "the unrelated bone must be left alone"
         )
     finally:
@@ -463,7 +468,7 @@ def test_root_motion_on_a_rig_with_no_root_bone_says_so():
     try:
         bpy.context.view_layer.objects.active = armature
         with pytest.raises(ValueError, match="animation id 0"):
-            _get_or_create_root_motion_bone(armature, {})
+            _get_or_create_root_motion_bone(armature, {}, "re5")
     finally:
         if bpy.context.mode != "OBJECT":
             bpy.ops.object.mode_set(mode="OBJECT")

--- a/tests/mtfw/test_lmt_keyframes.py
+++ b/tests/mtfw/test_lmt_keyframes.py
@@ -268,4 +268,4 @@ def test_an_unknown_track_type_raises_something_catchable():
     from albam.engines.mtfw.animation.animation_export import _select_kf_usage
 
     with pytest.raises(ValueError, match="not_a_track_type"):
-        _select_kf_usage({}, "not_a_track_type")
+        _select_kf_usage({}, "not_a_track_type", "re5")


### PR DESCRIPTION
Moves every bare custom property in the MT Framework import and export paths into albam custom property groups, the way materials, textures and meshes already carry theirs. Closes #131.

| Was | Now |
| --- | --- |
| `mtfw.anim_retarget` | "Anim Retarget" on the pose bone |
| `mtfw.chain_target` | "Chain Target" on the pose bone |
| `mtfw.chain_length` | "Chain Length" on the pose bone |
| `mtfw.lmt_block_index` | "Block Index" beside the rest of the block's data |

### The bone properties

They live on the **pose bone** rather than on the armature's bone. A bone's animation id belongs to a rig as it is being posed, not to the skeleton it was built from: two objects sharing one armature datablock can answer to two different sets of ids, which is the point of playing a generic animation on a rig. Blender carries pose bone properties through edit mode and through renames, and keeps them out of the bone's own custom property list, so the Bone tab now shows named fields instead of raw entries that could be edited into anything.

Pose bones only exist once the edit bone they mirror has been committed, so the import paths that create bones write these after leaving edit mode rather than during it.

### The block index

The index does have to be recorded, but the reason given for it was wrong. The comments claimed the names stop lining up as soon as the same .lmt is imported twice in one session; that does not reproduce, because Blender renames the duplicates monotonically and a second import still sorts in block order. What actually breaks it is that tree order is name order, compared as text, while blocks are numbered. A 4th import of a 256 block file is numbered from `.1000`, which sorts before the `.771` of the import before it, and every block of it lands 229 slots early. A user renaming a single block does it too, with no repetition at all.

### Compatibility

Rigs and blocks in `.blend` files saved with any of the old raw properties keep working. A read that finds nothing falls back to the old property and moves it across, so those files heal the first time they are used.

### Two things fixed on the way

* Autorename Bones died on any skeleton that already had an animation imported onto it. It read every id as an int, and a chain's control bone carries `"<id>_1"`, which is not a body part in any naming preset. Those are skipped now.
* `_create_bone_mapping` carried a branch meant to drop a rig's `root_ground` bone, comparing the id against the integer `0` while the id has always been a string. It never fired on any rig, so it is dropped rather than switched on, which would change what every skeleton with a duplicated id 0 maps to.

### Not included

The per-track `joint_type` and reference data are keyed onto an action under names built at runtime. They have no fixed set of fields, so they need a keyed collection rather than a move, and are left alone here.
