### PR TITLE
fix(blender_ui): scope batch-import folder walks to the selected archive's root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Autorename Bones applying one game's name corrections to every rig renamed
   afterwards in the same Blender session, silently giving them plausible but
   wrong bone names
+- Two archives added under the same name sharing one file-tree state, so
+  expanding either one listed both archives' contents
+- "Batch import folder" importing a second, same-named archive's identically
+  placed files along with the selected folder's own
 
 ### Changed
 

--- a/albam/blender_ui/import_panel.py
+++ b/albam/blender_ui/import_panel.py
@@ -54,6 +54,32 @@ def set_path_list_file_config(self, context):
     config_mgr.save()
 
 
+def folder_descendants(vfs, folder_item):
+    """Every non-folder vfile under `folder_item`, scoped to the root
+    `folder_item` itself belongs to.
+
+    A node id is `app_id::<path parts>` with no root in it (see
+    albam.vfs.Tree), so two archives mounted under the same name - and
+    therefore holding the same internal paths - give their identically
+    placed folders the *same* node id, and give the files under either one
+    an ancestor list naming that shared id. Matching on the ancestor id
+    alone then batch-imports both archives' copies when the user picked one
+    archive's folder in the file tree (#275). `tree_node.root_id` is unique
+    per root (VirtualFileSystemBase._unique_root_name), so it is what tells
+    the two apart; a root node carries its own id in `name` instead, with
+    `tree_node.root_id` left empty.
+    """
+    root_id = folder_item.name if folder_item.is_root else folder_item.tree_node.root_id
+    folder_node_id = folder_item.name
+    for item in vfs.file_list:
+        if item.is_expandable or item.is_root:
+            continue
+        if item.tree_node.root_id != root_id:
+            continue
+        if any(anc.node_id == folder_node_id for anc in item.tree_node_ancestors):
+            yield item
+
+
 @blender_registry.register_blender_prop_albam(name="apps")
 class AlbamApps(bpy.types.PropertyGroup):
     app_selected : bpy.props.EnumProperty(name="", items=APPS, update=get_app_dir_from_config)
@@ -104,23 +130,13 @@ class ALBAM_OT_Import(bpy.types.Operator):
 
     def _execute_batch(self, folder_item, context):
         vfs = context.scene.albam.vfs
-        folder_node_id = folder_item.name
         imported_count = 0
         failed = []
 
-        for item in vfs.file_list:
-            if item.is_expandable:
-                continue
+        for item in folder_descendants(vfs, folder_item):
             if not item.display_name.lower().endswith(".mod"):
                 continue
             if (item.app_id, item.extension) not in blender_registry.importable_extensions:
-                continue
-            is_child = False
-            for ancestor in item.tree_node_ancestors:
-                if ancestor.node_id == folder_node_id:
-                    is_child = True
-                    break
-            if not is_child:
                 continue
             try:
                 bl_object = self._execute(item, context)
@@ -504,18 +520,9 @@ class ALBAM_OT_BatchImportFolder(bpy.types.Operator):
             self.report({'WARNING'}, 'Select a folder, not a file')
             return {'CANCELLED'}
 
-        selected_node_id = selected.name
-
         # Find all .mod children of the selected folder
-        mod_items = []
-        for item in vfs.file_list:
-            if item.is_expandable:
-                continue
-            if item.display_name.lower().endswith(".mod"):
-                for ancestor in item.tree_node_ancestors:
-                    if ancestor.node_id == selected_node_id:
-                        mod_items.append(item)
-                        break
+        mod_items = [item for item in folder_descendants(vfs, selected)
+                     if item.display_name.lower().endswith(".mod")]
 
         if not mod_items:
             self.report({'WARNING'}, 'No .mod files found in selected folder')

--- a/tests/test_vfs_duplicate_root_names.py
+++ b/tests/test_vfs_duplicate_root_names.py
@@ -1,0 +1,190 @@
+"""
+Regression tests for two archives mounted under the same name (#275: "2
+archives with the same name drives the file explorer insane").
+
+The user-visible report was about the *tree*: expanding one of the two
+same-named roots also revealed the other one's children, while that other
+root's own triangle still read as collapsed. Its cause is that a root vfile
+is keyed by name in `vfs.file_list`, and a plain
+`app_id::<display name>` key is not unique across two archives that share a
+basename - so every child of the second root pointed its `tree_node.root_id`
+back at the first, and the UIList's expansion cache (keyed by root id) held
+one entry for what the user saw as two roots.
+`VirtualFileSystemBase._unique_root_name` gives the second root a `#N`
+suffix instead; `tests/test_vfs_fs_backed.py` covers the bytes half of that
+(each root reads its own FS), and the tree half is covered here.
+
+Node ids *below* a root are still `app_id::<path parts>` with no root in
+them, which is deliberate (see `_unique_root_name`'s docstring) but leaves
+anything that walks the tree by ancestor node id alone unable to tell the
+two archives apart - covered here too, for the batch-import folder walk.
+"""
+import bpy
+import pytest
+from fs.memoryfs import MemoryFS
+
+from albam.blender_ui.import_panel import (
+    ALBAM_UL_VirtualFileSystemUIBase,
+    folder_descendants,
+)
+from albam.lib import fs_registry
+from albam.vfs import ALBAM_OT_VirtualFileSystemCollapseToggle
+from tests.conftest import close_new_fs_roots, remove_new_vfs_roots, vfs_root_names
+
+DUPLICATE_NAME = "uPl00ChrisNormal.arc"
+
+
+@pytest.fixture(autouse=True)
+def _clean_vfs_state():
+    # Same session-scoped Blender state every other VFS test shares - see
+    # tests/test_vfs_fs_backed.py's own fixture for why this diffs instead
+    # of clearing. The UIList expansion cache is process-global class state
+    # on the operator, so it needs resetting around each test too.
+    before_roots = vfs_root_names()
+    before_fs = fs_registry.keys()
+    ALBAM_OT_VirtualFileSystemCollapseToggle.NODES_CACHE.clear()
+    yield
+    remove_new_vfs_roots(before_roots)
+    close_new_fs_roots(before_fs)
+    ALBAM_OT_VirtualFileSystemCollapseToggle.NODES_CACHE.clear()
+
+
+class _FileTreeUI(ALBAM_UL_VirtualFileSystemUIBase):
+    """The panel's UIList without Blender's UI around it.
+
+    `filter_items` is what decides which rows the file tree shows, and it
+    only needs `bitflag_filter_item` and the collapse operator class -
+    neither of which requires a registered, drawn `bpy.types.UIList`.
+    """
+    collapse_toggle_operator_cls = ALBAM_OT_VirtualFileSystemCollapseToggle
+    bitflag_filter_item = 1 << 30
+
+
+def _archive_fs(marker):
+    fs_instance = MemoryFS()
+    for folder in ("effect", "pawn", "sound"):
+        fs_instance.makedirs("/" + folder)
+        fs_instance.writebytes(f"/{folder}/thing.mod", marker)
+    return fs_instance
+
+
+def _add_duplicate_named_roots():
+    """Two archives with the same name, holding the same internal paths -
+    the setup in the issue's screenshot. Returns both roots' unique ids."""
+    vfs = bpy.context.scene.albam.vfs
+    vfs.add_fs_root("re5", _archive_fs(b"first"), display_name=DUPLICATE_NAME, is_archive=True)
+    vfs.add_fs_root("re5", _archive_fs(b"second"), display_name=DUPLICATE_NAME, is_archive=True)
+    roots = [vf.name for vf in vfs.file_list if vf.is_root and vf.display_name == DUPLICATE_NAME]
+    assert len(roots) == 2
+    return roots
+
+
+def _visible_rows(vfs):
+    """(display_name, root_id) of every row the file tree would draw."""
+    flags, _ = _FileTreeUI().filter_items(bpy.context, vfs, "file_list")
+    return [(vfs.file_list[i].display_name, vfs.file_list[i].tree_node.root_id)
+            for i, flag in enumerate(flags) if flag]
+
+
+def _index_of(vfs, root_id, display_name=None):
+    """Position of a row in `file_list`, addressed the way the tree UI does.
+
+    By position, not by `file_list[name]`: two same-named archives give
+    their identically placed folders the identical node id, and Blender's
+    CollectionProperty name lookup returns only the first match - which is
+    the very thing these tests are about. The collapse operator takes the
+    row's index for the same reason.
+    """
+    for i, vf in enumerate(vfs.file_list):
+        if display_name is None:
+            if vf.is_root and vf.name == root_id:
+                return i
+        elif vf.tree_node.root_id == root_id and vf.display_name == display_name:
+            return i
+    raise LookupError((root_id, display_name))
+
+
+def _toggle(vfs, root_id, display_name=None):
+    ALBAM_OT_VirtualFileSystemCollapseToggle.button_index = _index_of(
+        vfs, root_id, display_name)
+    ALBAM_OT_VirtualFileSystemCollapseToggle.execute(
+        ALBAM_OT_VirtualFileSystemCollapseToggle, bpy.context
+    )
+
+
+def _child_of(vfs, root_id, display_name):
+    return vfs.file_list[_index_of(vfs, root_id, display_name)]
+
+
+def test_expanding_one_of_two_same_named_roots_leaves_the_other_collapsed():
+    """The screenshot in #275: with both archives collapsed, expanding the
+    second one listed the first one's children too, under a root still
+    drawn as collapsed.
+    """
+    vfs = bpy.context.scene.albam.vfs
+    root_a, root_b = _add_duplicate_named_roots()
+
+    assert _visible_rows(vfs) == [(DUPLICATE_NAME, ""), (DUPLICATE_NAME, "")]
+
+    _toggle(vfs, root_b)
+
+    assert _visible_rows(vfs) == [
+        (DUPLICATE_NAME, ""),
+        (DUPLICATE_NAME, ""),
+        ("effect", root_b),
+        ("pawn", root_b),
+        ("sound", root_b),
+    ]
+    # The tree state has to match the triangle each root is drawn with.
+    assert vfs.file_list[root_a].is_expanded is False
+    assert vfs.file_list[root_b].is_expanded is True
+
+
+def test_same_named_roots_expand_their_own_subfolders_independently():
+    """Deeper than the root row: two same-named archives hold the same
+    internal paths, so their `effect` folders share a node id
+    (`re5::effect`) - only `tree_node.root_id` tells them apart.
+    """
+    vfs = bpy.context.scene.albam.vfs
+    root_a, root_b = _add_duplicate_named_roots()
+
+    _toggle(vfs, root_a)
+    _toggle(vfs, root_b)
+    shared_node_id = _child_of(vfs, root_a, "effect").name
+    assert shared_node_id == _child_of(vfs, root_b, "effect").name == "re5::effect"
+
+    _toggle(vfs, root_b, "effect")
+
+    visible = _visible_rows(vfs)
+    assert ("thing.mod", root_b) in visible
+    assert ("thing.mod", root_a) not in visible
+
+
+def test_folder_descendants_is_scoped_to_the_root_the_folder_belongs_to():
+    """"Batch import folder" on the second archive's folder used to import
+    the first archive's identically-placed files as well: it collected every
+    vfile whose ancestors named the selected folder's node id, and that id
+    is shared by both archives' copies of the folder.
+    """
+    vfs = bpy.context.scene.albam.vfs
+    _, root_b = _add_duplicate_named_roots()
+
+    picked = list(folder_descendants(vfs, _child_of(vfs, root_b, "pawn")))
+
+    assert [vf.get_bytes() for vf in picked] == [b"second"]
+    assert [vf.tree_node.root_id for vf in picked] == [root_b]
+
+
+def test_folder_descendants_on_a_root_takes_only_that_root():
+    """A root node keeps its own id in `name` and leaves `tree_node.root_id`
+    empty, so it needs the other half of the scoping - "Batch import folder"
+    accepts a root row too (it is expandable).
+    """
+    vfs = bpy.context.scene.albam.vfs
+    root_a, _ = _add_duplicate_named_roots()
+
+    picked = list(folder_descendants(vfs, vfs.file_list[root_a]))
+
+    assert len(picked) == 3  # effect/pawn/sound, one .mod each
+    assert {vf.get_bytes() for vf in picked} == {b"first"}
+    assert {vf.tree_node.root_id for vf in picked} == {root_a}

--- a/tests/test_vfs_duplicate_root_names.py
+++ b/tests/test_vfs_duplicate_root_names.py
@@ -79,11 +79,26 @@ def _add_duplicate_named_roots():
     return roots
 
 
-def _visible_rows(vfs):
-    """(display_name, root_id) of every row the file tree would draw."""
+def _visible_rows(vfs, root_ids):
+    """(display_name, root_id) of the rows the file tree would draw for
+    `root_ids`, in tree order.
+
+    Scoped to the roots under test on purpose: `vfs.file_list` is shared by
+    the whole session, and other suites' session-scoped game_fs_root
+    fixtures mount their own roots into it and never remove them (they run
+    under CI's --game-dir), so the whole visible list is not this test's to
+    assert on.
+    """
     flags, _ = _FileTreeUI().filter_items(bpy.context, vfs, "file_list")
-    return [(vfs.file_list[i].display_name, vfs.file_list[i].tree_node.root_id)
-            for i, flag in enumerate(flags) if flag]
+    rows = []
+    for i, flag in enumerate(flags):
+        if not flag:
+            continue
+        vfile = vfs.file_list[i]
+        owner = vfile.name if vfile.is_root else vfile.tree_node.root_id
+        if owner in root_ids:
+            rows.append((vfile.display_name, vfile.tree_node.root_id))
+    return rows
 
 
 def _index_of(vfs, root_id, display_name=None):
@@ -124,11 +139,14 @@ def test_expanding_one_of_two_same_named_roots_leaves_the_other_collapsed():
     vfs = bpy.context.scene.albam.vfs
     root_a, root_b = _add_duplicate_named_roots()
 
-    assert _visible_rows(vfs) == [(DUPLICATE_NAME, ""), (DUPLICATE_NAME, "")]
+    assert _visible_rows(vfs, (root_a, root_b)) == [
+        (DUPLICATE_NAME, ""),
+        (DUPLICATE_NAME, ""),
+    ]
 
     _toggle(vfs, root_b)
 
-    assert _visible_rows(vfs) == [
+    assert _visible_rows(vfs, (root_a, root_b)) == [
         (DUPLICATE_NAME, ""),
         (DUPLICATE_NAME, ""),
         ("effect", root_b),
@@ -155,7 +173,7 @@ def test_same_named_roots_expand_their_own_subfolders_independently():
 
     _toggle(vfs, root_b, "effect")
 
-    visible = _visible_rows(vfs)
+    visible = _visible_rows(vfs, (root_a, root_b))
     assert ("thing.mod", root_b) in visible
     assert ("thing.mod", root_a) not in visible
 


### PR DESCRIPTION
## Intent

Fix albam issue #275, "2 archives with the same name drives the file explorer insane" (https://github.com/Brachi/albam/issues/275), reported by HenryOfCarim:

"When you add 2 archives with the same name, VFS just applies the same state for the file tree for both of them"

The issue carries a screenshot of the file explorer in that state and no further detail. It is a user report, not a diagnosis: the cause is not yet established.

The captain asked for this to be worked on alongside two other bugs, describing it as duplicate archive names breaking the file browser.

## What Changed

- Added `folder_descendants()` in `albam/blender_ui/import_panel.py`, which yields a folder's non-folder vfiles filtered by both the ancestor node id *and* the owning root (`tree_node.root_id`, or the node's own name for a root). Node ids below a root omit the root, so two archives mounted under the same name previously matched each other's identically placed folders.
- Rewired both folder walks — `ALBAM_OT_Import._execute_batch` and `ALBAM_OT_BatchImportFolder` — onto the new helper, replacing their duplicated ancestor-id scans, so batch import only picks up `.mod` files from the archive whose folder the user selected.
- Added `tests/test_vfs_duplicate_root_names.py` covering the duplicate-name case: expanding one of two same-named roots leaves the other collapsed, the two roots expand subfolders independently, and `folder_descendants` stays scoped to one root both for a subfolder and for a root node. CHANGELOG entries added for both the tree-state and batch-import symptoms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Risk Assessment

✅ Low: The change is a small, well-bounded deduplication that adds one root-scoping predicate to two existing folder walks, backed by regression tests that fail without it; the fix-round commit is a minimal, correct test-scoping change with no new machinery.

## Testing

I installed bpy 5.2.0 in an isolated venv, registered the addon, and drove it as a user would: two real RE5 .arc archives sharing the name uPl00ChrisNormal.arc, added through the "Add files" code path, then expanded/collapsed rows through the real collapse operator and pressed "Batch import folder" and "Import" (with the batch option ticked) through bpy.ops. Expanding one archive reveals only its own children while the other stays collapsed, each archive's same-named "pawn" folder expands independently, and the batch walk now reports only the selected archive's .mod files — the same driver on the base commit reports all four files from both archives, which is the regression this change fixes. Root-row selections and the single-archive case behave as before. The new pytest file passes, and also passes with foreign roots pre-mounted into the shared session VFS, where the pre-review-fix version of that same file fails — confirming the review-round test-scoping fix. No reviewer-visible screenshot of the panel was possible: the addon's UI is a Blender panel, this host has no Blender GUI binary and no X/Xvfb display, and the pip `bpy` module is headless with no way to render or capture the UI; the evidence is instead a transcript of the exact rows the panel's own filter_items emits plus the operator report text Blender shows the user. Imports report "0 imported, N failed" because no real game .mod data exists on this host — the discriminating observable is which files each walk collected, which the transcripts show in full.

- Live validation: ✅ go - 6 of 8 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Adding two archives with the same name and expanding one shows only that archive&#39;s contents, with the other&#39;s triangle still collapsed | ✅ pass | live | duplicate-archives-after-fix.txt - after clicking the second uPl00ChrisNormal.arc&#39;s triangle, the tree the panel draws lists only rows owned by root re5::uPl00ChrisNormal.arc#1; the first archive&#39;s ro… |
| Each same-named archive&#39;s identically-named &#39;pawn&#39; folder expands independently | ✅ pass | live | duplicate-archives-after-fix.txt - expanding archive B&#39;s &#39;pawn&#39; reveals only only_in_b.mod/shared.mod under root #1; expanding archive A&#39;s own &#39;pawn&#39; afterwards reveals its own two files under root re… |
| &#34;Batch import folder&#34; on the second archive&#39;s folder imports only that archive&#39;s files (regression: base commit takes both) | ✅ pass | live | duplicate-archives-after-fix.txt vs duplicate-archives-before-fix.txt - operator report goes from &#39;4 failed: only_in_a.mod, shared.mod, only_in_b.mod, shared.mod&#39; (base 1539351) to &#39;2 failed: only_in_… |
| &#34;Import&#34; with the &#39;Batch import folder (.mod)&#39; option ticked is scoped the same way, including when a root row is the selection | ✅ pass | live | duplicate-archives-after-fix.txt - &#39;Batch imported 0 .mod file(s), 2 failed: only_in_a.mod, shared.mod&#39; for the first archive&#39;s root row; batch_import_folder on the second archive&#39;s root row likewise… |
| Adversarial: the ordinary single-archive case still batch-imports every .mod under the picked row | ✅ pass | live | single-archive-control.txt - root row reports 3 files (three.mod, one.mod, two.mod), &#39;pawn&#39; folder reports its 2 |
| Adversarial: the new regression tests still hold when other suites have already mounted unrelated roots into the shared session VFS (CI --game-dir) | ✅ pass | live | pytest-duplicate-root-tests.txt - all 4 pass with re1/umvc3 roots pre-mounted, while the pre-review-fix copy of the same file fails there |
| Importing a real game .mod out of one of two same-named archives produces a Blender object from the correct archive | ⏸️ untested | no | No RE5 game data on this host; the repo&#39;s real-asset tests need pytest --game-dir=re5::&lt;install root or r2://bucket/prefix&gt; plus R2 credentials (.env.example). Provide a local RE5 install path or the… |
| Reviewer-visible screenshot of the Albam file explorer panel in the duplicate-archive state | ⏸️ untested | no | The addon&#39;s surface is a Blender panel; this host has no Blender GUI binary and no X server/Xvfb, and the pip `bpy` module is headless (cannot draw or screenshot UI). Install a full Blender build plus… |

<details>
<summary>Evidence: File explorer + batch import transcript, two same-named archives, AFTER the fix</summary>

```text
=== albam file explorer + batch import, TWO archives named uPl00ChrisNormal.arc ===
=== code under test: 396b8dc (fix) ===

Two archives on disk, same file name, different folders:
  /tmp/albam-275-ie0log0c/modA/uPl00ChrisNormal.arc
  /tmp/albam-275-ie0log0c/modB/uPl00ChrisNormal.arc

Both added. File explorer, both collapsed:
  [ 0] > uPl00ChrisNormal.arc              # root=re5::uPl00ChrisNormal.arc
  [ 4] > uPl00ChrisNormal.arc              # root=re5::uPl00ChrisNormal.arc#1 

User clicks the SECOND uPl00ChrisNormal.arc's triangle:
  [ 0] > uPl00ChrisNormal.arc              # root=re5::uPl00ChrisNormal.arc
  [ 4] v uPl00ChrisNormal.arc              # root=re5::uPl00ChrisNormal.arc#1
  [ 5]     > pawn                          # root=re5::uPl00ChrisNormal.arc#1 

User expands that archive's 'pawn' folder:
  [ 0] > uPl00ChrisNormal.arc              # root=re5::uPl00ChrisNormal.arc
  [ 4] v uPl00ChrisNormal.arc              # root=re5::uPl00ChrisNormal.arc#1
  [ 5]     v pawn                          # root=re5::uPl00ChrisNormal.arc#1
  [ 6]           only_in_b.mod             # root=re5::uPl00ChrisNormal.arc#1
  [ 7]           shared.mod                # root=re5::uPl00ChrisNormal.arc#1 

User also expands the FIRST archive, and its own 'pawn':
  [ 0] v uPl00ChrisNormal.arc              # root=re5::uPl00ChrisNormal.arc
  [ 1]     v pawn                          # root=re5::uPl00ChrisNormal.arc
  [ 2]           only_in_a.mod             # root=re5::uPl00ChrisNormal.arc
  [ 3]           shared.mod                # root=re5::uPl00ChrisNormal.arc
  [ 4] v uPl00ChrisNormal.arc              # root=re5::uPl00ChrisNormal.arc#1
  [ 5]     v pawn                          # root=re5::uPl00ChrisNormal.arc#1
  [ 6]           only_in_b.mod             # root=re5::uPl00ChrisNormal.arc#1
  [ 7]           shared.mod                # root=re5::uPl00ChrisNormal.arc#1 

User selects the SECOND archive's 'pawn' folder and presses 'Batch import folder':
  Blender reports: Info: Imported 0 .mod file(s), 2 failed: only_in_b.mod, shared.mod

User selects the FIRST archive's 'pawn' folder and presses it:
  Blender reports: Info: Imported 0 .mod file(s), 2 failed: only_in_a.mod, shared.mod

User selects the SECOND archive's ROOT row and presses 'Batch import folder':
  Blender reports: Info: Imported 0 .mod file(s), 2 failed: only_in_b.mod, shared.mod

User ticks 'Batch import folder (.mod)' in Import Options, selects the FIRST archive's root row and presses 'Import':
  Blender reports: Info: Batch imported 0 .mod file(s), 2 failed: only_in_a.mod, shared.mod
```
</details>
<details>
<summary>Evidence: Same driver against base commit 1539351, BEFORE the fix (batch import takes both archives&#39; files)</summary>

```text
=== same driver, same two archives ===
=== code: base commit 1539351 (before the fix) ===

Two archives on disk, same file name, different folders:
  /tmp/albam-275-tnwf2g4d/modA/uPl00ChrisNormal.arc
  /tmp/albam-275-tnwf2g4d/modB/uPl00ChrisNormal.arc

Both added. File explorer, both collapsed:
  [ 0] > uPl00ChrisNormal.arc              # root=re5::uPl00ChrisNormal.arc
  [ 4] > uPl00ChrisNormal.arc              # root=re5::uPl00ChrisNormal.arc#1 

User clicks the SECOND uPl00ChrisNormal.arc's triangle:
  [ 0] > uPl00ChrisNormal.arc              # root=re5::uPl00ChrisNormal.arc
  [ 4] v uPl00ChrisNormal.arc              # root=re5::uPl00ChrisNormal.arc#1
  [ 5]     > pawn                          # root=re5::uPl00ChrisNormal.arc#1 

User expands that archive's 'pawn' folder:
  [ 0] > uPl00ChrisNormal.arc              # root=re5::uPl00ChrisNormal.arc
  [ 4] v uPl00ChrisNormal.arc              # root=re5::uPl00ChrisNormal.arc#1
  [ 5]     v pawn                          # root=re5::uPl00ChrisNormal.arc#1
  [ 6]           only_in_b.mod             # root=re5::uPl00ChrisNormal.arc#1
  [ 7]           shared.mod                # root=re5::uPl00ChrisNormal.arc#1 

User also expands the FIRST archive, and its own 'pawn':
  [ 0] v uPl00ChrisNormal.arc              # root=re5::uPl00ChrisNormal.arc
  [ 1]     v pawn                          # root=re5::uPl00ChrisNormal.arc
  [ 2]           only_in_a.mod             # root=re5::uPl00ChrisNormal.arc
  [ 3]           shared.mod                # root=re5::uPl00ChrisNormal.arc
  [ 4] v uPl00ChrisNormal.arc              # root=re5::uPl00ChrisNormal.arc#1
  [ 5]     v pawn                          # root=re5::uPl00ChrisNormal.arc#1
  [ 6]           only_in_b.mod             # root=re5::uPl00ChrisNormal.arc#1
  [ 7]           shared.mod                # root=re5::uPl00ChrisNormal.arc#1 

User selects the SECOND archive's 'pawn' folder and presses 'Batch import folder':
  Blender reports: Info: Imported 0 .mod file(s), 4 failed: only_in_a.mod, shared.mod, only_in_b.mod, shared.mod

User selects the FIRST archive's 'pawn' folder and presses it:
  Blender reports: Info: Imported 0 .mod file(s), 4 failed: only_in_a.mod, shared.mod, only_in_b.mod, shared.mod

User selects the SECOND archive's ROOT row and presses 'Batch import folder':
  Blender reports: Info: Imported 0 .mod file(s), 2 failed: only_in_b.mod, shared.mod

User ticks 'Batch import folder (.mod)' in Import Options, selects the FIRST archive's root row and presses 'Import':
  Blender reports: Info: Batch imported 0 .mod file(s), 2 failed: only_in_a.mod, shared.mod
```
</details>
<details>
<summary>Evidence: Single-archive control run</summary>

```text
=== control: a single archive, unchanged behaviour (396b8dc) ===

One archive only, expanded:
  [ 0] v uPl00ChrisNormal.arc              # root=re5::uPl00ChrisNormal.arc
  [ 1]     > effect                        # root=re5::uPl00ChrisNormal.arc
  [ 3]     > pawn                          # root=re5::uPl00ChrisNormal.arc 

Batch import folder on its root row:
  Blender reports: Info: Imported 0 .mod file(s), 3 failed: three.mod, one.mod, two.mod

Batch import folder on its 'pawn' folder:
  Blender reports: Info: Imported 0 .mod file(s), 2 failed: one.mod, two.mod
```
</details>
<details>
<summary>Evidence: Regression tests, plain and with foreign roots pre-mounted (CI --game-dir condition)</summary>

```text
# new regression tests, plain run
cachedir: .pytest_cache
tests/test_vfs_duplicate_root_names.py::test_expanding_one_of_two_same_named_roots_leaves_the_other_collapsed PASSED [ 25%]
tests/test_vfs_duplicate_root_names.py::test_same_named_roots_expand_their_own_subfolders_independently PASSED [ 50%]
tests/test_vfs_duplicate_root_names.py::test_folder_descendants_is_scoped_to_the_root_the_folder_belongs_to PASSED [ 75%]
tests/test_vfs_duplicate_root_names.py::test_folder_descendants_on_a_root_takes_only_that_root PASSED [100%]
============================== 4 passed in 0.01s ===============================

# same tests with foreign roots pre-mounted into the shared session VFS (what CI's --game-dir suites do)
tests/test_vfs_duplicate_root_names.py::test_expanding_one_of_two_same_named_roots_leaves_the_other_collapsed PASSED [ 12%]
tests/test_vfs_duplicate_root_names.py::test_same_named_roots_expand_their_own_subfolders_independently PASSED [ 25%]
tests/test_vfs_duplicate_root_names.py::test_folder_descendants_is_scoped_to_the_root_the_folder_belongs_to PASSED [ 37%]
tests/test_vfs_duplicate_root_names.py::test_folder_descendants_on_a_root_takes_only_that_root PASSED [ 50%]
::test_expanding_one_of_two_same_named_roots_leaves_the_other_collapsed FAILED [ 62%]
::test_same_named_roots_expand_their_own_subfolders_independently PASSED [ 75%]
::test_folder_descendants_is_scoped_to_the_root_the_folder_belongs_to PASSED [ 87%]
::test_folder_descendants_on_a_root_takes_only_that_root PASSED          [100%]
========================= 1 failed, 7 passed in 0.05s ==========================
  (rows above starting with '::' are the PRE-review-fix copy of the same file, 47b7ffa - it fails, which is what 396b8dc fixes)
```
</details>
<details>
<summary>Evidence: Live driver script used for the runs above</summary>

```text
"""Drive albam (Blender addon) the way a user hits issue #275:
add two RE5 .arc archives that happen to share a file name, then use the
file explorer's expand triangles and "Batch import folder"."""
import os, sys, tempfile

REPO = sys.argv[1]
sys.path.insert(0, REPO)
os.environ["ALBAM_RERAISE_ERRORS"] = ""

import bpy  # noqa
from albam import register  # noqa
register()

from albam.engines.mtfw.archive import _get_file_entry, _serialize_arc  # noqa
from albam.blender_ui.import_panel import (  # noqa
    ALBAM_UL_VirtualFileSystemUIBase, ALBAM_OT_BatchImportFolder)
from albam.vfs import (  # noqa
    ALBAM_OT_VirtualFileSystemAddFiles, ALBAM_OT_VirtualFileSystemCollapseToggle)


class FileTreeUI(ALBAM_UL_VirtualFileSystemUIBase):
    # The panel's real UIList logic without Blender's UIList shell around it
    # (a registered bpy.types.UIList cannot be instantiated from script).
    collapse_toggle_operator_cls = ALBAM_OT_VirtualFileSystemCollapseToggle
    bitflag_filter_item = 1 << 30

ARC_NAME = "uPl00ChrisNormal.arc"


class _Entry:
    """What archive._get_file_entry() returns, built by hand: a real .arc
    entry whose payload is placeholder bytes (no game data on this host)."""
    def __init__(self, rel_path, payload):
        import zlib
        from albam.engines.mtfw.archive import Arc
        from albam.engines.mtfw import EXTENSION_TO_FILE_ID
        chunk = zlib.compress(payload)
        item = Arc.FileEntry(None, _parent=None, _root=None)
        item.file_path = os.path.splitext(rel_path)[0].replace("/", "\\")
        item.file_type = EXTENSION_TO_FILE_ID["mod"]
        item.zsize = len(chunk)
        item.size = len(payload)
        item.flags = 2
        item.offset = 0
        item.raw_data = chunk
        self.item = item


def write_arc(dir_path, paths_payloads):
    os.makedirs(dir_path, exist_ok=True)
    entries = {p: _Entry(p, pl).item for p, pl in paths_payloads}
    data = _serialize_arc(entries, version=7)
    full = os.path.join(dir_path, ARC_NAME)
    with open(full, "wb") as f:
        f.write(data)
    return full


class _Files(list):
    """Stand-in for the file-select operator's `files` collection."""
    class F:
        def __init__(self, name): self.name = name


def add_archive(abs_path):
    """Exactly what the "Add files" button does with one picked .arc."""
    bpy.context.scene.albam.apps.app_selected = "re5"
    files = [type("F", (), {"name": os.path.basename(abs_path)})()]
    ALBAM_OT_VirtualFileSystemAddFiles._execute(
        bpy.context, os.path.dirname(abs_path) + os.sep, files)
    bpy.context.scene.albam.vfs.file_list.update()


def draw_tree():
    """The rows the Albam file explorer actually draws, as text."""
    vfs = bpy.context.scene.albam.vfs
    ui = FileTreeUI()
    flags, _ = ui.filter_items(bpy.context, vfs, "file_list")
    lines = []
    for i, flag in enumerate(flags):
        if not flag:
            continue
        vf = vfs.file_list[i]
        tri = ("v" if vf.is_expanded else ">") if vf.is_expandable else " "
        indent = "    " * vf.tree_node.depth
        owner = vf.name if vf.is_root else vf.tree_node.root_id
        lines.append(f"  [{i:>2}] {indent}{tri} {vf.display_name}"
                     f"{'':<{max(0, 34 - len(indent) - len(vf.display_name))}}"
                     f"# root={owner}")
    return "\n".join(lines)


def row_index(display_name, root_id, is_root=False):
    vfs = bpy.context.scene.albam.vfs
    for i, vf in enumerate(vfs.file_list):
        if is_root:
            if vf.is_root and vf.name == root_id:
                return i
        elif vf.tree_node.root_id == root_id and vf.display_name == display_name:
            return i
    raise LookupError((display_name, root_id))


def click_triangle(index):
    bpy.ops.albam.file_item_collapse_toggle(button_index=index)


REPORTS = []


def _run_capturing(op):
    """Run `op` with fd 1 captured: the operator's report() text is what
    Blender shows the user in the status bar / Info editor."""
    import tempfile as _tf
    sys.stdout.flush()
    with _tf.TemporaryFile(mode="w+") as cap:
        saved = os.dup(1)
        os.dup2(cap.fileno(), 1)
        try:
            op()
        finally:
            sys.stdout.flush()
            os.dup2(saved, 1)
            os.close(saved)
        cap.seek(0)
        return [ln for ln in cap.read().splitlines()
                if "Imported" in ln or "imported" in ln or "Warning" in ln]


def import_button(index):
    """Tick "Batch import folder (.mod)" in Import Options, select a row,
    press "Import"."""
    bpy.context.scene.albam.import_settings.batch_import_folder = True
    bpy.context.scene.albam.vfs.file_list_selected_index = index
    return _run_capturing(lambda: bpy.ops.albam.import_vfile())


def batch_import(index):
    """Click the folder row, then press "Batch import folder"."""
    bpy.context.scene.albam.vfs.file_list_selected_index = index
    # Capture what Blender prints for the operator's report() - the same
    # text the user sees in the status bar / Info editor.
    import io, tempfile as _tf
    sys.stdout.flush()
    with _tf.TemporaryFile(mode="w+") as cap:
        saved = os.dup(1)
        os.dup2(cap.fileno(), 1)
        try:
            bpy.ops.albam.batch_import_folder()
        finally:
            sys.stdout.flush()
            os.dup2(saved, 1)
            os.close(saved)
        cap.seek(0)
        out = cap.read()
    return [ln for ln in out.splitlines() if "Imported" in ln or "Info" in ln or "Warning" in ln]


def solo():
    """The ordinary case must keep working: one archive, batch import
    everything under it."""
    tmp = tempfile.mkdtemp(prefix="albam-275-solo-")
    a = write_arc(os.path.join(tmp, "mod"),
                  [("pawn/one.mod", b"one"), ("pawn/two.mod", b"two"),
                   ("effect/three.mod", b"three")])
    add_archive(a)
    vfs = bpy.context.scene.albam.vfs
    root = [vf.name for vf in vfs.file_list if vf.is_root][0]
    click_triangle(row_index(None, root, is_root=True))
    print("One archive only, expanded:")
    print(draw_tree(), "\n")
    print("Batch import folder on its root row:")
    for r in batch_import(row_index(None, root, is_root=True)):
        print(f"  Blender reports: {r}")
    print("\nBatch import folder on its 'pawn' folder:")
    for r in batch_import(row_index("pawn", root)):
        print(f"  Blender reports: {r}")


def main():
    tmp = tempfile.mkdtemp(prefix="albam-275-")
    a = write_arc(os.path.join(tmp, "modA"),
                  [("pawn/shared.mod", b"ARCHIVE-A shared"),
                   ("pawn/only_in_a.mod", b"ARCHIVE-A only")])
    b = write_arc(os.path.join(tmp, "modB"),
                  [("pawn/shared.mod", b"ARCHIVE-B shared"),
                   ("pawn/only_in_b.mod", b"ARCHIVE-B only")])
    print(f"Two archives on disk, same file name, different folders:\n  {a}\n  {b}\n")

    add_archive(a)
    add_archive(b)
    vfs = bpy.context.scene.albam.vfs
    roots = [vf.name for vf in vfs.file_list if vf.is_root]
    root_a, root_b = roots[0], roots[1]
    print("Both added. File explorer, both collapsed:")
    print(draw_tree(), "\n")

    print(f"User clicks the SECOND {ARC_NAME}'s triangle:")
    click_triangle(row_index(None, root_b, is_root=True))
    print(draw_tree(), "\n")

    print("User expands that archive's 'pawn' folder:")
    click_triangle(row_index("pawn", root_b))
    print(draw_tree(), "\n")

    print("User also expands the FIRST archive, and its own 'pawn':")
    click_triangle(row_index(None, root_a, is_root=True))
    click_triangle(row_index("pawn", root_a))
    print(draw_tree(), "\n")

    print("User selects the SECOND archive's 'pawn' folder and presses "
          "'Batch import folder':")
    idx = row_index("pawn", root_b)
    reports = batch_import(idx)
    for r in reports:
        print(f"  Blender reports: {r}")
    print()
    print("User selects the FIRST archive's 'pawn' folder and presses it:")
    for r in batch_import(row_index("pawn", root_a)):
        print(f"  Blender reports: {r}")
    print()
    print("User selects the SECOND archive's ROOT row and presses "
          "'Batch import folder':")
    for r in batch_import(row_index(None, root_b, is_root=True)):
        print(f"  Blender reports: {r}")
    print()
    print("User ticks 'Batch import folder (.mod)' in Import Options, "
          "selects the FIRST archive's root row and presses 'Import':")
    for r in import_button(row_index(None, root_a, is_root=True)):
        print(f"  Blender reports: {r}")


solo() if os.environ.get('SOLO') else main()
```
</details>
<details>
<summary>Evidence: pytest plugin pre-mounting other suites&#39; roots into the shared VFS</summary>

```text
"""Stand in for CI's --game-dir suites: mount roots into the shared
scene VFS before the duplicate-root tests run, and never remove them
(tests/mtfw/conftest.py and tests/hexn/conftest.py do exactly this with
their session-scoped game_fs_root fixtures)."""
import bpy
import pytest
from fs.memoryfs import MemoryFS


@pytest.fixture(scope="session", autouse=True)
def _other_suites_roots():
    vfs = bpy.context.scene.albam.vfs
    for app_id in ("re1", "umvc3"):
        fs_instance = MemoryFS()
        fs_instance.makedirs("/stage")
        fs_instance.writebytes("/stage/other.mod", b"other-suite")
        vfs.add_fs_root(app_id, fs_instance, display_name=f"{app_id}-local")
    vfs.file_list.update()
    print(f"\n[plugin] pre-mounted roots: "
          f"{[vf.name for vf in vfs.file_list if vf.is_root]}")
    yield
```
</details>
<details>
<summary>Evidence: Batch import report, second archive&#39;s &#39;pawn&#39; selected: after vs before the fix</summary>

```text
AFTER (396b8dc): Info: Imported 0 .mod file(s), 2 failed: only_in_b.mod, shared.mod
BEFORE (1539351): Info: Imported 0 .mod file(s), 4 failed: only_in_a.mod, shared.mod, only_in_b.mod, shared.mod
(0 imported because the .mod payloads are placeholders - no game data on this host; the point is which files each walk collected)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"396b8dc93e755b031ac4a2615db6dc206a429b06","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":6,"total":8}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `tests/test_vfs_duplicate_root_names.py:127` - test_expanding_one_of_two_same_named_roots_leaves_the_other_collapsed asserts exact equality against every visible row in the shared VFS (lines 127 and 131). CI runs pytest with --game-dir for re5/re1/umvc3/re4uhd/reorc (.github/workflows/tests.yml:99); tests/mtfw and tests/hexn collect before this top-level file and their session-scoped game_fs_root fixtures mount &#39;&lt;app&gt;-local&#39; roots into the same scene.albam.vfs and never remove them (tests/mtfw/conftest.py:72, tests/hexn/conftest.py:69). filter_items always emits a row for is_root, so those extra root rows precede the two under test and both asserts fail. It passes locally only because no --game-dir makes the fixtures skip. Remedy: scope _visible_rows to the two roots under test instead of snapshotting the whole list, matching how tests/test_vfs_fs_backed.py diffs against a before-snapshot.
- ℹ️ `albam/engines/mtfw/texture.py:310` - Residual, pre-existing duplicate-name path outside the fixed symptom: with two same-named RE5 .arc archives mounted, importing a .mod from the second resolves its .mrl and .tex through vfs.get_vfile(app_id, path) with no root_id (also albam/engines/mtfw/material.py:1214), and get_vfile falls back to the first matching root - so the model silently takes the first archive&#39;s materials/textures. get_vfile already supports root_id and hexn passes it (albam/engines/hexn/material.py:52). Not introduced by this change and not the file-explorer symptom issue #275 reports, so whether to extend the fix here is the author&#39;s call.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 6 of 8 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Adding two archives with the same name and expanding one shows only that archive&#39;s contents, with the other&#39;s triangle still collapsed | ✅ pass | live | duplicate-archives-after-fix.txt - after clicking the second uPl00ChrisNormal.arc&#39;s triangle, the tree the panel draws lists only rows owned by root re5::uPl00ChrisNormal.arc#1; the first archive&#39;s ro… |
| Each same-named archive&#39;s identically-named &#39;pawn&#39; folder expands independently | ✅ pass | live | duplicate-archives-after-fix.txt - expanding archive B&#39;s &#39;pawn&#39; reveals only only_in_b.mod/shared.mod under root #1; expanding archive A&#39;s own &#39;pawn&#39; afterwards reveals its own two files under root re… |
| &#34;Batch import folder&#34; on the second archive&#39;s folder imports only that archive&#39;s files (regression: base commit takes both) | ✅ pass | live | duplicate-archives-after-fix.txt vs duplicate-archives-before-fix.txt - operator report goes from &#39;4 failed: only_in_a.mod, shared.mod, only_in_b.mod, shared.mod&#39; (base 1539351) to &#39;2 failed: only_in_… |
| &#34;Import&#34; with the &#39;Batch import folder (.mod)&#39; option ticked is scoped the same way, including when a root row is the selection | ✅ pass | live | duplicate-archives-after-fix.txt - &#39;Batch imported 0 .mod file(s), 2 failed: only_in_a.mod, shared.mod&#39; for the first archive&#39;s root row; batch_import_folder on the second archive&#39;s root row likewise… |
| Adversarial: the ordinary single-archive case still batch-imports every .mod under the picked row | ✅ pass | live | single-archive-control.txt - root row reports 3 files (three.mod, one.mod, two.mod), &#39;pawn&#39; folder reports its 2 |
| Adversarial: the new regression tests still hold when other suites have already mounted unrelated roots into the shared session VFS (CI --game-dir) | ✅ pass | live | pytest-duplicate-root-tests.txt - all 4 pass with re1/umvc3 roots pre-mounted, while the pre-review-fix copy of the same file fails there |
| Importing a real game .mod out of one of two same-named archives produces a Blender object from the correct archive | ⏸️ untested | no | No RE5 game data on this host; the repo&#39;s real-asset tests need pytest --game-dir=re5::&lt;install root or r2://bucket/prefix&gt; plus R2 credentials (.env.example). Provide a local RE5 install path or the… |
| Reviewer-visible screenshot of the Albam file explorer panel in the duplicate-archive state | ⏸️ untested | no | The addon&#39;s surface is a Blender panel; this host has no Blender GUI binary and no X server/Xvfb, and the pip `bpy` module is headless (cannot draw or screenshot UI). Install a full Blender build plus… |

- <code>`python drive_275.py &lt;worktree&gt;` — live driver: registers the addon, writes two real RE5 .arc files named uPl00ChrisNormal.arc, adds both via ALBAM_OT_VirtualFileSystemAddFiles._execute, clicks expand triangles via `bpy.ops.albam.file_item_collapse_toggle`, runs `bpy.ops.albam.batch_import_folder` and `bpy.ops.albam.import_vfile`</code>
- <code>`python drive_275.py /tmp/albam-base` — identical driver against base commit 1539351 for the before/after comparison</code>
- <code>`SOLO=1 python drive_275.py &lt;worktree&gt;` — single-archive control (batch import on root row and on a subfolder)</code>
- `pytest tests/test_vfs_duplicate_root_names.py -v`
- <code>`pytest tests/test_vfs_duplicate_root_names.py /tmp/albam-drive/test_old_dup.py -p extra_roots_plugin -v` — same tests with re1/umvc3 roots pre-mounted into the shared scene VFS (simulating CI&#39;s --game-dir suites), alongside the pre-review-fix copy of the file</code>
- `pytest tests/test_vfs_fs_backed.py tests/test_vfs_duplicate_root_names.py tests/test_addon_lifecycle.py`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
