### PR TITLE
fix(cie): export RE4 UHD bone tables that name the same bone id twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   expanding either one listed both archives' contents
 - "Batch import folder" importing a second, same-named archive's identically
   placed files along with the selected folder's own
+- Resident Evil 4 UHD models whose bone table names the same bone id twice
+  exporting with one of the two entries missing, and the surviving one given
+  the other's position. Such a model could not be edited at all: the exporter
+  had no way to write back the table it came with
 
 ### Changed
 

--- a/albam/engines/cie/mesh.py
+++ b/albam/engines/cie/mesh.py
@@ -3,6 +3,7 @@ from kaitaistruct import KaitaiStream
 import bpy
 from mathutils import Vector
 import math
+import re
 import struct
 from ...registry import blender_registry
 from ...vfs import VirtualFile, VirtualFileData
@@ -47,6 +48,9 @@ VERSION_FLAGS_PLAIN = 0x20010801
 
 NO_PARENT = 0xFF
 NO_TEXTURE = 0xFF
+# What Blender appends to a name already taken in the same datablock - see
+# _bone_id.
+BLENDER_NAME_SUFFIX = re.compile(r"\.\d{3}$")
 MAX_BONE_INFLUENCES = 3
 # Both counts are u2, so a model cannot state more corners than this.
 MAX_VERTICES = 0xFFFF
@@ -165,6 +169,8 @@ def build_blender_model(vfile: VirtualFile, context: bpy.types.Context) -> bpy.t
         # weighted to are in nothing else here - see _bones_to_write.
         bl_mesh_ob[BONE_IDS_PROPERTY] = [bone.bone_id for bone in bin.bones]
         bl_mesh_ob[BONE_PARENTS_PROPERTY] = [bone.parent for bone in bin.bones]
+        bl_mesh_ob[BONE_OFFSETS_PROPERTY] = [
+            coordinate for bone in bin.bones for coordinate in (bone.x, bone.y, bone.z)]
         _apply_weights(bl_mesh_ob, bin)
         arm_mod = bl_mesh_ob.modifiers.new("Armature", 'ARMATURE')
         arm_mod.object = skeleton
@@ -339,14 +345,32 @@ def _apply_materials(bl_mesh, bin, mat_face_ranges, tpl_vfile):
 
 
 ARCHIVE_PROPERTY = "cie.source_archive"
-# The bone ids the model was imported with (see build_blender_model).
+# The bone ids the model was imported with, one per table entry and in the
+# order the table had them (see build_blender_model).
+#
+# A table may name the same id twice, and the armature cannot say so: a bone
+# is addressed by id everywhere it matters - the weights, the vertex groups
+# named after them, animation retargeting - so the scene has exactly one bone
+# per id and a second one would only be a bone named "5.001" that nothing
+# means. The repeats live here instead, and this list is what export writes
+# the table back from. The table is written in bone id order, which puts two
+# entries sharing an id next to each other, so their order here is the order
+# they are written in.
 BONE_IDS_PROPERTY = "cie.bone_ids"
-# The parent each of those bones had in this model's own table. A shared
+# The parent each of those entries had in this model's own table. A shared
 # armature cannot hold them: measured over one character archive, 10 of its
 # 119 bone ids are given different parents by different models, and some
 # models root a bone whose parent is present. Whatever the game reads them
 # for, they are the model's own and are carried rather than recomputed.
 BONE_PARENTS_PROPERTY = "cie.bone_parents"
+# The parent-relative offset each of those entries had, flattened to x, y, z
+# per entry - the raw values the file stores, not Blender's.
+#
+# Only a repeat reads them back. Every id the armature does have a bone for
+# is written from that bone, so moving it in Blender is an edit the export
+# sees; a repeat has no bone of its own to move, and writing back exactly
+# what it came with is the only answer that does not invent one.
+BONE_OFFSETS_PROPERTY = "cie.bone_offsets"
 
 
 def _find_reusable_armature(bin, context, archive_id):
@@ -388,7 +412,17 @@ def _build_armature(bl_object_name, bin, context, shared_armature=None, archive_
         print(f"[re4uhd] armature: reusing '{existing.name}' ({len(bin.bones)} bones)")
         return existing, False
 
-    bone_data = {b.bone_id: b for b in bin.bones}
+    # One bone per id, not one per table entry: see BONE_IDS_PROPERTY for
+    # why a repeated id has nowhere in the armature to go. The first entry
+    # is the one the bone stands for, and the repeats are carried on the mesh.
+    own_bones = []
+    seen_ids = set()
+    for bone in bin.bones:
+        if bone.bone_id not in seen_ids:
+            seen_ids.add(bone.bone_id)
+            own_bones.append(bone)
+
+    bone_data = {b.bone_id: b for b in own_bones}
 
     def world_pos(bone_id, visited=None):
         """Recursively accumulate local offsets (same unit as vertices) to world position."""
@@ -404,7 +438,7 @@ def _build_armature(bl_object_name, bin, context, shared_armature=None, archive_
             return local
         return world_pos(b.parent, visited) + local
 
-    world_positions = {b.bone_id: world_pos(b.bone_id) for b in bin.bones}
+    world_positions = {b.bone_id: world_pos(b.bone_id) for b in own_bones}
 
     arm_data = bpy.data.armatures.new(f"{bl_object_name}_armature")
     arm_ob = bpy.data.objects.new(f"{bl_object_name}_armature", arm_data)
@@ -419,12 +453,12 @@ def _build_armature(bl_object_name, bin, context, shared_armature=None, archive_
 
     edit_bone_map = {}
     # Create bones
-    for bone in bin.bones:
+    for bone in own_bones:
         blender_bone = arm_data.edit_bones.new(f"{bone.bone_id}")
         blender_bone['cie.anim_retarget'] = str(bone.bone_id)
         head = world_positions[bone.bone_id]
         blender_bone.head = head
-        children = [c for c in bin.bones
+        children = [c for c in own_bones
                     if c.parent == bone.bone_id and c.bone_id != bone.bone_id]
         if children:
             child_avg = sum((world_positions[c.bone_id] for c in children), Vector((0, 0, 0)))
@@ -436,7 +470,7 @@ def _build_armature(bl_object_name, bin, context, shared_armature=None, archive_
 
         edit_bone_map[bone.bone_id] = blender_bone
 
-    for bone in bin.bones:
+    for bone in own_bones:
         if bone.parent != bone.bone_id and bone.parent in edit_bone_map:
             edit_bone_map[bone.bone_id].parent = edit_bone_map[bone.parent]
             edit_bone_map[bone.bone_id].use_connect = False
@@ -707,8 +741,13 @@ def _bone_id(bl_bone, fallback):
     the id coming back. A bone the user added by hand won't be named that way;
     it gets its position in the armature instead, which at least stays inside
     the u1 the format allows.
+
+    Blender's own ".001" suffix is stripped first. Import used to make a bone
+    per table entry, so a scene saved before repeated ids were carried on the
+    mesh has a second bone named "5.001" for one named "5" - and reading that
+    as its position in the armature gave it some other bone's id entirely.
     """
-    name = bl_bone.name
+    name = BLENDER_NAME_SUFFIX.sub("", bl_bone.name)
     if name.isdigit() and int(name) < 255:
         return int(name)
     return min(fallback, 254)
@@ -771,11 +810,20 @@ def _bones_to_write(bl_armature, ids, used_ids, own_ids=()):
             kept.update(bone.name for bone in chain[shared:])
 
     # In the armature's own order, so the table is the same whichever order
-    # the weights happened to name their bones in.
-    return [bone for bone in all_bones if bone.name in kept]
+    # the weights happened to name their bones in. One bone per id: a scene
+    # saved before repeated ids were carried on the mesh has a "5.001"
+    # standing for the same id as its "5", and the repeats are written from
+    # what the model recorded, not from how many bones are named after an id.
+    written = []
+    seen = set()
+    for bone in all_bones:
+        if bone.name in kept and ids[bone.name] not in seen:
+            seen.add(ids[bone.name])
+            written.append(bone)
+    return written
 
 
-def _serialize_bones(dst_bin, bl_armature, used_ids=(), own_ids=(), own_parents=None):
+def _serialize_bones(dst_bin, bl_armature, used_ids=(), own_entries=None):
     """The bone table, as local offsets from each bone's parent.
 
     Holds the bones this model itself uses, not every bone of the armature it
@@ -783,8 +831,12 @@ def _serialize_bones(dst_bin, bl_armature, used_ids=(), own_ids=(), own_parents=
 
     Written in non-decreasing bone-id order, which every shipped model is
     laid out in. Blender's own bone order is not id order, and a table in any
-    other order does not read back as the same skeleton. Ids repeat in some
-    shipped tables, so the sort has to be stable rather than a sort of a set.
+    other order does not read back as the same skeleton.
+
+    Ids repeat in some shipped tables, and the armature has one bone per id,
+    so a bone is expanded into one entry per time the model's own table named
+    it - in the order it named them, which is what the sort puts them next to
+    each other for. See _own_bone_table.
 
     The file stores a parent-relative offset per bone, while Blender holds
     absolute rest positions, so each one is differenced against its parent on
@@ -792,40 +844,54 @@ def _serialize_bones(dst_bin, bl_armature, used_ids=(), own_ids=(), own_parents=
     absolute - which is how the bone the table starts at is written when the
     model hangs off part of a larger skeleton.
     """
+    own_entries = own_entries or {}
     all_bones = list(bl_armature.data.bones)
     ids = {bone.name: _bone_id(bone, i) for i, bone in enumerate(all_bones)}
-    bones = _bones_to_write(bl_armature, ids, used_ids, own_ids)
+    bones = _bones_to_write(bl_armature, ids, used_ids, own_entries.keys())
     if not bones:
         # Nothing said which bones are used - a model with no weights at all.
         bones = all_bones
     kept = {bone.name for bone in bones}
 
-    own_parents = own_parents or {}
-    by_id = {ids[bone.name]: bone for bone in all_bones}
+    by_id = {}
+    for bone in all_bones:
+        by_id.setdefault(ids[bone.name], bone)
 
     dst_bones = []
     for bone in sorted(bones, key=lambda b: ids[b.name]):
-        dst_bone = dst_bin.Bone(_parent=dst_bin, _root=dst_bin._root)
         bone_id = ids[bone.name]
-        dst_bone.bone_id = bone_id
+        # A bone the model never listed still gets one entry: it is weighted
+        # to now even if it was not before.
+        entries = own_entries.get(bone_id) or [(None, None)]
+        for occurrence, (recorded_parent, recorded_offset) in enumerate(entries):
+            dst_bone = dst_bin.Bone(_parent=dst_bin, _root=dst_bin._root)
+            dst_bone.bone_id = bone_id
 
-        # The model's own parent for this bone if it recorded one, since the
-        # armature it is bound to may be shared and disagree; otherwise the
-        # armature's own hierarchy, clipped to the bones being written.
-        recorded = own_parents.get(bone_id)
-        if recorded is not None and (recorded == NO_PARENT or recorded in by_id):
-            dst_bone.parent = recorded
-            parent = None if recorded == NO_PARENT else by_id[recorded]
-        else:
-            parent = bone.parent if bone.parent and bone.parent.name in kept else None
-            dst_bone.parent = ids[parent.name] if parent else NO_PARENT
-        head = bone.head_local
-        if parent:
-            head = head - parent.head_local
-        dst_bone.x, dst_bone.y, dst_bone.z = _zy_flip(head.x, head.y, head.z)
-        dst_bone.filler = 0
-        dst_bone._check()
-        dst_bones.append(dst_bone)
+            # The model's own parent for this entry if it recorded one, since
+            # the armature it is bound to may be shared and disagree;
+            # otherwise the armature's own hierarchy, clipped to the bones
+            # being written.
+            if (recorded_parent is not None and
+                    (recorded_parent == NO_PARENT or recorded_parent in by_id)):
+                dst_bone.parent = recorded_parent
+                parent = None if recorded_parent == NO_PARENT else by_id[recorded_parent]
+            else:
+                parent = bone.parent if bone.parent and bone.parent.name in kept else None
+                dst_bone.parent = ids[parent.name] if parent else NO_PARENT
+
+            if occurrence and recorded_offset is not None:
+                # A repeat has no bone of its own in the scene to read a
+                # position off, so it goes back exactly as it came in - see
+                # BONE_OFFSETS_PROPERTY.
+                dst_bone.x, dst_bone.y, dst_bone.z = recorded_offset
+            else:
+                head = bone.head_local
+                if parent:
+                    head = head - parent.head_local
+                dst_bone.x, dst_bone.y, dst_bone.z = _zy_flip(head.x, head.y, head.z)
+            dst_bone.filler = 0
+            dst_bone._check()
+            dst_bones.append(dst_bone)
     return dst_bones
 
 
@@ -1227,7 +1293,7 @@ def export_bin(bl_obj):
     dst_bin.header = _serialize_header(dst_bin, bl_mesh_objs[0])
     dst_bin.bones = (
         _serialize_bones(dst_bin, armature, _weighted_bone_ids(weight_table),
-                         _own_bone_ids(bl_mesh_objs), _own_bone_parents(bl_mesh_objs))
+                         _own_bone_table(bl_mesh_objs))
         if armature else [])
     # No armature means nothing to weight against, and a shipped model
     # without bones carries no weight block at all.
@@ -1272,34 +1338,41 @@ def _serialize_header(dst_bin, bl_mesh_ob):
     return header
 
 
-def _own_bone_ids(bl_mesh_objs):
-    """The bone ids the model was imported with, if it still says.
+def _own_bone_table(bl_mesh_objs):
+    """{bone id: [(parent, offset), ...]} as the model's own table had it.
 
-    Recorded on import (see BONE_IDS_PROPERTY) because a bone nothing is
-    weighted to is in nothing else on the Blender side, while the file it
-    came from listed it. Anything since weighted to a bone this does not name
-    is still written - the table is the union of the two.
+    One pair per time the table named that id, in the order it named them,
+    and `offset` is that entry's raw (x, y, z) or None where the model did
+    not record one. Recorded on import (see BONE_IDS_PROPERTY) because a bone
+    nothing is weighted to is in nothing else on the Blender side, while the
+    file it came from listed it, and because two entries can share an id -
+    which the armature, holding one bone per id, cannot express. Anything
+    since weighted to a bone this does not name is still written: the table
+    is the union of the two.
+
+    A scene saved before offsets were recorded has ids and parents but no
+    offsets, and gets None for every one of them.
     """
-    own = set()
+    table = {}
     for bl_mesh_ob in bl_mesh_objs:
-        own.update(bl_mesh_ob.get(BONE_IDS_PROPERTY) or ())
-    return own
-
-
-def _own_bone_parents(bl_mesh_objs):
-    """{bone id: parent id} as the model's own table had them.
-
-    See BONE_PARENTS_PROPERTY: the same bone is parented differently by
-    different models of one character, so the armature they share cannot
-    answer this and the model has to say.
-    """
-    parents = {}
-    for bl_mesh_ob in bl_mesh_objs:
-        ids = bl_mesh_ob.get(BONE_IDS_PROPERTY) or ()
-        recorded = bl_mesh_ob.get(BONE_PARENTS_PROPERTY) or ()
-        for bone_id, parent in zip(ids, recorded):
-            parents.setdefault(bone_id, parent)
-    return parents
+        ids = list(bl_mesh_ob.get(BONE_IDS_PROPERTY) or ())
+        parents = list(bl_mesh_ob.get(BONE_PARENTS_PROPERTY) or ())
+        offsets = list(bl_mesh_ob.get(BONE_OFFSETS_PROPERTY) or ())
+        counted = {}
+        for index, bone_id in enumerate(ids):
+            occurrence = counted.get(bone_id, 0)
+            counted[bone_id] = occurrence + 1
+            entries = table.setdefault(bone_id, [])
+            # Several meshes exporting as one model are merged the way their
+            # bone ids always were: the first to describe an occurrence is
+            # the one that describes it.
+            if occurrence != len(entries):
+                continue
+            parent = parents[index] if index < len(parents) else None
+            offset = (tuple(offsets[index * 3:index * 3 + 3])
+                      if len(offsets) >= index * 3 + 3 else None)
+            entries.append((parent, offset))
+    return table
 
 
 def _weighted_bone_ids(weight_table):

--- a/albam/engines/cie/mesh.py
+++ b/albam/engines/cie/mesh.py
@@ -1353,7 +1353,10 @@ def _own_bone_table(bl_mesh_objs):
     is the union of the two.
 
     A scene saved before offsets were recorded has ids and parents but no
-    offsets, and gets None for every one of them.
+    offsets, and gets None for every one of them. Its repeats are then
+    written from the one bone the scene has for that id - not what each
+    entry came in with, but every entry is at least there, and re-importing
+    the model records them properly.
     """
     table = {}
     for bl_mesh_ob in bl_mesh_objs:

--- a/albam/engines/cie/mesh.py
+++ b/albam/engines/cie/mesh.py
@@ -164,9 +164,11 @@ def build_blender_model(vfile: VirtualFile, context: bpy.types.Context) -> bpy.t
         archive_id=root_vfile.name if root_vfile else "")
 
     if skeleton:
-        # Which bones the model itself had. An armature it shares with the
-        # rest of its archive is not its skeleton, and bones nothing is
-        # weighted to are in nothing else here - see _bones_to_write.
+        # The model's own bone table, entry for entry. An armature it shares
+        # with the rest of its archive is not its skeleton, bones nothing is
+        # weighted to are in nothing else here (see _bones_to_write), and an
+        # id the table names twice has one bone between the two of them - so
+        # this is the only place the table itself survives.
         bl_mesh_ob[BONE_IDS_PROPERTY] = [bone.bone_id for bone in bin.bones]
         bl_mesh_ob[BONE_PARENTS_PROPERTY] = [bone.parent for bone in bin.bones]
         bl_mesh_ob[BONE_OFFSETS_PROPERTY] = [

--- a/docs/modding-a-character.md
+++ b/docs/modding-a-character.md
@@ -213,9 +213,6 @@ Add one layer of albam at a time, and whichever fails first names the layer:
 
 ## What does not work yet
 
-- **A model whose bone table names one bone id twice** cannot be exported
-  faithfully; import collapses the two. 69 of 738 models are affected, and the
-  build tool keeps their original bytes rather than shipping them wrong.
 - **Morph targets, bone pairs and adjacency** are not written back. A model with
   facial morphs loses them on export.
 - **Rooms** import - geometry, props and placement - but there is no exporter for

--- a/tests/cie/conftest.py
+++ b/tests/cie/conftest.py
@@ -1,7 +1,10 @@
 import os
 
+import bpy
 import pytest
 
+from albam.lib import fs_registry
+from tests.conftest import close_new_fs_roots, remove_new_vfs_roots, vfs_root_names
 from tests.mtfw.r2_config import R2_PROTOCOL_PREFIX, resolve_r2_source
 
 # app_id -> the directory its archives were fetched into this session.
@@ -92,3 +95,18 @@ def game_root(pytestconfig, local_app_id, tmp_path_factory):
     if not os.path.isdir(root):
         pytest.skip(f"--game-dir={local_app_id}::{root} does not exist")
     return root
+
+
+@pytest.fixture
+def _clean_scene():
+    # vfs, exported and bpy.data are session-scoped state: register() runs
+    # once per pytest session, so a test that leaves objects or roots behind
+    # changes what the next one sees.
+    before = fs_registry.keys()
+    before_roots = vfs_root_names()
+    yield
+    bpy.ops.object.select_all(action="SELECT")
+    bpy.ops.object.delete(use_global=True)
+    remove_new_vfs_roots(before_roots)
+    bpy.context.scene.albam.exported.file_list.clear()
+    close_new_fs_roots(before)

--- a/tests/cie/synthetic_bin.py
+++ b/tests/cie/synthetic_bin.py
@@ -1,0 +1,108 @@
+"""A RE4UHD mesh .bin built in memory.
+
+Every other RE4UHD test reads a shipped model, which is the right way to
+check albam against the format. It cannot pin down a case the shipped data
+only sometimes contains, though, and a test that skips unless the archive it
+was handed happens to hold one proves nothing on the day it skips. A bone
+table naming the same id twice is such a case: 69 of 738 models have one, and
+none of them is in a dataset a CI run can reach.
+
+Built from the generated struct classes (albam/engines/cie/structs), so what
+this writes is the format definition's own idea of a .bin rather than a
+second, hand-rolled one that could drift from it. The block layout is
+albam's, which is fine: every offset is explicit in the header, so a reader
+is told where each block is rather than assuming.
+"""
+from albam.engines.cie import mesh
+from albam.engines.cie.structs.re4_uhd_bin import Re4UhdBin
+
+# One triangle strip of four corners: a quad, the smallest thing that still
+# has two triangles, a UV layer and a weight index per corner.
+POSITIONS = [(0.0, 0.0, 0.0), (100.0, 0.0, 0.0), (0.0, 100.0, 0.0), (100.0, 100.0, 0.0)]
+UVS = [(0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (1.0, 1.0)]
+NORMAL = (0.0, 0.0, 1.0)
+NO_TEXTURE = 0xFF
+FTYPE_TRIANGLE_STRIP = 6
+
+
+def build_mesh_bin(bones, weights, weight_indices):
+    """The bytes of a one-quad mesh .bin carrying exactly this bone table.
+
+    `bones` is [(bone_id, parent, x, y, z)] as the file stores them, repeated
+    ids included; `weights` is [(bone_ids, percents, count)]; and
+    `weight_indices` is one index into `weights` per corner.
+    """
+    assert len(weight_indices) == len(POSITIONS)
+
+    dst_bin = Re4UhdBin()
+    dst_bin.header = dst_bin.UhdBinHeader(_parent=dst_bin, _root=dst_bin._root)
+    for attribute in ("offset_bones", "unk_00", "unk_01", "offset_vertex_colors",
+                      "offset_vertex_texcoord", "offset_weights", "num_weights",
+                      "num_bones", "num_materials", "offset_materials",
+                      "flags", "num_tpl", "vertex_scale", "unk_02", "num_weights2",
+                      "offset_morphs", "offset_vertex_position", "offset_vertex_normals",
+                      "num_vertices", "num_vertex_normals", "version_flags",
+                      "offset_bonepairs", "offset_adjacents", "offset_index_buffer",
+                      "offset_index_buffer2"):
+        setattr(dst_bin.header, attribute, 0)
+
+    dst_bin.bones = [_bone(dst_bin, *entry) for entry in bones]
+    dst_bin.weights = [_weight(dst_bin, *entry) for entry in weights]
+    dst_bin.vertex_positions = mesh._serialize_vec3s(dst_bin, POSITIONS)
+    dst_bin.normals = mesh._serialize_normals(dst_bin, [NORMAL] * len(POSITIONS))
+    dst_bin.texcoords = mesh._serialize_uvs(dst_bin, UVS)
+    dst_bin.vertex_colors = mesh._serialize_colors(dst_bin, len(POSITIONS))
+    dst_bin.indexes = list(weight_indices)
+    dst_bin.indexes2 = list(weight_indices)
+    dst_bin.materials = [_material(dst_bin, len(POSITIONS))]
+    return mesh._layout_and_write(dst_bin, len(POSITIONS))
+
+
+def bone_table(bin_bytes):
+    """[(bone id, parent, (x, y, z))] in the order the file writes them."""
+    parsed = Re4UhdBin.from_bytes(bin_bytes)
+    parsed._read()
+    return [(bone.bone_id, bone.parent, (bone.x, bone.y, bone.z)) for bone in parsed.bones]
+
+
+def _bone(dst_bin, bone_id, parent, x, y, z):
+    dst_bone = dst_bin.Bone(_parent=dst_bin, _root=dst_bin._root)
+    dst_bone.bone_id, dst_bone.parent = bone_id, parent
+    dst_bone.x, dst_bone.y, dst_bone.z = x, y, z
+    dst_bone.filler = 0
+    dst_bone._check()
+    return dst_bone
+
+
+def _weight(dst_bin, bone_ids, percents, count):
+    dst_weight = dst_bin.FmtbinWeight(_parent=dst_bin, _root=dst_bin._root)
+    dst_weight.bone_ids = list(bone_ids)
+    dst_weight.weights = list(percents)
+    dst_weight.count = count
+    dst_weight.unk00 = 0
+    dst_weight._check()
+    return dst_weight
+
+
+def _material(dst_bin, corners):
+    dst_material = dst_bin.Material(_parent=dst_bin, _root=dst_bin._root)
+    for attribute in mesh._MATERIAL_BYTE_FIELDS:
+        setattr(dst_material, attribute, 0)
+    for attribute in mesh._MATERIAL_NO_TEXTURE_FIELDS:
+        setattr(dst_material, attribute, NO_TEXTURE)
+
+    dst_face_index = dst_bin.FaceIndex(_parent=dst_material, _root=dst_bin._root)
+    strip = dst_bin.Strip(_parent=dst_face_index, _root=dst_bin._root)
+    strip.ftype, strip.fcount = FTYPE_TRIANGLE_STRIP, corners
+    strip._check()
+    dst_face_index.strip_count = 1
+    dst_face_index.strips = [strip]
+    dst_face_index.num_triangles = corners - 2
+    # buffer_size is measured from the strip_count word and padded to 16.
+    dst_face_index.buffer_size = mesh._align(8)
+    dst_face_index.padding = b"\x00" * (dst_face_index.buffer_size - 8)
+    dst_face_index._check()
+
+    dst_material.face_index = dst_face_index
+    dst_material._check()
+    return dst_material

--- a/tests/cie/synthetic_bin.py
+++ b/tests/cie/synthetic_bin.py
@@ -4,8 +4,9 @@ Every other RE4UHD test reads a shipped model, which is the right way to
 check albam against the format. It cannot pin down a case the shipped data
 only sometimes contains, though, and a test that skips unless the archive it
 was handed happens to hold one proves nothing on the day it skips. A bone
-table naming the same id twice is such a case: 69 of 738 models have one, and
-none of them is in a dataset a CI run can reach.
+table naming the same id twice is such a case: a minority of models have one,
+and whether any is in a dataset a CI run can reach is not something the test
+should depend on.
 
 Built from the generated struct classes (albam/engines/cie/structs), so what
 this writes is the format definition's own idea of a .bin rather than a

--- a/tests/cie/test_bin_duplicate_bone_ids.py
+++ b/tests/cie/test_bin_duplicate_bone_ids.py
@@ -1,0 +1,286 @@
+"""A RE4UHD bone table may name the same bone id twice.
+
+The scene has one bone per id and no way to hold a second: the weights name
+a bone by id, so do the vertex groups named after them, and so does
+animation retargeting. Import used to make a second bone anyway, which
+Blender uniquified to "5.001" - a bone nothing meant - and export wrote one
+entry per bone, so a table of five entries came back as four. The repeats
+are carried on the mesh instead, in the order the table had them (see
+albam/engines/cie/mesh.py, BONE_IDS_PROPERTY).
+
+Most of this is checked against a model built here rather than a shipped
+one: no dataset a CI run can reach holds a model with a repeated id (see
+tests/cie/synthetic_bin.py). The last test does check shipped models, and
+needs --game-dir.
+"""
+import json
+import os
+
+import bpy
+from mathutils import Vector
+import pytest
+
+from albam.lib import fs_registry
+from tests.conftest import close_new_fs_roots, remove_new_vfs_roots, vfs_root_names
+from tests.cie.lfs_paths import resolve_archive_hashes
+from tests.cie.synthetic_bin import bone_table, build_mesh_bin
+from tests.cie.test_bin_serialization import _is_mesh_bin
+
+DATASETS_DIR = os.path.join(os.path.dirname(__file__), "datasets")
+with open(os.path.join(DATASETS_DIR, "bin_export_fidelity_hashes.json")) as f:
+    EXPORT_FIDELITY_DATASET = json.load(f)
+
+APP_ID = "re4uhd"
+NO_PARENT = 0xFF
+
+# Bone 2 twice, with a different parent and a different offset each time -
+# the two things a repeat can disagree with its twin about. Bone 3 hangs off
+# it, so a table that dropped one of them would still have to name it.
+BONES = [
+    (0, NO_PARENT, 0.0, 0.0, 0.0),
+    (1, 0, 0.0, 100.0, 0.0),
+    (2, 1, 0.0, 100.0, 0.0),
+    (2, 0, 50.0, 0.0, 0.0),
+    (3, 2, 0.0, 100.0, 0.0),
+]
+# Bone 1 is in the table but nothing is weighted to it, which is what makes
+# the recorded ids rather than the weights the thing the table comes from.
+WEIGHTS = [((0, 0, 0), (100, 0, 0), 1), ((2, 0, 0), (100, 0, 0), 1)]
+WEIGHT_INDICES = [0, 0, 1, 1]
+
+
+@pytest.fixture
+def _clean_scene():
+    # vfs, exported and bpy.data are session-scoped state: register() runs
+    # once per pytest session, so a test that leaves objects or roots behind
+    # changes what the next one sees.
+    before = fs_registry.keys()
+    before_roots = vfs_root_names()
+    yield
+    bpy.ops.object.select_all(action="SELECT")
+    bpy.ops.object.delete(use_global=True)
+    remove_new_vfs_roots(before_roots)
+    bpy.context.scene.albam.exported.file_list.clear()
+    close_new_fs_roots(before)
+
+
+def pytest_generate_tests(metafunc):
+    if ("local_app_id" in metafunc.fixturenames and
+            "local_archive_path_hash" in metafunc.fixturenames):
+        argnames = ("local_app_id", "local_archive_path_hash")
+        argvalues = [(d["app_id"], d["archive_path_hash"]) for d in EXPORT_FIDELITY_DATASET]
+        ids = [f"{d['app_id']}-{d['archive_path_hash']}" for d in EXPORT_FIDELITY_DATASET]
+        metafunc.parametrize(argnames, argvalues, ids=ids, scope="session")
+
+
+def _import_bin(tmp_path, bin_bytes, name="repeated_bone_id.bin"):
+    """Import `bin_bytes` the way the add-on does, and return its object.
+
+    Through a directory root rather than a mounted .lfs: the importer reads
+    its bytes off a VirtualFile either way, and building an archive around
+    one model would only be testing the archive.
+    """
+    from albam.engines.cie.mesh import AUTO_TPL
+    from albam.registry import blender_registry
+
+    path = tmp_path / name
+    path.write_bytes(bin_bytes)
+
+    vfs = bpy.context.scene.albam.vfs
+    bpy.context.scene.albam.apps.app_selected = APP_ID
+    vfs.add_real_file(APP_ID, str(tmp_path))
+    vfile = next(vf for vf in vfs.file_list if vf.display_name == name)
+    vfs.file_list_selected_index = vfs.file_list.find(vfile.name)
+    bpy.context.scene.albam.import_options_bin.tpl_file_id = AUTO_TPL
+
+    bl_object = blender_registry.import_registry[(APP_ID, "bin")](vfile, bpy.context)
+    bl_object.albam_asset.app_id = APP_ID
+    bl_object.albam_asset.extension = "bin"
+    bl_object.albam_asset.relative_path = name
+    bl_object.albam_asset.original_bytes = bin_bytes
+    return bl_object
+
+
+def _export(bl_object):
+    from albam.registry import blender_registry
+
+    vfiles = blender_registry.export_registry[(APP_ID, "bin")](bl_object)
+    assert len(vfiles) == 1
+    return vfiles[0].data_bytes
+
+
+def _mesh_of(bl_object):
+    return next(o for o in bl_object.children_recursive if o.type == "MESH")
+
+
+def _armature_of(bl_object):
+    if bl_object.type == "ARMATURE":
+        return bl_object
+    return _mesh_of(bl_object).modifiers["Armature"].object
+
+
+def _identities(table):
+    return [(bone_id, parent) for bone_id, parent, _offset in table]
+
+
+def _offsets(table):
+    """Every entry's offset, flattened - pytest.approx compares a flat
+    sequence of numbers, not a sequence of tuples."""
+    return [coordinate for _bone_id, _parent, offset in table for coordinate in offset]
+
+
+def test_a_repeated_bone_id_is_written_back(tmp_path, _clean_scene):
+    """Both entries come back, each with what it came in with.
+
+    Import made one bone per table entry and export wrote one entry per bone,
+    so the repeat vanished on the way out - and the entry that survived was
+    written with the other one's offset, since the armature bone had taken
+    its position from whichever entry came last.
+    """
+    original = build_mesh_bin(BONES, WEIGHTS, WEIGHT_INDICES)
+    exported = _export(_import_bin(tmp_path, original))
+
+    assert _identities(bone_table(exported)) == _identities(bone_table(original))
+    assert _offsets(bone_table(exported)) == pytest.approx(_offsets(bone_table(original)))
+
+
+@pytest.mark.parametrize("swapped", [False, True])
+def test_repeated_entries_keep_the_order_they_came_in(tmp_path, swapped, _clean_scene):
+    """Not just the count of them.
+
+    The table is written in bone id order, which puts two entries sharing an
+    id next to each other and says nothing about which of the two comes
+    first. That order is the model's, so writing the pair back the other way
+    round would be as wrong as dropping one: it is what tells the two
+    entries apart.
+    """
+    bones = list(BONES)
+    if swapped:
+        bones[2], bones[3] = bones[3], bones[2]
+    original = build_mesh_bin(bones, WEIGHTS, WEIGHT_INDICES)
+    exported = _export(_import_bin(tmp_path, original))
+
+    repeats = [(parent, offset) for bone_id, parent, offset in bone_table(exported)
+               if bone_id == 2]
+    assert [parent for parent, _offset in repeats] == ([0, 1] if swapped else [1, 0])
+    flattened = [coordinate for _parent, offset in repeats for coordinate in offset]
+    assert flattened == pytest.approx(
+        [50.0, 0.0, 0.0, 0.0, 100.0, 0.0] if swapped
+        else [0.0, 100.0, 0.0, 50.0, 0.0, 0.0])
+
+
+def test_the_armature_gets_one_bone_per_id(tmp_path, _clean_scene):
+    """A repeat has nowhere in the scene to go.
+
+    Blender uniquifies a name already taken, so a second bone for id 2 came
+    in as "2.001" - a bone no weight, vertex group or retargeted animation
+    can name, sitting in the armature looking like part of the skeleton.
+    """
+    bl_object = _import_bin(tmp_path, build_mesh_bin(BONES, WEIGHTS, WEIGHT_INDICES))
+
+    names = {bone.name for bone in _armature_of(bl_object).data.bones}
+    assert names == {"0", "1", "2", "3"}
+    assert {group.name for group in _mesh_of(bl_object).vertex_groups} == {"0", "2"}
+
+
+def test_moving_the_bone_moves_the_entry_it_stands_for(tmp_path, _clean_scene):
+    """The model stays editable, and only the repeat is carried verbatim.
+
+    The armature bone stands for the first entry, so moving it is an edit the
+    export sees. The second has no bone of its own to move and goes back as
+    it came in, which is the only answer that does not invent a position for
+    it.
+    """
+    bl_object = _import_bin(tmp_path, build_mesh_bin(BONES, WEIGHTS, WEIGHT_INDICES))
+    armature = _armature_of(bl_object)
+
+    bpy.context.view_layer.objects.active = armature
+    bpy.ops.object.mode_set(mode="EDIT")
+    moved = armature.data.edit_bones["2"]
+    moved.head = moved.head + Vector((0.0, 0.0, 0.5))
+    moved.tail = moved.tail + Vector((0.0, 0.0, 0.5))
+    bpy.ops.object.mode_set(mode="OBJECT")
+
+    repeats = [(parent, offset) for bone_id, parent, offset
+               in bone_table(_export(bl_object)) if bone_id == 2]
+    assert len(repeats) == 2
+    assert repeats[0][0] == 1 and repeats[1][0] == 0
+    # 0.5 Blender metres is 500 of the millimetres the file counts in, and
+    # the file's y is Blender's z.
+    assert list(repeats[0][1]) == pytest.approx([0.0, 600.0, 0.0])
+    assert list(repeats[1][1]) == pytest.approx([50.0, 0.0, 0.0])
+
+
+def test_a_scene_saved_before_this_still_writes_every_entry(tmp_path, _clean_scene):
+    """A .blend saved by an older albam comes back with the repeat.
+
+    Such a scene has the ids and parents its model was imported with but no
+    offsets, and an armature holding the "2.001" that import used to make.
+    Both entries still have to be written, and the leftover bone must not
+    become a bone of its own: read as its position in the armature it stood
+    for some other id entirely.
+    """
+    from albam.engines.cie.mesh import BONE_OFFSETS_PROPERTY
+
+    bl_object = _import_bin(tmp_path, build_mesh_bin(BONES, WEIGHTS, WEIGHT_INDICES))
+    del _mesh_of(bl_object)[BONE_OFFSETS_PROPERTY]
+
+    armature = _armature_of(bl_object)
+    bpy.context.view_layer.objects.active = armature
+    bpy.ops.object.mode_set(mode="EDIT")
+    twin = armature.data.edit_bones["2"]
+    leftover = armature.data.edit_bones.new("2")
+    leftover.head, leftover.tail, leftover.parent = twin.head, twin.tail, twin.parent
+    bpy.ops.object.mode_set(mode="OBJECT")
+    assert "2.001" in armature.data.bones, "this is what the older importer left behind"
+
+    assert _identities(bone_table(_export(bl_object))) == _identities(bone_table(
+        build_mesh_bin(BONES, WEIGHTS, WEIGHT_INDICES)))
+
+
+def test_shipped_models_with_a_repeated_bone_id_round_trip(
+        game_root, local_app_id, local_archive_path_hash, _clean_scene):
+    """The same thing, against whatever the game actually ships.
+
+    Needs --game-dir. Every mesh model of the archive is imported and
+    exported unedited, and the ones whose table repeats an id have to come
+    back with that table entry for entry - which is the case
+    tests/tools/cie_build_mod.py refuses to put in an archive.
+    """
+    from albam.engines.cie.mesh import AUTO_TPL
+    from albam.registry import blender_registry
+
+    archive_path = resolve_archive_hashes(
+        game_root, {local_archive_path_hash})[local_archive_path_hash]
+
+    vfs = bpy.context.scene.albam.vfs
+    bpy.context.scene.albam.apps.app_selected = local_app_id
+    root = vfs.add_real_file(local_app_id, archive_path)
+    models = [vf for vf in vfs.file_list
+              if vf.tree_node.root_id == root.name and not vf.is_root and
+              vf.display_name.lower().endswith(".bin") and _is_mesh_bin(vf.get_bytes())]
+    assert models, "this archive should hold a mesh .bin"
+
+    import_function = blender_registry.import_registry[(local_app_id, "bin")]
+    bpy.context.scene.albam.import_options_bin.tpl_file_id = AUTO_TPL
+
+    repeated = []
+    for vfile in models:
+        original_bytes = vfile.get_bytes()
+        ids = [bone_id for bone_id, _parent, _offset in bone_table(original_bytes)]
+        if len(set(ids)) == len(ids):
+            continue
+        vfs.file_list_selected_index = vfs.file_list.find(vfile.name)
+        bl_object = import_function(vfile, bpy.context)
+        bl_object.albam_asset.app_id = local_app_id
+        bl_object.albam_asset.extension = "bin"
+        bl_object.albam_asset.relative_path = vfile.display_name
+        bl_object.albam_asset.original_bytes = original_bytes
+        exported_bytes = _export(bl_object)
+        assert _identities(bone_table(exported_bytes)) == _identities(
+            bone_table(original_bytes)), (
+            f"{vfile.display_name} did not write back the bone table it came with")
+        repeated.append(vfile.display_name)
+
+    if not repeated:
+        pytest.skip(f"none of this archive's {len(models)} models repeats a bone id")

--- a/tests/cie/test_bin_duplicate_bone_ids.py
+++ b/tests/cie/test_bin_duplicate_bone_ids.py
@@ -88,8 +88,13 @@ def _import_bin(tmp_path, bin_bytes, name="repeated_bone_id.bin"):
 
     vfs = bpy.context.scene.albam.vfs
     bpy.context.scene.albam.apps.app_selected = APP_ID
+    before = vfs_root_names()
     vfs.add_real_file(APP_ID, str(tmp_path))
-    vfile = next(vf for vf in vfs.file_list if vf.display_name == name)
+    # Scoped to the root this call added: another test's leftover root can
+    # hold a file of the same name, and tests do not run in a fixed order.
+    added = vfs_root_names() - before
+    vfile = next(vf for vf in vfs.file_list
+                 if vf.display_name == name and vf.tree_node.root_id in added)
     vfs.file_list_selected_index = vfs.file_list.find(vfile.name)
     bpy.context.scene.albam.import_options_bin.tpl_file_id = AUTO_TPL
 

--- a/tests/cie/test_bin_duplicate_bone_ids.py
+++ b/tests/cie/test_bin_duplicate_bone_ids.py
@@ -20,8 +20,7 @@ import bpy
 from mathutils import Vector
 import pytest
 
-from albam.lib import fs_registry
-from tests.conftest import close_new_fs_roots, remove_new_vfs_roots, vfs_root_names
+from tests.conftest import vfs_root_names
 from tests.cie.lfs_paths import resolve_archive_hashes
 from tests.cie.synthetic_bin import bone_table, build_mesh_bin
 from tests.cie.test_bin_serialization import _is_mesh_bin
@@ -47,21 +46,6 @@ BONES = [
 # the recorded ids rather than the weights the thing the table comes from.
 WEIGHTS = [((0, 0, 0), (100, 0, 0), 1), ((2, 0, 0), (100, 0, 0), 1)]
 WEIGHT_INDICES = [0, 0, 1, 1]
-
-
-@pytest.fixture
-def _clean_scene():
-    # vfs, exported and bpy.data are session-scoped state: register() runs
-    # once per pytest session, so a test that leaves objects or roots behind
-    # changes what the next one sees.
-    before = fs_registry.keys()
-    before_roots = vfs_root_names()
-    yield
-    bpy.ops.object.select_all(action="SELECT")
-    bpy.ops.object.delete(use_global=True)
-    remove_new_vfs_roots(before_roots)
-    bpy.context.scene.albam.exported.file_list.clear()
-    close_new_fs_roots(before)
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/cie/test_bin_duplicate_bone_ids.py
+++ b/tests/cie/test_bin_duplicate_bone_ids.py
@@ -253,6 +253,42 @@ def test_a_scene_saved_before_this_still_writes_every_entry(tmp_path, _clean_sce
         build_mesh_bin(BONES, WEIGHTS, WEIGHT_INDICES)))
 
 
+def test_the_repeats_survive_a_trip_through_a_blend_file(tmp_path, _clean_scene):
+    """Saved and read back, the model still writes its own table.
+
+    Blender has to be the one holding this between sessions, so the repeats
+    are kept as plain custom properties on the mesh - the same kind of value
+    a .blend already stores for the ids and parents beside them. Written to a
+    library and appended back rather than saved and reopened as the main
+    file: that is the same trip through the .blend format, without resetting
+    the session every other test is sharing.
+    """
+    original = build_mesh_bin(BONES, WEIGHTS, WEIGHT_INDICES)
+    bl_object = _import_bin(tmp_path, original)
+    library = str(tmp_path / "saved.blend")
+    bpy.data.libraries.write(library, {bl_object, _mesh_of(bl_object)})
+
+    before = set(bpy.data.objects)
+    with bpy.data.libraries.load(library) as (source, target):
+        target.objects = list(source.objects)
+    loaded = [bl_ob for bl_ob in bpy.data.objects if bl_ob not in before]
+    for bl_ob in loaded:
+        bpy.context.collection.objects.link(bl_ob)
+
+    reloaded = next(bl_ob for bl_ob in loaded if bl_ob.type == "ARMATURE")
+    assert _mesh_of(reloaded).modifiers["Armature"].object is reloaded, (
+        "the appended mesh should be bound to the appended armature, not the original")
+    reloaded.albam_asset.app_id = APP_ID
+    reloaded.albam_asset.extension = "bin"
+    reloaded.albam_asset.relative_path = "repeated_bone_id.bin"
+    reloaded.albam_asset.original_bytes = original
+
+    exported = bone_table(_export(reloaded))
+    assert _identities(exported) == _identities(bone_table(original))
+    # The repeat is written back from what was saved, so it is bit-exact.
+    assert exported[3][2] == bone_table(original)[3][2]
+
+
 def test_shipped_models_with_a_repeated_bone_id_round_trip(
         game_root, local_app_id, local_archive_path_hash, _clean_scene):
     """The same thing, against whatever the game actually ships.

--- a/tests/cie/test_bin_duplicate_bone_ids.py
+++ b/tests/cie/test_bin_duplicate_bone_ids.py
@@ -144,6 +144,21 @@ def test_a_repeated_bone_id_is_written_back(tmp_path, _clean_scene):
     assert _offsets(bone_table(exported)) == pytest.approx(_offsets(bone_table(original)))
 
 
+def test_a_table_without_repeats_is_unchanged(tmp_path, _clean_scene):
+    """The control: carrying the repeats must not move anything else.
+
+    Every entry of a table with no repeat is written from the armature bone
+    it stands for, exactly as before, so a model the old code round-tripped
+    has to come out the same way.
+    """
+    bones = [entry for entry in BONES if entry[:2] != (2, 0)]
+    original = build_mesh_bin(bones, WEIGHTS, WEIGHT_INDICES)
+    exported = _export(_import_bin(tmp_path, original))
+
+    assert _identities(bone_table(exported)) == _identities(bone_table(original))
+    assert _offsets(bone_table(exported)) == pytest.approx(_offsets(bone_table(original)))
+
+
 @pytest.mark.parametrize("swapped", [False, True])
 def test_repeated_entries_keep_the_order_they_came_in(tmp_path, swapped, _clean_scene):
     """Not just the count of them.
@@ -264,22 +279,37 @@ def test_shipped_models_with_a_repeated_bone_id_round_trip(
     import_function = blender_registry.import_registry[(local_app_id, "bin")]
     bpy.context.scene.albam.import_options_bin.tpl_file_id = AUTO_TPL
 
+    # Every model, in order, not only the ones with a repeat: import binds a
+    # model to an armature another already brought in, and a repeated id has
+    # to survive that too.
     repeated = []
     for vfile in models:
+        vfs.file_list_selected_index = vfs.file_list.find(vfile.name)
         original_bytes = vfile.get_bytes()
-        ids = [bone_id for bone_id, _parent, _offset in bone_table(original_bytes)]
+        bl_object = import_function(vfile, bpy.context)
+        original = bone_table(original_bytes)
+        ids = [bone_id for bone_id, _parent, _offset in original]
         if len(set(ids)) == len(ids):
             continue
-        vfs.file_list_selected_index = vfs.file_list.find(vfile.name)
-        bl_object = import_function(vfile, bpy.context)
+
         bl_object.albam_asset.app_id = local_app_id
         bl_object.albam_asset.extension = "bin"
         bl_object.albam_asset.relative_path = vfile.display_name
         bl_object.albam_asset.original_bytes = original_bytes
-        exported_bytes = _export(bl_object)
-        assert _identities(bone_table(exported_bytes)) == _identities(
-            bone_table(original_bytes)), (
+        exported = bone_table(_export(bl_object))
+        assert _identities(exported) == _identities(original), (
             f"{vfile.display_name} did not write back the bone table it came with")
+
+        # A repeat is written back verbatim, so it matches to the bit - unlike
+        # an entry read off an armature bone, whose position has been through
+        # Blender's floats and back.
+        counted = {}
+        for (bone_id, _parent, offset), (_id, _p, written) in zip(original, exported):
+            occurrence = counted.get(bone_id, 0)
+            counted[bone_id] = occurrence + 1
+            if occurrence:
+                assert written == offset, (
+                    f"{vfile.display_name} moved a repeated entry for bone {bone_id}")
         repeated.append(vfile.display_name)
 
     if not repeated:

--- a/tests/cie/test_bin_export_fidelity.py
+++ b/tests/cie/test_bin_export_fidelity.py
@@ -291,9 +291,10 @@ def test_model_sharing_an_armature_exports_its_own_bones(
         "no bone should be written that the model did not have")
     assert weighted <= set(exported_ids), (
         "every bone the weights name has to be in the table")
-    if len(set(original_ids)) == len(original_ids):
-        assert exported_ids == sorted(original_ids), (
-            "an unedited model should write back the bone table it came with")
+    # A table naming the same id twice was exempt from this until the repeats
+    # were carried through import - see tests/cie/test_bin_duplicate_bone_ids.py.
+    assert exported_ids == sorted(original_ids), (
+        "an unedited model should write back the bone table it came with")
     assert exported_ids == sorted(exported_ids), "the table is written in bone id order"
     # A bone names its parent by id, so a table that dropped one would leave
     # the bones under it unable to say where they hang from.

--- a/tests/cie/test_bin_export_fidelity.py
+++ b/tests/cie/test_bin_export_fidelity.py
@@ -18,8 +18,6 @@ import shutil
 import bpy
 import pytest
 
-from albam.lib import fs_registry
-from tests.conftest import close_new_fs_roots, remove_new_vfs_roots, vfs_root_names
 from tests.cie.lfs_paths import resolve_archive_hashes
 from tests.cie.test_bin_serialization import _is_mesh_bin, _texture_slots
 
@@ -51,21 +49,6 @@ def test_dataset_hashes_are_in_catalog():
         assert entry["archive_path_hash"] in catalog, (
             f"{entry['archive_path_hash']!r} is not in {catalog_path!r}"
         )
-
-
-@pytest.fixture
-def _clean_scene():
-    # vfs, exported and bpy.data are session-scoped state: register() runs
-    # once per pytest session, so a test that leaves objects or roots behind
-    # changes what the next one sees.
-    before = fs_registry.keys()
-    before_roots = vfs_root_names()
-    yield
-    bpy.ops.object.select_all(action="SELECT")
-    bpy.ops.object.delete(use_global=True)
-    remove_new_vfs_roots(before_roots)
-    bpy.context.scene.albam.exported.file_list.clear()
-    close_new_fs_roots(before)
 
 
 @pytest.fixture

--- a/tests/cie/test_bin_serialization.py
+++ b/tests/cie/test_bin_serialization.py
@@ -19,8 +19,6 @@ import os
 import bpy
 import pytest
 
-from albam.lib import fs_registry
-from tests.conftest import close_new_fs_roots, remove_new_vfs_roots, vfs_root_names
 from tests.cie.lfs_paths import resolve_archive_hashes
 
 DATASETS_DIR = os.path.join(os.path.dirname(__file__), "datasets")
@@ -51,21 +49,6 @@ def test_dataset_hashes_are_in_catalog():
         assert entry["archive_path_hash"] in catalog, (
             f"{entry['archive_path_hash']!r} is not in {catalog_path!r}"
         )
-
-
-@pytest.fixture
-def _clean_scene():
-    # vfs, exported and bpy.data are session-scoped state: register() runs
-    # once per pytest session, so a test that leaves objects or roots behind
-    # changes what the next one sees.
-    before = fs_registry.keys()
-    before_roots = vfs_root_names()
-    yield
-    bpy.ops.object.select_all(action="SELECT")
-    bpy.ops.object.delete(use_global=True)
-    remove_new_vfs_roots(before_roots)
-    bpy.context.scene.albam.exported.file_list.clear()
-    close_new_fs_roots(before)
 
 
 def _is_mesh_bin(data):

--- a/tests/cie/test_scenario_parsing.py
+++ b/tests/cie/test_scenario_parsing.py
@@ -20,8 +20,6 @@ import os
 import bpy
 import pytest
 
-from albam.lib import fs_registry
-from tests.conftest import close_new_fs_roots, remove_new_vfs_roots, vfs_root_names
 from tests.cie.lfs_paths import resolve_archive_hashes
 
 DATASETS_DIR = os.path.join(os.path.dirname(__file__), "datasets")
@@ -78,21 +76,6 @@ def scenarios(archive_path):
         fs.close()
     assert found, "a room archive in this dataset should hold at least one scenario"
     return found
-
-
-@pytest.fixture
-def _clean_scene():
-    # bpy.data and the VFS are session-scoped state: register() runs once per
-    # pytest session, so a test leaving objects or roots behind changes what
-    # the next one sees.
-    before = fs_registry.keys()
-    before_roots = vfs_root_names()
-    yield
-    bpy.ops.object.select_all(action="SELECT")
-    bpy.ops.object.delete(use_global=True)
-    remove_new_vfs_roots(before_roots)
-    bpy.context.scene.albam.exported.file_list.clear()
-    close_new_fs_roots(before)
 
 
 def _parse(data):


### PR DESCRIPTION
## Intent

Implement albam issue #265, "RE4UHD: models with duplicate bone ids cannot be exported faithfully" (https://github.com/Brachi/albam/issues/265).

The captain's ask, in the substance of that issue (which the captain wrote):

A bone table may name the same bone id twice. Import creates vertex groups named after bone ids, so the two collapse into one and the distinction is gone before export sees it.

69 of 738 models are affected. `tests/tools/cie_build_mod.py` keeps their original bytes rather than shipping them wrong, so the failure is contained, but those models cannot be edited.

Fixing it means carrying the duplicate ids through import in a form export can read back - the bone table is written in bone id order, so the two entries also have to keep their original relative order.

The captain, going away for the night, asked firstmate to work the board by value and named RE4 UHD as the focus.

## What Changed

- Import now records the model's own bone table entry-for-entry on the mesh: alongside `cie.bone_ids`/`cie.bone_parents`, a new `cie.bone_offsets` property stores each entry's raw parent-relative x/y/z. The armature still gets one bone per id (repeats are skipped when building bones, parents and world positions), so the repeated entries survive on the mesh instead of collapsing into one vertex group.
- Export rebuilds the table from that record: `_own_bone_ids`/`_own_bone_parents` are replaced by `_own_bone_table`, which returns `{bone id: [(parent, offset), ...]}` in original occurrence order, and `_serialize_bones` expands a bone into one entry per recorded occurrence — the first written from the scene's bone, later ones written back verbatim from the recorded offset. `_bones_to_write` now emits one bone per id, and `_bone_id` strips Blender's `.001` suffix so scenes saved before this change do not read a duplicate bone as some other bone's id.
- Adds `tests/cie/synthetic_bin.py`, which builds a mesh `.bin` in memory from the generated structs so a duplicate-id table can be tested without depending on the shipped corpus, plus `tests/cie/test_bin_duplicate_bone_ids.py` covering round-trip fidelity, tables without repeats, verbatim repeats on shipped models, and survival across a `.blend` save/load; the shared `_clean_scene` fixture moves into `tests/cie/conftest.py`. The CHANGELOG records the fix and the "does not work yet" entry is removed from `docs/modding-a-character.md`.

## Risk Assessment

✅ Low: The fix is narrow and well-bounded — it adds one recorded custom property and a per-occurrence expansion at a single serialization site, does not disturb any positionally-indexed structure, satisfies the intent's carry-through and relative-order requirements, and is backed by behavior-level tests (synthetic model plus a shipped-model round-trip) rather than source-text assertions; the only separable scope question was already raised and deliberately kept by the user.

## Testing

I stood the add-on up in Blender 5.2 (bpy 5.2.0) and drove it as a modder would against a real Resident Evil 4 UHD install: mounting a shipped .udas.lfs file, selecting the model whose bone table names id 0 twice, and pressing Import then Export through albam's own operators. On the target commit the 118-entry table comes back with 118 entries, both id-0 rows in their original order with their original offsets, and the armature holds 117 bones with no Blender-uniquified "0.001" left behind; running the identical driver with the base commit's mesh.py restored gives 117 entries and the phantom bone, so the reported failure is genuinely reproduced before and fixed after. I also ran the maintainer tool tests/tools/cie_build_mod.py, whose ground-truth gate is what the issue cites: before the fix it reported "bones 24/25 reproduced" and kept model 7's original bytes out of the edited archive; after, it reproduces 25/25 and writes every model into the scaled C_stored archive — the model is editable again. Order, in-place edits, an older .blend with a leftover duplicate bone, and a save/append trip through the .blend format were exercised through the new test module running the real import/export path in Blender, and the whole cie area (152 tests against real game data) still passes with no regression for tables that have no repeat. This change has no UI surface, so evidence is CLI transcripts of the real import/export rather than screenshots.

- Live validation: ✅ go - 9 of 9 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A modder imports a shipped RE4 UHD model whose bone table names id 0 twice and exports it unedited; the file that comes out has all 118 entries, not 117 | ✅ pass | live | drive_re4uhd_repeat.py against ~/Games/Resident Evil 4, a shipped .udas.lfs file, model pl00_007.bin, via bpy.ops.albam.import_vfile()/bpy.ops.albam.export() — after-fix-real-game-roundtrip.txt |
| The repeated entry no longer appears in the armature as a phantom bone nothing can name (&#34;0.001&#34;) | ✅ pass | live | Same live drive: armature reports 117 bones and no uniquified names after the fix, versus 118 bones including &#39;0.001&#39; on the base commit — after-fix / before-fix-real-game-roundtrip.txt |
| The two entries sharing an id come back in their original relative order with their own offsets, not swapped or merged | ✅ pass | live | Live drive prints bone 0 in/out as parent=255 (0,0,0) then parent=255 (-0,1140,0) in both directions; plus `pytest tests/cie/test_bin_duplicate_bone_ids.py::test_repeated_entries_keep_the_order_they_c… |
| Adversarial: the pre-fix code must actually fail this — the test reproduces the reported bug | ✅ pass | live | Base 25127af mesh.py restored: live drive exports 117 entries and drops one bone-0 row; new test module reports 8 failed, 1 passed — before-fix-real-game-roundtrip.txt, before-fix-new-tests.txt |
| A model that could not be edited before is now editable: cie_build_mod.py stops keeping its original bytes and ships it in the scaled archive | ✅ pass | live | tests/tools/cie_build_mod.py on a shipped .udas.lfs file: before &#34;bones 24/25 reproduced&#34; + &#34;keeping the original bytes for 1 model(s): [7]&#34;; after &#34;bones 25/25 reproduced&#34; and C_stored built with every model —… |
| Adversarial control: a model with no repeated id is written back exactly as before, so the carry does not disturb anything else | ✅ pass | live | The other 24 models in pl00 reproduce their bone tables in the build-mod gate before and after; `pytest tests/cie -q --game-dir=re4uhd::...` 152 passed, 29 skipped; test_a_table_without_repeats_is_unc… |
| A modder moves the bone that stands for the first entry and exports: the edit is written, the repeat still goes back verbatim | ✅ pass | live | `pytest tests/cie/test_bin_duplicate_bone_ids.py::test_moving_the_bone_moves_the_entry_it_stands_for` — real Blender edit-mode move through the add-on&#39;s export path |
| A .blend saved by an older albam (offset-less, with a leftover &#34;2.001&#34; bone) still exports every table entry and does not treat the leftover as a bone of its own | ✅ pass | live | `pytest tests/cie/test_bin_duplicate_bone_ids.py::test_a_scene_saved_before_this_still_writes_every_entry` — real bpy armature edited to recreate the old-importer state, exported through the add-on |
| The carried repeats survive being saved into a .blend and read back, so the model is still exportable in a later session | ✅ pass | live | `pytest tests/cie/test_bin_duplicate_bone_ids.py::test_the_repeats_survive_a_trip_through_a_blend_file` — bpy.data.libraries.write/load round trip, repeat compared bit-exact |

<details>
<summary>Evidence: cie_build_mod gate, before vs after: model 7 goes from un-editable to shipped</summary>

<code>=== BEFORE the fix (base 25127af) ===&#10;25 mesh models in a shipped .udas.lfs file&#10;GATE: no-edit re-export vs original, 25 models&#10;bones 24/25 reproduced &lt;-- FAILED&#10;slots 25/25 reproduced&#10;materials 25/25 reproduced&#10;model 7 bones: want [(0, 255), (0, 255), (1, 0), (2, 1), ...&#10;model 7 bones: got [(0, 255), (1, 0), (2, 1), (3, 2), ...&#10;&#10;keeping the original bytes for 1 model(s): [7]&#10;&#10;=== AFTER the fix (4b26dc3) ===&#10;25 mesh models in a shipped .udas.lfs file&#10;GATE: no-edit re-export vs original, 25 models&#10;bones 25/25 reproduced&#10;slots 25/25 reproduced&#10;materials 25/25 reproduced&#10;(no &#34;keeping the original bytes&#34; line: every model went into the edited archive)&#10;C_stored 743190 bytes (every model scaled 1.6x)</code>

```text
=== BEFORE the fix (albam/engines/cie/mesh.py at base 25127af) ===
25 mesh models in a shipped .udas.lfs file
GATE: no-edit re-export vs original, 25 models
  bones      24/25 reproduced   <-- FAILED
  slots      25/25 reproduced
  materials  25/25 reproduced
    model 7 bones: want [(0, 255), (0, 255), (1, 0), (2, 1), (3, 2), (4, 3), (5, 2), (6, 5), (
    model 7 bones: got  [(0, 255), (1, 0), (2, 1), (3, 2), (4, 3), (5, 2), (6, 5), (7, 5), (8,

keeping the original bytes for 1 model(s): [7]

=== AFTER the fix (4b26dc3) ===
25 mesh models in a shipped .udas.lfs file
GATE: no-edit re-export vs original, 25 models
  bones      25/25 reproduced
  slots      25/25 reproduced
  materials  25/25 reproduced
  (no "keeping the original bytes" line: every model went into the edited archive)
C_stored 743190 bytes (every model scaled 1.6x)
```
</details>
<details>
<summary>Evidence: Import/Export operators on the real shipped model, after the fix</summary>

<code>model : pl00_007.bin&#10;bone table : 118 entries, id(s) named twice: [0]&#10;Info: Import successful&#10;armature : 117 bones, names Blender had to uniquify: none&#10;Info: Export successful&#10;exported : 118 entries&#10;bone 0 in : parent=255 offset=(0.0, 0.0, 0.0) | parent=255 offset=(-0.0, 1140.0, 0.0)&#10;bone 0 out: parent=255 offset=(0.0, 0.0, 0.0) | parent=255 offset=(-0.0, 1140.0, 0.0)&#10;identical entry-for-entry (id, parent): True&#10;&#10;RESULT: OK</code>

```text
game install : ~/Games/Resident Evil 4
archive      : a shipped .udas.lfs file

model        : pl00_007.bin
bone table   : 118 entries, id(s) named twice: [0]
TPL is: pl00_003.tpl
Reading texture pack a shipped .pack file.yz2.lfs
[re4uhd] weights: 98 verts, 1 vertex groups
Info: Import successful
armature     : 117 bones, names Blender had to uniquify: none
vertex groups: 1
Info: Export successful
exported     : 118 entries
  bone 0 in : parent=255 offset=(0.0, 0.0, 0.0) | parent=255 offset=(-0.0, 1140.0, 0.0)
  bone 0 out: parent=255 offset=(0.0, 0.0, 0.0) | parent=255 offset=(-0.0, 1140.0, 0.0)
  identical entry-for-entry (id, parent): True

RESULT: OK
```
</details>
<details>
<summary>Evidence: Same drive against the base commit: the reported failure</summary>

<code>model : pl00_007.bin&#10;bone table : 118 entries, id(s) named twice: [0]&#10;armature : 118 bones, names Blender had to uniquify: [&#39;0.001&#39;]&#10;exported : 117 entries&#10;bone 0 in : parent=255 offset=(0.0, 0.0, 0.0) | parent=255 offset=(-0.0, 1140.0, 0.0)&#10;bone 0 out: parent=255 offset=(-0.0, 1140.0, 0.0)&#10;identical entry-for-entry (id, parent): False&#10;&#10;RESULT: 1 MODEL(S) WRONG</code>

```text
game install : ~/Games/Resident Evil 4
archive      : a shipped .udas.lfs file

model        : pl00_007.bin
bone table   : 118 entries, id(s) named twice: [0]
TPL is: pl00_003.tpl
Reading texture pack a shipped .pack file.yz2.lfs
[re4uhd] weights: 98 verts, 1 vertex groups
Info: Import successful
armature     : 118 bones, names Blender had to uniquify: ['0.001']
vertex groups: 1
Info: Export successful
exported     : 117 entries
  bone 0 in : parent=255 offset=(0.0, 0.0, 0.0) | parent=255 offset=(-0.0, 1140.0, 0.0)
  bone 0 out: parent=255 offset=(-0.0, 1140.0, 0.0)
  identical entry-for-entry (id, parent): False

RESULT: 1 MODEL(S) WRONG
```
</details>
<details>
<summary>Evidence: Driver script used to drive the add-on operators end to end</summary>

```text
"""Drive albam the way a modder does: mount a real RE4 UHD archive, import a
model whose bone table names the same bone id twice through the add-on's own
import operator, export it back through the export operator, and print the
bone table that came out beside the one that went in.
"""
import os
import sys

import bpy

sys.path.insert(0, os.environ["ALBAM_REPO"])

from albam import register  # noqa: E402
from tests.cie.lfs_paths import resolve_archive_hashes  # noqa: E402
from tests.cie.synthetic_bin import bone_table  # noqa: E402
from tests.cie.test_bin_serialization import _is_mesh_bin  # noqa: E402

ARCHIVE_HASH = "fd8d767380c71f51"
APP_ID = "re4uhd"

register()
game_root = os.environ["GAME_DIR"]
archive = resolve_archive_hashes(game_root, {ARCHIVE_HASH})[ARCHIVE_HASH]
print(f"game install : {game_root}")
print(f"archive      : {os.path.relpath(archive, game_root)}")

vfs = bpy.context.scene.albam.vfs
bpy.context.scene.albam.apps.app_selected = APP_ID
root = vfs.add_real_file(APP_ID, archive)
from albam.engines.cie.mesh import AUTO_TPL  # noqa: E402
bpy.context.scene.albam.import_options_bin.tpl_file_id = AUTO_TPL

models = [vf for vf in vfs.file_list
          if vf.tree_node.root_id == root.name and not vf.is_root
          and vf.display_name.lower().endswith(".bin") and _is_mesh_bin(vf.get_bytes())]

failures = 0
for vfile in models:
    original_bytes = vfile.get_bytes()
    original = bone_table(original_bytes)
    ids = [bone_id for bone_id, _p, _o in original]
    repeated = sorted({i for i in ids if ids.count(i) > 1})
    if not repeated:
        continue

    print(f"\nmodel        : {vfile.display_name}")
    print(f"bone table   : {len(original)} entries, id(s) named twice: {repeated}")

    # As a user: select it in the file list and press Import.
    vfs.file_list_selected_index = vfs.file_list.find(vfile.name)
    assert bpy.ops.albam.import_vfile() == {"FINISHED"}, "import operator failed"

    exportable = bpy.context.scene.albam.exportable.file_list
    exportable_index = len(exportable) - 1
    bpy.context.scene.albam.exportable.file_list_selected_index = exportable_index
    bl_object = exportable[exportable_index].bl_object
    armature = bl_object if bl_object.type == "ARMATURE" else None
    mesh_obj = next(o for o in bl_object.children_recursive if o.type == "MESH")
    if armature is None:
        armature = mesh_obj.modifiers["Armature"].object
    leftovers = sorted(b.name for b in armature.data.bones if "." in b.name)
    print(f"armature     : {len(armature.data.bones)} bones, "
          f"names Blender had to uniquify: {leftovers or 'none'}")
    print(f"vertex groups: {len(mesh_obj.vertex_groups)}")

    # As a user: press Export.
    assert bpy.ops.albam.export() == {"FINISHED"}, "export operator failed"
    exported_root = bpy.context.scene.albam.exported.file_list
    exported_vf = next(vf for vf in reversed(exported_root)
                       if vf.display_name.lower().endswith(".bin"))
    exported = bone_table(exported_vf.get_bytes())

    print(f"exported     : {len(exported)} entries")
    for bone_id in repeated:
        before = [(p, o) for i, p, o in original if i == bone_id]
        after = [(p, o) for i, p, o in exported if i == bone_id]
        print(f"  bone {bone_id} in : " + " | ".join(
            f"parent={p} offset=({o[0]:.1f}, {o[1]:.1f}, {o[2]:.1f})" for p, o in before))
        print(f"  bone {bone_id} out: " + " | ".join(
            f"parent={p} offset=({o[0]:.1f}, {o[1]:.1f}, {o[2]:.1f})" for p, o in after)
              if after else f"  bone {bone_id} out: MISSING")
    same_identity = ([(i, p) for i, p, _o in exported] == [(i, p) for i, p, _o in original])
    print(f"  identical entry-for-entry (id, parent): {same_identity}")
    failures += 0 if same_identity else 1

print(f"\nRESULT: {'OK' if failures == 0 else str(failures) + ' MODEL(S) WRONG'}")
sys.exit(1 if failures else 0)
```
</details>
<details>
<summary>Evidence: New tests against the pre-fix mesh.py (regression reproduced; the no-repeat control still passes)</summary>

<code>8 failed, 1 passed, 2 skipped in 8.73s&#10;(passing one: test_a_table_without_repeats_is_unchanged)</code>

```text
=============================== warnings summary ===============================
tests/cie/test_bin_duplicate_bone_ids.py: 80 warnings
  ~/.no-mistakes/worktrees/731f537710a6/01M2302YVHB94DJDB22XQAC4ZT/albam/engines/cie/material.py:22: DeprecationWarning: 'Material.use_nodes' is expected to be removed in Blender 6.0
    blender_material.use_nodes = True

tests/cie/test_bin_duplicate_bone_ids.py: 28 warnings
  ~/.no-mistakes/worktrees/731f537710a6/01M2302YVHB94DJDB22XQAC4ZT/albam/engines/cie/mesh.py:1103: DeprecationWarning: 'Material.use_nodes' is expected to be removed in Blender 6.0
    if not bl_material.use_nodes:

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED tests/cie/test_bin_duplicate_bone_ids.py::test_a_repeated_bone_id_is_written_back
FAILED tests/cie/test_bin_duplicate_bone_ids.py::test_repeated_entries_keep_the_order_they_came_in[False]
FAILED tests/cie/test_bin_duplicate_bone_ids.py::test_repeated_entries_keep_the_order_they_came_in[True]
FAILED tests/cie/test_bin_duplicate_bone_ids.py::test_the_armature_gets_one_bone_per_id
FAILED tests/cie/test_bin_duplicate_bone_ids.py::test_moving_the_bone_moves_the_entry_it_stands_for
FAILED tests/cie/test_bin_duplicate_bone_ids.py::test_a_scene_saved_before_this_still_writes_every_entry
FAILED tests/cie/test_bin_duplicate_bone_ids.py::test_the_repeats_survive_a_trip_through_a_blend_file
FAILED tests/cie/test_bin_duplicate_bone_ids.py::test_shipped_models_with_a_repeated_bone_id_round_trip[re4uhd-fd8d767380c71f51]
8 failed, 1 passed, 2 skipped, 108 warnings in 8.73s
```
</details>
<details>
<summary>Evidence: Full cie area against real game data on the target commit</summary>

`152 passed, 29 skipped in 68.00s`

```text
tests/cie/test_bin_duplicate_bone_ids.py: 32 warnings
tests/cie/test_bin_export_fidelity.py: 756 warnings
tests/cie/test_bin_serialization.py: 72 warnings
  ~/.no-mistakes/worktrees/731f537710a6/01M2302YVHB94DJDB22XQAC4ZT/albam/engines/cie/mesh.py:1171: DeprecationWarning: 'Material.use_nodes' is expected to be removed in Blender 6.0
    if not bl_material.use_nodes:

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
152 passed, 29 skipped, 1313 warnings in 68.00s (0:01:07)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"4b26dc3ca3fe8ef4209a101e331446285071bd2c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":9,"total":9}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `CHANGELOG.md` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `albam/engines/cie/mesh.py:53` - Scope: the change carries a second, separable component beyond the stated intent — a migration path for .blend scenes saved by the *older* importer. It is three coupled pieces: BLENDER_NAME_SUFFIX (line 53) with the strip in _bone_id (line 752), the one-bone-per-id dedup in _bones_to_write (lines 819-825), and the offset-less fallback in _own_bone_table / _serialize_bones (a repeat with recorded_offset None is written from the one bone the scene has), plus test_a_scene_saved_before_this_still_writes_every_entry. The intent requires carrying duplicate ids through import so export can read them back; it says nothing about repairing scenes already saved with a leftover &#34;5.001&#34; bone. Removing the component is the remedy if it is out of scope. Two consequences worth deciding on either way: (1) _bone_id now maps any bone whose name ends in exactly &#34;.NNN&#34; to the stripped digits, so a bone a user deliberately duplicated in Blender (&#34;5&#34; -&gt; &#34;5.001&#34;) resolves to id 5 instead of its armature-position fallback, and the _bones_to_write dedup then drops it from the table entirely, folding its vertex-group weights into bone 5&#39;s entry; (2) for an old scene the offset-less fallback writes occurrence 0 and the repeat from the same bone head, so the pair goes back with identical offsets — the code documents this, but it is a silently-approximate table rather than the verbatim one the intent asks for. Both are strictly better than the pre-change behavior, so this is a keep-or-remove question for the author, not a defect.
- ℹ️ `tests/cie/test_bin_duplicate_bone_ids.py:53` - The _clean_scene fixture (lines 52-65) is a verbatim copy of the one in tests/cie/test_bin_export_fidelity.py:57-69, comment included, and both depend on the same tests.conftest helpers. Moving it to tests/cie/conftest.py would remove the duplicate with no behavior change. Note that pytest_generate_tests (lines 68-74), also duplicated, must NOT move to conftest — a dir-level hook would try to parametrize other cie modules that own their own datasets.

🔧 Fix applied.
2 infos still open:

- ℹ️ `albam/engines/cie/mesh.py:883` - In _serialize_bones, occurrence 0 and later occurrences disagree about which source wins when the recorded parent cannot be honored. If `recorded_parent` is neither NO_PARENT nor present in `by_id` (a partial table naming a parent id the model&#39;s own armature has no bone for), the parent field falls back to the armature hierarchy (often NO_PARENT), but for occurrence &gt; 0 the offset is still written verbatim from `recorded_offset` — so that entry&#39;s parent and offset come from different frames of reference. Occurrence 0 stays self-consistent because its offset is recomputed from whichever parent it actually wrote. I could not construct a shipped model with that shape (a repeated id whose repeat names a parent absent from the same table), and if one exists the new test_shipped_models_with_a_repeated_bone_id_round_trip assertion compares parents and would fail rather than ship wrong bytes, and cie_build_mod.py keeps original bytes on any mismatch. Recording it as a bounded asymmetry, not a demonstrated defect.
- ℹ️ `tests/cie/conftest.py:99` - The fix commit (4b26dc3) moved _clean_scene into tests/cie/conftest.py and also removed the copies from tests/cie/test_bin_serialization.py and tests/cie/test_scenario_parsing.py, two files this change never otherwise touches — wider than the round-1 finding, which named only the test_bin_export_fidelity.py copy. I verified all four removed bodies were byte-identical (test_scenario_parsing.py differed only in its comment wording), that fs_registry / close_new_fs_roots / remove_new_vfs_roots / vfs_root_names are unused in each file after removal, that vfs_root_names is correctly kept in test_bin_duplicate_bone_ids.py, and that no other tests/cie module defines or shadows a fixture by that name. Behavior-identical, so no action needed; noting the scope expansion only.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 9 of 9 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A modder imports a shipped RE4 UHD model whose bone table names id 0 twice and exports it unedited; the file that comes out has all 118 entries, not 117 | ✅ pass | live | drive_re4uhd_repeat.py against ~/Games/Resident Evil 4, a shipped .udas.lfs file, model pl00_007.bin, via bpy.ops.albam.import_vfile()/bpy.ops.albam.export() — after-fix-real-game-roundtrip.txt |
| The repeated entry no longer appears in the armature as a phantom bone nothing can name (&#34;0.001&#34;) | ✅ pass | live | Same live drive: armature reports 117 bones and no uniquified names after the fix, versus 118 bones including &#39;0.001&#39; on the base commit — after-fix / before-fix-real-game-roundtrip.txt |
| The two entries sharing an id come back in their original relative order with their own offsets, not swapped or merged | ✅ pass | live | Live drive prints bone 0 in/out as parent=255 (0,0,0) then parent=255 (-0,1140,0) in both directions; plus `pytest tests/cie/test_bin_duplicate_bone_ids.py::test_repeated_entries_keep_the_order_they_c… |
| Adversarial: the pre-fix code must actually fail this — the test reproduces the reported bug | ✅ pass | live | Base 25127af mesh.py restored: live drive exports 117 entries and drops one bone-0 row; new test module reports 8 failed, 1 passed — before-fix-real-game-roundtrip.txt, before-fix-new-tests.txt |
| A model that could not be edited before is now editable: cie_build_mod.py stops keeping its original bytes and ships it in the scaled archive | ✅ pass | live | tests/tools/cie_build_mod.py on a shipped .udas.lfs file: before &#34;bones 24/25 reproduced&#34; + &#34;keeping the original bytes for 1 model(s): [7]&#34;; after &#34;bones 25/25 reproduced&#34; and C_stored built with every model —… |
| Adversarial control: a model with no repeated id is written back exactly as before, so the carry does not disturb anything else | ✅ pass | live | The other 24 models in pl00 reproduce their bone tables in the build-mod gate before and after; `pytest tests/cie -q --game-dir=re4uhd::...` 152 passed, 29 skipped; test_a_table_without_repeats_is_unc… |
| A modder moves the bone that stands for the first entry and exports: the edit is written, the repeat still goes back verbatim | ✅ pass | live | `pytest tests/cie/test_bin_duplicate_bone_ids.py::test_moving_the_bone_moves_the_entry_it_stands_for` — real Blender edit-mode move through the add-on&#39;s export path |
| A .blend saved by an older albam (offset-less, with a leftover &#34;2.001&#34; bone) still exports every table entry and does not treat the leftover as a bone of its own | ✅ pass | live | `pytest tests/cie/test_bin_duplicate_bone_ids.py::test_a_scene_saved_before_this_still_writes_every_entry` — real bpy armature edited to recreate the old-importer state, exported through the add-on |
| The carried repeats survive being saved into a .blend and read back, so the model is still exportable in a later session | ✅ pass | live | `pytest tests/cie/test_bin_duplicate_bone_ids.py::test_the_repeats_survive_a_trip_through_a_blend_file` — bpy.data.libraries.write/load round trip, repeat compared bit-exact |

- <code>`python tests/cie/../evidence/drive_re4uhd_repeat.py` — mounts a shipped .udas.lfs file from a real RE4 UHD install and drives `bpy.ops.albam.import_vfile()` + `bpy.ops.albam.export()` on the model with a repeated bone id (run on the target commit and on base 25127af)</code>
- <code>`python tests/tools/cie_build_mod.py &#34;<game install> Evil a shipped .udas.lfs file&#34; &lt;out&gt;` — the maintainer no-edit-re-export gate plus a 1.6x scaled rebuild, run on target and on base 25127af</code>
- <code>`pytest tests/cie/test_bin_duplicate_bone_ids.py --game-dir=re4uhd::<game install> Evil 4` — 9 passed, 2 skipped (archives with no repeat)</code>
- <code>`pytest tests/cie/test_bin_duplicate_bone_ids.py --game-dir=...` with base `albam/engines/cie/mesh.py` restored — 8 failed, 1 passed (the no-repeat control), confirming the regression is reproduced pre-fix</code>
- <code>`pytest tests/cie -q --game-dir=re4uhd::<game install> Evil 4` — 152 passed, 29 skipped</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/modding-a-character.md:214` - Judgment call, left unwritten: the guide no longer lists duplicate bone ids as broken, but it also does not state the one residual caveat the fix leaves — for an id the table names twice, only the first entry follows the bone in Blender; the repeat is written back with the offset it was imported with, since the scene has no second bone to move. Explaining it in the modding guide would mean introducing duplicate bone ids to an audience that never sees them (the repeat is invisible in Blender, and the effect is limited to a rest offset the user cannot edit anyway), so I judged the guide accurate as-is and left the invariant owned by the BONE_OFFSETS_PROPERTY comment in albam/engines/cie/mesh.py and its regression test. Flagging in case the author wants a line under &#34;What does not work yet&#34;.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

