### PR TITLE
Read context.active_pose_bone for the Bone custom properties panel

### DIFF
--- a/albam/blender_ui/custom_properties.py
+++ b/albam/blender_ui/custom_properties.py
@@ -562,12 +562,19 @@ class ALBAM_PT_CustomPropertiesMesh(ALBAM_PT_CustomPropertiesBase):
 
 @blender_registry.register_blender_type
 class ALBAM_PT_CustomPropertiesBone(ALBAM_PT_CustomPropertiesBase):
-    """`context.pose_bone`, not `context.bone`: that is where the group lives."""
+    """`context.active_pose_bone`, not `context.bone`: that is where the group lives.
+
+    The Properties Editor's Bone tab does not populate `context.pose_bone` (it
+    only sets `context.bone`, a `bpy.types.Bone` with no albam properties on
+    it), so this panel never polled true and silently never showed. The
+    window-level `context.active_pose_bone` is the `bpy.types.PoseBone` the
+    group actually lives on, and it is populated in the same Properties tab.
+    """
     bl_idname = "ALBAM_PT_CustomPropertiesBone"
     bl_space_type = 'PROPERTIES'
     bl_region_type = 'WINDOW'
     bl_context = "bone"
-    CONTEXT_ITEM_NAME = "pose_bone"
+    CONTEXT_ITEM_NAME = "active_pose_bone"
 
 
 @blender_registry.register_blender_prop_albam(name="clipboard")
@@ -606,7 +613,7 @@ def get_context_item(context):  # workaround for bledner 4.5 api
         elif space.context == 'DATA':
             return context.mesh
         elif space.context == 'BONE':
-            return getattr(context, "pose_bone", None)
+            return getattr(context, "active_pose_bone", None)
     else:
         return None
 

--- a/tests/test_bone_custom_properties_panel.py
+++ b/tests/test_bone_custom_properties_panel.py
@@ -1,0 +1,51 @@
+"""The "Custom Properties (Albam)" panel on the Bone properties tab.
+
+Synthetic: builds its own armature, no game data needed. See #286.
+"""
+
+from types import SimpleNamespace
+
+import bpy
+
+
+def test_bone_panel_polls_true_off_active_pose_bone_not_pose_bone():
+    """The Properties Editor's Bone tab never populates context.pose_bone.
+
+    Confirmed live in Blender 5.2: with a bone made active in Pose Mode,
+    Blender's own built-in Bone panels render fine off context.bone and
+    context.active_pose_bone, but context.pose_bone is never set - so a panel
+    reading it, like this one used to, silently never shows. This context
+    stands in for that real one: bone and active_pose_bone set, pose_bone
+    absent entirely, the way Blender's own Properties Editor presents it.
+    """
+    from albam.blender_ui.custom_properties import ALBAM_PT_CustomPropertiesBone
+    from albam.engines.mtfw.bone import set_anim_retarget
+
+    armature_data = bpy.data.armatures.new("bone_panel_rig")
+    armature = bpy.data.objects.new("bone_panel_rig", armature_data)
+    bpy.context.scene.collection.objects.link(armature)
+    previous = bpy.context.view_layer.objects.active
+    try:
+        armature.albam_asset.app_id = "re5"
+        armature.albam_asset.relative_path = "pawn/pl/pl00/model/pl0000.mod"
+        armature.albam_asset.asset_type = "MODEL"
+
+        bpy.context.view_layer.objects.active = armature
+        bpy.ops.object.mode_set(mode="EDIT")
+        edit_bone = armature_data.edit_bones.new("0")
+        edit_bone.tail = (0.0, 0.0, 0.1)
+        bpy.ops.object.mode_set(mode="OBJECT")
+
+        pose_bone = armature.pose.bones["0"]
+        set_anim_retarget(pose_bone, "re5", "0")
+
+        context = SimpleNamespace(bone=armature_data.bones["0"], active_pose_bone=pose_bone)
+
+        assert not hasattr(context, "pose_bone")
+        assert ALBAM_PT_CustomPropertiesBone.poll(context) is True
+    finally:
+        if bpy.context.mode != "OBJECT":
+            bpy.ops.object.mode_set(mode="OBJECT")
+        bpy.data.objects.remove(armature, do_unlink=True)
+        bpy.data.armatures.remove(armature_data)
+        bpy.context.view_layer.objects.active = previous


### PR DESCRIPTION
## Summary

The "Custom Properties (Albam)" panel on the Properties Editor's Bone tab
never shows, in Pose Mode or Edit Mode, on any armature. `poll()` (inherited
by `ALBAM_PT_CustomPropertiesBone` from `ALBAM_PT_CustomPropertiesBase`)
always returns `False` because `CONTEXT_ITEM_NAME = "pose_bone"` and
`getattr(context, "pose_bone", None)` is always `None` for this tab.
`get_context_item()` (used by the copy/paste/export/import custom-props
operators) has the same bug for its `'BONE'` branch.

Confirmed live in Blender 5.2: with a bone made active in Pose Mode by
clicking it in the 3D viewport, Blender's own built-in Bone panels (Transform,
Bendy Bones, Relations, Inverse Kinematics, Deform, Viewport Display, Custom
Properties) all render correctly in the same tab, and `context.bone` and
`context.active_pose_bone` are both populated - `context.pose_bone` never is.
This isn't something #278 introduced; the class has read `context.pose_bone`
since it was added, and as far as could be determined has never actually
shown in Blender 5.x.

## Fix

Both `ALBAM_PT_CustomPropertiesBone.CONTEXT_ITEM_NAME` and
`get_context_item()`'s `'BONE'` branch now read `context.active_pose_bone`
(the `bpy.types.PoseBone` `albam_custom_properties` actually lives on)
instead of `context.pose_bone`.

## Test plan

- [x] Added a synthetic test constructing the exact context Blender's Bone
      tab actually provides (`bone` and `active_pose_bone` set,
      `pose_bone` absent) and asserting `poll()` is `True`; confirmed it
      fails on the old code (`assert False is True`) and passes with the fix.
- [x] Confirmed live against a real Blender 5.2 session: the panel now shows
      with Anim Retarget / Mirror Bone / Chain Target fields.
- [x] `tests/mtfw/test_bone_retarget.py` still green.
- [x] `flake8` clean.

Fixes #286