### PR TITLE
fix(mtfw): compute weight bounds from the weights export actually writes

### DIFF
--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -2367,25 +2367,27 @@ def _encode_half_float_weight_slots(weight_values, max_bones_per_vertex):
     return None, None, None
 
 
-def _decode_half_float_weight_slots(weight_values, max_bones_per_vertex):
+def _written_half_float_weights(weight_values, max_bones_per_vertex):
     """
-    The weight each slot really carries once serialized by
-    `_encode_half_float_weight_slots` and read back the way `_get_weights`
-    does: the quantized written slots, then the unwritten last slot as the
-    remainder.
+    The weight of every slot `_encode_half_float_weight_slots` actually
+    writes into the vertex struct, in slot order, read back the way
+    `_get_weights` does. The last slot is not written - the game
+    reconstructs it as the remainder - so it has no entry here and the
+    result is one shorter than `max_bones_per_vertex`. A 1-weight format
+    carries no weight field at all: its single bone index is the whole
+    skinning, so it is reported as a full weight.
     """
     if max_bones_per_vertex == 1:
         return [1.0]
     position_w, packed_weights, packed_weights_2 = _encode_half_float_weight_slots(
         weight_values, max_bones_per_vertex)
-    decoded = [position_w / 32767]
+    written = [position_w / 32767]
     if max_bones_per_vertex == 8:
-        decoded.extend(w / 255 for w in packed_weights)
-        decoded.extend(unpack("e", w)[0] for w in packed_weights_2)
+        written.extend(w / 255 for w in packed_weights)
+        written.extend(unpack("e", w)[0] for w in packed_weights_2)
     elif max_bones_per_vertex == 4:
-        decoded.extend(unpack("e", w)[0] for w in packed_weights)
-    decoded.append(1.0 - sum(decoded))
-    return decoded
+        written.extend(unpack("e", w)[0] for w in packed_weights)
+    return written
 
 
 def _bones_with_exported_weight(influence_list, max_bones_per_vertex, half_float):
@@ -2393,11 +2395,13 @@ def _bones_with_exported_weight(influence_list, max_bones_per_vertex, half_float
     The bone indices the exported vertex data really skins a vertex to.
 
     A vertex counts towards a bone's weight bound exactly when the exporter
-    writes a non-zero weight for that bone, so this runs the exporter's own
-    truncate/normalize/quantize instead of testing the raw vertex-group
-    weight: normalizing can lift a weight far below one quantization step
-    into a substantial exported one, and quantizing can drop a small one to
-    nothing (see issue #253).
+    writes a non-zero weight for that bone into the file, so this runs the
+    exporter's own truncate/normalize/quantize instead of testing the raw
+    vertex-group weight: normalizing can lift a weight far below one
+    quantization step into a substantial exported one, and quantizing can
+    drop a small one to nothing (see issue #253). The half-float formats
+    never write their last slot, so a bone that only holds it is not
+    skinned in the exported file and does not count.
     """
     weights_data = _process_vertex_weights(
         influence_list, max_bones_per_vertex, half_float)
@@ -2408,9 +2412,9 @@ def _bones_with_exported_weight(influence_list, max_bones_per_vertex, half_float
 
     weight_values = [w for _, w in weights_data]
     weight_values.extend([0] * (max_bones_per_vertex - len(weight_values)))
-    exported = _decode_half_float_weight_slots(weight_values, max_bones_per_vertex)
+    written = _written_half_float_weights(weight_values, max_bones_per_vertex)
     return {
-        bone_index for (bone_index, _), weight in zip(weights_data, exported) if weight
+        bone_index for (bone_index, _), weight in zip(weights_data, written) if weight
     }
 
 

--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -1841,12 +1841,11 @@ def _serialize_meshes_data(bl_obj, bl_meshes, src_mod, dst_mod, materials_map, b
 
         mesh._check()
         meshes_data.meshes.append(mesh)
-        # The same per-vertex bone limit `_export_vertices` used to truncate
-        # influences before normalizing, so the weight bound filter agrees
-        # with what actually got exported.
-        weight_bound_max_bones = VERTEX_FORMATS_BONE_LIMIT.get(vertex_format, 4)
+        # The same bone limit and weight encoding `_export_vertices` used, so
+        # the weight bound filter agrees with what actually got exported.
+        wb_max_bones, wb_half_float = _weight_export_params(dst_mod, vertex_format)
         mesh_weight_bounds = _calculate_weight_bounds(
-            bl_obj, bl_mesh, dst_mod, meshes_data, weight_bound_max_bones)
+            bl_obj, bl_mesh, dst_mod, meshes_data, wb_max_bones, wb_half_float)
         meshes_data.weight_bounds.extend(mesh_weight_bounds)
         mesh.num_weight_bounds = len(mesh_weight_bounds)
 
@@ -2042,12 +2041,10 @@ def _export_vertices(app_id, bl_mesh, mesh, mesh_bone_palette, dst_mod, bbox_dat
         VertexCls = VERTEX_FORMATS_MAPPER.get(vertex_format)
         vtx_stride = VertexCls().size_
 
-    MAX_BONES = VERTEX_FORMATS_BONE_LIMIT.get(vertex_format, 4)
+    MAX_BONES, weight_half_float = _weight_export_params(dst_mod, vertex_format)
     # It breaks index serealization without clamping
     if max_bones_per_vertex > MAX_BONES:
         max_bones_per_vertex = MAX_BONES
-    weight_half_float = (dst_mod.header.version in (210, 211, 212) and
-                         vertex_format not in VERTEX_FORMATS_BRIDGE)
     weights_per_vertex = _process_weights_for_export(
         weights_per_vertex, max_bones_per_vertex=MAX_BONES, half_float=weight_half_float)
     vtx_stream = KaitaiStream(
@@ -2235,26 +2232,17 @@ def _export_vertices(app_id, bl_mesh, mesh, mesh_bone_palette, dst_mod, bbox_dat
                 bone_indices.insert(3, 128)
             vertex_struct.bone_indices = bone_indices
             if dst_mod.header.version not in (153, 156) and vertex_format not in VERTEX_FORMATS_BRIDGE:
-                match MAX_BONES:
-                    case 2:
-                        vertex_struct.bone_indices = [
-                            pack('e', bone_indices[0]), pack('e', bone_indices[1])]
-                        vertex_struct.position.w = round(weight_values[0] * 32767)
-                    case 4:
-                        vertex_struct.position.w = round(weight_values[0] * 32767)
-                        vertex_struct.weight_values = [0, 0]
-                        vertex_struct.weight_values[0] = pack("e", weight_values[1])
-                        vertex_struct.weight_values[1] = pack("e", weight_values[2])
-                    case 8:
-                        vertex_struct.position.w = round(weight_values[0] * 32767)
-                        vertex_struct.weight_values = [0, 0, 0, 0]
-                        vertex_struct.weight_values[0] = round(weight_values[1] * 255)
-                        vertex_struct.weight_values[1] = round(weight_values[2] * 255)
-                        vertex_struct.weight_values[2] = round(weight_values[3] * 255)
-                        vertex_struct.weight_values[3] = round(weight_values[4] * 255)
-                        vertex_struct.weight_values2 = [0, 0]
-                        vertex_struct.weight_values2[0] = pack("e", weight_values[5])
-                        vertex_struct.weight_values2[1] = pack("e", weight_values[6])
+                if MAX_BONES == 2:
+                    vertex_struct.bone_indices = [
+                        pack('e', bone_indices[0]), pack('e', bone_indices[1])]
+                position_w, packed_weights, packed_weights_2 = _encode_half_float_weight_slots(
+                    weight_values, MAX_BONES)
+                if position_w is not None:
+                    vertex_struct.position.w = position_w
+                if packed_weights is not None:
+                    vertex_struct.weight_values = packed_weights
+                if packed_weights_2 is not None:
+                    vertex_struct.weight_values2 = packed_weights_2
             else:
                 vertex_struct.weight_values = weight_values
         if has_vertex_buffer_2:
@@ -2299,17 +2287,25 @@ def _apply_bbox_transforms(xyz_tuple, dst_mod, bbox_data):
     return (round(x), round(y), round(z))
 
 
-def _normalize_and_quantize_weights(influence_list, max_bones_per_vertex):
+def _weight_export_params(dst_mod, vertex_format):
     """
-    Reproduce, for a single vertex, the byte-weight arithmetic
-    `_process_weights_for_export` applies before serializing: keep the top
-    `max_bones_per_vertex` influences, normalize them to sum to 1, then
-    quantize each to a 0-255 byte with a floor of 1 (a kept influence can
-    never serialize to zero). Returns [(bone_index, weight_byte), ...] -
-    a bone_index is written with a non-zero weight for this vertex iff it
-    appears in the result. Used by both the exporter and the weight-bound
-    filter so the two agree by construction (see issue #253).
+    The per-vertex bone limit and weight encoding `_export_vertices` uses
+    for `vertex_format`. Shared with the weight bound filter so it mirrors
+    whichever branch the exporter actually takes (see issue #253).
     """
+    max_bones_per_vertex = VERTEX_FORMATS_BONE_LIMIT.get(vertex_format, 4)
+    half_float = (dst_mod.header.version in VERSIONS_MOD_21 and
+                  vertex_format not in VERTEX_FORMATS_BRIDGE)
+    return max_bones_per_vertex, half_float
+
+
+def _truncate_and_normalize_weights(influence_list, max_bones_per_vertex):
+    """
+    Keep a vertex's `max_bones_per_vertex` strongest influences and
+    normalize them to sum to 1. Returns (bone_indices, weights), both
+    ordered by descending weight.
+    """
+    # limit max bones
     if len(influence_list) > max_bones_per_vertex:
         influence_list = sorted(
             influence_list, key=lambda t: t[1])[-max_bones_per_vertex:]
@@ -2322,17 +2318,100 @@ def _normalize_and_quantize_weights(influence_list, max_bones_per_vertex):
     total_weight = sum(weights)
     if total_weight:
         weights = [round((w / total_weight), 4) for w in weights]
-    # can't have zero values
-    weights = [round(w * 255) or 1 for w in weights]
-    if not weights:
-        return []
-    # correct precision
-    excess = sum(weights) - 255
-    if excess:
-        max_index, _ = max(enumerate(weights), key=lambda p: p[1])
-        weights[max_index] -= excess
+    return bone_indices, weights
+
+
+def _process_vertex_weights(influence_list, max_bones_per_vertex, half_float):
+    """
+    The (bone_index, weight) pairs `_export_vertices` serializes for a
+    single vertex, or None when the byte path is left with nothing to write.
+    """
+    bone_indices, weights = _truncate_and_normalize_weights(
+        influence_list, max_bones_per_vertex)
+    if half_float:
+        weights = _check_weights(weights, max_bones_per_vertex)
+    else:
+        # can't have zero values
+        weights = [round(w * 255) or 1 for w in weights]
+        if not weights:
+            # XXX vertex_position_2 research, beware
+            return None
+        # correct precision
+        excess = sum(weights) - 255
+        if excess:
+            max_index, _ = max(enumerate(weights), key=lambda p: p[1])
+            weights[max_index] -= excess
 
     return list(zip(bone_indices, weights))
+
+
+def _encode_half_float_weight_slots(weight_values, max_bones_per_vertex):
+    """
+    Encode a vertex's weights into the fields the mod-21 non-bridge vertex
+    formats serialize: (position.w, weight_values, weight_values2), each
+    None for a slot group the format doesn't carry. The last slot is never
+    written: the game reconstructs it as one minus the rest, the way
+    `_get_weights` does on import.
+    """
+    match max_bones_per_vertex:
+        case 2:
+            return round(weight_values[0] * 32767), None, None
+        case 4:
+            return (round(weight_values[0] * 32767),
+                    [pack("e", weight_values[1]), pack("e", weight_values[2])],
+                    None)
+        case 8:
+            return (round(weight_values[0] * 32767),
+                    [round(weight_values[i] * 255) for i in range(1, 5)],
+                    [pack("e", weight_values[5]), pack("e", weight_values[6])])
+    return None, None, None
+
+
+def _decode_half_float_weight_slots(weight_values, max_bones_per_vertex):
+    """
+    The weight each slot really carries once serialized by
+    `_encode_half_float_weight_slots` and read back the way `_get_weights`
+    does: the quantized written slots, then the unwritten last slot as the
+    remainder.
+    """
+    if max_bones_per_vertex == 1:
+        return [1.0]
+    position_w, packed_weights, packed_weights_2 = _encode_half_float_weight_slots(
+        weight_values, max_bones_per_vertex)
+    decoded = [position_w / 32767]
+    if max_bones_per_vertex == 8:
+        decoded.extend(w / 255 for w in packed_weights)
+        decoded.extend(unpack("e", w)[0] for w in packed_weights_2)
+    elif max_bones_per_vertex == 4:
+        decoded.extend(unpack("e", w)[0] for w in packed_weights)
+    decoded.append(1.0 - sum(decoded))
+    return decoded
+
+
+def _bones_with_exported_weight(influence_list, max_bones_per_vertex, half_float):
+    """
+    The bone indices the exported vertex data really skins a vertex to.
+
+    A vertex counts towards a bone's weight bound exactly when the exporter
+    writes a non-zero weight for that bone, so this runs the exporter's own
+    truncate/normalize/quantize instead of testing the raw vertex-group
+    weight: normalizing can lift a weight far below one quantization step
+    into a substantial exported one, and quantizing can drop a small one to
+    nothing (see issue #253).
+    """
+    weights_data = _process_vertex_weights(
+        influence_list, max_bones_per_vertex, half_float)
+    if not weights_data:
+        return set()
+    if not half_float:
+        return {bone_index for bone_index, weight in weights_data if weight}
+
+    weight_values = [w for _, w in weights_data]
+    weight_values.extend([0] * (max_bones_per_vertex - len(weight_values)))
+    exported = _decode_half_float_weight_slots(weight_values, max_bones_per_vertex)
+    return {
+        bone_index for (bone_index, _), weight in zip(weights_data, exported) if weight
+    }
 
 
 def _process_weights_for_export(weights_per_vertex, max_bones_per_vertex=4, half_float=False):
@@ -2348,35 +2427,17 @@ def _process_weights_for_export(weights_per_vertex, max_bones_per_vertex=4, half
     """
     # TODO: move to mtframework.utils
     new_weights_per_vertex = {}
-    limit = max_bones_per_vertex
     for vertex_index, influence_list in weights_per_vertex.items():
-        if half_float:
-            # limit max bones
-            if len(influence_list) > limit:
-                influence_list = sorted(
-                    influence_list, key=lambda t: t[1])[-limit:]
-
-            weight_data = {t[0]: t[1] for t in influence_list}
-            wd_sorted = {k: v for k, v in sorted(weight_data.items(), key=lambda item: item[1], reverse=True)}
-            bone_indices = [bi for bi in wd_sorted.keys()]
-            weights = [w for w in wd_sorted.values()]
-            # normalize
-            total_weight = sum(weights)
-            if total_weight:
-                weights = [round((w / total_weight), 4) for w in weights]
-            weights = _check_weights(weights, limit)
-            new_weights_per_vertex[vertex_index] = list(zip(bone_indices, weights))
-        else:
-            quantized = _normalize_and_quantize_weights(influence_list, limit)
-            if not quantized:
-                # XXX vertex_position_2 research, beware
-                continue
-            new_weights_per_vertex[vertex_index] = quantized
+        weights_data = _process_vertex_weights(
+            influence_list, max_bones_per_vertex, half_float)
+        if weights_data is None:
+            continue
+        new_weights_per_vertex[vertex_index] = weights_data
 
     return new_weights_per_vertex
 
 
-def _calculate_weight_bounds(bl_obj, bl_mesh, dst_mod, meshes_data, max_bones_per_vertex=4):
+def _calculate_weight_bounds(bl_obj, bl_mesh, dst_mod, meshes_data, max_bones_per_vertex, half_float):
     unsorted_weight_bounds = []
     if bl_obj.type != "ARMATURE":
         weight_bound = _set_static_mesh_weight_bounds(
@@ -2385,10 +2446,14 @@ def _calculate_weight_bounds(bl_obj, bl_mesh, dst_mod, meshes_data, max_bones_pe
     else:
         mesh_vertex_groups = get_mesh_vertex_groups(bl_mesh)
         weights_per_vertex = get_bone_indices_and_weights_per_vertex(bl_mesh)
+        vertices_per_bone = {}
+        for vertex_index, influence_list in weights_per_vertex.items():
+            for bone_index in _bones_with_exported_weight(
+                    influence_list, max_bones_per_vertex, half_float):
+                vertices_per_bone.setdefault(bone_index, set()).add(vertex_index)
         for vg in bl_mesh.vertex_groups:
             weight_bound = _calculate_vertex_group_weight_bound(
-                mesh_vertex_groups, bl_obj, vg, dst_mod, meshes_data,
-                weights_per_vertex, max_bones_per_vertex,
+                mesh_vertex_groups, bl_obj, vg, dst_mod, meshes_data, vertices_per_bone,
             )
             if weight_bound:
                 unsorted_weight_bounds.append(weight_bound)
@@ -2489,23 +2554,15 @@ def _set_static_mesh_weight_bounds(dst_mod, bl_mesh_ob, meshes_data):
 
 
 def _calculate_vertex_group_weight_bound(
-    mesh_vertex_groups, armature, vertex_group, dst_mod, meshes_data,
-    weights_per_vertex, max_bones_per_vertex,
+    mesh_vertex_groups, armature, vertex_group, dst_mod, meshes_data, vertices_per_bone,
 ):
-    # A vertex counts towards a bone's bound exactly when the exporter
-    # writes a non-zero weight for that bone: mirror
-    # `_process_weights_for_export`'s truncate/normalize/quantize steps
-    # instead of testing the raw vertex-group weight. Normalizing a mesh's
-    # weights can lift a raw weight far below one quantization step up to a
-    # real exported byte value (see issue #253).
     bone_index = armature.pose.bones.find(vertex_group.name)
+    exported_vertices = vertices_per_bone.get(bone_index, ())
 
-    vertices_in_group = []
-    for v in mesh_vertex_groups.get(vertex_group.index, ()):
-        influence_list = weights_per_vertex.get(v.index, ())
-        quantized = _normalize_and_quantize_weights(influence_list, max_bones_per_vertex)
-        if any(bi == bone_index for bi, _ in quantized):
-            vertices_in_group.append(v)
+    vertices_in_group = [
+        v for v in mesh_vertex_groups.get(vertex_group.index, ())
+        if v.index in exported_vertices
+    ]
 
     if not vertices_in_group:
         return

--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -2367,54 +2367,58 @@ def _encode_half_float_weight_slots(weight_values, max_bones_per_vertex):
     return None, None, None
 
 
-def _written_half_float_weights(weight_values, max_bones_per_vertex):
+def _reconstruct_half_float_weights(weight_values, max_bones_per_vertex):
     """
-    The weight of every slot `_encode_half_float_weight_slots` actually
-    writes into the vertex struct, in slot order, read back the way
-    `_get_weights` does. The last slot is not written - the game
-    reconstructs it as the remainder - so it has no entry here and the
-    result is one shorter than `max_bones_per_vertex`. A 1-weight format
-    carries no weight field at all: its single bone index is the whole
-    skinning, so it is reported as a full weight.
+    The weight each slot ends up with once a vertex encoded by
+    `_encode_half_float_weight_slots` is read back, per format, exactly the
+    way `_get_weights` reconstructs it. Every one of these formats derives
+    its last slot from the remainder rather than a written field, and a
+    1-weight format has no weight field at all, so its single slot is a
+    full weight.
     """
     if max_bones_per_vertex == 1:
         return [1.0]
     position_w, packed_weights, packed_weights_2 = _encode_half_float_weight_slots(
         weight_values, max_bones_per_vertex)
-    written = [position_w / 32767]
+    weights = [position_w / 32767]
     if max_bones_per_vertex == 8:
-        written.extend(w / 255 for w in packed_weights)
-        written.extend(unpack("e", w)[0] for w in packed_weights_2)
+        weights.extend(w / 255 for w in packed_weights)
+        weights.extend(unpack("e", w)[0] for w in packed_weights_2)
+        weights.append(1.0 - sum(weights))
     elif max_bones_per_vertex == 4:
-        written.extend(unpack("e", w)[0] for w in packed_weights)
-    return written
+        weights.extend(unpack("e", w)[0] for w in packed_weights)
+        weights.append(round(1.0 - sum(weights), 3))
+    else:
+        weights.append(1.0 - weights[0])
+    return weights
 
 
 def _bones_with_exported_weight(influence_list, max_bones_per_vertex, half_float):
     """
     The bone indices the exported vertex data really skins a vertex to.
 
-    A vertex counts towards a bone's weight bound exactly when the exporter
-    writes a non-zero weight for that bone into the file, so this runs the
-    exporter's own truncate/normalize/quantize instead of testing the raw
+    A vertex counts towards a bone's weight bound exactly when the game
+    ends up with a non-zero weight for that bone, so this runs the
+    exporter's own truncate/normalize/quantize and then reads the result
+    back the way `_get_weights` does, instead of testing the raw
     vertex-group weight: normalizing can lift a weight far below one
     quantization step into a substantial exported one, and quantizing can
-    drop a small one to nothing (see issue #253). The half-float formats
-    never write their last slot, so a bone that only holds it is not
-    skinned in the exported file and does not count.
+    drop a small one to nothing (see issue #253).
     """
     weights_data = _process_vertex_weights(
         influence_list, max_bones_per_vertex, half_float)
     if not weights_data:
         return set()
     if not half_float:
-        return {bone_index for bone_index, weight in weights_data if weight}
+        return {bone_index for bone_index, weight in weights_data if weight > 0}
 
     weight_values = [w for _, w in weights_data]
     weight_values.extend([0] * (max_bones_per_vertex - len(weight_values)))
-    written = _written_half_float_weights(weight_values, max_bones_per_vertex)
+    reconstructed = _reconstruct_half_float_weights(weight_values, max_bones_per_vertex)
     return {
-        bone_index for (bone_index, _), weight in zip(weights_data, written) if weight
+        bone_index
+        for (bone_index, _), weight in zip(weights_data, reconstructed)
+        if weight > 0
     }
 
 

--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -308,8 +308,6 @@ VERSIONS_USE_TRISTRIPS = {153, 156, 212}
 # The versions mod-21.ksy covers, which size their index buffer as
 # num_faces * 2 rather than (num_faces * 2) - 2.
 VERSIONS_MOD_21 = {210, 211, 212}
-# Bone weights serialize as u1, so a weight is written as round(w * 255).
-WEIGHT_QUANTIZATION_STEPS = 255
 
 MAIN_LODS = {
     "re0": [1, 255],
@@ -1843,8 +1841,12 @@ def _serialize_meshes_data(bl_obj, bl_meshes, src_mod, dst_mod, materials_map, b
 
         mesh._check()
         meshes_data.meshes.append(mesh)
+        # The same per-vertex bone limit `_export_vertices` used to truncate
+        # influences before normalizing, so the weight bound filter agrees
+        # with what actually got exported.
+        weight_bound_max_bones = VERTEX_FORMATS_BONE_LIMIT.get(vertex_format, 4)
         mesh_weight_bounds = _calculate_weight_bounds(
-            bl_obj, bl_mesh, dst_mod, meshes_data)
+            bl_obj, bl_mesh, dst_mod, meshes_data, weight_bound_max_bones)
         meshes_data.weight_bounds.extend(mesh_weight_bounds)
         mesh.num_weight_bounds = len(mesh_weight_bounds)
 
@@ -2297,6 +2299,42 @@ def _apply_bbox_transforms(xyz_tuple, dst_mod, bbox_data):
     return (round(x), round(y), round(z))
 
 
+def _normalize_and_quantize_weights(influence_list, max_bones_per_vertex):
+    """
+    Reproduce, for a single vertex, the byte-weight arithmetic
+    `_process_weights_for_export` applies before serializing: keep the top
+    `max_bones_per_vertex` influences, normalize them to sum to 1, then
+    quantize each to a 0-255 byte with a floor of 1 (a kept influence can
+    never serialize to zero). Returns [(bone_index, weight_byte), ...] -
+    a bone_index is written with a non-zero weight for this vertex iff it
+    appears in the result. Used by both the exporter and the weight-bound
+    filter so the two agree by construction (see issue #253).
+    """
+    if len(influence_list) > max_bones_per_vertex:
+        influence_list = sorted(
+            influence_list, key=lambda t: t[1])[-max_bones_per_vertex:]
+
+    weight_data = {t[0]: t[1] for t in influence_list}
+    wd_sorted = {k: v for k, v in sorted(weight_data.items(), key=lambda item: item[1], reverse=True)}
+    bone_indices = [bi for bi in wd_sorted.keys()]
+    weights = [w for w in wd_sorted.values()]
+    # normalize
+    total_weight = sum(weights)
+    if total_weight:
+        weights = [round((w / total_weight), 4) for w in weights]
+    # can't have zero values
+    weights = [round(w * 255) or 1 for w in weights]
+    if not weights:
+        return []
+    # correct precision
+    excess = sum(weights) - 255
+    if excess:
+        max_index, _ = max(enumerate(weights), key=lambda p: p[1])
+        weights[max_index] -= excess
+
+    return list(zip(bone_indices, weights))
+
+
 def _process_weights_for_export(weights_per_vertex, max_bones_per_vertex=4, half_float=False):
     """
     Given a dict `weights_per_vertex` with vertex_indices as keys and
@@ -2312,39 +2350,33 @@ def _process_weights_for_export(weights_per_vertex, max_bones_per_vertex=4, half
     new_weights_per_vertex = {}
     limit = max_bones_per_vertex
     for vertex_index, influence_list in weights_per_vertex.items():
-        # limit max bones
-        if len(influence_list) > limit:
-            influence_list = sorted(
-                influence_list, key=lambda t: t[1])[-limit:]
-
-        weight_data = {t[0]: t[1] for t in influence_list}
-        wd_sorted = {k: v for k, v in sorted(weight_data.items(), key=lambda item: item[1], reverse=True)}
-        bone_indices = [bi for bi in wd_sorted.keys()]
-        weights = [w for w in wd_sorted.values()]
-        # normalize
-        total_weight = sum(weights)
-        if total_weight:
-            weights = [round((w / total_weight), 4) for w in weights]
         if half_float:
+            # limit max bones
+            if len(influence_list) > limit:
+                influence_list = sorted(
+                    influence_list, key=lambda t: t[1])[-limit:]
+
+            weight_data = {t[0]: t[1] for t in influence_list}
+            wd_sorted = {k: v for k, v in sorted(weight_data.items(), key=lambda item: item[1], reverse=True)}
+            bone_indices = [bi for bi in wd_sorted.keys()]
+            weights = [w for w in wd_sorted.values()]
+            # normalize
+            total_weight = sum(weights)
+            if total_weight:
+                weights = [round((w / total_weight), 4) for w in weights]
             weights = _check_weights(weights, limit)
+            new_weights_per_vertex[vertex_index] = list(zip(bone_indices, weights))
         else:
-            # can't have zero values
-            weights = [round(w * 255) or 1 for w in weights]
-            # correct precision
-            if not weights:
+            quantized = _normalize_and_quantize_weights(influence_list, limit)
+            if not quantized:
                 # XXX vertex_position_2 research, beware
                 continue
-            excess = sum(weights) - 255
-            if excess:
-                max_index, _ = max(enumerate(weights), key=lambda p: p[1])
-                weights[max_index] -= excess
-
-        new_weights_per_vertex[vertex_index] = list(zip(bone_indices, weights))
+            new_weights_per_vertex[vertex_index] = quantized
 
     return new_weights_per_vertex
 
 
-def _calculate_weight_bounds(bl_obj, bl_mesh, dst_mod, meshes_data):
+def _calculate_weight_bounds(bl_obj, bl_mesh, dst_mod, meshes_data, max_bones_per_vertex=4):
     unsorted_weight_bounds = []
     if bl_obj.type != "ARMATURE":
         weight_bound = _set_static_mesh_weight_bounds(
@@ -2352,9 +2384,11 @@ def _calculate_weight_bounds(bl_obj, bl_mesh, dst_mod, meshes_data):
         unsorted_weight_bounds.append(weight_bound)
     else:
         mesh_vertex_groups = get_mesh_vertex_groups(bl_mesh)
+        weights_per_vertex = get_bone_indices_and_weights_per_vertex(bl_mesh)
         for vg in bl_mesh.vertex_groups:
             weight_bound = _calculate_vertex_group_weight_bound(
-                mesh_vertex_groups, bl_obj, vg, dst_mod, meshes_data
+                mesh_vertex_groups, bl_obj, vg, dst_mod, meshes_data,
+                weights_per_vertex, max_bones_per_vertex,
             )
             if weight_bound:
                 unsorted_weight_bounds.append(weight_bound)
@@ -2454,27 +2488,28 @@ def _set_static_mesh_weight_bounds(dst_mod, bl_mesh_ob, meshes_data):
     return wb
 
 
-def _weight_in_group(bl_vertex, group_index):
-    for group in bl_vertex.groups:
-        if group.group == group_index:
-            return group.weight
-    return 0.0
+def _calculate_vertex_group_weight_bound(
+    mesh_vertex_groups, armature, vertex_group, dst_mod, meshes_data,
+    weights_per_vertex, max_bones_per_vertex,
+):
+    # A vertex counts towards a bone's bound exactly when the exporter
+    # writes a non-zero weight for that bone: mirror
+    # `_process_weights_for_export`'s truncate/normalize/quantize steps
+    # instead of testing the raw vertex-group weight. Normalizing a mesh's
+    # weights can lift a raw weight far below one quantization step up to a
+    # real exported byte value (see issue #253).
+    bone_index = armature.pose.bones.find(vertex_group.name)
 
+    vertices_in_group = []
+    for v in mesh_vertex_groups.get(vertex_group.index, ()):
+        influence_list = weights_per_vertex.get(v.index, ())
+        quantized = _normalize_and_quantize_weights(influence_list, max_bones_per_vertex)
+        if any(bi == bone_index for bi, _ in quantized):
+            vertices_in_group.append(v)
 
-def _calculate_vertex_group_weight_bound(mesh_vertex_groups, armature, vertex_group, dst_mod, meshes_data):
-    # Only vertices whose weight survives the format's 8 bit quantization
-    # count towards the bound. Normalizing a mesh's weights leaves residuals
-    # far below one step - a bone can end up holding ~2e-05 across every
-    # vertex - and a weight that serializes to 0 influences nothing, so a
-    # bound for it would describe a bone the exported mesh isn't bound to.
-    vertices_in_group = [
-        v for v in mesh_vertex_groups.get(vertex_group.index, ())
-        if round(_weight_in_group(v, vertex_group.index) * WEIGHT_QUANTIZATION_STEPS)
-    ]
     if not vertices_in_group:
         return
 
-    bone_index = armature.pose.bones.find(vertex_group.name)
     pose_bone = armature.pose.bones[bone_index]
     pose_bone_matrix = Matrix.Translation(pose_bone.head).inverted()
 

--- a/tests/mtfw/test_weight_bound_filter.py
+++ b/tests/mtfw/test_weight_bound_filter.py
@@ -1,0 +1,161 @@
+"""_calculate_vertex_group_weight_bound must agree with what the exporter
+actually writes for a vertex - see issue #253.
+
+The bug: the filter tested a vertex's raw vertex-group weight, while the
+exporter (_process_weights_for_export) normalizes a vertex's kept
+influences and then floors any surviving one to at least 1/255
+(`round(w * 255) or 1`). Two weights that are both far below one
+quantization step - the residue Blender's "Normalize All" leaves behind -
+can normalize each other up into a real exported byte while each raw value
+still rounds to 0, so the filter dropped a vertex the exporter kept.
+
+Not reachable through an import/export round trip: importer-derived
+weights come from the file's already-quantized values, so none of them
+round to zero raw. It only shows up on weights authored/edited directly in
+Blender, which is why these tests build their vertex groups directly
+(no game data needed) instead of round-tripping a file.
+"""
+
+import bpy
+import pytest
+
+from albam.engines.mtfw.mesh import (
+    _calculate_weight_bounds,
+    _normalize_and_quantize_weights,
+    _process_weights_for_export,
+)
+from albam.engines.mtfw.structs.mod_156 import Mod156
+from albam.lib.blender import get_bone_indices_and_weights_per_vertex
+
+
+class _FakeMeshesData:
+    """Stand-in for the real MeshesData kaitai struct.
+
+    _calculate_vertex_group_weight_bound only needs something with a
+    `_root` a WeightBound (and its children) can be built and _check()ed
+    against consistently - it never touches file I/O, so no real Mod156
+    instance is required.
+    """
+
+    def __init__(self):
+        self._root = self
+
+
+@pytest.fixture
+def weight_bound_rig():
+    """A 2-bone armature ("A", "B") plus a 1-vertex mesh weighted to both,
+    with an ARMATURE modifier wiring them together - everything
+    get_bone_indices_and_weights_per_vertex/get_mesh_vertex_groups need.
+    """
+    armature_data = bpy.data.armatures.new("weight_bound_rig")
+    armature = bpy.data.objects.new("weight_bound_rig", armature_data)
+    bpy.context.scene.collection.objects.link(armature)
+    previous_active = bpy.context.view_layer.objects.active
+    try:
+        bpy.context.view_layer.objects.active = armature
+        bpy.ops.object.mode_set(mode="EDIT")
+        bone_a = armature_data.edit_bones.new("A")
+        bone_a.head = (0.0, 0.0, 0.0)
+        bone_a.tail = (0.0, 0.0, 0.1)
+        bone_b = armature_data.edit_bones.new("B")
+        bone_b.head = (1.0, 0.0, 0.0)
+        bone_b.tail = (1.0, 0.0, 0.1)
+        bpy.ops.object.mode_set(mode="OBJECT")
+
+        mesh_data = bpy.data.meshes.new("weight_bound_mesh")
+        mesh_data.from_pydata([(0.5, 0.0, 0.0)], [], [])
+        mesh_data.update()
+        mesh_obj = bpy.data.objects.new("weight_bound_mesh", mesh_data)
+        bpy.context.scene.collection.objects.link(mesh_obj)
+        mesh_obj.vertex_groups.new(name="A")
+        mesh_obj.vertex_groups.new(name="B")
+        modifier = mesh_obj.modifiers.new(name="Armature", type="ARMATURE")
+        modifier.object = armature
+
+        yield armature, mesh_obj
+    finally:
+        if bpy.context.mode != "OBJECT":
+            bpy.ops.object.mode_set(mode="OBJECT")
+        bpy.data.objects.remove(mesh_obj, do_unlink=True)
+        bpy.data.meshes.remove(mesh_data)
+        bpy.data.objects.remove(armature, do_unlink=True)
+        bpy.data.armatures.remove(armature_data)
+        bpy.context.view_layer.objects.active = previous_active
+
+
+def _bound_bone_ids(armature, mesh_obj, max_bones_per_vertex=4):
+    meshes_data = _FakeMeshesData()
+    weight_bounds = _calculate_weight_bounds(
+        armature, mesh_obj, Mod156, meshes_data, max_bones_per_vertex)
+    return {wb.bone_id for wb in weight_bounds}
+
+
+def _exported_weight(mesh_obj, bone_index, max_bones_per_vertex=4):
+    weights_per_vertex = get_bone_indices_and_weights_per_vertex(mesh_obj)
+    processed = _process_weights_for_export(
+        weights_per_vertex, max_bones_per_vertex=max_bones_per_vertex, half_float=False)
+    (vertex_index, influences), = processed.items()
+    by_bone = dict(influences)
+    return by_bone.get(bone_index)
+
+
+# raw weights on the vertex -> weight B actually exports at (table in #253)
+TABLE_ROWS = [
+    pytest.param({"A": 0.9, "B": 0.001}, 1, id="A0.9-B0.001"),
+    pytest.param({"A": 0.99998, "B": 0.00002}, 1, id="A0.99998-B0.00002"),
+    pytest.param({"A": 0.002, "B": 0.0015}, 109, id="A0.002-B0.0015"),
+]
+
+
+@pytest.mark.parametrize("raw_weights, expected_b_export", TABLE_ROWS)
+def test_filter_agrees_with_export_for_weights_below_one_quantization_step(
+    weight_bound_rig, raw_weights, expected_b_export,
+):
+    armature, mesh_obj = weight_bound_rig
+    for name, weight in raw_weights.items():
+        mesh_obj.vertex_groups[name].add([0], weight, "REPLACE")
+
+    bone_index_b = armature.pose.bones.find("B")
+    assert _exported_weight(mesh_obj, bone_index_b) == expected_b_export
+
+    # The exported vertex data skins this vertex to B at a non-zero weight
+    # in every row (the "or 1" floor guarantees it once B survives the
+    # max_bones_per_vertex truncation, which it does here - only 2
+    # influences). The filter must count it towards B's bound exactly when
+    # that happens, not when B's *raw* weight alone happens to round to 0.
+    assert bone_index_b in _bound_bone_ids(armature, mesh_obj)
+
+
+def test_third_row_used_to_slip_past_the_filter(weight_bound_rig):
+    """Direct check of the arithmetic issue #253 flags as the dangerous
+    case: both raw weights are below one quantization step, so the old
+    raw-weight test excluded B while normalization pushed it up to a
+    substantial 109/255 in the exported data.
+    """
+    influence_list = [("A", 0.002), ("B", 0.0015)]
+    quantized = dict(_normalize_and_quantize_weights(influence_list, max_bones_per_vertex=4))
+
+    assert quantized["B"] == 109
+    # a raw-weight test at the export quantization step would have dropped it
+    assert round(0.0015 * 255) == 0
+
+
+def test_ordinary_vertex_is_unaffected(weight_bound_rig):
+    """A normal, well-formed vertex (weights well above one quantization
+    step) must be included in both bones' bounds, same as before the fix.
+    """
+    armature, mesh_obj = weight_bound_rig
+    mesh_obj.vertex_groups["A"].add([0], 0.7, "REPLACE")
+    mesh_obj.vertex_groups["B"].add([0], 0.3, "REPLACE")
+
+    bone_index_a = armature.pose.bones.find("A")
+    bone_index_b = armature.pose.bones.find("B")
+
+    # both influences are well above one quantization step (1/255), so
+    # neither the "or 1" floor nor the excess correction hides anything
+    assert _exported_weight(mesh_obj, bone_index_a) > 1
+    assert _exported_weight(mesh_obj, bone_index_b) > 1
+
+    bound_ids = _bound_bone_ids(armature, mesh_obj)
+    assert bone_index_a in bound_ids
+    assert bone_index_b in bound_ids

--- a/tests/mtfw/test_weight_bound_filter.py
+++ b/tests/mtfw/test_weight_bound_filter.py
@@ -9,6 +9,11 @@ quantization step - the residue Blender's "Normalize All" leaves behind -
 can normalize each other up into a real exported byte while each raw value
 still rounds to 0, so the filter dropped a vertex the exporter kept.
 
+The mod-21 half-float formats encode weights differently again, so the
+filter mirrors whichever branch `_export_vertices` will take: there a
+normalized weight below 1/510 really does serialize to 0 and must not
+count towards that bone's bound.
+
 Not reachable through an import/export round trip: importer-derived
 weights come from the file's already-quantized values, so none of them
 round to zero raw. It only shows up on weights authored/edited directly in
@@ -16,12 +21,15 @@ Blender, which is why these tests build their vertex groups directly
 (no game data needed) instead of round-tripping a file.
 """
 
+from contextlib import contextmanager
+
 import bpy
 import pytest
 
 from albam.engines.mtfw.mesh import (
+    _bones_with_exported_weight,
     _calculate_weight_bounds,
-    _normalize_and_quantize_weights,
+    _encode_half_float_weight_slots,
     _process_weights_for_export,
 )
 from albam.engines.mtfw.structs.mod_156 import Mod156
@@ -41,10 +49,11 @@ class _FakeMeshesData:
         self._root = self
 
 
-@pytest.fixture
-def weight_bound_rig():
-    """A 2-bone armature ("A", "B") plus a 1-vertex mesh weighted to both,
-    with an ARMATURE modifier wiring them together - everything
+@contextmanager
+def _rig(bone_names):
+    """An armature with one bone per name, plus a 1-vertex mesh with a
+    matching vertex group per bone and an ARMATURE modifier wiring them
+    together - everything
     get_bone_indices_and_weights_per_vertex/get_mesh_vertex_groups need.
     """
     armature_data = bpy.data.armatures.new("weight_bound_rig")
@@ -54,12 +63,10 @@ def weight_bound_rig():
     try:
         bpy.context.view_layer.objects.active = armature
         bpy.ops.object.mode_set(mode="EDIT")
-        bone_a = armature_data.edit_bones.new("A")
-        bone_a.head = (0.0, 0.0, 0.0)
-        bone_a.tail = (0.0, 0.0, 0.1)
-        bone_b = armature_data.edit_bones.new("B")
-        bone_b.head = (1.0, 0.0, 0.0)
-        bone_b.tail = (1.0, 0.0, 0.1)
+        for i, bone_name in enumerate(bone_names):
+            bone = armature_data.edit_bones.new(bone_name)
+            bone.head = (float(i), 0.0, 0.0)
+            bone.tail = (float(i), 0.0, 0.1)
         bpy.ops.object.mode_set(mode="OBJECT")
 
         mesh_data = bpy.data.meshes.new("weight_bound_mesh")
@@ -67,8 +74,8 @@ def weight_bound_rig():
         mesh_data.update()
         mesh_obj = bpy.data.objects.new("weight_bound_mesh", mesh_data)
         bpy.context.scene.collection.objects.link(mesh_obj)
-        mesh_obj.vertex_groups.new(name="A")
-        mesh_obj.vertex_groups.new(name="B")
+        for bone_name in bone_names:
+            mesh_obj.vertex_groups.new(name=bone_name)
         modifier = mesh_obj.modifiers.new(name="Armature", type="ARMATURE")
         modifier.object = armature
 
@@ -83,20 +90,35 @@ def weight_bound_rig():
         bpy.context.view_layer.objects.active = previous_active
 
 
-def _bound_bone_ids(armature, mesh_obj, max_bones_per_vertex=4):
+@pytest.fixture
+def weight_bound_rig():
+    with _rig(["A", "B"]) as rig:
+        yield rig
+
+
+@pytest.fixture
+def weight_bound_rig_8():
+    with _rig(["A", "B", "C", "D", "E", "F", "G", "H"]) as rig:
+        yield rig
+
+
+def _bound_bone_ids(armature, mesh_obj, max_bones_per_vertex=4, half_float=False):
     meshes_data = _FakeMeshesData()
     weight_bounds = _calculate_weight_bounds(
-        armature, mesh_obj, Mod156, meshes_data, max_bones_per_vertex)
+        armature, mesh_obj, Mod156, meshes_data, max_bones_per_vertex, half_float)
     return {wb.bone_id for wb in weight_bounds}
 
 
-def _exported_weight(mesh_obj, bone_index, max_bones_per_vertex=4):
+def _processed_weights(mesh_obj, max_bones_per_vertex=4, half_float=False):
     weights_per_vertex = get_bone_indices_and_weights_per_vertex(mesh_obj)
     processed = _process_weights_for_export(
-        weights_per_vertex, max_bones_per_vertex=max_bones_per_vertex, half_float=False)
+        weights_per_vertex, max_bones_per_vertex=max_bones_per_vertex, half_float=half_float)
     (vertex_index, influences), = processed.items()
-    by_bone = dict(influences)
-    return by_bone.get(bone_index)
+    return influences
+
+
+def _exported_weight(mesh_obj, bone_index, max_bones_per_vertex=4):
+    return dict(_processed_weights(mesh_obj, max_bones_per_vertex)).get(bone_index)
 
 
 # raw weights on the vertex -> weight B actually exports at (table in #253)
@@ -126,14 +148,15 @@ def test_filter_agrees_with_export_for_weights_below_one_quantization_step(
     assert bone_index_b in _bound_bone_ids(armature, mesh_obj)
 
 
-def test_third_row_used_to_slip_past_the_filter(weight_bound_rig):
+def test_third_row_used_to_slip_past_the_filter():
     """Direct check of the arithmetic issue #253 flags as the dangerous
     case: both raw weights are below one quantization step, so the old
     raw-weight test excluded B while normalization pushed it up to a
     substantial 109/255 in the exported data.
     """
     influence_list = [("A", 0.002), ("B", 0.0015)]
-    quantized = dict(_normalize_and_quantize_weights(influence_list, max_bones_per_vertex=4))
+    quantized = dict(_process_weights_for_export(
+        {0: influence_list}, max_bones_per_vertex=4, half_float=False)[0])
 
     assert quantized["B"] == 109
     # a raw-weight test at the export quantization step would have dropped it
@@ -159,3 +182,55 @@ def test_ordinary_vertex_is_unaffected(weight_bound_rig):
     bound_ids = _bound_bone_ids(armature, mesh_obj)
     assert bone_index_a in bound_ids
     assert bone_index_b in bound_ids
+
+
+# One 8-influence vertex: A..D are ordinary, E..H are the residue weights.
+# Ranked by weight, E lands in an 8-weight half-float slot that serializes
+# as round(w * 255), and its normalized weight (0.001) is below 1/510, so
+# the exported vertex carries a literal 0 for it.
+HALF_FLOAT_RAW_WEIGHTS = {
+    "A": 0.5, "B": 0.3, "C": 0.19, "D": 0.005,
+    "E": 0.001, "F": 0.0009, "G": 0.0008, "H": 0.0007,
+}
+
+
+def test_half_float_zero_weight_is_not_counted(weight_bound_rig_8):
+    """The byte path floors every kept influence to at least 1/255, but the
+    mod-21 half-float path does not: a normalized weight under 1/510
+    serializes as 0, so that bone is not skinned and must not get a bound.
+    """
+    armature, mesh_obj = weight_bound_rig_8
+    for name, weight in HALF_FLOAT_RAW_WEIGHTS.items():
+        mesh_obj.vertex_groups[name].add([0], weight, "REPLACE")
+
+    weights_data = _processed_weights(mesh_obj, max_bones_per_vertex=8, half_float=True)
+    weight_values = [w for _, w in weights_data]
+    _, packed_weights, _ = _encode_half_float_weight_slots(weight_values, 8)
+
+    bone_index_d = armature.pose.bones.find("D")
+    bone_index_e = armature.pose.bones.find("E")
+    # slots 1-4 of the vertex struct, i.e. D and E among others
+    assert dict(weights_data)[bone_index_d] > dict(weights_data)[bone_index_e]
+    assert packed_weights[2] == 1  # D
+    assert packed_weights[3] == 0  # E, nothing is written for it
+
+    bound_ids = _bound_bone_ids(
+        armature, mesh_obj, max_bones_per_vertex=8, half_float=True)
+    assert bone_index_d in bound_ids
+    assert bone_index_e not in bound_ids
+
+
+def test_half_float_and_byte_paths_disagree_for_the_same_vertex():
+    """The same vertex, exported by the two branches: the byte path's
+    `or 1` floor keeps E skinned, the half-float path drops it. The filter
+    has to follow whichever branch the format actually takes rather than
+    always assuming the byte one.
+    """
+    influence_list = list(HALF_FLOAT_RAW_WEIGHTS.items())
+
+    byte_bones = _bones_with_exported_weight(influence_list, 8, half_float=False)
+    half_float_bones = _bones_with_exported_weight(influence_list, 8, half_float=True)
+
+    assert "E" in byte_bones
+    assert "E" not in half_float_bones
+    assert byte_bones - half_float_bones == {"E"}

--- a/tests/mtfw/test_weight_bound_filter.py
+++ b/tests/mtfw/test_weight_bound_filter.py
@@ -11,8 +11,9 @@ still rounds to 0, so the filter dropped a vertex the exporter kept.
 
 The mod-21 half-float formats encode weights differently again, so the
 filter mirrors whichever branch `_export_vertices` will take: there a
-normalized weight below 1/510 really does serialize to 0 and must not
-count towards that bone's bound.
+normalized weight below 1/510 really does serialize to 0, and the last
+slot is never serialized at all, so neither counts towards its bone's
+bound.
 
 Not reachable through an import/export round trip: importer-derived
 weights come from the file's already-quantized values, so none of them
@@ -185,19 +186,22 @@ def test_ordinary_vertex_is_unaffected(weight_bound_rig):
 
 
 # One 8-influence vertex: A..D are ordinary, E..H are the residue weights.
-# Ranked by weight, E lands in an 8-weight half-float slot that serializes
-# as round(w * 255), and its normalized weight (0.001) is below 1/510, so
-# the exported vertex carries a literal 0 for it.
+# Ranked by weight it fills all eight slots of an 8-weight mod-21 format,
+# so it exercises both ways that format declines to write a weight:
+# E lands in a slot serialized as round(w * 255) and its normalized weight
+# (0.001) is below 1/510, so a literal 0 goes into the file; H lands in the
+# eighth slot, which the vertex struct has no field for at all.
 HALF_FLOAT_RAW_WEIGHTS = {
     "A": 0.5, "B": 0.3, "C": 0.19, "D": 0.005,
     "E": 0.001, "F": 0.0009, "G": 0.0008, "H": 0.0007,
 }
 
 
-def test_half_float_zero_weight_is_not_counted(weight_bound_rig_8):
+def test_half_float_unwritten_weights_are_not_counted(weight_bound_rig_8):
     """The byte path floors every kept influence to at least 1/255, but the
-    mod-21 half-float path does not: a normalized weight under 1/510
-    serializes as 0, so that bone is not skinned and must not get a bound.
+    mod-21 half-float path does not: a weight that serializes as 0, and the
+    eighth weight that is never serialized at all, leave their bones
+    unskinned in the exported file, so neither may get a weight bound.
     """
     armature, mesh_obj = weight_bound_rig_8
     for name, weight in HALF_FLOAT_RAW_WEIGHTS.items():
@@ -205,32 +209,35 @@ def test_half_float_zero_weight_is_not_counted(weight_bound_rig_8):
 
     weights_data = _processed_weights(mesh_obj, max_bones_per_vertex=8, half_float=True)
     weight_values = [w for _, w in weights_data]
-    _, packed_weights, _ = _encode_half_float_weight_slots(weight_values, 8)
+    position_w, packed_weights, packed_weights_2 = _encode_half_float_weight_slots(
+        weight_values, 8)
 
-    bone_index_d = armature.pose.bones.find("D")
-    bone_index_e = armature.pose.bones.find("E")
-    # slots 1-4 of the vertex struct, i.e. D and E among others
-    assert dict(weights_data)[bone_index_d] > dict(weights_data)[bone_index_e]
+    bones = [armature.pose.bones.find(name) for name in "ABCDEFGH"]
+    # the influences rank in A..H order, so each bone lands in its own slot
+    assert [bone for bone, _ in weights_data] == bones
+    # position.w + weight_values[0:4] + weight_values2[0:2] is seven slots;
+    # the eighth (H) has nowhere to go in the vertex struct
+    assert position_w > 0
     assert packed_weights[2] == 1  # D
-    assert packed_weights[3] == 0  # E, nothing is written for it
+    assert packed_weights[3] == 0  # E, a literal zero goes into the file
+    assert len(packed_weights) + len(packed_weights_2) + 1 == 7
 
     bound_ids = _bound_bone_ids(
         armature, mesh_obj, max_bones_per_vertex=8, half_float=True)
-    assert bone_index_d in bound_ids
-    assert bone_index_e not in bound_ids
+    assert set(bones) - bound_ids == {bones[4], bones[7]}  # E and H
 
 
 def test_half_float_and_byte_paths_disagree_for_the_same_vertex():
     """The same vertex, exported by the two branches: the byte path's
-    `or 1` floor keeps E skinned, the half-float path drops it. The filter
-    has to follow whichever branch the format actually takes rather than
-    always assuming the byte one.
+    `or 1` floor keeps every influence skinned, the half-float path drops
+    the zero-quantized one and the never-written eighth. The filter has to
+    follow whichever branch the format actually takes rather than always
+    assuming the byte one.
     """
     influence_list = list(HALF_FLOAT_RAW_WEIGHTS.items())
 
     byte_bones = _bones_with_exported_weight(influence_list, 8, half_float=False)
     half_float_bones = _bones_with_exported_weight(influence_list, 8, half_float=True)
 
-    assert "E" in byte_bones
-    assert "E" not in half_float_bones
-    assert byte_bones - half_float_bones == {"E"}
+    assert byte_bones == set("ABCDEFGH")
+    assert byte_bones - half_float_bones == {"E", "H"}

--- a/tests/mtfw/test_weight_bound_filter.py
+++ b/tests/mtfw/test_weight_bound_filter.py
@@ -10,10 +10,12 @@ can normalize each other up into a real exported byte while each raw value
 still rounds to 0, so the filter dropped a vertex the exporter kept.
 
 The mod-21 half-float formats encode weights differently again, so the
-filter mirrors whichever branch `_export_vertices` will take: there a
-normalized weight below 1/510 really does serialize to 0, and the last
-slot is never serialized at all, so neither counts towards its bone's
-bound.
+filter mirrors whichever branch `_export_vertices` will take and then
+reads the result back the way `_get_weights` does. There a normalized
+weight below 1/510 really does serialize to 0 and its bone is unskinned,
+while the final slot - which every one of those formats reconstructs from
+the remainder rather than a written field - is skinned whenever that
+remainder is positive.
 
 Not reachable through an import/export round trip: importer-derived
 weights come from the file's already-quantized values, so none of them
@@ -32,6 +34,7 @@ from albam.engines.mtfw.mesh import (
     _calculate_weight_bounds,
     _encode_half_float_weight_slots,
     _process_weights_for_export,
+    _reconstruct_half_float_weights,
 )
 from albam.engines.mtfw.structs.mod_156 import Mod156
 from albam.lib.blender import get_bone_indices_and_weights_per_vertex
@@ -94,6 +97,12 @@ def _rig(bone_names):
 @pytest.fixture
 def weight_bound_rig():
     with _rig(["A", "B"]) as rig:
+        yield rig
+
+
+@pytest.fixture
+def weight_bound_rig_4():
+    with _rig(["A", "B", "C", "D"]) as rig:
         yield rig
 
 
@@ -187,20 +196,21 @@ def test_ordinary_vertex_is_unaffected(weight_bound_rig):
 
 # One 8-influence vertex: A..D are ordinary, E..H are the residue weights.
 # Ranked by weight it fills all eight slots of an 8-weight mod-21 format,
-# so it exercises both ways that format declines to write a weight:
+# so it exercises both ways that format can leave a bone unskinned:
 # E lands in a slot serialized as round(w * 255) and its normalized weight
 # (0.001) is below 1/510, so a literal 0 goes into the file; H lands in the
-# eighth slot, which the vertex struct has no field for at all.
+# eighth slot, whose remainder comes back negative once the seven written
+# slots are quantized.
 HALF_FLOAT_RAW_WEIGHTS = {
     "A": 0.5, "B": 0.3, "C": 0.19, "D": 0.005,
     "E": 0.001, "F": 0.0009, "G": 0.0008, "H": 0.0007,
 }
 
 
-def test_half_float_unwritten_weights_are_not_counted(weight_bound_rig_8):
+def test_half_float_unskinned_weights_are_not_counted(weight_bound_rig_8):
     """The byte path floors every kept influence to at least 1/255, but the
-    mod-21 half-float path does not: a weight that serializes as 0, and the
-    eighth weight that is never serialized at all, leave their bones
+    mod-21 half-float path does not: a weight that serializes as 0, and a
+    final-slot remainder that comes back negative, leave their bones
     unskinned in the exported file, so neither may get a weight bound.
     """
     armature, mesh_obj = weight_bound_rig_8
@@ -209,18 +219,16 @@ def test_half_float_unwritten_weights_are_not_counted(weight_bound_rig_8):
 
     weights_data = _processed_weights(mesh_obj, max_bones_per_vertex=8, half_float=True)
     weight_values = [w for _, w in weights_data]
-    position_w, packed_weights, packed_weights_2 = _encode_half_float_weight_slots(
-        weight_values, 8)
+    _, packed_weights, _ = _encode_half_float_weight_slots(weight_values, 8)
+    reconstructed = _reconstruct_half_float_weights(weight_values, 8)
 
     bones = [armature.pose.bones.find(name) for name in "ABCDEFGH"]
     # the influences rank in A..H order, so each bone lands in its own slot
     assert [bone for bone, _ in weights_data] == bones
-    # position.w + weight_values[0:4] + weight_values2[0:2] is seven slots;
-    # the eighth (H) has nowhere to go in the vertex struct
-    assert position_w > 0
     assert packed_weights[2] == 1  # D
     assert packed_weights[3] == 0  # E, a literal zero goes into the file
-    assert len(packed_weights) + len(packed_weights_2) + 1 == 7
+    assert reconstructed[4] == 0.0  # so the game reads E as unweighted
+    assert reconstructed[7] < 0  # and H's remainder is not a real influence
 
     bound_ids = _bound_bone_ids(
         armature, mesh_obj, max_bones_per_vertex=8, half_float=True)
@@ -229,10 +237,9 @@ def test_half_float_unwritten_weights_are_not_counted(weight_bound_rig_8):
 
 def test_half_float_and_byte_paths_disagree_for_the_same_vertex():
     """The same vertex, exported by the two branches: the byte path's
-    `or 1` floor keeps every influence skinned, the half-float path drops
-    the zero-quantized one and the never-written eighth. The filter has to
-    follow whichever branch the format actually takes rather than always
-    assuming the byte one.
+    `or 1` floor keeps every influence skinned, the half-float path leaves
+    two of them unskinned. The filter has to follow whichever branch the
+    format actually takes rather than always assuming the byte one.
     """
     influence_list = list(HALF_FLOAT_RAW_WEIGHTS.items())
 
@@ -241,3 +248,57 @@ def test_half_float_and_byte_paths_disagree_for_the_same_vertex():
 
     assert byte_bones == set("ABCDEFGH")
     assert byte_bones - half_float_bones == {"E", "H"}
+
+
+# Every mod-21 half-float format derives its *last* slot from the remainder
+# instead of a written field (see _get_weights), so a bone that only ever
+# lands in that slot is still skinned in the exported file and still needs a
+# weight bound. A blanket "the last slot is never written, so it never
+# counts" rule silently deletes the 4th influence on 0x14D40020, the default
+# skinned format, and the 2nd influence on every 2-weight format.
+FULL_VERTEX_PER_FORMAT = [
+    pytest.param(1, {"A": 1.0}, id="1wt"),
+    pytest.param(2, {"A": 0.6, "B": 0.4}, id="2wt"),
+    pytest.param(4, {"A": 0.4, "B": 0.3, "C": 0.2, "D": 0.1}, id="4wt-default-skinned"),
+    pytest.param(8, dict.fromkeys("ABCDEFGH", 0.125), id="8wt"),
+]
+
+
+@pytest.mark.parametrize("max_bones_per_vertex, raw_weights", FULL_VERTEX_PER_FORMAT)
+def test_half_float_remainder_slot_is_still_skinned(max_bones_per_vertex, raw_weights):
+    """A vertex whose influences exactly fill its format: every bone,
+    including the one in the reconstructed final slot, is skinned in the
+    exported file, so every one of them counts.
+    """
+    influence_list = list(raw_weights.items())
+
+    reconstructed = _reconstruct_half_float_weights(
+        [w for _, w in _process_weights_for_export(
+            {0: influence_list}, max_bones_per_vertex, half_float=True)[0]],
+        max_bones_per_vertex,
+    )
+    assert len(reconstructed) == max_bones_per_vertex
+    assert all(w > 0 for w in reconstructed)
+    assert sum(reconstructed) == pytest.approx(1.0, abs=1e-3)
+
+    assert _bones_with_exported_weight(
+        influence_list, max_bones_per_vertex, half_float=True) == set(raw_weights)
+
+
+def test_fourth_influence_on_the_default_skinned_format_gets_a_bound(weight_bound_rig_4):
+    """The findings trace end to end: on 0x14D40020's 4-weight half-float
+    layout the game reconstructs D as 1 - w1 - w2 - w3 = 0.1, so a bone
+    that is only ever a 4th influence is genuinely skinned and must get a
+    weight bound.
+    """
+    armature, mesh_obj = weight_bound_rig_4
+    for name, weight in {"A": 0.4, "B": 0.3, "C": 0.2, "D": 0.1}.items():
+        mesh_obj.vertex_groups[name].add([0], weight, "REPLACE")
+
+    weights_data = _processed_weights(mesh_obj, max_bones_per_vertex=4, half_float=True)
+    reconstructed = _reconstruct_half_float_weights([w for _, w in weights_data], 4)
+    assert reconstructed[3] == pytest.approx(0.1, abs=1e-3)
+
+    bound_ids = _bound_bone_ids(
+        armature, mesh_obj, max_bones_per_vertex=4, half_float=True)
+    assert bound_ids == {armature.pose.bones.find(name) for name in "ABCD"}


### PR DESCRIPTION
## Intent

Fix albam issue #253, "Weight bound filter tests raw weights, but export normalizes them first" (https://github.com/Brachi/albam/issues/253).

The captain's ask, in the substance of that issue (which the captain wrote):

_calculate_vertex_group_weight_bound decides which vertices count towards a bone's weight bound by testing the raw vertex-group weight, while _process_weights_for_export does not write that value: it keeps the vertex's top influences, normalizes them by their sum, and then forces a floor with round(w * 255) or 1.

Normalization scales small weights up, and or 1 guarantees any kept influence serializes to at least 1/255. So a vertex the filter drops can still be skinned to that bone in the exported vertex data.

Worked through both paths:

raw weights on a vertex | filter keeps the second? | weight actually exported
{A: 0.9, B: 0.001} | no | 1
{A: 0.99998, B: 0.00002} | no | 1
{A: 0.002, B: 0.0015} | no | 109

The third case is the important one. Both weights are below one quantization step, so normalization scales both up and B exports at 109/255, a substantial influence, while being excluded from B's bound. The result is a bound computed over too few vertices, or, when every vertex in the group falls below the threshold, a bone genuinely skinned in the exported data with no weight bound written for it at all. That is the opposite of what the filter is for.

Why no test catches it: it is not reachable through an import/export round trip, because the importer derives weights from the file's already-quantized values, so none of them round to zero. Measured across pawn/pl/pl00, pawn/pl/pl01, umvc3's Ryu and a umvc3 stage, the filter excludes 0 vertices on every one. It needs weights authored or edited in Blender, which is the exporter's actual use case - residuals "far below one step ... ~2e-05 across every vertex", which is what Normalize All leaves behind.

Suggested fix: mirror what the exporter does before testing. Take the vertex's kept influences after the max_bones_per_vertex truncation, normalize by their sum, apply the or 1 floor, and test that. A vertex counts towards a bone's bound exactly when the exporter writes a non-zero weight for that bone. Sharing one helper between the two would be better than duplicating the arithmetic, since the point is that they must agree.

## What Changed

- `_calculate_weight_bounds` no longer decides membership from the raw vertex-group weight. It now runs each vertex through the exporter's own truncate/normalize/quantize path via the new `_bones_with_exported_weight` helper and counts a vertex towards a bone's bound exactly when the exported vertex data ends up with a non-zero weight for that bone (issue #253). `_weight_in_group` and the `WEIGHT_QUANTIZATION_STEPS` constant are gone.
- Extracted the per-vertex weight logic out of `_process_weights_for_export` into shared helpers (`_truncate_and_normalize_weights`, `_process_vertex_weights`) and factored the mod-21 vertex-format encoding out of `_export_vertices` into `_encode_half_float_weight_slots`, with `_reconstruct_half_float_weights` reading those slots back the way `_get_weights` does on import. The bone limit and half-float decision now come from one `_weight_export_params` helper used by both the exporter and the bound filter, so `_serialize_meshes_data` passes the same parameters to `_calculate_weight_bounds`.
- Added `tests/mtfw/test_weight_bound_filter.py` covering the sub-quantization-step case that previously slipped past the filter, the byte and half-float paths disagreeing on the same vertex, half-float weights that really do serialize to zero, and the remainder-derived final slot still counting as skinned.

## Risk Assessment

✅ Low: The exporter refactor is provably behavior-preserving, the per-format reconstruction now mirrors `_get_weights` (I hand-traced the 4wt default-skinned, 2wt, 1wt and 8wt cases and the issue #253 byte-path table), the prior round's over-broad \"final slot never counts\" regression is genuinely reversed, and the added tests assert the correct outcomes rather than just the current ones.

## Testing

Exercised the change in a real Blender (bpy 4.2) session with the albam addon registered, authoring vertex groups the way an end user would and running the exporter's own weight-bound path plus a bytes round trip through the real kaitai vertex structs and the importer's _get_weights. The issue #253 residual-weight vertex (A=0.002/B=0.0015, exported as 146/109) now yields bounds for both bones, an ordinary vertex is unchanged, influences truncated past the format's bone limit still get no bound, and on every mod-21 half-float format (8wt, 4wt default-skinned, 2wt) the set of bones with a weight bound exactly matches the set the written bytes decode to as non-zero — including excluding the 8wt slot that serializes as a literal 0 and the 8th-slot remainder that comes back negative, while keeping the reconstructed final slot on 4wt/2wt. The same driver run against base 367c0b8 drops bone B (exported at 109/255) and drops F and G on the 8wt format, so the regression is reproduced before the fix and gone after. There is no UI surface in this change, so no visual artifact applies; the only thing not drivable here is a full export_mod operator round trip, which requires real game archives via --game-dir. Worktree left clean.

- Live validation: ✅ go - 7 of 8 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Issue #253 row 3: a vertex authored A=0.002/B=0.0015 exports B at 109/255 and B now gets a weight bound | ✅ pass | live | after-fix-HEAD.txt S1 (bound = [&#39;A&#39;,&#39;B&#39;]) vs before-fix-base-367c0b8.txt S1 (bound = [&#39;A&#39;]) |
| Issue #253 row 1: a residual influence floored to 1/255 by the exporter gets a weight bound | ✅ pass | live | after-fix-HEAD.txt S1b (writes A=254 B=1, bound = [&#39;A&#39;,&#39;B&#39;]); base drops B |
| An ordinary well-formed vertex (0.7/0.3) is unaffected — both bones keep their bounds | ✅ pass | live | after-fix-HEAD.txt S2, identical to base |
| Adversarial: 6 influences on a 4-bone format — the two truncated-away bones get no bound | ✅ pass | live | after-fix-HEAD.txt S6 (exporter writes A/B/C/D only; bound = [&#39;A&#39;,&#39;B&#39;,&#39;C&#39;,&#39;D&#39;], E and F excluded) |
| Adversarial 8wt half-float (0x75c3e025): bones whose written byte is 0 or whose remainder decodes negative get no bound, while the tiny-but-written ones do | ✅ pass | live | after-fix-HEAD.txt S3 — vertex bytes re-parsed and decoded by the importer&#39;s _get_weights; skinned set == bound set == A,B,C,D,F,G (base gave A,B,C,D) |
| 4wt default skinned format (0x14d40020): the 4th influence reconstructed from the remainder (0.1) still gets a weight bound | ✅ pass | live | after-fix-HEAD.txt S4 — game reads back D=0.1 from the written bytes; bound = A,B,C,D |
| 2wt half-float format (0xc31f201c): the second slot, purely reconstructed from the remainder, still gets a weight bound | ✅ pass | live | after-fix-HEAD.txt S5 — game reads back A=0.59999 B=0.40001; bound = A,B |
| Full addon export: import a real .mod from a game archive, edit weights in Blender, export and inspect the weight_bounds block in the written file | ⏸️ untested | no | Requires real MT Framework game archives supplied via pytest&#39;s --game-dir (or R2 credentials for tests/mtfw/r2_config.py); no game data is present on this machine and none may be committed. Provide a… |

<details>
<summary>Evidence: Driver transcript at HEAD — filter agrees with the bytes for every format</summary>

```text

=== S1 issue #253 row 3: both raw weights below one quantization step
  format=0x0 mod version=156 max_bones=4 half_float=False
  authored blender weights: {'A': 0.002, 'B': 0.0015}
  exporter writes:          {'A': 146, 'B': 109}
  bones with weight bound:  ['A', 'B']

=== S1b issue #253 row 1
  format=0x0 mod version=156 max_bones=4 half_float=False
  authored blender weights: {'A': 0.9, 'B': 0.001}
  exporter writes:          {'A': 254, 'B': 1}
  bones with weight bound:  ['A', 'B']

=== S2 ordinary vertex
  format=0x0 mod version=156 max_bones=4 half_float=False
  authored blender weights: {'A': 0.7, 'B': 0.3}
  exporter writes:          {'A': 179, 'B': 76}
  bones with weight bound:  ['A', 'B']

=== S6 adversarial: 6 influences on a 4-bone format - the two weakest are truncated away and must NOT get a bound
  format=0x0 mod version=156 max_bones=4 half_float=False
  authored blender weights: {'A': 0.5, 'B': 0.2, 'C': 0.15, 'D': 0.1, 'E': 0.03, 'F': 0.02}
  exporter writes:          {'A': 134, 'B': 54, 'C': 40, 'D': 27}
  bones with weight bound:  ['A', 'B', 'C', 'D']

=== S3 mod-21 8wt 0x75c3e025: residue weights that really are unskinned
  format=0x75c3e025 mod version=212 max_bones=8 half_float=True
  authored blender weights: {'A': 0.5, 'B': 0.3, 'C': 0.19, 'D': 0.005, 'E': 0.001, 'F': 0.0009, 'G': 0.0008, 'H': 0.0007}
  exporter writes:          {'A': 0.5008087405011139, 'B': 0.30196078431372547, 'C': 0.19215686274509805, 'D': 0.00392156862745098, 'E': 0.0, 'F': 0.0008997917175292969, 'G': 0.0008001327514648438, 'H': 0.0007}
  serialized vertex bytes:  0000000000001a40000000004d3101000000000000000000000000005f138e120000000000000000
  game reads back:          {'A': 0.50081, 'B': 0.30196, 'C': 0.19216, 'D': 0.00392, 'E': 0.0, 'F': 0.0009, 'G': 0.0008, 'H': -0.00055}
  bones skinned in file:    ['A', 'B', 'C', 'D', 'F', 'G']
  bones with weight bound:  ['A', 'B', 'C', 'D', 'F', 'G']
  AGREE: True

=== S4 mod-21 4wt 0x14d40020 (default skinned): 4th influence is reconstructed
  format=0x14d40020 mod version=212 max_bones=4 half_float=True
  authored blender weights: {'A': 0.4, 'B': 0.3, 'C': 0.2, 'D': 0.1}
  exporter writes:          {'A': 0.4000061037018952, 'B': 0.300048828125, 'C': 0.199951171875, 'D': 0.1}
  serialized vertex bytes:  000000000000333300000000000000000000000000000000cd346632
  game reads back:          {'A': 0.40001, 'B': 0.30005, 'C': 0.19995, 'D': 0.1}
  bones skinned in file:    ['A', 'B', 'C', 'D']
  bones with weight bound:  ['A', 'B', 'C', 'D']
  AGREE: True

=== S5 mod-21 2wt 0xc31f201c: 2nd slot is the reconstructed remainder
  format=0xc31f201c mod version=212 max_bones=2 half_float=True
  authored blender weights: {'A': 0.6, 'B': 0.4}
  exporter writes:          {'A': 0.6, 'B': 0.4}
  serialized vertex bytes:  000000000000cc4c0000000000000000000000000000003c
  game reads back:          {'A': 0.59999, 'B': 0.40001}
  bones skinned in file:    ['A', 'B']
  bones with weight bound:  ['A', 'B']
  AGREE: True

OVERALL: PASS
```
</details>
<details>
<summary>Evidence: Same driver at base 367c0b8 — #253 bug reproduced (B, F, G lose their bounds)</summary>

```text

=== S1 issue #253 row 3: both raw weights below one quantization step
  format=0x0 mod version=156 max_bones=4 half_float=False
  authored blender weights: {'A': 0.002, 'B': 0.0015}
  exporter writes:          {'A': 146, 'B': 109}
  bones with weight bound:  ['A']

=== S1b issue #253 row 1
  format=0x0 mod version=156 max_bones=4 half_float=False
  authored blender weights: {'A': 0.9, 'B': 0.001}
  exporter writes:          {'A': 254, 'B': 1}
  bones with weight bound:  ['A']

=== S2 ordinary vertex
  format=0x0 mod version=156 max_bones=4 half_float=False
  authored blender weights: {'A': 0.7, 'B': 0.3}
  exporter writes:          {'A': 179, 'B': 76}
  bones with weight bound:  ['A', 'B']

=== S3 mod-21 8wt 0x75c3e025: residue weights that really are unskinned
  format=0x75c3e025 mod version=212 max_bones=8 half_float=True
  authored blender weights: {'A': 0.5, 'B': 0.3, 'C': 0.19, 'D': 0.005, 'E': 0.001, 'F': 0.0009, 'G': 0.0008, 'H': 0.0007}
  exporter writes:          {'A': 0.5008087405011139, 'B': 0.30196078431372547, 'C': 0.19215686274509805, 'D': 0.00392156862745098, 'E': 0.0, 'F': 0.0008997917175292969, 'G': 0.0008001327514648438, 'H': 0.0007}
  bones with weight bound:  ['A', 'B', 'C', 'D']

=== S4 mod-21 4wt 0x14d40020 (default skinned): 4th influence is reconstructed
  format=0x14d40020 mod version=212 max_bones=4 half_float=True
  authored blender weights: {'A': 0.4, 'B': 0.3, 'C': 0.2, 'D': 0.1}
  exporter writes:          {'A': 0.4000061037018952, 'B': 0.300048828125, 'C': 0.199951171875, 'D': 0.1}
  bones with weight bound:  ['A', 'B', 'C', 'D']

=== S5 mod-21 2wt 0xc31f201c: 2nd slot is the reconstructed remainder
  format=0xc31f201c mod version=212 max_bones=2 half_float=True
  authored blender weights: {'A': 0.6, 'B': 0.4}
  exporter writes:          {'A': 0.6, 'B': 0.4}
  bones with weight bound:  ['A', 'B']

OVERALL: FAIL
```
</details>
<details>
<summary>Evidence: Driver script (real bpy session + kaitai byte round trip)</summary>

```text
"""Drives albam's exporter weight-bound path in a real Blender (bpy) session.

Builds an armature + weighted mesh the way a user would author one in
Blender, runs the exporter's own weight-bound calculation for a given
mod version + vertex format, and (for the mod-21 half-float formats)
serializes the vertex through the real kaitai vertex struct, re-parses the
bytes and asks the *importer's* _get_weights what the game will read back.
"""
import sys
from types import SimpleNamespace

import bpy
from kaitaistruct import KaitaiStream, BytesIO

import albam
albam.register()

from albam.engines.mtfw import mesh as M
from albam.engines.mtfw.structs.mod_156 import Mod156
from albam.engines.mtfw.structs.mod_21 import Mod21
from albam.lib.kaitai_utils import check_recursive

VERTEX_CLS = M.VERTEX_FORMATS_MAPPER

class FakeMeshesData:
    def __init__(self):
        self._root = self

def build_rig(names, weights, coords=None):
    coords = coords or [(0.5, 0.0, 0.0), (0.7, 0.2, 0.1)]
    arm_data = bpy.data.armatures.new("rig")
    arm = bpy.data.objects.new("rig", arm_data)
    bpy.context.scene.collection.objects.link(arm)
    bpy.context.view_layer.objects.active = arm
    bpy.ops.object.mode_set(mode="EDIT")
    for i, n in enumerate(names):
        b = arm_data.edit_bones.new(n)
        b.head = (float(i), 0.0, 0.0)
        b.tail = (float(i), 0.0, 0.1)
    bpy.ops.object.mode_set(mode="OBJECT")
    me = bpy.data.meshes.new("m")
    me.from_pydata(coords, [], [])
    me.update()
    ob = bpy.data.objects.new("m", me)
    bpy.context.scene.collection.objects.link(ob)
    for n in names:
        ob.vertex_groups.new(name=n)
    mod = ob.modifiers.new(name="Armature", type="ARMATURE")
    mod.object = arm
    for n, w in weights.items():
        ob.vertex_groups[n].add(list(range(len(coords))), w, "REPLACE")
    return arm, ob

def bounds(arm, ob, mod_cls, version, vertex_format):
    class DstMod:
        """The destination mod class the exporter builds structs from, with
        the header version the export is targeting."""
        header = SimpleNamespace(version=version)

        def __getattr__(self, name):
            return getattr(mod_cls, name)
    dst_mod = DstMod()
    if hasattr(M, "_weight_export_params"):
        max_bones, half_float = M._weight_export_params(dst_mod, vertex_format)
        wbs = M._calculate_weight_bounds(arm, ob, dst_mod, FakeMeshesData(), max_bones, half_float)
    else:  # base commit signature
        max_bones = M.VERTEX_FORMATS_BONE_LIMIT.get(vertex_format, 4)
        half_float = version in (210, 211, 212) and vertex_format not in M.VERTEX_FORMATS_BRIDGE
        wbs = M._calculate_weight_bounds(arm, ob, dst_mod, FakeMeshesData())
    names = {arm.pose.bones.find(b.name): b.name for b in ob.vertex_groups}
    return max_bones, half_float, {names[wb.bone_id] for wb in wbs}

def game_weights(ob, version, vertex_format, max_bones, names):
    """Serialize the vertex through the real struct and read it back with
    the importer's _get_weights - what the game actually ends up with."""
    wpv = M._process_weights_for_export(
        M.get_bone_indices_and_weights_per_vertex(ob),
        max_bones_per_vertex=max_bones, half_float=True)
    influences = wpv[0]
    values = [w for _, w in influences] + [0] * (max_bones - len(influences))
    bone_ids = [b for b, _ in influences] + [0] * (max_bones - len(influences))
    VertexCls = VERTEX_CLS[vertex_format]
    v = VertexCls(KaitaiStream(BytesIO(b"\x00" * VertexCls().size_)))
    v._read()
    pw, packed, packed2 = M._encode_half_float_weight_slots(values, max_bones)
    if max_bones == 2:
        v.bone_indices = [M.pack("e", bone_ids[0]), M.pack("e", bone_ids[1])]
    if pw is not None:
        v.position.w = pw
    if packed is not None:
        v.weight_values = packed
    if packed2 is not None:
        v.weight_values2 = packed2
    check_recursive(v)  # exactly what _export_vertices does before writing
    out = KaitaiStream(BytesIO(bytearray(VertexCls().size_)))
    v._write(out)
    raw = out.to_byte_array()
    parsed = VertexCls(KaitaiStream(BytesIO(raw)))
    parsed._read()
    fake_mesh = SimpleNamespace(vertex_format=vertex_format)
    fake_mod = SimpleNamespace(header=SimpleNamespace(version=version))
    read = M._get_weights(fake_mod, fake_mesh, parsed)
    idx_to_name = {arm_idx: n for n, arm_idx in names.items()}
    return raw, {idx_to_name[b]: w for b, w in zip(bone_ids[:len(influences)], read)}

def clear():
    for coll in (bpy.data.objects,):
        for o in list(coll):
            coll.remove(o, do_unlink=True)
    for coll in (bpy.data.meshes, bpy.data.armatures):
        for o in list(coll):
            coll.remove(o)

def scenario(title, names, weights, version, vertex_format, mod_cls, show_bytes=False):
    clear()
    arm, ob = build_rig(names, weights)
    max_bones, half_float, bound = bounds(arm, ob, mod_cls, version, vertex_format)
    print(f"\n=== {title}")
    print(f"  format={hex(vertex_format)} mod version={version} "
          f"max_bones={max_bones} half_float={half_float}")
    print(f"  authored blender weights: {weights}")
    processed = M._process_weights_for_export(
        M.get_bone_indices_and_weights_per_vertex(ob),
        max_bones_per_vertex=max_bones, half_float=half_float)[0]
    idx = {arm.pose.bones.find(n): n for n in names}
    print(f"  exporter writes:          "
          f"{ {idx[b]: w for b, w in processed} }")
    if half_float and show_bytes and hasattr(M, '_encode_half_float_weight_slots'):
        name_to_idx = {n: arm.pose.bones.find(n) for n in names}
        raw, read_back = game_weights(ob, version, vertex_format, max_bones, name_to_idx)
        print(f"  serialized vertex bytes:  {raw.hex()}")
        print(f"  game reads back:          "
              f"{ {k: round(v, 5) for k, v in read_back.items()} }")
        skinned = {k for k, v in read_back.items() if v > 0}
        print(f"  bones skinned in file:    {sorted(skinned)}")
        print(f"  bones with weight bound:  {sorted(bound)}")
        print(f"  AGREE: {skinned == bound}")
    else:
        print(f"  bones with weight bound:  {sorted(bound)}")
    return bound

arm = None
if __name__ == "__main__":
    which = sys.argv[1] if len(sys.argv) > 1 else "all"
    ok = True
    if which in ("all", "byte"):
        b = scenario("S1 issue #253 row 3: both raw weights below one quantization step",
                     ["A", "B"], {"A": 0.002, "B": 0.0015}, 156, 0x0, Mod156)
        ok &= (b == {"A", "B"})
        b = scenario("S1b issue #253 row 1", ["A", "B"], {"A": 0.9, "B": 0.001}, 156, 0x0, Mod156)
        ok &= (b == {"A", "B"})
        b = scenario("S2 ordinary vertex", ["A", "B"], {"A": 0.7, "B": 0.3}, 156, 0x0, Mod156)
        ok &= (b == {"A", "B"})
        b = scenario("S6 adversarial: 6 influences on a 4-bone format - the two "
                     "weakest are truncated away and must NOT get a bound",
                     list("ABCDEF"),
                     {"A": 0.5, "B": 0.2, "C": 0.15, "D": 0.1, "E": 0.03, "F": 0.02},
                     156, 0x0, Mod156)
        ok &= (b == set("ABCD"))
    if which in ("all", "half"):
        b = scenario("S3 mod-21 8wt 0x75c3e025: residue weights that really are unskinned",
                     list("ABCDEFGH"),
                     {"A": 0.5, "B": 0.3, "C": 0.19, "D": 0.005,
                      "E": 0.001, "F": 0.0009, "G": 0.0008, "H": 0.0007},
                     212, 0x75c3e025, Mod21, show_bytes=True)
        ok &= (b == set("ABCDFG"))
        b = scenario("S4 mod-21 4wt 0x14d40020 (default skinned): 4th influence is reconstructed",
                     list("ABCD"), {"A": 0.4, "B": 0.3, "C": 0.2, "D": 0.1},
                     212, 0x14d40020, Mod21, show_bytes=True)
        ok &= (b == set("ABCD"))
        b = scenario("S5 mod-21 2wt 0xc31f201c: 2nd slot is the reconstructed remainder",
                     list("AB"), {"A": 0.6, "B": 0.4}, 212, 0xc31f201c, Mod21, show_bytes=True)
        ok &= (b == set("AB"))
    print(f"\nOVERALL: {'PASS' if ok else 'FAIL'}")
    sys.exit(0 if ok else 1)
```
</details>
<details>
<summary>Evidence: tests/mtfw/test_weight_bound_filter.py -v</summary>

```text
============================= test session starts ==============================
platform linux -- Python 3.11.16, pytest-9.1.1, pluggy-1.6.0 -- <temp path>
rootdir: ~/.no-mistakes/worktrees/731f537710a6/01M22AS402A0KZM92Y568CW2DB
configfile: pyproject.toml
collecting ... collected 12 items

tests/mtfw/test_weight_bound_filter.py::test_filter_agrees_with_export_for_weights_below_one_quantization_step[A0.9-B0.001] PASSED [  8%]
tests/mtfw/test_weight_bound_filter.py::test_filter_agrees_with_export_for_weights_below_one_quantization_step[A0.99998-B0.00002] PASSED [ 16%]
tests/mtfw/test_weight_bound_filter.py::test_filter_agrees_with_export_for_weights_below_one_quantization_step[A0.002-B0.0015] PASSED [ 25%]
tests/mtfw/test_weight_bound_filter.py::test_third_row_used_to_slip_past_the_filter PASSED [ 33%]
tests/mtfw/test_weight_bound_filter.py::test_ordinary_vertex_is_unaffected PASSED [ 41%]
tests/mtfw/test_weight_bound_filter.py::test_half_float_unskinned_weights_are_not_counted PASSED [ 50%]
tests/mtfw/test_weight_bound_filter.py::test_half_float_and_byte_paths_disagree_for_the_same_vertex PASSED [ 58%]
tests/mtfw/test_weight_bound_filter.py::test_half_float_remainder_slot_is_still_skinned[1wt] PASSED [ 66%]
tests/mtfw/test_weight_bound_filter.py::test_half_float_remainder_slot_is_still_skinned[2wt] PASSED [ 75%]
tests/mtfw/test_weight_bound_filter.py::test_half_float_remainder_slot_is_still_skinned[4wt-default-skinned] PASSED [ 83%]
tests/mtfw/test_weight_bound_filter.py::test_half_float_remainder_slot_is_still_skinned[8wt] PASSED [ 91%]
tests/mtfw/test_weight_bound_filter.py::test_fourth_influence_on_the_default_skinned_format_gets_a_bound PASSED [100%]

============================== 12 passed in 0.02s ==============================
```
</details>
<details>
<summary>Evidence: 8wt half-float: written bytes vs bones with a bound</summary>

```text
=== S3 mod-21 8wt 0x75c3e025
authored: A0.5 B0.3 C0.19 D0.005 E0.001 F0.0009 G0.0008 H0.0007
serialized vertex bytes: 0000000000001a40000000004d3101000000000000000000000000005f138e120000000000000000
game reads back: {'A': 0.50081, 'B': 0.30196, 'C': 0.19216, 'D': 0.00392, 'E': 0.0, 'F': 0.0009, 'G': 0.0008, 'H': -0.00055}
bones skinned in file: ['A', 'B', 'C', 'D', 'F', 'G']
bones with weight bound: ['A', 'B', 'C', 'D', 'F', 'G']
AGREE: True
(base 367c0b8 on the same scene: bones with weight bound: ['A', 'B', 'C', 'D'])
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"cd03f4a11ef6ac96dad744592e717a55e53422b8","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":7,"total":8}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `albam/engines/mtfw/mesh.py:2506` - The filter calls _normalize_and_quantize_weights (the byte path) unconditionally, but _export_vertices selects half_float=True for dst_mod.header.version in (210, 211, 212) when vertex_format is not in VERTEX_FORMATS_BRIDGE (mesh.py:2049), and _process_weights_for_export then takes the _check_weights branch instead. For an 8-weight mod-21 format, _check_weights re-quantizes slots 1-4 as round(w*255) (a normalized weight under 1/510 exports as 0.0) and the 8th weight (weights[i+3]) is never written into the vertex struct at all (mesh.py:2248-2257). Concrete case: a vertex on an re6/umvc3 8-weight skinned mesh with influences normalizing to [0.60, 0.20, 0.15, 0.04, 0.008, 0.001, 0.001, 0.0005] - the bone at slot 5 exports weight_values[3]=round(0.001*255)=0, and the slot-7 bone is not serialized at all, yet the byte helper floors both to 1 so the filter counts that vertex towards both bones&#39; bounds. The direction is over-inclusive (a slightly oversized bound), the opposite of the #253 failure, so it does not reintroduce the reported bug, but it contradicts the stated invariant in the new comment/docstring (&#34;a bone_index is written with a non-zero weight for this vertex iff it appears in the result&#34;). The smallest honest remedy - teaching the shared helper to reproduce the half_float arithmetic too, or restricting the invariant claim - extends the change beyond the intent&#39;s byte-path scope, so the remedy, not the defect, is what needs authorization.
- ⚠️ `albam/engines/mtfw/mesh.py:2504` - _calculate_vertex_group_weight_bound re-runs _normalize_and_quantize_weights for every (vertex group, vertex) pair, so each vertex&#39;s full truncate/sort/dict/normalize/quantize pipeline is repeated once per vertex group it belongs to - typically 4x (up to 8x on 8-weight formats) more work than needed, on every mesh of every export. The old _weight_in_group test was a cheap scan of v.groups, so this is a real added constant factor on large meshes. Equivalent and cheaper: call _process_weights_for_export(weights_per_vertex, max_bones_per_vertex=..., half_float=False) once in _calculate_weight_bounds and build a {bone_index: set(vertex_index)} map, then have the per-group function look up membership. Pure refactor, identical results.
- ℹ️ `albam/engines/mtfw/mesh.py:2353` - The refactor moved the truncate / sort / build-dict / normalize prefix into the half_float branch verbatim while the byte branch gets it from _normalize_and_quantize_weights, so the same arithmetic now exists twice in one function. Extracting that shared prefix (e.g. a helper returning (bone_indices, normalized_weights)) that both branches call removes the copy without changing behavior.
- ⚠️ `albam/engines/mtfw/mesh.py:2379` - Simplification: the new max_bones_per_vertex=4 default on _calculate_weight_bounds is a fallback the intent does not require - the sole production caller (mesh.py:1849) always passes the format&#39;s real limit, and the tests pass it explicitly too. A silent default of 4 would quietly compute the wrong truncation for an 8- or 2-weight format if a future call site omits it. The narrower form that satisfies the intent is a required positional parameter; recommend dropping the default.
- ℹ️ `tests/mtfw/test_weight_bound_filter.py:129` - test_third_row_used_to_slip_past_the_filter takes the weight_bound_rig fixture but never uses it - it only exercises _normalize_and_quantize_weights on a literal influence list. Building and tearing down a Blender armature, mesh and modifier for it is pure overhead; drop the parameter.

🔧 Fix applied.
2 issues (1 warning, 1 info) still open:

- ⚠️ `albam/engines/mtfw/mesh.py:2387` - The half-float mirror counts the last (never-serialized) weight slot whenever its reconstructed remainder is non-zero, which is the opposite of the remedy the previous round approved (&#34;including not counting a weight the exporter never writes (the 8th half-float slot)&#34;). _decode_half_float_weight_slots appends `1.0 - sum(decoded)` as the final slot, and _bones_with_exported_weight treats any non-zero value there as &#34;skinned&#34;. Traced with the test&#39;s own 8-influence vertex (A..H = 0.5/0.3/0.19/0.005/0.001/0.0009/0.0008/0.0007 on an 8-weight mod-21 format): the seven written slots decode to [0.50081, 0.30196, 0.19216, 0.00392, 0.0, 0.00090, 0.00080] and the 8th slot&#39;s remainder comes out as -0.00055 — a negative weight — yet H is still counted towards its bone&#39;s bound, and tests/mtfw/test_weight_bound_filter.py:236 (`byte_bones - half_float_bones == {&#34;E&#34;}`) locks that in. So the exact case the accepted finding named is still counted, only via a different route. The code&#39;s rationale is defensible (the game reconstructs the last slot the way _get_weights does on import, so the bone genuinely is influenced), but it is a deliberate reinterpretation of the approved remedy and a user-visible decision about which bones get bounds, so it needs the author&#39;s confirmation rather than a silent fix. If the reconstructed-remainder reading is the intended one, the round-1 wording should be corrected; if not, the last slot should be excluded and the test assertion updated to `{&#34;E&#34;, &#34;H&#34;}`.
- ℹ️ `albam/engines/mtfw/mesh.py:2448` - Every exported mesh now runs the whole weight pipeline twice: _export_vertices (mesh.py:2009/2048) calls get_bone_indices_and_weights_per_vertex + _process_weights_for_export, and moments later _calculate_weight_bounds (mesh.py:2448-2453) repeats both over the same object with the same MAX_BONES/half_float. The result of the first pass is exactly the input the filter needs — only the half-float decode step is extra — so _export_vertices could return its processed `weights_per_vertex` and _calculate_weight_bounds could consume it. Noting the cost rather than prescribing it: the fix would widen an already 6-element return tuple, and this code has been reworked twice already, so it is not worth another churn round unless export time on large meshes is a concern.

🔧 Fix applied.
1 error still open:

- 🚨 `albam/engines/mtfw/mesh.py:2384` - The round-2 rule &#34;the final half-float slot is never written, so it never counts&#34; is applied to every half-float format, not only the 8th-slot residual case it was reasoned about, and on the 2- and 4-weight formats it deletes large, genuinely skinned influences from the bounds. `_written_half_float_weights` always returns max_bones_per_vertex - 1 entries, and `_bones_with_exported_weight` (mesh.py:2404) zips that against the influence list, so the last-ranked bone of a full vertex is always dropped. Concrete trace on 0x14D40020, which is DEFAULT_VERTEX_FORMAT_SKIN (mesh.py:82) - the default mod-21 skinned export: vertex weighted A=0.4 B=0.3 C=0.2 D=0.1. `_process_vertex_weights` keeps all four, `_encode_half_float_weight_slots` writes position.w and two half-floats, and the game reconstructs D as 1 - 0.4 - 0.3 - 0.2 = 0.1 exactly the way `_get_weights` does (mesh.py:618), so D is skinned at 10% in the exported file - yet D is excluded, and a bone that is only ever a 4th influence gets no weight bound written at all. Worse on the 2-weight formats (0xc31f201c, 0xd9e801d, 0xa013501e, 0xb392101f): only slot 0 is ever counted, so for A=0.4/B=0.6 bone A is dropped on every vertex. Same class on 8-weight with eight equal 0.125 influences. This reproduces the exact failure the intent names: &#34;a bone genuinely skinned in the exported data with no weight bound written for it at all. That is the opposite of what the filter is for.&#34; The added tests only exercise the 8-weight format (tests/mtfw/test_weight_bound_filter.py:186), where the last slot happens to be a tiny residual, so nothing catches it. This is ask-user rather than auto-fix because the exclusion is exactly what the round-2 instruction demanded (&#34;the reconstructed remainder in the final slot is excluded from the &#39;skinned&#39; determination&#34;) and reversing it is the author&#39;s call; the two rules the run has been given now conflict. The narrower rule that satisfies both: count the final slot&#39;s bone iff the reconstructed remainder 1 - sum(written slots) is &gt; 0 - that still excludes the negative-remainder 8th-slot case round 2 was reacting to (-0.00055 for the test&#39;s A..H vertex) while keeping D&#39;s real 0.1. Whichever rule is chosen, the half-float tests need 2-weight and 4-weight cases, since today they only pin the 8-weight shape.

🔧 Fix applied.
1 info still open:

- ℹ️ `albam/engines/mtfw/mesh.py:2374` - `_reconstruct_half_float_weights` is a second definition of the game-side weight reconstruction that `_get_weights` (mesh.py:590) already encodes, keyed differently: the new helper dispatches on the bone limit from VERTEX_FORMATS_BONE_LIMIT, while `_get_weights` dispatches on an explicit list of vertex_format hexes. They already disagree: 0xa013501e (IASkinTBC2wt) and 0xd9e801d (IASkinTBN2wt) have bone limit 2 and are not in `_get_weights`&#39;s 2w list, so `_get_weights` falls through to the `else` and returns (0, 0, 0, 0) with a &#34;Can&#39;t get weights&#34; print, whereas the new helper applies the 2wt `1 - w1` rule. The new helper is the one that matches what the game does, so no weight bound is wrong today and I am not proposing a change - but the docstring&#39;s claim &#34;exactly the way `_get_weights` reconstructs it&#34; is not true for those two formats, and the two copies can drift as formats are added. Noting it rather than prescribing a fix: unifying them would mean repairing `_get_weights`&#39;s format table, which is outside this change&#39;s scope.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 7 of 8 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Issue #253 row 3: a vertex authored A=0.002/B=0.0015 exports B at 109/255 and B now gets a weight bound | ✅ pass | live | after-fix-HEAD.txt S1 (bound = [&#39;A&#39;,&#39;B&#39;]) vs before-fix-base-367c0b8.txt S1 (bound = [&#39;A&#39;]) |
| Issue #253 row 1: a residual influence floored to 1/255 by the exporter gets a weight bound | ✅ pass | live | after-fix-HEAD.txt S1b (writes A=254 B=1, bound = [&#39;A&#39;,&#39;B&#39;]); base drops B |
| An ordinary well-formed vertex (0.7/0.3) is unaffected — both bones keep their bounds | ✅ pass | live | after-fix-HEAD.txt S2, identical to base |
| Adversarial: 6 influences on a 4-bone format — the two truncated-away bones get no bound | ✅ pass | live | after-fix-HEAD.txt S6 (exporter writes A/B/C/D only; bound = [&#39;A&#39;,&#39;B&#39;,&#39;C&#39;,&#39;D&#39;], E and F excluded) |
| Adversarial 8wt half-float (0x75c3e025): bones whose written byte is 0 or whose remainder decodes negative get no bound, while the tiny-but-written ones do | ✅ pass | live | after-fix-HEAD.txt S3 — vertex bytes re-parsed and decoded by the importer&#39;s _get_weights; skinned set == bound set == A,B,C,D,F,G (base gave A,B,C,D) |
| 4wt default skinned format (0x14d40020): the 4th influence reconstructed from the remainder (0.1) still gets a weight bound | ✅ pass | live | after-fix-HEAD.txt S4 — game reads back D=0.1 from the written bytes; bound = A,B,C,D |
| 2wt half-float format (0xc31f201c): the second slot, purely reconstructed from the remainder, still gets a weight bound | ✅ pass | live | after-fix-HEAD.txt S5 — game reads back A=0.59999 B=0.40001; bound = A,B |
| Full addon export: import a real .mod from a game archive, edit weights in Blender, export and inspect the weight_bounds block in the written file | ⏸️ untested | no | Requires real MT Framework game archives supplied via pytest&#39;s --game-dir (or R2 credentials for tests/mtfw/r2_config.py); no game data is present on this machine and none may be committed. Provide a… |

- <code>`<temp path> .../drive_weight_bounds.py all` at HEAD (real bpy 4.2 session, addon registered) — all 7 driven scenarios PASS</code>
- <code>same driver after `git restore --source=367c0b8 --worktree albam/engines/mtfw/mesh.py` — reproduces the #253 failure, then worktree restored clean</code>
- <code>`pytest tests/mtfw/test_weight_bound_filter.py -v` (12 passed) under bpy 4.2</code>
- <code>byte-level round trip: `_encode_half_float_weight_slots` -&gt; `check_recursive`/`_write` of Mod21.Vertex75c3 / Vertex14d4 / VertexC31f -&gt; re-parse -&gt; `albam.engines.mtfw.mesh._get_weights`</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `CHANGELOG.md:25` - Judgment call, no edit made: I deliberately did not add a CHANGELOG &#34;Fixed&#34; entry for this weight-bound filter fix. The buggy raw-weight filter (WEIGHT_QUANTIZATION_STEPS / _weight_in_group) was introduced in 688bd56 (&#34;Support for umvc3, import only&#34;, 2026-08-31), which is after the 0.5.0 release (2026-04-03) and is itself still in the unreleased section, so no released version ever shipped the wrong weight bounds. Per Keep a Changelog, fixing an unreleased regression within the same cycle is not a user-facing change to log. If the project prefers to log fixes to unreleased code as well, add a line under [unreleased] &gt; Fixed such as &#34;Weight bounds skipping bones the exporter genuinely skins, when a vertex&#39;s raw weights are below one quantization step and normalization scales them up&#34;.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

