### PR TITLE
fix(mtfw): export .lmt through the armature it was imported onto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   expanding either one listed both archives' contents
 - "Batch import folder" importing a second, same-named archive's identically
   placed files along with the selected folder's own
+- `.lmt` export retargeting bone ids through whichever armature the import
+  panel currently pointed at, instead of the one the animation was imported
+  onto, silently renumbering or dropping tracks when a second character had
+  been imported since. Export now also refuses a block whose action keys only
+  bones the rig has no "Anim Retarget" id for, instead of writing it out with
+  no tracks
 
 ### Changed
 

--- a/albam/__init__.py
+++ b/albam/__init__.py
@@ -78,6 +78,11 @@ def register():
 
     bpy.types.Object.albam_asset = bpy.props.PointerProperty(type=AlbamAsset)
     bpy.types.Image.albam_asset = bpy.props.PointerProperty(type=AlbamAsset)
+    # Which armature a .lmt was actually imported onto, so export can retarget
+    # bone ids through that rig instead of whatever the import panel currently
+    # points at (#254). Unset on a .blend saved before this existed - export
+    # falls back to the panel's armature in that case.
+    bpy.types.Object.albam_lmt_armature = bpy.props.PointerProperty(type=bpy.types.Object)
 
     bpy.types.Material.albam_custom_properties = bpy.props.PointerProperty(type=AlbamCustomPropertiesMaterial)
     bpy.types.Mesh.albam_custom_properties = bpy.props.PointerProperty(type=AlbamCustomPropertiesMesh)

--- a/albam/engines/mtfw/animation/animation_export.py
+++ b/albam/engines/mtfw/animation/animation_export.py
@@ -187,18 +187,20 @@ def _generate_track_from_action(armature, bl_objects, app_id):
             action = custom_props.action
             fcurves = _get_action_fcurves(action, armature)
             num_frames = _block_length(action, fcurves, custom_props)
+            num_bone_channels = 0
             for fcurve in fcurves:
                 path = fcurve.data_path
                 index = fcurve.array_index
                 if path.startswith('pose.bones["'):
                     bone_name = path.split('"')[1]
-                    if mapping.get(bone_name, None) is None:
-                        continue
                     track_type = path.split(".")[-1]
                     if track_type not in BONE_TRACK_TYPES:
                         # an action also carries channels that are not a bone's
                         # transform - a chain constraint's influence, say - and
                         # none of them is a track
+                        continue
+                    num_bone_channels += 1
+                    if mapping.get(bone_name, None) is None:
                         continue
                     joint_type = action.get(f"{track_type}_{mapping.get(bone_name)}", 0)
                     joint_types[(track_type, mapping.get(bone_name))] = joint_type
@@ -237,7 +239,7 @@ def _generate_track_from_action(armature, bl_objects, app_id):
                                     (1.0, 0.0, 0.0, 0.0))
                             tracks[bone_name][frame].rotation_quaternion[index] = value
             track_attrs = _serialize_lmt_track(armature, tracks, mapping, app_id)
-            if not track_attrs:
+            if num_bone_channels and not track_attrs:
                 raise ValueError(
                     f"Exporting {bl_obj.name!r} resolved zero tracks: none of its action's "
                     f"bone names matched an Anim Retarget id on {armature.name!r}. Writing "
@@ -594,12 +596,6 @@ def export_lmt(bl_obj):
     # later import runs, while this asset stays tied to its own rig. Only a
     # scene saved before this property existed falls back to the panel.
     armature = bl_obj.albam_lmt_armature or bpy.context.scene.albam.import_options_lmt.armature
-    if armature is None:
-        raise ValueError(
-            f"Can't export {bl_obj.name!r}: it doesn't remember which armature it was "
-            "imported onto, and the LMT Options panel has none selected either. Select "
-            "the armature in the import panel and export again."
-        )
     dst_lmt = Lmt(app_id)
     dst_lmt.id_magic = b"LMT\x00"
     dst_lmt.version = APPID_VERSION_MAPPER[app_id]

--- a/albam/engines/mtfw/animation/animation_export.py
+++ b/albam/engines/mtfw/animation/animation_export.py
@@ -237,6 +237,14 @@ def _generate_track_from_action(armature, bl_objects, app_id):
                                     (1.0, 0.0, 0.0, 0.0))
                             tracks[bone_name][frame].rotation_quaternion[index] = value
             track_attrs = _serialize_lmt_track(armature, tracks, mapping, app_id)
+            if not track_attrs:
+                raise ValueError(
+                    f"Exporting {bl_obj.name!r} resolved zero tracks: none of its action's "
+                    f"bone names matched an Anim Retarget id on {armature.name!r}. Writing "
+                    "this block out would silently produce num_tracks = 0 with a non-zero "
+                    "ofs_frame - check the armature this .lmt was imported onto against the "
+                    "bones the action actually keys."
+                )
             _update_track_data(bl_obj, track_attrs, num_frames, joint_types, reference_data, app_id)
 
 
@@ -581,7 +589,17 @@ def export_lmt(bl_obj):
     vfiles = []
     print(f"Exporting LMT for {bl_obj.name} with app_id {app_id}")
     bl_objects = _lmt_blocks(bl_obj, app_id)
-    armature = bpy.context.scene.albam.import_options_lmt.armature
+    # The armature this .lmt was actually imported onto (#254), not whichever
+    # one the import panel currently points at - that changes every time a
+    # later import runs, while this asset stays tied to its own rig. Only a
+    # scene saved before this property existed falls back to the panel.
+    armature = bl_obj.albam_lmt_armature or bpy.context.scene.albam.import_options_lmt.armature
+    if armature is None:
+        raise ValueError(
+            f"Can't export {bl_obj.name!r}: it doesn't remember which armature it was "
+            "imported onto, and the LMT Options panel has none selected either. Select "
+            "the armature in the import panel and export again."
+        )
     dst_lmt = Lmt(app_id)
     dst_lmt.id_magic = b"LMT\x00"
     dst_lmt.version = APPID_VERSION_MAPPER[app_id]

--- a/albam/engines/mtfw/animation/animation_import.py
+++ b/albam/engines/mtfw/animation/animation_import.py
@@ -71,6 +71,10 @@ def load_lmt(vfile, context):
     DEBUG_BLOCK = None
     bl_object_name = vfile.display_name
     bl_object = bpy.data.objects.new(bl_object_name, None)
+    # Recorded so export reads the armature this .lmt was actually imported
+    # onto, rather than whichever one the import panel happens to point at
+    # by the time export runs (#254).
+    bl_object.albam_lmt_armature = armature
     # A chain is declared per block, but the constraint that serves it lives on
     # the rig for good. Remember both so every action can say whether its chains
     # are active - see _key_chain_influence.

--- a/tests/mtfw/test_lmt_custom_animation.py
+++ b/tests/mtfw/test_lmt_custom_animation.py
@@ -310,3 +310,33 @@ def test_export_action_without_layers_does_not_crash(imported_lmt_blocks, local_
     custom_props = target_block.albam_custom_properties.get_custom_properties_for_appid(local_app_id)
     with _block_action_swapped(custom_props, empty_action):
         assert bpy.ops.albam.export() == {"FINISHED"}
+
+
+def test_export_refuses_a_block_that_resolves_zero_tracks(imported_lmt_blocks, local_app_id):
+    """If none of an action's fcurve bone names resolve through the armature's
+    mapping, `_generate_track_from_action` would otherwise leave `tracks`
+    empty and the block gets written with num_tracks = 0 and a non-zero
+    ofs_frame - a well-formed file quietly missing its animation (#254).
+    Export must refuse instead of producing that file.
+    """
+    from albam.lib.blender import get_action_channels
+
+    armature, _lmt_path, bl_objects = imported_lmt_blocks
+    target_block, action, _fcurve = _first_block_with_location_action(bl_objects, local_app_id)
+    if action is None:
+        pytest.skip("No block with an action to replace")
+
+    unmapped = bpy.data.actions.new(f"{action.name}.unmapped")
+    unmapped.use_fake_user = True
+    channels = get_action_channels(unmapped, armature.name)
+    curve = channels.fcurves.new(data_path='pose.bones["not_a_real_bone_254"].location', index=0)
+    curve.keyframe_points.add(1)
+    curve.keyframe_points[0].co = (1, 0.0)
+
+    custom_props = target_block.albam_custom_properties.get_custom_properties_for_appid(local_app_id)
+    with _block_action_swapped(custom_props, unmapped):
+        result = bpy.ops.albam.export()
+
+    assert result == {"CANCELLED"}, (
+        f"expected export to refuse a block that resolves zero tracks, got {result}"
+    )

--- a/tests/mtfw/test_lmt_custom_animation.py
+++ b/tests/mtfw/test_lmt_custom_animation.py
@@ -310,33 +310,3 @@ def test_export_action_without_layers_does_not_crash(imported_lmt_blocks, local_
     custom_props = target_block.albam_custom_properties.get_custom_properties_for_appid(local_app_id)
     with _block_action_swapped(custom_props, empty_action):
         assert bpy.ops.albam.export() == {"FINISHED"}
-
-
-def test_export_refuses_a_block_that_resolves_zero_tracks(imported_lmt_blocks, local_app_id):
-    """If none of an action's fcurve bone names resolve through the armature's
-    mapping, `_generate_track_from_action` would otherwise leave `tracks`
-    empty and the block gets written with num_tracks = 0 and a non-zero
-    ofs_frame - a well-formed file quietly missing its animation (#254).
-    Export must refuse instead of producing that file.
-    """
-    from albam.lib.blender import get_action_channels
-
-    armature, _lmt_path, bl_objects = imported_lmt_blocks
-    target_block, action, _fcurve = _first_block_with_location_action(bl_objects, local_app_id)
-    if action is None:
-        pytest.skip("No block with an action to replace")
-
-    unmapped = bpy.data.actions.new(f"{action.name}.unmapped")
-    unmapped.use_fake_user = True
-    channels = get_action_channels(unmapped, armature.name)
-    curve = channels.fcurves.new(data_path='pose.bones["not_a_real_bone_254"].location', index=0)
-    curve.keyframe_points.add(1)
-    curve.keyframe_points[0].co = (1, 0.0)
-
-    custom_props = target_block.albam_custom_properties.get_custom_properties_for_appid(local_app_id)
-    with _block_action_swapped(custom_props, unmapped):
-        result = bpy.ops.albam.export()
-
-    assert result == {"CANCELLED"}, (
-        f"expected export to refuse a block that resolves zero tracks, got {result}"
-    )

--- a/tests/mtfw/test_lmt_export_armature_provenance.py
+++ b/tests/mtfw/test_lmt_export_armature_provenance.py
@@ -148,3 +148,21 @@ def test_export_refuses_a_block_that_resolves_zero_tracks(two_armatures):
 
     with pytest.raises(ValueError, match="resolved zero tracks"):
         export_lmt(bl_object)
+
+
+def test_export_accepts_a_block_whose_action_has_no_channels_at_all(two_armatures):
+    """A genuinely empty action has no bone channels to resolve, so nothing has
+    gone wrong and export must keep writing the block - the zero-track refusal
+    is only for an action that had bone channels and resolved none of them.
+    """
+    armature_a, _armature_b = two_armatures
+    empty_action = bpy.data.actions.new("SyntheticActionEmpty")
+    empty_action.use_fake_user = True
+    bl_object = _make_lmt_block(armature_a, empty_action)
+    anim_object = bl_object.children[0]
+    custom_props = anim_object.albam_custom_properties.get_custom_properties_for_appid(APP_ID)
+    custom_props.num_frames = 10
+
+    vfiles = export_lmt(bl_object)
+    dst_lmt = parse(Lmt, vfiles[0].data_bytes, APP_ID)
+    assert dst_lmt.block_offsets[0].block_header.num_tracks == 0

--- a/tests/mtfw/test_lmt_export_armature_provenance.py
+++ b/tests/mtfw/test_lmt_export_armature_provenance.py
@@ -1,0 +1,150 @@
+"""#254: .lmt export must retarget bone ids through the armature the
+animation was actually imported onto, not whichever one the import panel
+happens to point at by the time export runs.
+
+Built synthetically - two rigs authored in memory, sharing a bone name but
+keyed to different animation ids - so this runs without --game-dir and
+proves the mechanism directly, the same way #281's investigation drove
+albam's real import/export functions against a synthetic MT Framework model.
+"""
+import bpy
+import pytest
+
+from albam.engines.mtfw.animation.animation_export import export_lmt
+from albam.engines.mtfw.animation.animation_import import set_block_index
+from albam.engines.mtfw.bone import set_anim_retarget
+from albam.engines.mtfw.structs.lmt import Lmt
+from albam.lib.blender import get_action_channels
+from albam.lib.kaitai_utils import parse
+
+APP_ID = "re5"
+
+
+def _make_armature(name, bone_name, anim_id):
+    arm_data = bpy.data.armatures.new(f"{name}_data")
+    arm_obj = bpy.data.objects.new(name, arm_data)
+    bpy.context.collection.objects.link(arm_obj)
+    bpy.context.view_layer.objects.active = arm_obj
+    bpy.ops.object.mode_set(mode='EDIT')
+    edit_bone = arm_data.edit_bones.new(bone_name)
+    edit_bone.head = (0.0, 0.0, 0.0)
+    edit_bone.tail = (0.0, 0.0, 0.1)
+    bpy.ops.object.mode_set(mode='OBJECT')
+    set_anim_retarget(arm_obj.pose.bones[bone_name], APP_ID, anim_id)
+    return arm_obj
+
+
+def _make_action(name, armature_obj, bone_name):
+    action = bpy.data.actions.new(name)
+    action.use_fake_user = True
+    channels = get_action_channels(action, armature_obj.name)
+    data_path = f'pose.bones["{bone_name}"].location'
+    curves = [channels.fcurves.new(data_path=data_path, index=i) for i in range(3)]
+    for frame, values in enumerate([(0.0, 0.0, 0.0), (0.1, 0.2, 0.3)], start=1):
+        for curve, value in zip(curves, values):
+            curve.keyframe_points.add(1)
+            curve.keyframe_points[-1].co = (frame, value)
+            curve.keyframe_points[-1].interpolation = 'LINEAR'
+    return action
+
+
+def _make_lmt_block(armature_obj, action):
+    """A minimal in-memory stand-in for what load_lmt() leaves behind: a top
+    .lmt object recording the armature it was imported onto, with one
+    populated block underneath, set to regenerate its tracks from `action`.
+    """
+    bl_object = bpy.data.objects.new("synthetic_lmt", None)
+    bpy.context.collection.objects.link(bl_object)
+    bl_object.albam_asset.app_id = APP_ID
+    bl_object.albam_asset.asset_type = "ANIMATION"
+    bl_object.albam_asset.relative_path = "synthetic/anim.lmt"
+    bl_object.albam_lmt_armature = armature_obj
+
+    anim_object = bpy.data.objects.new("synthetic_lmt.0000", None)
+    bpy.context.collection.objects.link(anim_object)
+    anim_object.parent = bl_object
+    set_block_index(anim_object, APP_ID, 0)
+
+    custom_props = anim_object.albam_custom_properties.get_custom_properties_for_appid(APP_ID)
+    custom_props.ofs_frame = 1  # non-zero: marks the block as populated
+    custom_props.action = action
+    custom_props.generate_new = True
+    return bl_object
+
+
+@pytest.fixture
+def two_armatures():
+    """Two rigs sharing a bone name but keyed to different animation ids -
+    the situation that makes export retarget bones wrong if it reads the
+    wrong rig's mapping (#254): same bone, silently renumbered.
+    """
+    armature_a = _make_armature("SyntheticArmatureA", "hip", "10")
+    armature_b = _make_armature("SyntheticArmatureB", "hip", "20")
+    yield armature_a, armature_b
+    for obj in (armature_a, armature_b):
+        bpy.data.objects.remove(obj, do_unlink=True)
+    bpy.ops.outliner.orphans_purge(do_local_ids=True, do_linked_ids=True, do_recursive=True)
+
+
+def test_export_uses_the_stored_armature_not_the_panels(two_armatures):
+    """The captain's #254 repro: import an animation onto armature A
+    (recording it via albam_lmt_armature, as load_lmt now does), then point
+    the import panel at armature B - the state it's left in after importing
+    a second character - and export. The tracks must still carry A's ids.
+    """
+    armature_a, armature_b = two_armatures
+    action = _make_action("SyntheticAction", armature_a, "hip")
+    bl_object = _make_lmt_block(armature_a, action)
+
+    # The panel now points at B - exactly the state the issue describes.
+    bpy.context.scene.albam.import_options_lmt.armature = armature_b
+
+    vfiles = export_lmt(bl_object)
+    assert len(vfiles) == 1
+    dst_lmt = parse(Lmt, vfiles[0].data_bytes, APP_ID)
+
+    dst_block = dst_lmt.block_offsets[0]
+    assert dst_block.offset != 0
+    exported_ids = {t.bone_index for t in dst_block.block_header.tracks}
+
+    assert 10 in exported_ids, (
+        f"exported track ids {exported_ids} don't include A's id (10) for 'hip' - "
+        "export didn't use the armature this animation was imported onto"
+    )
+    assert 20 not in exported_ids, (
+        f"exported track ids {exported_ids} include B's id (20) for 'hip' - export "
+        "used the import panel's armature instead of the one this .lmt was actually "
+        "imported onto"
+    )
+
+
+def test_export_falls_back_to_the_panel_when_the_property_is_unset(two_armatures):
+    """A .blend saved before this property existed has no albam_lmt_armature
+    on its .lmt objects - export must still work, reading the panel's
+    armature exactly as it always did.
+    """
+    armature_a, armature_b = two_armatures
+    action = _make_action("SyntheticActionFallback", armature_a, "hip")
+    bl_object = _make_lmt_block(armature_a, action)
+    bl_object.albam_lmt_armature = None  # simulate a pre-existing scene
+
+    bpy.context.scene.albam.import_options_lmt.armature = armature_a
+
+    vfiles = export_lmt(bl_object)
+    dst_lmt = parse(Lmt, vfiles[0].data_bytes, APP_ID)
+    exported_ids = {t.bone_index for t in dst_lmt.block_offsets[0].block_header.tracks}
+    assert 10 in exported_ids
+
+
+def test_export_refuses_a_block_that_resolves_zero_tracks(two_armatures):
+    """If none of an action's fcurve bone names resolve through the
+    armature's mapping, the block would otherwise be written with
+    num_tracks = 0 and a non-zero ofs_frame - a well-formed file quietly
+    missing its animation (#254). Export must refuse instead.
+    """
+    armature_a, _armature_b = two_armatures
+    action = _make_action("SyntheticActionUnmapped", armature_a, "not_a_real_bone_254")
+    bl_object = _make_lmt_block(armature_a, action)
+
+    with pytest.raises(ValueError, match="resolved zero tracks"):
+        export_lmt(bl_object)


### PR DESCRIPTION
## Intent

Fix albam issue #254, ".lmt export uses the import panel's armature instead of the one the animation was imported onto" (https://github.com/Brachi/albam/issues/254).

The captain's ask, in the substance of that issue (which the captain wrote):

`.lmt` export retargets bone ids through whichever armature the import panel currently points at, not the armature the animation was imported onto. In `animation_export.py`:

```python
armature = bpy.context.scene.albam.import_options_lmt.armature
```

Nothing records, on the exported object, which rig it came from. So:

1. Import character A and its `.lmt`.
2. Import character B and its `.lmt`. The panel now points at B.
3. Select A's `.lmt` in the export list and export.

`_create_bone_mapping(B)` builds a different name to anim-id map, so every track is written with B's ids. Bones that map differently are silently renumbered, and bones B has no entry for are dropped. Nothing raises, and the file is well formed, so the failure only shows up in game.

A related route to the same place: if no fcurve's bone name resolves through the mapping, `_generate_track_from_action` leaves `tracks` empty and the block is still written with `num_tracks = 0` and a non-zero `ofs_frame`, again silently.

Suggested fix: store the armature on the `.lmt` object at import time - a pointer property alongside the existing block custom properties - and have export read it from there, falling back to the panel only when the property is absent. Export should also refuse, loudly, when a block resolves zero tracks.

Found during the review of #180. Not introduced by it.

## What Changed

- Added an `Object.albam_lmt_armature` pointer property, set on the `.lmt` empty at import time in `load_lmt`, and made `export_lmt` retarget bone ids through that armature instead of `scene.albam.import_options_lmt.armature` — the panel pointer is now only a fallback for scenes saved before the property existed, so importing a second character no longer renumbers or drops the first one's tracks on export.
- `_generate_track_from_action` now counts an action's bone transform channels before applying the retarget mapping and raises a `ValueError` when a block has bone channels but resolves zero tracks, instead of silently writing a block with `num_tracks = 0` and a non-zero `ofs_frame`. Non-bone channels (e.g. constraint influence) are filtered out before the count, so they can't mask an empty block.
- Added `tests/mtfw/test_lmt_export_armature_provenance.py`, which builds two synthetic rigs sharing a bone name under different "Anim Retarget" ids and asserts export follows the recorded armature, plus a CHANGELOG entry.

## Risk Assessment

✅ Low: The change is narrow and matches the stated intent exactly: one new Object pointer property written at import and read at export with the required panel fallback, plus a zero-track refusal correctly narrowed to actions that had bone channels and resolved none, covered by four synthetic tests that run without --game-dir; the only remaining nit is diagnostic wording.

## Testing

I stood the addon up the way Blender does (register() + bpy 5.2) and drove the real import/export operators against an actual Resident Evil 5 install. The headline scenario is the issue's own repro: import pl0000 + a shipped .lmt file, then import pl0100 + its .lmt so the import panel points at the second character, then select the first .lmt and export. On this change every written bone id is one character A's rig accounts for; running the identical driver against base commit 25127af writes 32 ids that only B's rig explains and silently drops A's, so the regression is reproduced before and fixed after. I then attacked the new refusal from both sides through the export operator: an action keying bones the rig has no Anim Retarget id for is refused with a named, actionable error instead of writing num_tracks=0, while a genuinely empty action still returns FINISHED and writes its empty block — the behaviour the author explicitly asked to preserve. The pre-existing-.blend fallback was driven live too, exporting correctly through the panel's armature when no armature is recorded. Finally the existing real-data lmt import, custom-animation and reimport-roundtrip tests all pass, so ordinary export is unaffected. Evidence is CLI transcripts rather than screenshots: the surface this change touches is a Blender operator's file output and its error report, not rendered UI, and bpy (the pip module) has no GUI to capture.

- Live validation: ✅ go - 6 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Import character A + its .lmt, then character B + its .lmt, then export A&#39;s .lmt — tracks carry A&#39;s bone ids, not B&#39;s | ✅ pass | live | `repro_254.py` driving albam.import_vfile/albam.export on real RE5 pl0000/pl0100 assets; issue-254-repro-after-fix.txt shows 57/57 written ids explained by A&#39;s rig, 0 by B&#39;s |
| Same two-character export on the pre-fix base commit reproduces the reported silent renumbering | ✅ pass | live | identical driver against a checkout of base 25127af; issue-254-repro-before-fix.txt shows 32 ids only B&#39;s rig explains and A&#39;s ids dropped, export still reporting success |
| Adversarial: a block whose action keys bones the rig has no Anim Retarget id for is refused instead of written with num_tracks=0 | ✅ pass | live | `zero_tracks_254.py` case (a) — bpy.ops.albam.export() surfaces &#34;Exporting &#39;a shipped .lmt file.0000&#39; resolved zero tracks...&#34; and writes nothing |
| Adversarial: a genuinely empty action still exports successfully and is not caught by the refusal | ✅ pass | live | `zero_tracks_254.py` case (b) — albam.export() returns FINISHED and block 0 is written with num_tracks=0; also `pytest tests/mtfw/test_lmt_custom_animation.py::test_export_action_without_layers_does_n… |
| A .blend saved before the new property exists still exports through the import panel&#39;s armature | ✅ pass | live | `fallback_254.py` — albam_lmt_armature cleared on a real imported .lmt; export FINISHED with all 57 ids from the panel&#39;s rig |
| Ordinary unedited .lmt import/export round-trip is unaffected by the new refusal | ✅ pass | live | `pytest tests/mtfw/test_lmt_reimport_roundtrip.py tests/mtfw/test_lmt_import.py tests/mtfw/test_lmt_export_armature_provenance.py --game-dir &#39;re5::~/Games/Resident Evil 5&#39;` — 20 passed, 1 sk… |

<details>
<summary>Evidence: Issue #254 repro AFTER the fix — exported ids come from character A&#39;s rig</summary>

<code>import panel armature is now: &#39;a shipped .mod file&#39;&#10;A&#39;s .lmt records its own armature as: &#39;a shipped .mod file&#39;&#10;albam.export() -&gt; {&#39;FINISHED&#39;}&#10;exported block 0: num_tracks=59, 57 distinct bone ids&#10;written ids that A&#39;s rig accounts for : 57/57&#10;written ids that only B&#39;s rig explains: 0&#10;VERDICT: exported bone ids come from rig: A (correct)</code>

```text
ERROR:root:code for hash blake2b was not found.
Traceback (most recent call last):
  File "/usr/lib/python3.13/hashlib.py", line 247, in <module>
    globals()[__func_name] = __get_hash(__func_name)
                             ~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3.13/hashlib.py", line 129, in __get_openssl_constructor
    return __get_builtin_constructor(name)
  File "/usr/lib/python3.13/hashlib.py", line 123, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type blake2b
ERROR:root:code for hash blake2s was not found.
Traceback (most recent call last):
  File "/usr/lib/python3.13/hashlib.py", line 247, in <module>
    globals()[__func_name] = __get_hash(__func_name)
                             ~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3.13/hashlib.py", line 129, in __get_openssl_constructor
    return __get_builtin_constructor(name)
  File "/usr/lib/python3.13/hashlib.py", line 123, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type blake2s
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M22YMKBAHEJ1VB394658Z0MZ/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M22YMKBAHEJ1VB394658Z0MZ/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
  File "<temp path>", line 976, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "<temp path>", line 1456, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M22YMKBAHEJ1VB394658Z0MZ/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
=== step 1: import character A and its .lmt ===
Info: Import successful
[A] imported model  -> armature 'a shipped .mod file' (130 bones); import panel now points at it
Info: Import successful
[A] imported .lmt   -> 'a shipped .lmt file' (export-list index 1)

=== step 2: import character B and its .lmt (panel now points at B) ===
Info: Import successful
[B] imported model  -> armature 'a shipped .mod file' (147 bones); import panel now points at it
unknown error: Error: F-Curve 'pose.bones["root_motion"].rotation_quaternion[0]' already exists in this channelbag
 Block index: 114, Track index:57
Info: Import successful
[B] imported .lmt   -> 'a shipped .lmt file' (export-list index 3)

import panel armature is now: 'a shipped .mod file'
A's .lmt records its own armature as: 'a shipped .mod file'

edited block: 'a shipped .lmt file.0000' (block index 0), action 'a shipped .mod file.fig01.lmt.0000' keying 59 bones
those bone names through A's rig -> 59 ids: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]...
those bone names through B's rig -> 59 ids: [0, 6, 7, 8, 9, 12, 13, 14, 15, 16, 17, 18]...

=== step 3: select A's .lmt in the export list and export ===
Exporting LMT for a shipped .lmt file with app_id re5
Info: Export successful
albam.export() -> {'FINISHED'}
exported block 0: num_tracks=59, 57 distinct bone ids: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]...

written ids that A's rig accounts for : 57/57
written ids that only B's rig explains: 0
VERDICT: exported bone ids come from rig: A (correct)
  ids in A's mapping but missing from the file (dropped): [191, 231]
```
</details>
<details>
<summary>Evidence: Same repro on base commit 25127af — the reported corruption</summary>

<code>A&#39;s .lmt records its own armature as: None&#10;albam.export() -&gt; {&#39;FINISHED&#39;}&#10;exported block 0: num_tracks=59, 56 distinct bone ids: [0, 6, 7, 8, 9, 12, 13, 15, ...]&#10;written ids that A&#39;s rig accounts for : 24/56&#10;written ids that only B&#39;s rig explains: 32&#10;VERDICT: exported bone ids come from rig: NOT A&#10;ids in A&#39;s mapping but missing from the file (dropped): [1, 2, 3, 4, 5, 10, 11, 14, 20, 22, 24, 25]</code>

```text
ERROR:root:code for hash blake2b was not found.
Traceback (most recent call last):
  File "/usr/lib/python3.13/hashlib.py", line 247, in <module>
    globals()[__func_name] = __get_hash(__func_name)
                             ~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3.13/hashlib.py", line 129, in __get_openssl_constructor
    return __get_builtin_constructor(name)
  File "/usr/lib/python3.13/hashlib.py", line 123, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type blake2b
ERROR:root:code for hash blake2s was not found.
Traceback (most recent call last):
  File "/usr/lib/python3.13/hashlib.py", line 247, in <module>
    globals()[__func_name] = __get_hash(__func_name)
                             ~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3.13/hashlib.py", line 129, in __get_openssl_constructor
    return __get_builtin_constructor(name)
  File "/usr/lib/python3.13/hashlib.py", line 123, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type blake2s
Traceback (most recent call last):
  File "<temp path>", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "<temp path>", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
  File "<temp path>", line 976, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "<temp path>", line 1456, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "<temp path>", line 14, in get_app_dir_from_config
=== step 1: import character A and its .lmt ===
Info: Import successful
[A] imported model  -> armature 'a shipped .mod file' (130 bones); import panel now points at it
Info: Import successful
[A] imported .lmt   -> 'a shipped .lmt file' (export-list index 1)

=== step 2: import character B and its .lmt (panel now points at B) ===
Info: Import successful
[B] imported model  -> armature 'a shipped .mod file' (147 bones); import panel now points at it
unknown error: Error: F-Curve 'pose.bones["root_motion"].rotation_quaternion[0]' already exists in this channelbag
 Block index: 114, Track index:57
Info: Import successful
[B] imported .lmt   -> 'a shipped .lmt file' (export-list index 3)

import panel armature is now: 'a shipped .mod file'
A's .lmt records its own armature as: None

edited block: 'a shipped .lmt file.0000' (block index 0), action 'a shipped .mod file.fig01.lmt.0000' keying 59 bones
those bone names through A's rig -> 59 ids: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]...
those bone names through B's rig -> 59 ids: [0, 6, 7, 8, 9, 12, 13, 14, 15, 16, 17, 18]...

=== step 3: select A's .lmt in the export list and export ===
Exporting LMT for a shipped .lmt file with app_id re5
Info: Export successful
albam.export() -> {'FINISHED'}
exported block 0: num_tracks=59, 56 distinct bone ids: [0, 6, 7, 8, 9, 12, 13, 15, 16, 17, 18, 19]...

written ids that A's rig accounts for : 24/56
written ids that only B's rig explains: 32
VERDICT: exported bone ids come from rig: NOT A
  ids in A's mapping but missing from the file (dropped): [1, 2, 3, 4, 5, 10, 11, 14, 20, 22, 24, 25]
```
</details>
<details>
<summary>Evidence: Zero-track refusal vs. empty action, through bpy.ops.albam.export()</summary>

<code>=== case (b): the block&#39;s action is a genuinely empty one ===&#10;albam.export() -&gt; {&#39;FINISHED&#39;}&#10;block 0 written with num_tracks=0 - export still finished&#10;&#10;=== case (a): the action keys bones the rig has no Anim Retarget id for ===&#10;Error: Export failed: ValueError: Exporting &#39;a shipped .lmt file.0000&#39; resolved zero tracks: none of its action&#39;s bone names matched an Anim Retarget id on &#39;a shipped .mod file&#39;. Writing this block out would silently produce num_tracks = 0 with a non-zero ofs_frame - check the armature this .lmt was imported onto against the bones the action actually keys.</code>

```text
ERROR:root:code for hash blake2b was not found.
Traceback (most recent call last):
  File "/usr/lib/python3.13/hashlib.py", line 247, in <module>
    globals()[__func_name] = __get_hash(__func_name)
                             ~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3.13/hashlib.py", line 129, in __get_openssl_constructor
    return __get_builtin_constructor(name)
  File "/usr/lib/python3.13/hashlib.py", line 123, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type blake2b
ERROR:root:code for hash blake2s was not found.
Traceback (most recent call last):
  File "/usr/lib/python3.13/hashlib.py", line 247, in <module>
    globals()[__func_name] = __get_hash(__func_name)
                             ~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3.13/hashlib.py", line 129, in __get_openssl_constructor
    return __get_builtin_constructor(name)
  File "/usr/lib/python3.13/hashlib.py", line 123, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type blake2s
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M22YMKBAHEJ1VB394658Z0MZ/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M22YMKBAHEJ1VB394658Z0MZ/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
  File "<temp path>", line 976, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "<temp path>", line 1456, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M22YMKBAHEJ1VB394658Z0MZ/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
Info: Import successful
Info: Import successful
imported 'a shipped .mod file' + 'a shipped .lmt file'

=== case (b): the block's action is a genuinely empty one ===
Exporting LMT for a shipped .lmt file with app_id re5
Info: Export successful
albam.export() -> {'FINISHED'}
block 0 written with num_tracks=0 - export still finished

=== case (a): the action keys bones the rig has no Anim Retarget id for ===
Exporting LMT for a shipped .lmt file with app_id re5
WARNING: a shipped .mod file->0 doesn't contain a mapped bone
WARNING: a shipped .mod file->1 doesn't contain a mapped bone
WARNING: a shipped .mod file->2 doesn't contain a mapped bone
WARNING: a shipped .mod file->3 doesn't contain a mapped bone
WARNING: a shipped .mod file->4 doesn't contain a mapped bone
WARNING: a shipped .mod file->5 doesn't contain a mapped bone
WARNING: a shipped .mod file->6 doesn't contain a mapped bone
WARNING: a shipped .mod file->7 doesn't contain a mapped bone
WARNING: a shipped .mod file->8 doesn't contain a mapped bone
WARNING: a shipped .mod file->9 doesn't contain a mapped bone
WARNING: a shipped .mod file->10 doesn't contain a mapped bone
WARNING: a shipped .mod file->11 doesn't contain a mapped bone
WARNING: a shipped .mod file->12 doesn't contain a mapped bone
WARNING: a shipped .mod file->13 doesn't contain a mapped bone
WARNING: a shipped .mod file->14 doesn't contain a mapped bone
WARNING: a shipped .mod file->15 doesn't contain a mapped bone
WARNING: a shipped .mod file->16 doesn't contain a mapped bone
WARNING: a shipped .mod file->17 doesn't contain a mapped bone
WARNING: a shipped .mod file->18 doesn't contain a mapped bone
WARNING: a shipped .mod file->19 doesn't contain a mapped bone
WARNING: a shipped .mod file->20 doesn't contain a mapped bone
WARNING: a shipped .mod file->21 doesn't contain a mapped bone
WARNING: a shipped .mod file->22 doesn't contain a mapped bone
WARNING: a shipped .mod file->23 doesn't contain a mapped bone
WARNING: a shipped .mod file->24 doesn't contain a mapped bone
WARNING: a shipped .mod file->25 doesn't contain a mapped bone
WARNING: a shipped .mod file->26 doesn't contain a mapped bone
WARNING: a shipped .mod file->27 doesn't contain a mapped bone
WARNING: a shipped .mod file->28 doesn't contain a mapped bone
WARNING: a shipped .mod file->29 doesn't contain a mapped bone
WARNING: a shipped .mod file->30 doesn't contain a mapped bone
WARNING: a shipped .mod file->31 doesn't contain a mapped bone
WARNING: a shipped .mod file->32 doesn't contain a mapped bone
WARNING: a shipped .mod file->33 doesn't contain a mapped bone
WARNING: a shipped .mod file->34 doesn't contain a mapped bone
WARNING: a shipped .mod file->35 doesn't contain a mapped bone
WARNING: a shipped .mod file->36 doesn't contain a mapped bone
WARNING: a shipped .mod file->37 doesn't contain a mapped bone
WARNING: a shipped .mod file->38 doesn't contain a mapped bone
WARNING: a shipped .mod file->39 doesn't contain a mapped bone
WARNING: a shipped .mod file->40 doesn't contain a mapped bone
WARNING: a shipped .mod file->41 doesn't contain a mapped bone
WARNING: a shipped .mod file->42 doesn't contain a mapped bone
WARNING: a shipped .mod file->43 doesn't contain a mapped bone
WARNING: a shipped .mod file->44 doesn't contain a mapped bone
WARNING: a shipped .mod file->45 doesn't contain a mapped bone
WARNING: a shipped .mod file->46 doesn't contain a mapped bone
WARNING: a shipped .mod file->47 doesn't contain a mapped bone
WARNING: a shipped .mod file->48 doesn't contain a mapped bone
WARNING: a shipped .mod file->49 doesn't contain a mapped bone
WARNING: a shipped .mod file->50 doesn't contain a mapped bone
WARNING: a shipped .mod file->51 doesn't contain a mapped bone
WARNING: a shipped .mod file->52 doesn't contain a mapped bone
WARNING: a shipped .mod file->53 doesn't contain a mapped bone
WARNING: a shipped .mod file->54 doesn't contain a mapped bone
WARNING: a shipped .mod file->55 doesn't contain a mapped bone
WARNING: a shipped .mod file->56 doesn't contain a mapped bone
WARNING: a shipped .mod file->57 doesn't contain a mapped bone
WARNING: a shipped .mod file->58 doesn't contain a mapped bone
WARNING: a shipped .mod file->59 doesn't contain a mapped bone
WARNING: a shipped .mod file->60 doesn't contain a mapped bone
WARNING: a shipped .mod file->61 doesn't contain a mapped bone
WARNING: a shipped .mod file->62 doesn't contain a mapped bone
WARNING: a shipped .mod file->63 doesn't contain a mapped bone
WARNING: a shipped .mod file->64 doesn't contain a mapped bone
WARNING: a shipped .mod file->65 doesn't contain a mapped bone
WARNING: a shipped .mod file->66 doesn't contain a mapped bone
WARNING: a shipped .mod file->67 doesn't contain a mapped bone
WARNING: a shipped .mod file->68 doesn't contain a mapped bone
WARNING: a shipped .mod file->69 doesn't contain a mapped bone
WARNING: a shipped .mod file->70 doesn't contain a mapped bone
WARNING: a shipped .mod file->71 doesn't contain a mapped bone
WARNING: a shipped .mod file->72 doesn't contain a mapped bone
WARNING: a shipped .mod file->73 doesn't contain a mapped bone
WARNING: a shipped .mod file->74 doesn't contain a mapped bone
WARNING: a shipped .mod file->75 doesn't contain a mapped bone
WARNING: a shipped .mod file->76 doesn't contain a mapped bone
WARNING: a shipped .mod file->77 doesn't contain a mapped bone
WARNING: a shipped .mod file->78 doesn't contain a mapped bone
WARNING: a shipped .mod file->79 doesn't contain a mapped bone
WARNING: a shipped .mod file->80 doesn't contain a mapped bone
WARNING: a shipped .mod file->81 doesn't contain a mapped bone
WARNING: a shipped .mod file->82 doesn't contain a mapped bone
WARNING: a shipped .mod file->83 doesn't contain a mapped bone
WARNING: a shipped .mod file->84 doesn't contain a mapped bone
WARNING: a shipped .mod file->85 doesn't contain a mapped bone
WARNING: a shipped .mod file->86 doesn't contain a mapped bone
WARNING: a shipped .mod file->87 doesn't contain a mapped bone
WARNING: a shipped .mod file->88 doesn't contain a mapped bone
WARNING: a shipped .mod file->89 doesn't contain a mapped bone
WARNING: a shipped .mod file->90 doesn't contain a mapped bone
WARNING: a shipped .mod file->91 doesn't contain a mapped bone
WARNING: a shipped .mod file->92 doesn't contain a mapped bone
WARNING: a shipped .mod file->93 doesn't contain a mapped bone
WARNING: a shipped .mod file->94 doesn't contain a mapped bone
WARNING: a shipped .mod file->95 doesn't contain a mapped bone
WARNING: a shipped .mod file->96 doesn't contain a mapped bone
WARNING: a shipped .mod file->97 doesn't contain a mapped bone
WARNING: a shipped .mod file->98 doesn't contain a mapped bone
WARNING: a shipped .mod file->99 doesn't contain a mapped bone
WARNING: a shipped .mod file->100 doesn't contain a mapped bone
WARNING: a shipped .mod file->101 doesn't contain a mapped bone
WARNING: a shipped .mod file->102 doesn't contain a mapped bone
WARNING: a shipped .mod file->103 doesn't contain a mapped bone
WARNING: a shipped .mod file->104 doesn't contain a mapped bone
WARNING: a shipped .mod file->105 doesn't contain a mapped bone
WARNING: a shipped .mod file->106 doesn't contain a mapped bone
WARNING: a shipped .mod file->107 doesn't contain a mapped bone
WARNING: a shipped .mod file->108 doesn't contain a mapped bone
WARNING: a shipped .mod file->109 doesn't contain a mapped bone
WARNING: a shipped .mod file->110 doesn't contain a mapped bone
WARNING: a shipped .mod file->111 doesn't contain a mapped bone
WARNING: a shipped .mod file->112 doesn't contain a mapped bone
WARNING: a shipped .mod file->113 doesn't contain a mapped bone
WARNING: a shipped .mod file->114 doesn't contain a mapped bone
WARNING: a shipped .mod file->115 doesn't contain a mapped bone
WARNING: a shipped .mod file->116 doesn't contain a mapped bone
WARNING: a shipped .mod file->117 doesn't contain a mapped bone
WARNING: a shipped .mod file->118 doesn't contain a mapped bone
WARNING: a shipped .mod file->119 doesn't contain a mapped bone
WARNING: a shipped .mod file->120 doesn't contain a mapped bone
WARNING: a shipped .mod file->121 doesn't contain a mapped bone
WARNING: a shipped .mod file->122 doesn't contain a mapped bone
WARNING: a shipped .mod file->123 doesn't contain a mapped bone
WARNING: a shipped .mod file->124 doesn't contain a mapped bone
WARNING: a shipped .mod file->125 doesn't contain a mapped bone
WARNING: a shipped .mod file->126 doesn't contain a mapped bone
WARNING: a shipped .mod file->127 doesn't contain a mapped bone
WARNING: a shipped .mod file->128 doesn't contain a mapped bone
WARNING: a shipped .mod file->129 doesn't contain a mapped bone
WARNING: a shipped .mod file->root_motion doesn't contain a mapped bone
WARNING: a shipped .mod file->IK_Foot.R doesn't contain a mapped bone
WARNING: a shipped .mod file->IK_Foot.L doesn't contain a mapped bone

==================
Albam error report
==================

Blender version: 5.2.0
Albam version: 0.5.0
Operating System: Linux-7.2.3-arch1-2-x86_64-with-glibc2.44
Error: ValueError: Exporting 'a shipped .lmt file.0000' resolved zero tracks: none of its action's bone names matched an Anim Retarget id on 'a shipped .mod file'. Writing this block out would silently produce num_tracks = 0 with a non-zero ofs_frame - check the armature this .lmt was imported onto against the bones the action actually keys.
Traceback:
  File "******/.no-mistakes/worktrees/731f537710a6/01M22YMKBAHEJ1VB394658Z0MZ/albam/blender_ui/export_panel.py", line 289, in execute
    self._execute(context, item)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "******/.no-mistakes/worktrees/731f537710a6/01M22YMKBAHEJ1VB394658Z0MZ/albam/blender_ui/export_panel.py", line 303, in _execute
    vfiles = export_function(item.bl_object)
  File "******/.no-mistakes/worktrees/731f537710a6/01M22YMKBAHEJ1VB394658Z0MZ/albam/engines/mtfw/animation/animation_export.py", line 604, in export_lmt
    _generate_track_from_action(armature, bl_objects, app_id)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "******/.no-mistakes/worktrees/731f537710a6/01M22YMKBAHEJ1VB394658Z0MZ/albam/engines/mtfw/animation/animation_export.py", line 243, in _generate_track_from_action
    raise ValueError(
    ...<5 lines>...
    )

=================

Error: Export failed: ValueError: Exporting 'a shipped .lmt file.0000' resolved zero tracks: none of its action's bone names matched an Anim Retarget id on 'a shipped .mod file'. Writing this block out would silently produce num_tracks = 0 with a non-zero ofs_frame - check the armature this .lmt was imported onto against the bones the action actually keys.
Traceback (most recent call last):
  File "~/.no-mistakes/evidence/01M22YMKBAHEJ1VB394658Z0MZ/zero_tracks_254.py", line 93, in <module>
    result = bpy.ops.albam.export()
RuntimeError: Error: Export failed: ValueError: Exporting 'a shipped .lmt file.0000' resolved zero tracks: none of its action's bone names matched an Anim Retarget id on 'a shipped .mod file'. Writing this block out would silently produce num_tracks = 0 with a non-zero ofs_frame - check the armature this .lmt was imported onto against the bones the action actually keys.
```
</details>
<details>
<summary>Evidence: Fallback to the import panel when no armature is recorded</summary>

<code>albam_lmt_armature cleared; import panel armature = &#39;a shipped .mod file&#39;&#10;albam.export() -&gt; {&#39;FINISHED&#39;}&#10;block 0: num_tracks=59, 57 ids, all from the panel&#39;s rig: True</code>

```text
ERROR:root:code for hash blake2b was not found.
Traceback (most recent call last):
  File "/usr/lib/python3.13/hashlib.py", line 247, in <module>
    globals()[__func_name] = __get_hash(__func_name)
                             ~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3.13/hashlib.py", line 129, in __get_openssl_constructor
    return __get_builtin_constructor(name)
  File "/usr/lib/python3.13/hashlib.py", line 123, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type blake2b
ERROR:root:code for hash blake2s was not found.
Traceback (most recent call last):
  File "/usr/lib/python3.13/hashlib.py", line 247, in <module>
    globals()[__func_name] = __get_hash(__func_name)
                             ~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3.13/hashlib.py", line 129, in __get_openssl_constructor
    return __get_builtin_constructor(name)
  File "/usr/lib/python3.13/hashlib.py", line 123, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type blake2s
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M22YMKBAHEJ1VB394658Z0MZ/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M22YMKBAHEJ1VB394658Z0MZ/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
  File "<temp path>", line 976, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "<temp path>", line 1456, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M22YMKBAHEJ1VB394658Z0MZ/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
Info: Import successful
Info: Import successful
albam_lmt_armature cleared; import panel armature = 'a shipped .mod file'
Exporting LMT for a shipped .lmt file with app_id re5
Info: Export successful
albam.export() -> {'FINISHED'}
block 0: num_tracks=59, 57 ids, all from the panel's rig: True
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"25669134b3eb4e011c031f081b57677b838a984d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":6,"total":6}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `tests/mtfw/test_lmt_custom_animation.py:312` - The new zero-track raise in `_generate_track_from_action` (animation_export.py:240) contradicts the existing `test_export_action_without_layers_does_not_crash`. That test sets `generate_new = True` and swaps in a brand-new empty action, then asserts `bpy.ops.albam.export() == {&#34;FINISHED&#34;}`. With the change, an empty action yields no fcurves -&gt; `tracks` empty -&gt; `_serialize_lmt_track` returns an empty list -&gt; ValueError -&gt; the operator returns `{&#34;CANCELLED&#34;}`. The test skips only when `hasattr(action, &#34;fcurves&#34;)` is true (bpy 4.2), so it runs and fails on the bpy 5.2 matrix leg whenever `--game-dir` is available. The intent explicitly requires refusing zero-track blocks, so the raise is correct and the old test&#39;s expectation is what needs to change - but that is a deliberate behavior decision (a keyless action now aborts the whole export rather than writing an empty block), so it needs the author&#39;s call rather than a silent edit.
- ⚠️ `albam/engines/mtfw/animation/animation_export.py:597` - Simplification: the `if armature is None: raise ValueError(...)` guard added in `export_lmt` is a new branch the intent does not require. The intent asks only that export read the stored armature and &#34;fall back to the panel only when the property is absent&#34;; it says nothing about the both-absent case, which previously surfaced as an AttributeError inside `_create_bone_mapping` and already produced a CANCELLED export with a &#34;Export failed&#34; report. No test in this change exercises this branch either. Recommend removing it unless the friendlier message is deliberately wanted.
- ℹ️ `albam/engines/mtfw/animation/animation_export.py:240` - The zero-track raise fires mid-loop over `bl_objects`, after `_update_track_data` has already rewritten the secondary track props of every earlier block in the same export. The scene is therefore left partially regenerated when export refuses. Impact is low - those blocks still have `generate_new = True` and get regenerated on the next export - but it is worth knowing the refusal is not side-effect free.
- ℹ️ `tests/mtfw/test_lmt_export_armature_provenance.py:141` - `test_export_refuses_a_block_that_resolves_zero_tracks` exists twice with the same name and the same assertion target: once here (synthetic, runs without --game-dir) and once in tests/mtfw/test_lmt_custom_animation.py:315 (requires the game fixture). The synthetic one covers the behavior on every CI leg; the game-dir copy adds no distinct coverage of the raise.

🔧 Fix applied.
1 info still open:

- ℹ️ `albam/engines/mtfw/animation/animation_export.py:243` - The refusal message asserts &#34;none of its action&#39;s bone names matched an Anim Retarget id&#34;, but the condition it guards (`num_bone_channels and not track_attrs`) also fires when bone names DO resolve and every one of their fcurves has zero keyframe_points - a user who deletes all keys from a channel in the dope sheet leaves the fcurve behind. In that path `tracks[bone_name] = {}` is created (line 220), `_serialize_lmt_track` encodes nothing, and the export aborts with a message pointing the user at an armature/retarget mismatch when the actual cause is a keyless channel. Refusing is still the right outcome (the block would be num_tracks=0 with a non-zero ofs_frame), so only the diagnostic text is inaccurate; not worth widening the condition.

- ℹ️ `albam/engines/mtfw/animation/animation_export.py:243` - The refusal message states &#34;none of its action&#39;s bone names matched an Anim Retarget id&#34;, but the guarded condition (`num_bone_channels and not track_attrs`) also fires when bone names DO resolve and every one of their fcurves is keyless (an fcurve created or left behind with zero keyframe_points): `tracks[bone_name] = {}` is created at line 220, `_serialize_lmt_track` encodes nothing, and export aborts pointing the user at an armature/retarget mismatch that isn&#39;t the cause. Refusing is still correct there (the block would be num_tracks = 0 with a non-zero ofs_frame), so only the diagnostic wording is imprecise; widening the condition is not warranted. Noted previously in round 2 and unchanged.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 6 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Captain&#39;s repro: import character A + its .lmt, import character B, export A&#39;s .lmt - tracks keep A&#39;s bone ids | ✅ pass | live | evidence/repro-254-fixed.log - real RE5 import of a shipped .mod file + a shipped .lmt file then a shipped .mod file, panel repointed at pl0100, bpy.ops.albam.export() -&gt; FINISHED, all 111 populated blocks&#39; track bone ids i… |
| Regression proof: the same repro on base 367c0b8 silently writes B&#39;s bone ids | ✅ pass | live | evidence/repro-254-base-367c0b8-BEFORE-FIX.log - identical driver against a git archive of the base commit reports Export successful while all 111 blocks come out renumbered (56 tracks -&gt; 52) |
| Export refuses loudly when a block resolves zero tracks instead of writing num_tracks = 0 | ✅ pass | live | evidence/adversarial-fallback-and-zero-tracks.log - panel pointed at a rig with no Anim Retarget ids; export aborts with ValueError naming the block and the rig, no file written |
| A genuinely keyless action still exports successfully (the refusal stays narrowed) | ✅ pass | live | `pytest tests/mtfw/test_lmt_custom_animation.py::test_export_action_without_layers_does_not_crash --game-dir=re5::...` on bpy 5.2 - runs (does not skip) and passes with bpy.ops.albam.export() == FINIS… |
| A .blend saved before the property existed still exports through the import panel&#39;s armature | ✅ pass | live | evidence/adversarial-fallback-and-zero-tracks.log - albam_lmt_armature cleared on the imported .lmt, panel set to pl0000, export FINISHED with bone ids matching the source .lmt |
| New synthetic provenance tests pass on both supported Blender versions | ✅ pass | live | `pytest tests/mtfw/test_lmt_export_armature_provenance.py -q` under bpy 4.2.0 and bpy 5.2.0 - 4 passed on each |

- <code>`~/.cache/albam-venvs/py311-bpy4.2.0/bin/python -m pytest tests/mtfw/test_lmt_export_armature_provenance.py -q` (bpy 4.2, 4 passed)</code>
- <code>`<temp path> -m pytest tests/mtfw/test_lmt_export_armature_provenance.py -q` (bpy 5.2, 4 passed)</code>
- <code>`<temp path> -m pytest tests/mtfw/test_lmt_custom_animation.py -v -rs &#39;--game-dir=re5::~/Games/Resident Evil 5&#39;` (bpy 5.2, 3 passed incl. test_export_action_without_layers_does_not_crash, which runs rather than skips on this leg)</code>
- <code>Manual product driver: real RE5 import of a shipped .mod file + a shipped .lmt file, then a shipped .mod file, panel repointed at pl0100, export via `bpy.ops.albam.export()`, exported .lmt parsed and its per-block track bone ids diffed against the source .lmt (evidence/driver-repro-254.py)</code>
- <code>Same driver run against a `git archive 367c0b8` copy of the base commit to confirm the bug reproduces before the fix</code>
- `Manual adversarial driver: albam_lmt_armature cleared (pre-fix .blend) exporting through the panel, then panel pointed at a fresh armature with no Anim Retarget ids to force the zero-track path (evidence/driver-fallback-and-zero-tracks.py)`

✅ No issues found.
- Live validation: ✅ go - 6 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Import character A + its .lmt, then character B + its .lmt, then export A&#39;s .lmt — tracks carry A&#39;s bone ids, not B&#39;s | ✅ pass | live | `repro_254.py` driving albam.import_vfile/albam.export on real RE5 pl0000/pl0100 assets; issue-254-repro-after-fix.txt shows 57/57 written ids explained by A&#39;s rig, 0 by B&#39;s |
| Same two-character export on the pre-fix base commit reproduces the reported silent renumbering | ✅ pass | live | identical driver against a checkout of base 25127af; issue-254-repro-before-fix.txt shows 32 ids only B&#39;s rig explains and A&#39;s ids dropped, export still reporting success |
| Adversarial: a block whose action keys bones the rig has no Anim Retarget id for is refused instead of written with num_tracks=0 | ✅ pass | live | `zero_tracks_254.py` case (a) — bpy.ops.albam.export() surfaces &#34;Exporting &#39;a shipped .lmt file.0000&#39; resolved zero tracks...&#34; and writes nothing |
| Adversarial: a genuinely empty action still exports successfully and is not caught by the refusal | ✅ pass | live | `zero_tracks_254.py` case (b) — albam.export() returns FINISHED and block 0 is written with num_tracks=0; also `pytest tests/mtfw/test_lmt_custom_animation.py::test_export_action_without_layers_does_n… |
| A .blend saved before the new property exists still exports through the import panel&#39;s armature | ✅ pass | live | `fallback_254.py` — albam_lmt_armature cleared on a real imported .lmt; export FINISHED with all 57 ids from the panel&#39;s rig |
| Ordinary unedited .lmt import/export round-trip is unaffected by the new refusal | ✅ pass | live | `pytest tests/mtfw/test_lmt_reimport_roundtrip.py tests/mtfw/test_lmt_import.py tests/mtfw/test_lmt_export_armature_provenance.py --game-dir &#39;re5::~/Games/Resident Evil 5&#39;` — 20 passed, 1 sk… |

- <code>`python repro_254.py &lt;worktree&gt; &#34;~/Games/Resident Evil 5&#34;` — captain&#39;s 2-character import/export repro through albam.import_vfile/albam.export (fixed code)</code>
- `same driver run against a clean checkout of base commit 25127af to reproduce the pre-fix corruption`
- <code>`python zero_tracks_254.py ...` — real RE5 block exported with (b) a genuinely empty action and (a) an action whose bone names resolve to no Anim Retarget id, via bpy.ops.albam.export() with albam&#39;s normal operator error handling</code>
- <code>`python fallback_254.py ...` — real RE5 .lmt with albam_lmt_armature cleared, exported through the import panel&#39;s armature</code>
- `pytest tests/mtfw/test_lmt_custom_animation.py -v --game-dir 're5::~/Games/Resident Evil 5'`
- `pytest tests/mtfw/test_lmt_reimport_roundtrip.py tests/mtfw/test_lmt_import.py tests/mtfw/test_lmt_export_armature_provenance.py -q --game-dir 're5::...'`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>

