### PR TITLE
tests: fix the shared-VFS-wipe hazard in test_vfs_fs_backed.py (#271)

### DIFF
--- a/tests/cie/conftest.py
+++ b/tests/cie/conftest.py
@@ -1,9 +1,6 @@
 import os
 
-import bpy
 import pytest
-
-from albam.lib import fs_registry
 
 from tests.mtfw.r2_config import R2_PROTOCOL_PREFIX, resolve_r2_source
 
@@ -95,49 +92,3 @@ def game_root(pytestconfig, local_app_id, tmp_path_factory):
     if not os.path.isdir(root):
         pytest.skip(f"--game-dir={local_app_id}::{root} does not exist")
     return root
-
-
-def close_new_fs_roots(before):
-    """Close the FS roots registered since `before` was taken.
-
-    Not fs_registry.clear(): that closes every filesystem in the process.
-    Session-scoped parametrization interleaves this suite's tests with
-    tests/mtfw's, whose game_fs_root is one session-scoped MTFW_FS shared by
-    every test in it - so clearing here closed it mid-run and every mtfw test
-    after this point failed with FilesystemClosed.
-    """
-    for key in fs_registry.keys():
-        if key not in before:
-            fs_registry.unregister(key)
-
-
-def vfs_root_names():
-    """Names of every root vfile currently in the main VFS - a snapshot to
-    diff against after a test, so only the roots it added get removed (see
-    remove_new_vfs_roots)."""
-    return {vf.name for vf in bpy.context.scene.albam.vfs.file_list if vf.is_root}
-
-
-def remove_new_vfs_roots(before):
-    """Remove only the VFS roots added since `before` was taken (see
-    vfs_root_names()), each via the real "Remove imported files" operator so
-    a root's whole subtree goes with it - not
-    scene.albam.vfs.file_list.clear().
-
-    vfs.file_list is one collection shared by every engine's tests in the
-    same session, same reasoning as close_new_fs_roots() above: mtfw's and
-    hexn's own game_fs_root fixtures mount their whole-game root once per
-    session and expect it to still be there on every later test. Clearing
-    the whole list here emptied it out from under them - the later test's
-    own session-scoped fixture, having already run once, never re-mounts,
-    so every VFS lookup after that silently found nothing.
-    """
-    vfs = bpy.context.scene.albam.vfs
-    for name in [vf.name for vf in vfs.file_list if vf.is_root]:
-        if name in before:
-            continue
-        index = vfs.file_list.find(name)
-        if index == -1:
-            continue  # already removed as part of an earlier root's own cleanup
-        vfs.file_list_selected_index = index
-        bpy.ops.albam.remove_imported()

--- a/tests/cie/test_bin_export_fidelity.py
+++ b/tests/cie/test_bin_export_fidelity.py
@@ -19,7 +19,7 @@ import bpy
 import pytest
 
 from albam.lib import fs_registry
-from tests.cie.conftest import close_new_fs_roots, remove_new_vfs_roots, vfs_root_names
+from tests.conftest import close_new_fs_roots, remove_new_vfs_roots, vfs_root_names
 from tests.cie.lfs_paths import resolve_archive_hashes
 from tests.cie.test_bin_serialization import _is_mesh_bin, _texture_slots
 

--- a/tests/cie/test_bin_serialization.py
+++ b/tests/cie/test_bin_serialization.py
@@ -20,7 +20,7 @@ import bpy
 import pytest
 
 from albam.lib import fs_registry
-from tests.cie.conftest import close_new_fs_roots, remove_new_vfs_roots, vfs_root_names
+from tests.conftest import close_new_fs_roots, remove_new_vfs_roots, vfs_root_names
 from tests.cie.lfs_paths import resolve_archive_hashes
 
 DATASETS_DIR = os.path.join(os.path.dirname(__file__), "datasets")

--- a/tests/cie/test_lfs_vfs.py
+++ b/tests/cie/test_lfs_vfs.py
@@ -11,7 +11,7 @@ import bpy
 import pytest
 
 from albam.lib import fs_registry
-from tests.cie.conftest import close_new_fs_roots, remove_new_vfs_roots, vfs_root_names
+from tests.conftest import close_new_fs_roots, remove_new_vfs_roots, vfs_root_names
 from tests.cie.lfs_paths import resolve_archive_hashes
 
 DATASETS_DIR = os.path.join(os.path.dirname(__file__), "datasets")

--- a/tests/cie/test_scenario_parsing.py
+++ b/tests/cie/test_scenario_parsing.py
@@ -21,7 +21,7 @@ import bpy
 import pytest
 
 from albam.lib import fs_registry
-from tests.cie.conftest import close_new_fs_roots, remove_new_vfs_roots, vfs_root_names
+from tests.conftest import close_new_fs_roots, remove_new_vfs_roots, vfs_root_names
 from tests.cie.lfs_paths import resolve_archive_hashes
 
 DATASETS_DIR = os.path.join(os.path.dirname(__file__), "datasets")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,11 @@
 import os
 
+import bpy
 import pytest
 
 from albam import register, unregister
 from albam.blender_ui.error_handling import RERAISE_ERRORS_ENV_VAR
+from albam.lib import fs_registry
 
 
 # Written by pytest_sessionfinish so CI can recover the real exit status when
@@ -116,3 +118,49 @@ def pytest_configure(config):
                     f"must always be explicit: 'r2://<bucket>/<prefix>' (game root, e.g. "
                     f"r2://albam/re5) or 'r2://<key>' (reng's path-list segment)"
                 )
+
+
+def close_new_fs_roots(before):
+    """Close the FS roots registered since `before` was taken.
+
+    Not fs_registry.clear(): that closes every filesystem in the process.
+    Session-scoped parametrization interleaves every engine's tests in the
+    same session - cie's with mtfw's and hexn's, whose game_fs_root is one
+    session-scoped FS shared by every test in it - so clearing here closed
+    it mid-run and every later test using it failed with FilesystemClosed.
+    """
+    for key in fs_registry.keys():
+        if key not in before:
+            fs_registry.unregister(key)
+
+
+def vfs_root_names():
+    """Names of every root vfile currently in the main VFS - a snapshot to
+    diff against after a test, so only the roots it added get removed (see
+    remove_new_vfs_roots)."""
+    return {vf.name for vf in bpy.context.scene.albam.vfs.file_list if vf.is_root}
+
+
+def remove_new_vfs_roots(before):
+    """Remove only the VFS roots added since `before` was taken (see
+    vfs_root_names()), each via the real "Remove imported files" operator so
+    a root's whole subtree goes with it - not
+    scene.albam.vfs.file_list.clear().
+
+    vfs.file_list is one collection shared by every engine's tests in the
+    same session, same reasoning as close_new_fs_roots() above: mtfw's and
+    hexn's own game_fs_root fixtures mount their whole-game root once per
+    session and expect it to still be there on every later test. Clearing
+    the whole list here emptied it out from under them - the later test's
+    own session-scoped fixture, having already run once, never re-mounts,
+    so every VFS lookup after that silently found nothing.
+    """
+    vfs = bpy.context.scene.albam.vfs
+    for name in [vf.name for vf in vfs.file_list if vf.is_root]:
+        if name in before:
+            continue
+        index = vfs.file_list.find(name)
+        if index == -1:
+            continue  # already removed as part of an earlier root's own cleanup
+        vfs.file_list_selected_index = index
+        bpy.ops.albam.remove_imported()

--- a/tests/test_vfs_fs_backed.py
+++ b/tests/test_vfs_fs_backed.py
@@ -12,6 +12,7 @@ from fs.memoryfs import MemoryFS
 
 from albam.lib import fs_registry
 from albam.vfs import VirtualFileData
+from tests.conftest import close_new_fs_roots, remove_new_vfs_roots, vfs_root_names
 
 
 @pytest.fixture(autouse=True)
@@ -20,10 +21,19 @@ def _clean_vfs_state():
     # per pytest session), so without this, roots added by one test would
     # collide by name with roots added by another - node ids are keyed by
     # app_id::relative_path only, not by which root added them.
+    #
+    # vfs.file_list and fs_registry are shared with every other engine's
+    # tests in the same session (mtfw's and hexn's own game_fs_root
+    # fixtures mount their whole-game root once per session and expect it
+    # to still be there on every later test) - see remove_new_vfs_roots's
+    # and close_new_fs_roots's own docstrings for what a wholesale
+    # .clear() there broke.
+    before_roots = vfs_root_names()
+    before_fs = fs_registry.keys()
     yield
-    bpy.context.scene.albam.vfs.file_list.clear()
+    remove_new_vfs_roots(before_roots)
     bpy.context.scene.albam.exported.file_list.clear()
-    fs_registry.clear()
+    close_new_fs_roots(before_fs)
 
 
 def _sample_fs():
@@ -246,6 +256,13 @@ def test_remove_root_unregisters_fs():
     from albam.vfs import ALBAM_OT_VirtualFileSystemRemoveRootVFile
 
     vfs = bpy.context.scene.albam.vfs
+    # Not "len(vfs.file_list) == 0" afterward: vfs.file_list is one
+    # collection shared by every engine's tests in the same session (see
+    # tests/conftest.py's remove_new_vfs_roots), so another suite's own
+    # session-scoped root can legitimately already be sitting in it -
+    # what this test actually promises is that removal takes back exactly
+    # what this root added, not that the whole VFS was empty to begin with.
+    before_size = len(vfs.file_list)
     root = vfs.add_fs_root("re5", _sample_fs(), display_name="removable-root")
     key = root.fs_key
     assert fs_registry.get(key) is not None
@@ -255,7 +272,8 @@ def test_remove_root_unregisters_fs():
         ALBAM_OT_VirtualFileSystemRemoveRootVFile, bpy.context
     )
 
-    assert len(vfs.file_list) == 0
+    assert len(vfs.file_list) == before_size
+    assert vfs.file_list.find(root.name) == -1
     with pytest.raises(KeyError):
         fs_registry.get(key)
 


### PR DESCRIPTION
Part of #271. Fixes the same class of bug already fixed in tests/cie/: an autouse teardown was calling scene.albam.vfs.file_list.clear() and fs_registry.clear() unconditionally, wiping state shared with every other engine's session-scoped test fixtures (mtfw's and hexn's own game_fs_root fixtures mount their whole-game root once per session and never re-mount).

Fix: moved the scoped-cleanup helpers (close_new_fs_roots, vfs_root_names, remove_new_vfs_roots) from tests/cie/conftest.py to the root tests/conftest.py, and switched this file's teardown to use them - removes only the roots/filesystems this file's own tests actually added.

Also fixes test_remove_root_unregisters_fs, which asserted the whole VFS was empty after removing its own root - true only because the old wholesale-clear teardown kept the list empty by accident. Now checks its own root is specifically gone and the list size is back to what it was before.

Direct in-test fs_registry.clear() calls elsewhere in the file are untouched - those are deliberately testing recovery from a real registry clear (Reload Scripts, process restart), not incidental cleanup.

Verified against the exact 5-app_id CI invocation twice (not just this file in isolation): 664 passed, 0 failed both times.