### PR TITLE
mtfw: stop clobbering disp on export for mod-21 apps

### DIFF
--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -1546,11 +1546,14 @@ def _serialize_meshes_data(bl_obj, bl_meshes, src_mod, dst_mod, materials_map, b
         if export_settings.force_lod255:
             custom_properties.level_of_detail = 255
         custom_properties.copy_custom_properties_to(mesh)
-        # Checked against every mesh (132161) in every .mod-156 in the local re5 install:
-        # disp is always True, no shipped file ever disables it, so it's no longer a
-        # stored/editable custom property. Applied here for dmc4 (mod-153) too, since both
-        # share this property group and export path, but only re5's data was checked.
-        mesh.disp = 1
+        if not hasattr(custom_properties, "disp"):
+            # Checked against every mesh (132161) in every .mod-156 in the local re5 install:
+            # disp is always True, no shipped file ever disables it, so it's no longer a
+            # stored/editable custom property there (or on mod-153/dmc4, which shares this
+            # property group). Mod21MeshCustomProperties (re0/re1/re6/rev1/rev2/dd/umvc3)
+            # still has a real, user-editable disp - copy_custom_properties_to() above already
+            # set it, so it must not be clobbered here too.
+            mesh.disp = 1
 
         # TODO: pre-check for no materials
         mesh.idx_material = materials_map[bl_mesh.data.materials[0].name]


### PR DESCRIPTION
Fixes a bug that silently forces every mesh visible on export for re0, re1, re6, rev1, rev2, dd and umvc3.

`_serialize_meshes_data()` is shared across every MT Framework app_id. It ends with an unconditional `mesh.disp = 1`, added when re5/dmc4's `disp` custom property was found to always be `True` and dropped. But `Mod21MeshCustomProperties` (the other seven app_ids) still has a real, user-editable "Display Mesh in Game" checkbox, and `copy_custom_properties_to()` had already set `mesh.disp` from it one line earlier - the unconditional assignment right after threw that away every time.

Now only applied where `disp` isn't a real custom property (re5/dmc4), which is what it was meant for.