### PR TITLE
fix(blender_ui): stop Autorename Bones leaking one game's name fixes into later rigs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - A second animation file imported onto the same skeleton leaving its limb
   chains solving towards goals none of its blocks move
 - Spurious "Array iterator out of range" messages printed on every export of a mesh with fewer UV layers than the vertex format allows
+- Autorename Bones applying one game's name corrections to every rig renamed
+  afterwards in the same Blender session, silently giving them plausible but
+  wrong bone names
 
 ### Changed
 

--- a/albam/blender_ui/tools.py
+++ b/albam/blender_ui/tools.py
@@ -915,13 +915,11 @@ def set_image_albam_attr(blender_material, app_id, local_path):
 
 
 def rename_bones(armature_ob, app_id, body_type):
-    names_preset = BONE_NAMES.get(body_type)
-    fixes_preset = NAME_FIXES.get(body_type)
-    fixed_name = fixes_preset.get(app_id, None)
+    names_preset = dict(BONE_NAMES.get(body_type))
+    fixed_name = NAME_FIXES.get(body_type, {}).get(app_id)
     bone_name = None
     if fixed_name:
-        for k, v in fixed_name.items():
-            names_preset[k] = v
+        names_preset.update(fixed_name)
     renamed = {}
     for pose_bone in armature_ob.pose.bones:
         reference_bone_id = get_anim_retarget(pose_bone, app_id)

--- a/albam/blender_ui/tools.py
+++ b/albam/blender_ui/tools.py
@@ -915,6 +915,10 @@ def set_image_albam_attr(blender_material, app_id, local_path):
 
 
 def rename_bones(armature_ob, app_id, body_type):
+    # A copy: BONE_NAMES holds the module-level BONES_BODY/BONES_HEAD dicts
+    # themselves, and a game's NAME_FIXES entry reassigns ids rather than just
+    # respelling them, so merging in place would corrupt the tables for every other
+    # game renamed later in the same session (see #245).
     names_preset = dict(BONE_NAMES.get(body_type))
     fixed_name = NAME_FIXES.get(body_type, {}).get(app_id)
     bone_name = None

--- a/tests/mtfw/test_bone_retarget.py
+++ b/tests/mtfw/test_bone_retarget.py
@@ -127,6 +127,55 @@ def test_autorenaming_bones_keeps_mirror_bone_pointing_at_a_real_bone():
         bpy.context.view_layer.objects.active = previous
 
 
+def test_autorenaming_bones_does_not_mutate_the_shared_name_tables():
+    """Autorename Bones must not corrupt BONES_BODY/BONES_HEAD for other games.
+
+    NAME_FIXES entries (e.g. re1's) reassign meanings, not just spellings: id
+    24 is thumb_01_r by default and knee_r under re1's fixes. rename_bones
+    used to build its working map as `BONE_NAMES.get(body_type)`, which is
+    the module-level dict itself, not a copy - so applying re1's fixes wrote
+    them straight into BONES_BODY, and the next rig renamed in the same
+    session (re5, which has no NAME_FIXES entry of its own) got re1's names.
+    See #245.
+    """
+    from albam.blender_ui.tools import rename_bones
+    from albam.engines.mtfw.bone import set_anim_retarget
+    from albam.lib.bone_names import BONES_BODY, BONES_HEAD
+
+    body_before = dict(BONES_BODY)
+    head_before = dict(BONES_HEAD)
+
+    armature_data = bpy.data.armatures.new("shared_table_rig")
+    armature = bpy.data.objects.new("shared_table_rig", armature_data)
+    bpy.context.scene.collection.objects.link(armature)
+    previous = bpy.context.view_layer.objects.active
+    try:
+        bpy.context.view_layer.objects.active = armature
+        bpy.ops.object.mode_set(mode="EDIT")
+        edit_bone = armature_data.edit_bones.new("24")
+        edit_bone.tail = (0.0, 0.0, 0.1)
+        bpy.ops.object.mode_set(mode="OBJECT")
+        set_anim_retarget(armature.pose.bones["24"], "re1", "24")
+
+        # re1 has a NAME_FIXES entry that reassigns id 24 away from BONES_BODY's
+        # default (thumb_01_r -> knee_r); this is what a fix must not leak.
+        rename_bones(armature, "re1", "Body")
+
+        assert armature.pose.bones[0].name == "knee_r"
+        assert BONES_BODY == body_before, (
+            "rename_bones must not mutate the shared BONES_BODY table"
+        )
+        assert BONES_HEAD == head_before, (
+            "rename_bones must not mutate the shared BONES_HEAD table"
+        )
+    finally:
+        if bpy.context.mode != "OBJECT":
+            bpy.ops.object.mode_set(mode="OBJECT")
+        bpy.data.objects.remove(armature, do_unlink=True)
+        bpy.data.armatures.remove(armature_data)
+        bpy.context.view_layer.objects.active = previous
+
+
 def test_a_rig_saved_before_the_move_still_maps_its_bones():
     """.blend files predating the move carry the id as a raw bone property.
 

--- a/tests/test_vfs_fs_backed.py
+++ b/tests/test_vfs_fs_backed.py
@@ -265,15 +265,18 @@ def test_remove_root_unregisters_fs():
     before_size = len(vfs.file_list)
     root = vfs.add_fs_root("re5", _sample_fs(), display_name="removable-root")
     key = root.fs_key
+    # Copied out now: removing the item invalidates every reference into
+    # file_list, so reading root.name afterward reads freed memory.
+    root_name = root.name
     assert fs_registry.get(key) is not None
 
-    vfs.file_list_selected_index = vfs.file_list.find(root.name)
+    vfs.file_list_selected_index = vfs.file_list.find(root_name)
     ALBAM_OT_VirtualFileSystemRemoveRootVFile.execute(
         ALBAM_OT_VirtualFileSystemRemoveRootVFile, bpy.context
     )
 
     assert len(vfs.file_list) == before_size
-    assert vfs.file_list.find(root.name) == -1
+    assert vfs.file_list.find(root_name) == -1
     with pytest.raises(KeyError):
         fs_registry.get(key)
 


### PR DESCRIPTION
## Intent

Fix albam issue #245, "rename_bones mutates the shared BONES_BODY table, corrupting it for other games" (https://github.com/Brachi/albam/issues/245).

The captain's ask, in the substance of that issue (which the captain wrote):

`rename_bones` in `albam/blender_ui/tools.py` writes a game's name corrections into the shared naming table in place, rather than into a per-call copy. `BONE_NAMES["Body"]` *is* the module-level `BONES_BODY` dict from `albam.lib.bone_names`, not a copy of it, so this loop rewrites the shared table:

```python
names_preset = BONE_NAMES.get(body_type) # not a copy
fixes_preset = NAME_FIXES.get(body_type)
fixed_name = fixes_preset.get(app_id, None)
if fixed_name:
for k, v in fixed_name.items():
names_preset[k] = v # <-- mutates BONES_BODY
```

Why it matters: the correction tables reassign meanings, not just spellings. `BODY_NAMES_FIX_RE1` alone reassigns 75 of the 107 ids that `BONES_BODY` names - for example id 24 is `thumb_01_r` by default and `knee_r` in re1. So after renaming a re1 armature, renaming an re5 armature in the same Blender session names its thumb bone `knee_r`. Every game without its own `NAME_FIXES` entry is affected, re5 among them, and the damage is silent: the bones simply come out with plausible-looking wrong names.

Reproduction from the issue, which needs no Blender - the aliasing is the whole bug:

```python
from albam.lib.bone_names import BONES_BODY, NAME_FIXES

BONE_NAMES = {"Body": BONES_BODY}
before = BONES_BODY[24]

names_preset = BONE_NAMES.get("Body")
assert names_preset is BONES_BODY # passes

for k, v in NAME_FIXES["Body"]["re1"].items():
names_preset[k] = v

print(before, "->", BONES_BODY[24]) # thumb_01_r -> knee_r
```

In the UI this is: rename bones on a re1 character, then rename bones on an re5 character, and inspect the re5 armature's hand.

The fix suggested in the issue is to build the merged mapping in a local copy:

```python
names_preset = dict(BONE_NAMES.get(body_type))
fixed_name = NAME_FIXES.get(body_type, {}).get(app_id)
if fixed_name:
names_preset.update(fixed_name)
```

## What Changed

- `rename_bones` in `albam/blender_ui/tools.py` now builds its working name map as a local `dict(BONE_NAMES.get(body_type))` copy and merges the game's `NAME_FIXES` entry with `update()`, instead of writing the fixes straight into the module-level `BONES_BODY`/`BONES_HEAD` tables. Previously, renaming a re1 rig reassigned shared ids (id 24: `thumb_01_r` -> `knee_r`), so every rig renamed afterwards in the same Blender session — any game without its own `NAME_FIXES` entry, re5 included — silently got re1's names.
- Added `test_autorenaming_bones_does_not_mutate_the_shared_name_tables` in `tests/mtfw/test_bone_retarget.py`, which renames a single-bone armature with `app_id="re1"`, asserts the bone comes out as `knee_r`, and asserts `BONES_BODY`/`BONES_HEAD` are unchanged afterwards.
- Documented the copy invariant in a comment at the call site and added a CHANGELOG entry under Fixed.

## Also Included: Automated CI Repair (Unrelated to This Fix)

While this PR's CI was running, `tests (5.2.0, 3.13)` failed on
`tests/test_vfs_fs_backed.py::test_remove_root_unregisters_fs` with
`UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb0 ... invalid start byte`.
This is a pre-existing, unrelated flaky test bug, not something introduced by the
`rename_bones` change above: the test kept `root`, a reference to an item in a
Blender `CollectionProperty` (`vfs.file_list`), and read `root.name` *after*
removing that item via `ALBAM_OT_VirtualFileSystemRemoveRootVFile`. Removing an
item from the collection invalidates references into it, so the post-removal
read decoded freed memory - which is why it only surfaces some of the time (it
passed on the other matrix leg, bpy 4.2/py3.11, in the same run).

The no-mistakes pipeline's CI step diagnosed this automatically and applied the
smallest fix - hoisting `root_name = root.name` before the removal and using
that local for both `vfs.file_list.find(...)` calls - then re-pushed for
revalidation. No production code changed. This is included in this PR only
because the pipeline needed CI green to proceed and the failure was blocking;
it is not part of the `rename_bones` fix itself.

## Risk Assessment

✅ Low: A three-line, well-bounded fix that replaces an in-place mutation of shared module-level tables with a per-call copy exactly as the issue prescribed, covered by a behavioral regression test that fails before the fix.

## Testing

I stood the addon up the way a user does — registered albam inside headless Blender (bpy 4.2), built rigs carrying albam animation ids, selected each rig, picked the game and bone-name preset in scene settings, and pressed the real Autorename Bones operator — then ran the same driver against a pristine checkout of the base commit. After the fix every scenario passes: re1 keeps its own corrections (id 24 → knee_r), a subsequently renamed re5 rig gets the untouched defaults (thumb_01_r), interleaved renames across re0/dd/re5/re1/re6 each produce that game's own names, and BONES_BODY/BONES_HEAD compare equal to snapshots taken before any rename. Against the base commit the identical driver reproduces the reported corruption (re5 → knee_r, and dd's fixes leaking into a later re5 rig as thumb_03_r), and the committed regression test likewise fails there and passes on the fix. No visual artifact is included because this surface is a Blender addon operator and the environment has only the headless `bpy` pip module with no GUI window (the only stub in the driver was the success toast, since window_manager.popup_menu segfaults without a window); the CLI transcripts capture the actual bone names the user would see. Overall result: go.

- Live validation: ✅ go - 6 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Rename a re1 character&#39;s bones, then an re5 character&#39;s bones in the same Blender session; the re5 hand keeps its default name (thumb_01_r, not knee_r) | ✅ pass | live | autorename_after_fix.log — bpy.ops.albam.autorename_bones() [re1/Body] then [re5/Body]; re5 rig -&gt; [&#39;thumb_01_r&#39;,&#39;thumb_02_r&#39;,&#39;root&#39;,&#39;spine_lower&#39;] |
| The re1 rig still receives re1&#39;s own name corrections (id 24 -&gt; knee_r), so the copy did not disable the fixes | ✅ pass | live | autorename_after_fix.log — re1 rig -&gt; [&#39;knee_r&#39;,&#39;knee_l&#39;,&#39;root&#39;,&#39;spine_lower&#39;] |
| Shared BONES_BODY/BONES_HEAD tables are unchanged after renaming through the operator | ✅ pass | live | autorename_after_fix.log — &#39;BONES_BODY unchanged&#39; / &#39;BONES_HEAD unchanged&#39; compared against snapshots taken before any rename |
| Adversarial: six interleaved renames across re0, dd, re5, re1, re6, re5 each produce that game&#39;s own names and leave the tables intact | ✅ pass | live | autorename_after_fix.log Scenario 3 — dd -&gt; thumb_03_r, re1 -&gt; knee_r, re5/re6/re0 -&gt; thumb_01_r; &#39;BONES_BODY still unchanged after 6 more renames&#39; |
| Adversarial: Head preset renames (a table with no NAME_FIXES entries) leave BONES_HEAD intact and yield the pristine defaults | ✅ pass | live | autorename_after_fix.log Scenario 4 — head re5 -&gt; [&#39;thumb_01_r&#39;,&#39;thumb_02_r&#39;,&#39;root&#39;,&#39;spine_lower&#39;], BONES_HEAD unchanged |
| Regression proof: the same end-user session on the pre-fix code reproduces the reported corruption | ✅ pass | live | autorename_before_fix_base_commit.log — re5 rig -&gt; [&#39;knee_r&#39;,&#39;knee_l&#39;,...] and &#39;BONES_BODY unchanged: got=False&#39;; committed test test_autorenaming_bones_does_not_mutate_the_shared_name_tables also fai… |

<details>
<summary>Evidence: Autorename Bones driver transcript — after fix (all checks pass)</summary>

```text
== Scenario 1: re1 rig renamed first, then an re5 rig in the same session ==
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
    (selected app=re1 preset=Body)
    [popup] Armature bones were renamed
  bpy.ops.albam.autorename_bones() [re1/Body] -> {'FINISHED'}
  PASS: re1 rig gets re1's own corrections (id 24 -> knee_r)
        got=['knee_r', 'knee_l', 'root', 'spine_lower']
        want=['knee_r', 'knee_l', 'root', 'spine_lower']
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
    (selected app=re5 preset=Body)
    [popup] Armature bones were renamed
  bpy.ops.albam.autorename_bones() [re5/Body] -> {'FINISHED'}
  PASS: re5 rig (no NAME_FIXES of its own) keeps the default names (id 24 -> thumb_01_r)
        got=['thumb_01_r', 'thumb_02_r', 'root', 'spine_lower']
        want=['thumb_01_r', 'thumb_02_r', 'root', 'spine_lower']
== Scenario 2: shared tables are unchanged after the renames ==
  PASS: BONES_BODY unchanged
        got=True
        want=True
  PASS: BONES_HEAD unchanged
        got=True
        want=True
== Scenario 3 (adversarial): repeated / interleaved renames across games ==
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
    (selected app=re0 preset=Body)
    [popup] Armature bones were renamed
  bpy.ops.albam.autorename_bones() [re0/Body] -> {'FINISHED'}
  PASS: re0: id 24 -> thumb_01_r
        got='thumb_01_r'
        want='thumb_01_r'
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
    (selected app=dd preset=Body)
    [popup] Armature bones were renamed
  bpy.ops.albam.autorename_bones() [dd/Body] -> {'FINISHED'}
  PASS: dd: id 24 -> thumb_03_r
        got='thumb_03_r'
        want='thumb_03_r'
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
    (selected app=re5 preset=Body)
    [popup] Armature bones were renamed
  bpy.ops.albam.autorename_bones() [re5/Body] -> {'FINISHED'}
  PASS: re5: id 24 -> thumb_01_r
        got='thumb_01_r'
        want='thumb_01_r'
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
    (selected app=re1 preset=Body)
    [popup] Armature bones were renamed
  bpy.ops.albam.autorename_bones() [re1/Body] -> {'FINISHED'}
  PASS: re1: id 24 -> knee_r
        got='knee_r'
        want='knee_r'
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
    (selected app=re6 preset=Body)
    [popup] Armature bones were renamed
  bpy.ops.albam.autorename_bones() [re6/Body] -> {'FINISHED'}
  PASS: re6: id 24 -> thumb_01_r
        got='thumb_01_r'
        want='thumb_01_r'
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
    (selected app=re5 preset=Body)
    [popup] Armature bones were renamed
  bpy.ops.albam.autorename_bones() [re5/Body] -> {'FINISHED'}
  PASS: re5: id 24 -> thumb_01_r
        got='thumb_01_r'
        want='thumb_01_r'
  PASS: BONES_BODY still unchanged after 6 more renames
        got=True
        want=True
== Scenario 4 (adversarial): Head preset, and a game with no fixes after one with fixes ==
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
    (selected app=re1 preset=Head)
    [popup] Armature bones were renamed
  bpy.ops.albam.autorename_bones() [re1/Head] -> {'FINISHED'}
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M225RA0KJGG1FQ1BRBMAZPXZ/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
    (selected app=re5 preset=Head)
    [popup] Armature bones were renamed
  bpy.ops.albam.autorename_bones() [re5/Head] -> {'FINISHED'}
  head re1 -> ['thumb_01_r', 'thumb_02_r', 'root', 'spine_lower']
  head re5 -> ['thumb_01_r', 'thumb_02_r', 'root', 'spine_lower']
  PASS: BONES_HEAD unchanged after Head-preset renames
        got=True
        want=True
  PASS: Head preset re5 names are the pristine table defaults
        got=['thumb_01_r', 'thumb_02_r', 'root', 'spine_lower']
        want=['thumb_01_r', 'thumb_02_r', 'root', 'spine_lower']

RESULT: all checks passed
```
</details>
<details>
<summary>Evidence: Same driver on base commit — reproduces issue #245</summary>

```text
== Scenario 1: re1 rig renamed first, then an re5 rig in the same session ==
Traceback (most recent call last):
  File "/tmp/nm_albam_base_245/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm_albam_base_245/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "/tmp/nm_albam_base_245/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
    (selected app=re1 preset=Body)
    [popup] Armature bones were renamed
  bpy.ops.albam.autorename_bones() [re1/Body] -> {'FINISHED'}
  PASS: re1 rig gets re1's own corrections (id 24 -> knee_r)
        got=['knee_r', 'knee_l', 'root', 'spine_lower']
        want=['knee_r', 'knee_l', 'root', 'spine_lower']
Traceback (most recent call last):
  File "/tmp/nm_albam_base_245/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm_albam_base_245/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "/tmp/nm_albam_base_245/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
    (selected app=re5 preset=Body)
    [popup] Armature bones were renamed
  bpy.ops.albam.autorename_bones() [re5/Body] -> {'FINISHED'}
  FAIL: re5 rig (no NAME_FIXES of its own) keeps the default names (id 24 -> thumb_01_r)
        got=['knee_r', 'knee_l', 'root', 'spine_lower']
        want=['thumb_01_r', 'thumb_02_r', 'root', 'spine_lower']
== Scenario 2: shared tables are unchanged after the renames ==
  FAIL: BONES_BODY unchanged
        got=False
        want=True
  PASS: BONES_HEAD unchanged
        got=True
        want=True
== Scenario 3 (adversarial): repeated / interleaved renames across games ==
Traceback (most recent call last):
  File "/tmp/nm_albam_base_245/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm_albam_base_245/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "/tmp/nm_albam_base_245/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
    (selected app=re0 preset=Body)
    [popup] Armature bones were renamed
  bpy.ops.albam.autorename_bones() [re0/Body] -> {'FINISHED'}
  PASS: re0: id 24 -> thumb_01_r
        got='thumb_01_r'
        want='thumb_01_r'
Traceback (most recent call last):
  File "/tmp/nm_albam_base_245/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm_albam_base_245/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "/tmp/nm_albam_base_245/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
    (selected app=dd preset=Body)
    [popup] Armature bones were renamed
  bpy.ops.albam.autorename_bones() [dd/Body] -> {'FINISHED'}
  PASS: dd: id 24 -> thumb_03_r
        got='thumb_03_r'
        want='thumb_03_r'
Traceback (most recent call last):
  File "/tmp/nm_albam_base_245/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm_albam_base_245/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "/tmp/nm_albam_base_245/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
    (selected app=re5 preset=Body)
    [popup] Armature bones were renamed
  bpy.ops.albam.autorename_bones() [re5/Body] -> {'FINISHED'}
  FAIL: re5: id 24 -> thumb_01_r
        got='thumb_03_r'
        want='thumb_01_r'
Traceback (most recent call last):
  File "/tmp/nm_albam_base_245/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm_albam_base_245/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "/tmp/nm_albam_base_245/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
    (selected app=re1 preset=Body)
    [popup] Armature bones were renamed
  bpy.ops.albam.autorename_bones() [re1/Body] -> {'FINISHED'}
  PASS: re1: id 24 -> knee_r
        got='knee_r'
        want='knee_r'
Traceback (most recent call last):
  File "/tmp/nm_albam_base_245/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm_albam_base_245/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "/tmp/nm_albam_base_245/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
    (selected app=re6 preset=Body)
    [popup] Armature bones were renamed
  bpy.ops.albam.autorename_bones() [re6/Body] -> {'FINISHED'}
  FAIL: re6: id 24 -> thumb_01_r
        got='knee_r'
        want='thumb_01_r'
Traceback (most recent call last):
  File "/tmp/nm_albam_base_245/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm_albam_base_245/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "/tmp/nm_albam_base_245/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
    (selected app=re5 preset=Body)
    [popup] Armature bones were renamed
  bpy.ops.albam.autorename_bones() [re5/Body] -> {'FINISHED'}
  FAIL: re5: id 24 -> thumb_01_r
        got='knee_r'
        want='thumb_01_r'
  FAIL: BONES_BODY still unchanged after 6 more renames
        got=False
        want=True
== Scenario 4 (adversarial): Head preset, and a game with no fixes after one with fixes ==
Traceback (most recent call last):
  File "/tmp/nm_albam_base_245/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm_albam_base_245/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "/tmp/nm_albam_base_245/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
    (selected app=re1 preset=Head)
    [popup] Armature bones were renamed
  bpy.ops.albam.autorename_bones() [re1/Head] -> {'FINISHED'}
Traceback (most recent call last):
  File "/tmp/nm_albam_base_245/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm_albam_base_245/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nm-bpy42/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "/tmp/nm_albam_base_245/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
    (selected app=re5 preset=Head)
    [popup] Armature bones were renamed
  bpy.ops.albam.autorename_bones() [re5/Head] -> {'FINISHED'}
  head re1 -> ['thumb_01_r', 'thumb_02_r', 'root', 'spine_lower']
  head re5 -> ['thumb_01_r', 'thumb_02_r', 'root', 'spine_lower']
  PASS: BONES_HEAD unchanged after Head-preset renames
        got=True
        want=True
  PASS: Head preset re5 names are the pristine table defaults
        got=['thumb_01_r', 'thumb_02_r', 'root', 'spine_lower']
        want=['thumb_01_r', 'thumb_02_r', 'root', 'spine_lower']

RESULT: 6 FAILED -> ['re5 rig (no NAME_FIXES of its own) keeps the default names (id 24 -> thumb_01_r)', 'BONES_BODY unchanged', 're5: id 24 -> thumb_01_r', 're6: id 24 -> thumb_01_r', 're5: id 24 -> thumb_01_r', 'BONES_BODY still unchanged after 6 more renames']
```
</details>

- Evidence: Driver script (real bpy.ops.albam.autorename_bones session) (local file: <code>~/.no-mistakes/evidence/01M225RA0KJGG1FQ1BRBMAZPXZ/drive_autorename.py</code>)

<details>
<summary>Evidence: Before/after of the reported symptom (id 24 on an re5 rig renamed after a re1 rig)</summary>

```text
base 1539351: bpy.ops.albam.autorename_bones() [re5/Body] -> {'FINISHED'}
FAIL: got=['knee_r', 'knee_l', 'root', 'spine_lower'] want=['thumb_01_r', 'thumb_02_r', 'root', 'spine_lower']
FAIL: BONES_BODY unchanged -> False

fixed 2e1a832: bpy.ops.albam.autorename_bones() [re5/Body] -> {'FINISHED'}
PASS: got=['thumb_01_r', 'thumb_02_r', 'root', 'spine_lower']
PASS: BONES_BODY unchanged -> True
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8e295c2df70916ccb0869f9ed30d606c247dd0d4","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `tests/mtfw/test_bone_retarget.py:168` - The `BONES_HEAD == head_before` assertion can never fail from this test: it calls `rename_bones(armature, &#34;re1&#34;, &#34;Body&#34;)`, which only ever touches `BONE_NAMES[&#34;Body&#34;]`, and `NAME_FIXES_HEAD` is empty (albam/lib/bone_names.py:727) so no Head fix exists to leak. It is harmless as a future guard; noting it only so it isn&#39;t mistaken for coverage of the Head path.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 6 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Rename a re1 character&#39;s bones, then an re5 character&#39;s bones in the same Blender session; the re5 hand keeps its default name (thumb_01_r, not knee_r) | ✅ pass | live | autorename_after_fix.log — bpy.ops.albam.autorename_bones() [re1/Body] then [re5/Body]; re5 rig -&gt; [&#39;thumb_01_r&#39;,&#39;thumb_02_r&#39;,&#39;root&#39;,&#39;spine_lower&#39;] |
| The re1 rig still receives re1&#39;s own name corrections (id 24 -&gt; knee_r), so the copy did not disable the fixes | ✅ pass | live | autorename_after_fix.log — re1 rig -&gt; [&#39;knee_r&#39;,&#39;knee_l&#39;,&#39;root&#39;,&#39;spine_lower&#39;] |
| Shared BONES_BODY/BONES_HEAD tables are unchanged after renaming through the operator | ✅ pass | live | autorename_after_fix.log — &#39;BONES_BODY unchanged&#39; / &#39;BONES_HEAD unchanged&#39; compared against snapshots taken before any rename |
| Adversarial: six interleaved renames across re0, dd, re5, re1, re6, re5 each produce that game&#39;s own names and leave the tables intact | ✅ pass | live | autorename_after_fix.log Scenario 3 — dd -&gt; thumb_03_r, re1 -&gt; knee_r, re5/re6/re0 -&gt; thumb_01_r; &#39;BONES_BODY still unchanged after 6 more renames&#39; |
| Adversarial: Head preset renames (a table with no NAME_FIXES entries) leave BONES_HEAD intact and yield the pristine defaults | ✅ pass | live | autorename_after_fix.log Scenario 4 — head re5 -&gt; [&#39;thumb_01_r&#39;,&#39;thumb_02_r&#39;,&#39;root&#39;,&#39;spine_lower&#39;], BONES_HEAD unchanged |
| Regression proof: the same end-user session on the pre-fix code reproduces the reported corruption | ✅ pass | live | autorename_before_fix_base_commit.log — re5 rig -&gt; [&#39;knee_r&#39;,&#39;knee_l&#39;,...] and &#39;BONES_BODY unchanged: got=False&#39;; committed test test_autorenaming_bones_does_not_mutate_the_shared_name_tables also fai… |

- <code>`LD_LIBRARY_PATH=... PYTHONPATH=&lt;worktree&gt; python -u ~/.no-mistakes/evidence/01M225RA0KJGG1FQ1BRBMAZPXZ/drive_autorename.py` — drives bpy.ops.albam.autorename_bones() over 10 rigs across games/presets (fixed commit: all checks pass)</code>
- <code>Same driver run against a clean `git archive` checkout of base commit 1539351 — reproduces issue #245 (6 failing checks)</code>
- <code>`python -m pytest tests/mtfw/test_bone_retarget.py -q` on the fixed worktree — 7 passed</code>
- <code>Same test file copied onto the base-commit checkout — `test_autorenaming_bones_does_not_mutate_the_shared_name_tables` fails (regression test proven to catch the bug)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

