### PR TITLE
Fix Autorename Bones to carry Mirror Bone through a rename

### DIFF
--- a/albam/blender_ui/tools.py
+++ b/albam/blender_ui/tools.py
@@ -5,7 +5,7 @@ from mathutils import Vector, bvhtree
 
 
 from ..registry import blender_registry
-from ..engines.mtfw.bone import get_anim_retarget, guess_mirrors, set_mirror
+from ..engines.mtfw.bone import get_anim_retarget, get_mirror, guess_mirrors, set_mirror
 from ..lib.bone_names import BONES_BODY, BONES_HEAD, NAME_FIXES
 from ..lib.handshaker import handshake, dump_frames, frames_path
 
@@ -922,6 +922,7 @@ def rename_bones(armature_ob, app_id, body_type):
     if fixed_name:
         for k, v in fixed_name.items():
             names_preset[k] = v
+    renamed = {}
     for pose_bone in armature_ob.pose.bones:
         reference_bone_id = get_anim_retarget(pose_bone, app_id)
         # a control bone carries "<id>_<n>", and is no body part
@@ -929,7 +930,14 @@ def rename_bones(armature_ob, app_id, body_type):
             continue
         bone_name = names_preset.get(int(reference_bone_id), None)
         if bone_name:
+            renamed[pose_bone.name] = bone_name
             pose_bone.name = bone_name
+    # Mirror Bone is held by name (see bone.py), so a rename here would
+    # otherwise leave it pointing at a name that no longer exists.
+    for pose_bone in armature_ob.pose.bones:
+        mirror = get_mirror(pose_bone, app_id)
+        if mirror in renamed:
+            set_mirror(pose_bone, app_id, renamed[mirror])
 
 
 def merge_vgroups(vg_a, vg_b):

--- a/tests/mtfw/test_bone_retarget.py
+++ b/tests/mtfw/test_bone_retarget.py
@@ -88,6 +88,45 @@ def test_autorenaming_bones_keeps_them_addressable_by_animation_id():
         bpy.context.view_layer.objects.active = previous
 
 
+def test_autorenaming_bones_keeps_mirror_bone_pointing_at_a_real_bone():
+    """Mirror Bone is held by name, which Autorename Bones changes.
+
+    Renaming without updating it leaves Mirror Bone pointing at a name that no
+    longer exists, which export (mesh.py's _derive_mirror_ids) rejects with an
+    AlbamCheckFailure the moment "Export bones" is on. See #285.
+    """
+    from albam.blender_ui.tools import rename_bones
+    from albam.engines.mtfw.bone import get_mirror, set_anim_retarget, set_mirror
+
+    armature_data = bpy.data.armatures.new("mirror_rename_rig")
+    armature = bpy.data.objects.new("mirror_rename_rig", armature_data)
+    bpy.context.scene.collection.objects.link(armature)
+    previous = bpy.context.view_layer.objects.active
+    try:
+        bpy.context.view_layer.objects.active = armature
+        bpy.ops.object.mode_set(mode="EDIT")
+        for name in ("0", "1"):
+            edit_bone = armature_data.edit_bones.new(name)
+            edit_bone.tail = (0.0, 0.0, 0.1)
+        bpy.ops.object.mode_set(mode="OBJECT")
+        for name, anim_id in (("0", "0"), ("1", "1")):
+            set_anim_retarget(armature.pose.bones[name], "re5", anim_id)
+        set_mirror(armature.pose.bones["0"], "re5", "1")
+        set_mirror(armature.pose.bones["1"], "re5", "0")
+
+        rename_bones(armature, "re5", "Body")
+
+        # BONES_BODY names ids 0 and 1 "root" and "spine_lower"
+        assert get_mirror(armature.pose.bones["root"], "re5") == "spine_lower"
+        assert get_mirror(armature.pose.bones["spine_lower"], "re5") == "root"
+    finally:
+        if bpy.context.mode != "OBJECT":
+            bpy.ops.object.mode_set(mode="OBJECT")
+        bpy.data.objects.remove(armature, do_unlink=True)
+        bpy.data.armatures.remove(armature_data)
+        bpy.context.view_layer.objects.active = previous
+
+
 def test_a_rig_saved_before_the_move_still_maps_its_bones():
     """.blend files predating the move carry the id as a raw bone property.
 


### PR DESCRIPTION
## Summary

PR #278 added a `Mirror Bone` custom property, held by bone **name** rather
than index so it survives reordering. Export (`_derive_mirror_ids` in
`mesh.py`) resolves that name back to a bone index and raises
`AlbamCheckFailure` if the name doesn't match any bone in the rig.

"Autorename Bones" (`rename_bones` in `tools.py`) renames `pose_bone.name`
but never updated any `Mirror Bone` value pointing at the old name. So:
import a model with mirror data set, run Autorename Bones, export with
"Export bones" on, and export fails, because every mirror reference still
names the pre-rename bone.

## Fix

`rename_bones` now records old->new name pairs as it renames, then remaps
each bone's `Mirror Bone` property through that table. Bones the preset
leaves untouched (e.g. control bones) keep whatever they had.

## Test plan

- [x] Added `test_autorenaming_bones_keeps_mirror_bone_pointing_at_a_real_bone`;
      confirmed it fails on the old code (`AssertionError: assert '1' ==
      'spine_lower'`) and passes with the fix.
- [x] Full `test_bone_retarget.py` file green.
- [x] `flake8` clean.

Fixes #285