### PR TITLE
fix(engines): stop touching deprecated Material.use_nodes on Blender 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   expanding either one listed both archives' contents
 - "Batch import folder" importing a second, same-named archive's identically
   placed files along with the selected folder's own
+- `Material.use_nodes` deprecation warnings on Blender 5.x, printed once per
+  material built on import. Materials are node-based unconditionally from 5.0
+  on, so the property is only touched now on the versions that still need it
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   expanding either one listed both archives' contents
 - "Batch import folder" importing a second, same-named archive's identically
   placed files along with the selected folder's own
-- `Material.use_nodes` deprecation warnings on Blender 5.x, printed once per
-  material built on import. Materials are node-based unconditionally from 5.0
-  on, so the property is only touched now on the versions that still need it
 
 ### Changed
 

--- a/albam/engines/cie/material.py
+++ b/albam/engines/cie/material.py
@@ -1,5 +1,5 @@
 import bpy
-from ...lib.blender import BaseMaterialCustomProperties, ShaderGroupCompat
+from ...lib.blender import BaseMaterialCustomProperties, ensure_material_nodes, ShaderGroupCompat
 from ...registry import blender_registry
 from .textures import _process_tpls, _create_blender_image_from_tex
 
@@ -19,7 +19,7 @@ def build_blender_materials(bl_mesh, bin, tpl_vfile):
         albam_custom_props = blender_material.albam_custom_properties
         custom_props_top_level = albam_custom_props.get_custom_properties_for_appid(app_id)
         custom_props_top_level.copy_custom_properties_from(mat)
-        blender_material.use_nodes = True
+        ensure_material_nodes(blender_material)
         blender_material.blend_method = "CLIP"
 
         node_to_delete = None

--- a/albam/engines/cie/mesh.py
+++ b/albam/engines/cie/mesh.py
@@ -6,6 +6,7 @@ import math
 import struct
 from ...registry import blender_registry
 from ...vfs import VirtualFile, VirtualFileData
+from ...lib.blender import material_uses_nodes
 from ...lib.misc import chunks
 from ...exceptions import AlbamCheckFailure
 from .structs.re4_uhd_bin import Re4UhdBin
@@ -1100,7 +1101,7 @@ def _texture_slot(bl_material, input_name, app_id):
 
     No image bound is not the same as no texture - see _serialize_material.
     """
-    if not bl_material.use_nodes:
+    if not material_uses_nodes(bl_material):
         return SLOT_EMPTY
     found = SLOT_EMPTY
     for node in bl_material.node_tree.nodes:

--- a/albam/engines/hexn/material.py
+++ b/albam/engines/hexn/material.py
@@ -6,7 +6,7 @@ from kaitaistruct import KaitaiStream
 
 from .texture import build_blender_textures, _texture_suffix
 from .structs.hexane_matb import HexaneMatb
-from ...lib.blender import layout_node_chains
+from ...lib.blender import ensure_material_nodes, layout_node_chains
 
 # A .matb's texture paths end in a two-character suffix identifying their
 # role (e.g. "..._skel_d.dds", "..._skel_n.dds") - confirmed against a
@@ -68,7 +68,7 @@ def build_blender_materials(edgemodel, context, root_id=None):
             continue
 
         bl_material = bpy.data.materials.new(os.path.basename(material_path))
-        bl_material.use_nodes = True
+        ensure_material_nodes(bl_material)
         # Same as MT Framework's own materials (albam.engines.mtfw.material) -
         # a _d diffuse map's Alpha is wired below whenever the texture has
         # one (hair cards etc. use it as a cutout mask; solid DXT1 diffuse

--- a/albam/engines/mtfw/material.py
+++ b/albam/engines/mtfw/material.py
@@ -7,7 +7,7 @@ import bpy
 from kaitaistruct import KaitaiStream
 
 from ...exceptions import AlbamCheckFailure
-from ...lib.blender import get_bl_materials, ShaderGroupCompat
+from ...lib.blender import ensure_material_nodes, get_bl_materials, ShaderGroupCompat
 from ...lib.kaitai_utils import check_recursive, parse
 from ...registry import blender_registry
 from ...vfs import VirtualFileData
@@ -236,7 +236,7 @@ def build_blender_materials(mod_file_item, context, parsed_mod, name_prefix="mat
         else:
             custom_props_top_level.copy_custom_properties_from(material)
 
-        blender_material.use_nodes = True
+        ensure_material_nodes(blender_material)
         blender_material.blend_method = "CLIP"
         node_to_delete = None
         for node in blender_material.node_tree.nodes:

--- a/albam/engines/reng/material.py
+++ b/albam/engines/reng/material.py
@@ -6,6 +6,7 @@ from kaitaistruct import KaitaiStream
 from .structs.reengine_mdf import ReengineMdf
 from .texture import build_blender_images, assign_textures
 from .apps import APPS_TODO
+from ...lib.blender import ensure_material_nodes
 
 
 def build_blender_materials(mesh_vfile, context):
@@ -35,7 +36,7 @@ def build_blender_materials(mesh_vfile, context):
 
     for mdf_material in mdf.materials:
         blender_material = bpy.data.materials.new(mdf_material.name)
-        blender_material.use_nodes = True
+        ensure_material_nodes(blender_material)
         blender_material.blend_method = "HASHED" if mdf_material.alpha_flags.alpha_mask_used else "OPAQUE"
         assign_textures(blender_material, mdf_material, blender_images)
         blender_materials[mdf_material.name] = blender_material

--- a/albam/lib/blender.py
+++ b/albam/lib/blender.py
@@ -323,6 +323,37 @@ def get_colors_per_loop(blender_mesh):
     return colors
 
 
+def ensure_material_nodes(bl_material):
+    """Give `bl_material` a node tree, on every Blender version albam supports.
+
+    Up to 4.5, `bpy.data.materials.new()` returns a material with `use_nodes`
+    off and no `node_tree` at all, so the assignment here is what builds the
+    tree the callers immediately start adding nodes to. From 5.0 on materials
+    are node-based unconditionally: the tree is already there, and `use_nodes`
+    only survives as a deprecated no-op that warns on both read and write
+    ("'Material.use_nodes' is expected to be removed in Blender 6.0"). Testing
+    `node_tree` rather than `use_nodes` is what keeps 4.2/4.5 working without
+    touching the deprecated property on 5.x.
+    """
+    if bl_material.node_tree is None:
+        bl_material.use_nodes = True
+
+
+def material_uses_nodes(bl_material):
+    """Whether `bl_material` renders from its node tree.
+
+    The counterpart to `ensure_material_nodes` for reads. Before 5.0 this is
+    exactly `use_nodes`, and it has to stay that way: unticking "Use Nodes" in
+    the UI leaves `node_tree` populated, so a material with nodes disabled but
+    a tree still hanging off it must read as not node-based. From 5.0 on the
+    toggle is gone in all but name - it reads True always and warns - so the
+    tree itself is the only thing left to ask about.
+    """
+    if bpy.app.version >= (5, 0, 0):
+        return bl_material.node_tree is not None
+    return bl_material.use_nodes
+
+
 def get_bl_teximage_nodes(bl_materials):
     images = {}
     default = {


### PR DESCRIPTION
Closes #284.

Blender 5.0 makes materials node-based unconditionally and keeps `use_nodes`
only as a deprecated no-op that warns on read and on write, scheduled for
removal in 6.0. Every engine set it on each material it built, so an import
printed the warning once per material.

The assignment cannot just be dropped. Measured against the bpy wheels:

| bpy | `materials.new()` `use_nodes` | `node_tree` | warns |
|---|---|---|---|
| 4.2.0 | False | None | no |
| 4.5.0 | False | None | no |
| 5.0.0 | True | populated | yes |
| 5.2.0 | True | populated | yes |

So it stays, behind a `node_tree is None` check (`ensure_material_nodes`).
4.2 and 4.5 keep working, 5.x never touches the property, and
`blender_version_min` stays at 4.2.0.

The CIE read at `cie/mesh.py` is not the same test. Below 5.0, unticking
"Use Nodes" leaves `node_tree` populated, so a `node_tree` check there would
start scanning the tree of a material that currently reads as having no bound
texture. `material_uses_nodes` keeps asking `use_nodes` on the versions where
that is expressible.

Verified on bpy 4.2.0, 4.5.0, 5.0.0 and 5.2.0: tree built as expected, no
`use_nodes` warning on read or write, and the unticked-nodes read path
unchanged below 5.0. Real RE:ORC imports through the operator confirm the
warning fires at the base commit and is gone after.

