### PR TITLE
fix(mtfw): resolve .mrl and .tex through the model's own archive root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   expanding either one listed both archives' contents
 - "Batch import folder" importing a second, same-named archive's identically
   placed files along with the selected folder's own
+- A model imported from the second of two same-named archives taking its
+  materials and textures from the first archive's `.mrl` and `.tex` files, so
+  the mesh was right but silently wore the other archive's look
 
 ### Changed
 

--- a/albam/engines/mtfw/material.py
+++ b/albam/engines/mtfw/material.py
@@ -1200,34 +1200,46 @@ def _create_mtfw_shader():
     return shader_group
 
 
-def _infer_mrl(context, mod_vfile, app_id, root_id=None):
+def _infer_mrl(context, mod_vfile, app_id, root_id):
     """
     Assuming mrl file is next to the .mod file with
     the same name. Or try with different suffixes
 
-    root_id prefers the model's own mounted root: two same-named archives
-    can each mount an .mrl under this same path, and without it a lookup
+    root_id is the model's own mounted root: two same-named archives can
+    each mount an .mrl under this same path, and without it a lookup
     could silently resolve to whichever root's copy was added first (see
     vfs.get_vfile's own docstring).
+
+    Two passes over `suffixes`: a strict one first, then the tolerant one.
+    A plain root_id-preferring lookup on a single suffix can still fall
+    back cross-root and resolve there before a *later* suffix under the
+    model's own root is ever tried (e.g. root A mounted first has
+    "x.mrl", root B - the model's own - only has "x_1.mrl": the ".mrl"
+    iteration would silently take A's file and stop, never reaching
+    "_1.mrl") - exactly the failure issue #294 describes. The strict pass
+    rules that out by considering every suffix under root_id alone before
+    any cross-root fallback is allowed; the second, tolerant pass then
+    preserves get_vfile's own fallback for a genuinely shared .mrl mounted
+    as its own root elsewhere.
     """
     vfs = context.scene.albam.vfs
     base = str(mod_vfile.relative_path_windows_no_ext)
     suffixes = [".mrl", "_0.mrl", "_1.mrl", "_2.mrl", "_3.mrl"]
-    mrl = None
 
-    for suffix in suffixes:
-        try:
-            mrl_vfile = vfs.get_vfile(app_id, base + suffix, root_id=root_id)
-            mrl_bytes = mrl_vfile.get_bytes()
-            mrl = parse(Mrl, mrl_bytes, app_id)
-            assert mrl.materials and mrl.textures
-            break
-        except KeyError:
-            pass
-        except AssertionError:
-            pass
+    for strict in (True, False):
+        for suffix in suffixes:
+            try:
+                mrl_vfile = vfs.get_vfile(app_id, base + suffix, root_id=root_id, strict=strict)
+                mrl_bytes = mrl_vfile.get_bytes()
+                mrl = parse(Mrl, mrl_bytes, app_id)
+                assert mrl.materials and mrl.textures
+                return mrl
+            except KeyError:
+                pass
+            except AssertionError:
+                pass
 
-    return mrl
+    return None
 
 
 def check_mtfw_shader_group(func):

--- a/albam/engines/mtfw/material.py
+++ b/albam/engines/mtfw/material.py
@@ -175,12 +175,13 @@ MRL_RASTERIZER_STATE_STR = {
 
 def build_blender_materials(mod_file_item, context, parsed_mod, name_prefix="material"):
     app_id = mod_file_item.app_id
+    root_id = mod_file_item.tree_node.root_id
     materials = {}
-    mrl = _infer_mrl(context, mod_file_item, app_id)
+    mrl = _infer_mrl(context, mod_file_item, app_id, root_id)
     if parsed_mod.header.version in VERSION_USES_MRL and not mrl:
         return materials
 
-    textures = build_blender_textures(app_id, context, parsed_mod, mrl)
+    textures = build_blender_textures(app_id, context, parsed_mod, mrl, root_id=root_id)
     if parsed_mod.header.version in VERSION_USES_MRL:
         src_materials = mrl.materials
     else:
@@ -1199,10 +1200,15 @@ def _create_mtfw_shader():
     return shader_group
 
 
-def _infer_mrl(context, mod_vfile, app_id):
+def _infer_mrl(context, mod_vfile, app_id, root_id=None):
     """
     Assuming mrl file is next to the .mod file with
     the same name. Or try with different suffixes
+
+    root_id prefers the model's own mounted root: two same-named archives
+    can each mount an .mrl under this same path, and without it a lookup
+    could silently resolve to whichever root's copy was added first (see
+    vfs.get_vfile's own docstring).
     """
     vfs = context.scene.albam.vfs
     base = str(mod_vfile.relative_path_windows_no_ext)
@@ -1211,7 +1217,7 @@ def _infer_mrl(context, mod_vfile, app_id):
 
     for suffix in suffixes:
         try:
-            mrl_vfile = vfs.get_vfile(app_id, base + suffix)
+            mrl_vfile = vfs.get_vfile(app_id, base + suffix, root_id=root_id)
             mrl_bytes = mrl_vfile.get_bytes()
             mrl = parse(Mrl, mrl_bytes, app_id)
             assert mrl.materials and mrl.textures

--- a/albam/engines/mtfw/texture.py
+++ b/albam/engines/mtfw/texture.py
@@ -289,7 +289,7 @@ def convert_tex_to_dds(tex: [Tex112, Tex157]) -> bytes:
     return dds
 
 
-def build_blender_textures(app_id, context, parsed_mod, mrl=None, root_id=None):
+def build_blender_textures(app_id, context, parsed_mod, mrl=None, *, root_id):
     textures = []
 
     src_textures = getattr(parsed_mod.materials_data, "textures", None) or getattr(mrl, "textures", None)

--- a/albam/engines/mtfw/texture.py
+++ b/albam/engines/mtfw/texture.py
@@ -289,7 +289,7 @@ def convert_tex_to_dds(tex: [Tex112, Tex157]) -> bytes:
     return dds
 
 
-def build_blender_textures(app_id, context, parsed_mod, mrl=None):
+def build_blender_textures(app_id, context, parsed_mod, mrl=None, root_id=None):
     textures = []
 
     src_textures = getattr(parsed_mod.materials_data, "textures", None) or getattr(mrl, "textures", None)
@@ -307,13 +307,19 @@ def build_blender_textures(app_id, context, parsed_mod, mrl=None):
             is_rtex = True
             ext = ".rtex"
         try:
-            texture_vfile = context.scene.albam.vfs.get_vfile(app_id, texture_path + ext)
+            # root_id prefers the model's own mounted root: two same-named
+            # archives can each mount a texture under this same path, and
+            # without it a lookup could silently resolve to whichever
+            # root's copy was added first (see vfs.get_vfile's own
+            # docstring).
+            texture_vfile = context.scene.albam.vfs.get_vfile(app_id, texture_path + ext, root_id=root_id)
             tex_bytes = texture_vfile.get_bytes()
         except KeyError:
             tex_bytes = None
         if RtexCls == Rtex112 and not tex_bytes:
             try:
-                texture_vfile = context.scene.albam.vfs.get_vfile(app_id, texture_path + ".rtex")
+                texture_vfile = context.scene.albam.vfs.get_vfile(
+                    app_id, texture_path + ".rtex", root_id=root_id)
                 tex_bytes = texture_vfile.get_bytes()
                 is_rtex = True
             except KeyError:

--- a/albam/engines/mtfw/texture.py
+++ b/albam/engines/mtfw/texture.py
@@ -306,24 +306,35 @@ def build_blender_textures(app_id, context, parsed_mod, mrl=None, *, root_id):
         if RtexCls == Rtex157 and texture_type == 2013850128:
             is_rtex = True
             ext = ".rtex"
-        try:
-            # root_id prefers the model's own mounted root: two same-named
-            # archives can each mount a texture under this same path, and
-            # without it a lookup could silently resolve to whichever
-            # root's copy was added first (see vfs.get_vfile's own
-            # docstring).
-            texture_vfile = context.scene.albam.vfs.get_vfile(app_id, texture_path + ext, root_id=root_id)
-            tex_bytes = texture_vfile.get_bytes()
-        except KeyError:
-            tex_bytes = None
-        if RtexCls == Rtex112 and not tex_bytes:
-            try:
-                texture_vfile = context.scene.albam.vfs.get_vfile(
-                    app_id, texture_path + ".rtex", root_id=root_id)
-                tex_bytes = texture_vfile.get_bytes()
-                is_rtex = True
-            except KeyError:
-                tex_bytes = None
+        # Candidate extensions for the same logical texture, in preference
+        # order: re5/dmc4 (Rtex112) store it as either ".tex" or ".rtex".
+        candidates = [(ext, is_rtex)]
+        if RtexCls == Rtex112:
+            candidates.append((".rtex", True))
+        # Two passes, strict first, mirroring _infer_mrl: root_id prefers
+        # the model's own mounted root, but a tolerant lookup on the
+        # *first* candidate can fall back cross-root and win before the
+        # second candidate under the model's own root is ever tried (two
+        # same-named archives, one holding "x.tex", the model's own only
+        # "x.rtex") - exactly the failure issue #294 describes. The strict
+        # pass considers every candidate under root_id alone before any
+        # cross-root fallback; the tolerant pass then preserves
+        # get_vfile's fallback for a texture genuinely mounted as its own
+        # root elsewhere.
+        tex_bytes = None
+        for strict in (True, False):
+            for cand_ext, cand_is_rtex in candidates:
+                try:
+                    texture_vfile = context.scene.albam.vfs.get_vfile(
+                        app_id, texture_path + cand_ext, root_id=root_id, strict=strict)
+                    tex_bytes = texture_vfile.get_bytes()
+                except KeyError:
+                    continue
+                if tex_bytes:
+                    is_rtex = cand_is_rtex
+                    break
+            if tex_bytes:
+                break
         if not tex_bytes:
             # Both cases append None - assign_textures() tells them apart by
             # the path, and only the placeholder is skipped there.

--- a/albam/vfs.py
+++ b/albam/vfs.py
@@ -172,19 +172,17 @@ class VirtualFileSystemBase:
         """
         path = PureWindowsPath(relative_path)
         file_id = self.SEPARATOR.join((app_id,) + path.parts)
-        if root_id is None:
-            return self.file_list[file_id]
-        fallback = None
+        first = self.file_list.get(file_id)
+        if first is None:
+            raise KeyError(file_id)
+        if root_id is None or first.tree_node.root_id == root_id:
+            return first
         for vfile in self.file_list:
-            if vfile.name != file_id:
-                continue
-            if vfile.tree_node.root_id == root_id:
+            if vfile.name == file_id and vfile.tree_node.root_id == root_id:
                 return vfile
-            if fallback is None:
-                fallback = vfile
-        if fallback is not None and not strict:
-            return fallback
-        raise KeyError(file_id)
+        if strict:
+            raise KeyError(file_id)
+        return first
 
     def select_vfile(self, app_id, relative_path):
         path = PureWindowsPath(relative_path)

--- a/albam/vfs.py
+++ b/albam/vfs.py
@@ -144,7 +144,7 @@ class VirtualFileSystemBase:
     SEPARATOR = "::"
     VFS_ID = "vfs"
 
-    def get_vfile(self, app_id, relative_path, root_id=None):
+    def get_vfile(self, app_id, relative_path, root_id=None, strict=False):
         """The vfile at `relative_path`, preferring the one that also
         belongs to root `root_id` when given.
 
@@ -159,6 +159,16 @@ class VirtualFileSystemBase:
         root - e.g. a shared texture mounted as its own archive alongside
         the model that references it - still resolves via the same
         first-match fallback a plain lookup uses.
+
+        strict (opt-in, default False) turns that fallback off: only an
+        entry actually belonging to root_id resolves, raising KeyError
+        otherwise - every existing caller (root_id alone, or neither
+        argument) keeps the tolerant fallback above, byte-for-byte
+        unchanged. Meant for a caller trying several candidate paths for
+        the same logical file (e.g. mtfw's _infer_mrl trying multiple
+        suffixes): without it, a plain root_id lookup on the *first*
+        candidate can fall back cross-root and return before a *later*
+        candidate under the caller's own root is ever tried.
         """
         path = PureWindowsPath(relative_path)
         file_id = self.SEPARATOR.join((app_id,) + path.parts)
@@ -172,7 +182,7 @@ class VirtualFileSystemBase:
                 return vfile
             if fallback is None:
                 fallback = vfile
-        if fallback is not None:
+        if fallback is not None and not strict:
             return fallback
         raise KeyError(file_id)
 

--- a/tests/mtfw/conftest.py
+++ b/tests/mtfw/conftest.py
@@ -168,6 +168,12 @@ def mount_vfs_root():
     failed: leaving the roots behind turns one real failure into a cascade of
     unrelated ones. Roots come out in reverse order, and only the ones actually
     mounted, so nothing has to be kept in sync by hand.
+
+    Returns the root_id *string*, not the VirtualFile: a reference taken
+    before further file_list.add() calls (any later mount) goes stale and
+    silently reads back as "" (see _expand_archive's comment in albam/vfs.py
+    and add_fs_root's own re-fetch), which a test would then pass root_id=""
+    around without noticing.
     """
     mounted = []
 
@@ -179,8 +185,9 @@ def mount_vfs_root():
         # mounted (see its own docstring), and reconstructing the unsuffixed
         # form here would then miss the real root at teardown, leaking it.
         # root_vfile.name is whatever key actually got used.
-        mounted.append(root_vfile.name)
-        return root_vfile
+        root_id = root_vfile.name
+        mounted.append(root_id)
+        return root_id
 
     yield mount
 

--- a/tests/mtfw/test_root_id_resolution.py
+++ b/tests/mtfw/test_root_id_resolution.py
@@ -173,3 +173,41 @@ def test_infer_mrl_prefers_a_later_suffix_under_its_own_root_over_an_earlier_one
 
     assert mrl is not None
     assert mrl.materials[0] == b"MRL-FROM-ROOT-B-SUFFIX-1"
+
+
+def test_build_blender_textures_prefers_rtex_under_its_own_root_over_tex_elsewhere(
+        mount_vfs_root, monkeypatch):
+    """The same cross-root leak one layer down, for re5/dmc4 (Rtex112), where
+    the same logical texture is either ".tex" or ".rtex": archives A and B
+    share a name; A (mounted first) holds "dup.tex", B (the model's own root)
+    holds only "dup.rtex". A naive tolerant ".tex" lookup would resolve
+    cross-root to A and never try B's own ".rtex" - the strict-then-tolerant
+    passes must take B's ".rtex" instead.
+    """
+    monkeypatch.setattr(
+        mtfw_texture, "parse",
+        lambda cls, data, app_id: _FakeTex(height=2, width=2),
+    )
+
+    mount_vfs_root(APP_ID, _memory_fs({
+        "models/dup.tex": b"TEX-FROM-ROOT-A",
+    }), display_name="dup.arc")
+    root_b = mount_vfs_root(APP_ID, _memory_fs({
+        "models/dup.mod": b"MOD-BYTES-B",
+        "models/dup.rtex": b"RTEX-FROM-ROOT-B",
+    }), display_name="dup.arc")
+
+    class _FakeMaterialsData:
+        textures = ["models/dup"]
+
+    class _FakeParsedMod:
+        materials_data = _FakeMaterialsData()
+
+    textures = mtfw_texture.build_blender_textures(
+        APP_ID, bpy.context, _FakeParsedMod(), root_id=root_b.name)
+
+    assert len(textures) == 1
+    bl_image = textures[0]
+    assert bl_image is not None
+    assert bl_image.albam_asset.extension == "rtex"
+    assert bl_image.albam_asset.relative_path == "models/dup.rtex"

--- a/tests/mtfw/test_root_id_resolution.py
+++ b/tests/mtfw/test_root_id_resolution.py
@@ -49,17 +49,17 @@ class _FakeTex:
 def two_roots_same_path(mount_vfs_root):
     """Two roots, same relative paths inside, distinct bytes - the exact
     setup issue #294 describes ("two same-named archives mounted")."""
-    root1 = mount_vfs_root(APP_ID, _memory_fs({
+    root1_id = mount_vfs_root(APP_ID, _memory_fs({
         "models/dup.mod": b"MOD-BYTES-ROOT-1",
         "models/dup.mrl": b"MRL-BYTES-ROOT-1",
         "models/dup.tex": b"TEX-BYTES-ROOT-1",
     }), display_name="dup.arc")
-    root2 = mount_vfs_root(APP_ID, _memory_fs({
+    root2_id = mount_vfs_root(APP_ID, _memory_fs({
         "models/dup.mod": b"MOD-BYTES-ROOT-2",
         "models/dup.mrl": b"MRL-BYTES-ROOT-2",
         "models/dup.tex": b"TEX-BYTES-ROOT-2",
     }), display_name="dup.arc")
-    return root1, root2
+    return root1_id, root2_id
 
 
 def test_infer_mrl_resolves_through_the_mod_files_own_root(two_roots_same_path, monkeypatch):
@@ -67,7 +67,7 @@ def test_infer_mrl_resolves_through_the_mod_files_own_root(two_roots_same_path, 
     imported (the second root here), not whichever same-path .mrl happened
     to be mounted first (the first root).
     """
-    root1, root2 = two_roots_same_path
+    _root1_id, root2_id = two_roots_same_path
     vfs = bpy.context.scene.albam.vfs
 
     monkeypatch.setattr(
@@ -75,7 +75,7 @@ def test_infer_mrl_resolves_through_the_mod_files_own_root(two_roots_same_path, 
         lambda cls, data, app_id: _FakeTex(materials=[data], textures=[data]),
     )
 
-    mod_vfile = vfs.get_vfile(APP_ID, "models/dup.mod", root_id=root2.name)
+    mod_vfile = vfs.get_vfile(APP_ID, "models/dup.mod", root_id=root2_id)
     assert mod_vfile.get_bytes() == b"MOD-BYTES-ROOT-2"
 
     mrl = mtfw_material._infer_mrl(bpy.context, mod_vfile, APP_ID, root_id=mod_vfile.tree_node.root_id)
@@ -89,7 +89,7 @@ def test_build_blender_textures_resolves_through_the_mod_files_own_root(two_root
     the .mod (and its .mrl) came from, not whichever same-path .tex
     happened to be mounted first.
     """
-    root1, root2 = two_roots_same_path
+    _root1_id, root2_id = two_roots_same_path
 
     monkeypatch.setattr(
         mtfw_texture, "parse",
@@ -106,7 +106,7 @@ def test_build_blender_textures_resolves_through_the_mod_files_own_root(two_root
         materials_data = _FakeMaterialsData()
 
     textures = mtfw_texture.build_blender_textures(
-        APP_ID, bpy.context, _FakeParsedMod(), root_id=root2.name)
+        APP_ID, bpy.context, _FakeParsedMod(), root_id=root2_id)
 
     assert len(textures) == 1
     bl_image = textures[0]
@@ -128,7 +128,7 @@ def test_infer_mrl_still_falls_back_to_a_shared_mrl_mounted_as_its_own_root(
         lambda cls, data, app_id: _FakeTex(materials=[data], textures=[data]),
     )
 
-    model_root = mount_vfs_root(APP_ID, _memory_fs({
+    model_root_id = mount_vfs_root(APP_ID, _memory_fs({
         "models/dup.mod": b"MOD-BYTES",
     }), display_name="dup-model.arc")
     mount_vfs_root(APP_ID, _memory_fs({
@@ -136,9 +136,9 @@ def test_infer_mrl_still_falls_back_to_a_shared_mrl_mounted_as_its_own_root(
     }), display_name="dup-shared-mrl.arc")
 
     vfs = bpy.context.scene.albam.vfs
-    mod_vfile = vfs.get_vfile(APP_ID, "models/dup.mod", root_id=model_root.name)
+    mod_vfile = vfs.get_vfile(APP_ID, "models/dup.mod", root_id=model_root_id)
 
-    mrl = mtfw_material._infer_mrl(bpy.context, mod_vfile, APP_ID, root_id=model_root.name)
+    mrl = mtfw_material._infer_mrl(bpy.context, mod_vfile, APP_ID, root_id=model_root_id)
 
     assert mrl is not None
     assert mrl.materials[0] == b"SHARED-MRL-BYTES"
@@ -161,15 +161,15 @@ def test_infer_mrl_prefers_a_later_suffix_under_its_own_root_over_an_earlier_one
     mount_vfs_root(APP_ID, _memory_fs({
         "models/dup.mrl": b"MRL-FROM-ROOT-A",
     }), display_name="dup.arc")
-    root_b = mount_vfs_root(APP_ID, _memory_fs({
+    root_b_id = mount_vfs_root(APP_ID, _memory_fs({
         "models/dup.mod": b"MOD-BYTES-B",
         "models/dup_1.mrl": b"MRL-FROM-ROOT-B-SUFFIX-1",
     }), display_name="dup.arc")
 
     vfs = bpy.context.scene.albam.vfs
-    mod_vfile = vfs.get_vfile(APP_ID, "models/dup.mod", root_id=root_b.name)
+    mod_vfile = vfs.get_vfile(APP_ID, "models/dup.mod", root_id=root_b_id)
 
-    mrl = mtfw_material._infer_mrl(bpy.context, mod_vfile, APP_ID, root_id=root_b.name)
+    mrl = mtfw_material._infer_mrl(bpy.context, mod_vfile, APP_ID, root_id=root_b_id)
 
     assert mrl is not None
     assert mrl.materials[0] == b"MRL-FROM-ROOT-B-SUFFIX-1"
@@ -192,7 +192,7 @@ def test_build_blender_textures_prefers_rtex_under_its_own_root_over_tex_elsewhe
     mount_vfs_root(APP_ID, _memory_fs({
         "models/dup.tex": b"TEX-FROM-ROOT-A",
     }), display_name="dup.arc")
-    root_b = mount_vfs_root(APP_ID, _memory_fs({
+    root_b_id = mount_vfs_root(APP_ID, _memory_fs({
         "models/dup.mod": b"MOD-BYTES-B",
         "models/dup.rtex": b"RTEX-FROM-ROOT-B",
     }), display_name="dup.arc")
@@ -204,7 +204,7 @@ def test_build_blender_textures_prefers_rtex_under_its_own_root_over_tex_elsewhe
         materials_data = _FakeMaterialsData()
 
     textures = mtfw_texture.build_blender_textures(
-        APP_ID, bpy.context, _FakeParsedMod(), root_id=root_b.name)
+        APP_ID, bpy.context, _FakeParsedMod(), root_id=root_b_id)
 
     assert len(textures) == 1
     bl_image = textures[0]

--- a/tests/mtfw/test_root_id_resolution.py
+++ b/tests/mtfw/test_root_id_resolution.py
@@ -1,0 +1,140 @@
+"""Regression tests for issue #294: with two same-named archives mounted,
+resolving a .mod's .mrl/.tex through vfs.get_vfile() could silently pick the
+wrong archive's copy - file_id is built from app_id + relative path only,
+with no root baked in (see get_vfile's own docstring), so a plain lookup
+always resolves to whichever root was mounted first.
+
+Self-contained: mounts two in-memory FS roots (via conftest.py's
+mount_vfs_root fixture) holding distinct bytes at the same relative path,
+rather than depending on real game archives - see conftest.py's
+game_fs_root for why nothing else in this package needs that.
+"""
+import bpy
+import pytest
+from fs.memoryfs import MemoryFS
+from fs.path import dirname
+
+from albam.engines.mtfw import material as mtfw_material
+from albam.engines.mtfw import texture as mtfw_texture
+
+APP_ID = "re5"
+
+
+def _memory_fs(files):
+    mem_fs = MemoryFS()
+    for path, data in files.items():
+        full_path = "/" + path
+        mem_fs.makedirs(dirname(full_path), recreate=True)
+        mem_fs.writebytes(full_path, data)
+    return mem_fs
+
+
+class _FakeTex:
+    """Stands in for a parsed Tex112. Every attribute build_blender_textures
+    reads off a real Tex112 (the DDS header fields, then
+    Tex112CustomProperties.set_from_source()'s sweep over its own
+    annotations) defaults to 0 unless overridden here, which is enough to
+    run that real DDS/PropertyGroup code untouched. Only the vfs lookup -
+    the thing under test - is what should determine what comes out.
+    """
+
+    def __init__(self, **overrides):
+        self._overrides = overrides
+
+    def __getattr__(self, name):
+        return self._overrides.get(name, 0)
+
+
+@pytest.fixture
+def two_roots_same_path(mount_vfs_root):
+    """Two roots, same relative paths inside, distinct bytes - the exact
+    setup issue #294 describes ("two same-named archives mounted")."""
+    root1 = mount_vfs_root(APP_ID, _memory_fs({
+        "models/dup.mod": b"MOD-BYTES-ROOT-1",
+        "models/dup.mrl": b"MRL-BYTES-ROOT-1",
+        "models/dup.tex": b"TEX-BYTES-ROOT-1",
+    }), display_name="dup.arc")
+    root2 = mount_vfs_root(APP_ID, _memory_fs({
+        "models/dup.mod": b"MOD-BYTES-ROOT-2",
+        "models/dup.mrl": b"MRL-BYTES-ROOT-2",
+        "models/dup.tex": b"TEX-BYTES-ROOT-2",
+    }), display_name="dup.arc")
+    return root1, root2
+
+
+def test_infer_mrl_resolves_through_the_mod_files_own_root(two_roots_same_path, monkeypatch):
+    """_infer_mrl() must resolve the .mrl next to the *specific* .mod being
+    imported (the second root here), not whichever same-path .mrl happened
+    to be mounted first (the first root).
+    """
+    root1, root2 = two_roots_same_path
+    vfs = bpy.context.scene.albam.vfs
+
+    monkeypatch.setattr(
+        mtfw_material, "parse",
+        lambda cls, data, app_id: _FakeTex(materials=[data], textures=[data]),
+    )
+
+    mod_vfile = vfs.get_vfile(APP_ID, "models/dup.mod", root_id=root2.name)
+    assert mod_vfile.get_bytes() == b"MOD-BYTES-ROOT-2"
+
+    mrl = mtfw_material._infer_mrl(bpy.context, mod_vfile, APP_ID, root_id=mod_vfile.tree_node.root_id)
+
+    assert mrl is not None
+    assert mrl.materials[0] == b"MRL-BYTES-ROOT-2"
+
+
+def test_build_blender_textures_resolves_through_the_mod_files_own_root(two_roots_same_path, monkeypatch):
+    """build_blender_textures() must resolve a .tex through the same root
+    the .mod (and its .mrl) came from, not whichever same-path .tex
+    happened to be mounted first.
+    """
+    root1, root2 = two_roots_same_path
+
+    monkeypatch.setattr(
+        mtfw_texture, "parse",
+        lambda cls, data, app_id: _FakeTex(
+            compression_format=14, height=2, width=2,
+            num_mipmaps_per_image=1, num_images=1, dds_data=b"\x00\x00\x00\x00",
+        ),
+    )
+
+    class _FakeMaterialsData:
+        textures = ["models/dup"]
+
+    class _FakeParsedMod:
+        materials_data = _FakeMaterialsData()
+
+    textures = mtfw_texture.build_blender_textures(
+        APP_ID, bpy.context, _FakeParsedMod(), root_id=root2.name)
+
+    assert len(textures) == 1
+    bl_image = textures[0]
+    assert bl_image is not None
+    assert bytes(bl_image.albam_asset.original_bytes) == b"TEX-BYTES-ROOT-2"
+
+
+def test_infer_mrl_still_falls_back_when_only_reachable_through_another_root(
+        two_roots_same_path, monkeypatch):
+    """root_id is a preference, not a restriction (see get_vfile's own
+    docstring): a shared .mrl mounted as its own archive, reachable only
+    through a *different* root than the .mod referencing it, must still
+    resolve rather than error out.
+    """
+    root1, root2 = two_roots_same_path
+    vfs = bpy.context.scene.albam.vfs
+
+    monkeypatch.setattr(
+        mtfw_material, "parse",
+        lambda cls, data, app_id: _FakeTex(materials=[data], textures=[data]),
+    )
+
+    # A .mod with no matching .mrl in either root - only reachable through
+    # root1's namespace, so root_id="does-not-exist" can never match, and
+    # the lookup has to fall back to root1's .mrl instead of raising.
+    mod_vfile = vfs.get_vfile(APP_ID, "models/dup.mod", root_id=root1.name)
+
+    mrl = mtfw_material._infer_mrl(bpy.context, mod_vfile, APP_ID, root_id="does-not-exist")
+
+    assert mrl is not None
+    assert mrl.materials[0] == b"MRL-BYTES-ROOT-1"

--- a/tests/mtfw/test_root_id_resolution.py
+++ b/tests/mtfw/test_root_id_resolution.py
@@ -114,27 +114,62 @@ def test_build_blender_textures_resolves_through_the_mod_files_own_root(two_root
     assert bytes(bl_image.albam_asset.original_bytes) == b"TEX-BYTES-ROOT-2"
 
 
-def test_infer_mrl_still_falls_back_when_only_reachable_through_another_root(
-        two_roots_same_path, monkeypatch):
+def test_infer_mrl_still_falls_back_to_a_shared_mrl_mounted_as_its_own_root(
+        mount_vfs_root, monkeypatch):
     """root_id is a preference, not a restriction (see get_vfile's own
     docstring): a shared .mrl mounted as its own archive, reachable only
-    through a *different* root than the .mod referencing it, must still
-    resolve rather than error out.
+    through a *different* root than the model referencing it, must still
+    resolve rather than error out. Neither of _infer_mrl's two passes (see
+    its own docstring) should tighten that - the strict pass finds nothing
+    under the model's own root and falls through to the tolerant one.
     """
-    root1, root2 = two_roots_same_path
-    vfs = bpy.context.scene.albam.vfs
-
     monkeypatch.setattr(
         mtfw_material, "parse",
         lambda cls, data, app_id: _FakeTex(materials=[data], textures=[data]),
     )
 
-    # A .mod with no matching .mrl in either root - only reachable through
-    # root1's namespace, so root_id="does-not-exist" can never match, and
-    # the lookup has to fall back to root1's .mrl instead of raising.
-    mod_vfile = vfs.get_vfile(APP_ID, "models/dup.mod", root_id=root1.name)
+    model_root = mount_vfs_root(APP_ID, _memory_fs({
+        "models/dup.mod": b"MOD-BYTES",
+    }), display_name="dup-model.arc")
+    mount_vfs_root(APP_ID, _memory_fs({
+        "models/dup.mrl": b"SHARED-MRL-BYTES",
+    }), display_name="dup-shared-mrl.arc")
 
-    mrl = mtfw_material._infer_mrl(bpy.context, mod_vfile, APP_ID, root_id="does-not-exist")
+    vfs = bpy.context.scene.albam.vfs
+    mod_vfile = vfs.get_vfile(APP_ID, "models/dup.mod", root_id=model_root.name)
+
+    mrl = mtfw_material._infer_mrl(bpy.context, mod_vfile, APP_ID, root_id=model_root.name)
 
     assert mrl is not None
-    assert mrl.materials[0] == b"MRL-BYTES-ROOT-1"
+    assert mrl.materials[0] == b"SHARED-MRL-BYTES"
+
+
+def test_infer_mrl_prefers_a_later_suffix_under_its_own_root_over_an_earlier_one_elsewhere(
+        mount_vfs_root, monkeypatch):
+    """The exact cross-root leak issue #294 (and review-1 on this fix) named:
+    archives A and B share a name; A (mounted first) holds "dup.mrl", B (the
+    model's own root) holds only "dup_1.mrl". A naive single tolerant pass
+    over suffixes would resolve ".mrl" cross-root to A and stop, never
+    reaching B's own "_1.mrl" - _infer_mrl's strict-then-tolerant two passes
+    (see its own docstring) must take B's "_1.mrl" instead.
+    """
+    monkeypatch.setattr(
+        mtfw_material, "parse",
+        lambda cls, data, app_id: _FakeTex(materials=[data], textures=[data]),
+    )
+
+    mount_vfs_root(APP_ID, _memory_fs({
+        "models/dup.mrl": b"MRL-FROM-ROOT-A",
+    }), display_name="dup.arc")
+    root_b = mount_vfs_root(APP_ID, _memory_fs({
+        "models/dup.mod": b"MOD-BYTES-B",
+        "models/dup_1.mrl": b"MRL-FROM-ROOT-B-SUFFIX-1",
+    }), display_name="dup.arc")
+
+    vfs = bpy.context.scene.albam.vfs
+    mod_vfile = vfs.get_vfile(APP_ID, "models/dup.mod", root_id=root_b.name)
+
+    mrl = mtfw_material._infer_mrl(bpy.context, mod_vfile, APP_ID, root_id=root_b.name)
+
+    assert mrl is not None
+    assert mrl.materials[0] == b"MRL-FROM-ROOT-B-SUFFIX-1"


### PR DESCRIPTION
## Intent

Implement albam issue #294, "MT Framework: textures and materials resolve through the wrong archive when two share a name" (https://github.com/Brachi/albam/issues/294).

The issue, which firstmate filed at the captain's instruction after it surfaced while fixing #275:

With two same-named archives mounted, importing a .mod from the second one resolves its .mrl and .tex files through the first archive. The mesh is right; the materials and textures silently come from the wrong archive.

Three call sites pass no root_id:
- albam/engines/mtfw/material.py:1214 - _infer_mrl(): vfs.get_vfile(app_id, base + suffix)
- albam/engines/mtfw/texture.py:310 - build_blender_textures(): get_vfile(app_id, texture_path + ext)
- albam/engines/mtfw/texture.py:316 - the same, for the .rtex fallback

The hexn equivalents do pass it, with a comment describing exactly this hazard:
- albam/engines/hexn/material.py:52
- albam/engines/hexn/texture.py:107

get_vfile builds file_id from app_id joined with the path parts, with no root in it, so two same-named archives of the same game produce identical ids for every file they share, and a plain lookup resolves to whichever root was mounted first. Nothing errors: the model loads wearing the other archive's materials and textures.

Suggested fix from the issue: the root is already in hand at the entry point. build_blender_materials(mod_file_item, context, parsed_mod, ...) has the model's own vfile, so mod_file_item.tree_node.root_id is available; it needs threading into _infer_mrl() and build_blender_textures(), mirroring what hexn does.

## What Changed

- `build_blender_materials()` now reads `mod_file_item.tree_node.root_id` and threads it into `_infer_mrl()` and `build_blender_textures()` (the latter as a required keyword-only `root_id`), so a `.mod` imported from the second of two same-named archives no longer picks up the first archive's `.mrl` and `.tex`/`.rtex` files.
- `vfs.get_vfile()` gains an opt-in `strict` flag that disables its cross-root fallback (raising `KeyError` instead); the default path is unchanged, and it now short-circuits on the first hit when the root already matches or no `root_id` was given. `_infer_mrl()` and `build_blender_textures()` use it to sweep every candidate suffix/extension under the model's own root before allowing any cross-root fallback, so an earlier candidate in another archive can't win over a later one in the right archive.
- Added `tests/mtfw/test_root_id_resolution.py`, mounting two same-named in-memory FS roots with distinct bytes at identical paths; `conftest.py`'s `mount_vfs_root` fixture now returns the root_id string rather than a `VirtualFile` reference that goes stale after later mounts.

## Risk Assessment

✅ Low: The fix round's get_vfile rewrite is a case-by-case behavior-preserving optimization that restores the pre-change lookup cost for the single-root and missing-file paths, the three call sites named in the intent all thread root_id as required, and the new tests are genuine regression tests that fail against the unfixed code rather than asserting on source text.

## Testing

I stood the addon up the way a user runs it — headless Blender (bpy 5.2 + libSM/libICE staged in /tmp since no system packages could be installed), albam registered, real .arc archives written to disk and mounted through the addon's Add Files operator — and drove six scenarios: a .tex, an .rtex-only fallback and an .mrl each present in two same-named archives; the model's own archive holding only a later "a shipped .mrl file" suffix or only the .rtex; and the two adversarial no-regression cases where the texture/.mrl exists only in a *different* archive. All six pass on the target commit. Running the identical script against base 25127af reproduces the reported bug: the model wears the first archive's texture and material (four scenarios FAIL there, the two fallback ones still pass), which is the fail-before/pass-after proof. Visual evidence is a before/after image of the actual imported Blender texture — red (wrong archive) on base, blue (the model's own archive) on the fix — decoded from real DXT5 Tex112 bytes through the real import path. I also measured the review-1 perf fix on a realistic large mount (one 20000-entry archive, 30 texture slots): unresolved slots cost 178 ms at base, 1074 ms before the perf commit and 365 ms at the target; resolved slots and the two-same-named-mount case are unchanged at ~0.09 ms/slot, confirming the common lookup no longer takes a full file_list scan. The repo's own regression tests for this area plus the vfs and hexn suites pass. A full end-to-end .mod import through the import operator was not possible — that needs real game archives (--game-dir or R2 credentials), neither of which exists here — so the model-side entry point was driven at its material/texture build functions with the model's real vfile and root_id taken from the mounted archive.

- Live validation: ✅ go - 7 of 8 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Two same-named archives mounted; importing the second one&#39;s model loads that archive&#39;s .tex (blue), not the first archive&#39;s (red) | ✅ pass | live | issue294_before_after.txt SCENARIO1 + before_after_scenario1.png: target RGBA=(0,0,1,1) bytes match archive B; base RGBA=(1,0,0,1) bytes match archive A |
| Model&#39;s own archive holds only .rtex while a same-named archive holds .tex — the .rtex from the model&#39;s own archive is used | ✅ pass | live | issue294_before_after.txt SCENARIO2: target resolves models/other.rtex (ext rtex); base resolves a shipped .tex file |
| Adversarial: a texture that exists only in a different archive still resolves (root_id must stay a preference, not a restriction) | ✅ pass | live | issue294_before_after.txt SCENARIO3: shared.dds imported, pixel (1,1,0,1) — passes on both base and target |
| Two same-named archives both holding the model&#39;s .mrl — materials come from the model&#39;s own archive | ✅ pass | live | issue294_before_after.txt SCENARIO4: target mrl texture slot &#39;models/tex_from_B&#39; (own archive); base &#39;models/tex_from_A&#39; (wrong archive) |
| Adversarial suffix case: first-mounted archive has &#39;suf.mrl&#39;, the model&#39;s own archive only &#39;a shipped .mrl file&#39; — the own archive&#39;s later suffix wins | ✅ pass | live | issue294_before_after.txt SCENARIO5: target &#39;models/tex_from_D&#39; (own archive&#39;s a shipped .mrl file); base &#39;models/tex_from_C&#39; |
| Adversarial: an .mrl mounted as its own separate archive still resolves for a model that lacks one | ✅ pass | live | issue294_before_after.txt SCENARIO6: &#39;models/tex_shared&#39; resolved on both base and target |
| Large single mount stays cheap: 20000-entry archive, 30-slot model — no full file_list scan per lookup | ✅ pass | live | perf_before_after.txt: unresolved slots 1074 ms (pre-perf-fix) -&gt; 365 ms (target); resolved slots 0.08-0.09 ms/slot unchanged from base |
| Full .mod import through the albam import operator with two same-named real game archives mounted | ⏸️ untested | no | Requires real MT Framework game archives: either a local install passed as --game-dir &lt;app-id&gt;::&lt;path&gt;, or R2 credentials (R2_ACCOUNT_ID/R2_ACCESS_KEY_ID/R2_SECRET_ACCESS_KEY/R2_BUCKET_NAME in .env, s… |

<details>
<summary>Evidence: Before/after transcript of all six scenarios driven in a real Blender session</summary>

```text
\### FIXED (target 5695b05) - real Blender session, real .arc archives mounted via the Add Files operator
mounted roots: 're5::dup.arc' (red tex), 're5::dup.arc#1' (blue tex)
model being imported: re5::models::dup.mod from root 're5::dup.arc#1', bytes=b'MOD-B'
SCENARIO1 imported texture first pixel RGBA=(0.0, 0.0, 1.0, 1.0) bytes_match_root_b=True bytes_match_root_a=False
SCENARIO2 resolved asset: path='models/other.rtex' ext='rtex' (root_c='re5::dup.arc#2' holds .tex, model's own root_d='re5::dup.arc#3' holds only .rtex)
SCENARIO3 shared texture in a different archive resolved: shared.dds pixel=(1.0, 1.0, 0.0, 1.0)
SCENARIO4 mrl resolved for the model in 're1::mrl.arc#1': texture slot='models/tex_from_B' (root 're1::mrl.arc' holds 'models/tex_from_A')
SCENARIO5 mrl resolved: texture slot='models/tex_from_D' ('re1::mrl.arc#2' holds 'suf.mrl', the model's own 're1::mrl.arc#3' holds only 'a shipped .mrl file')
SCENARIO6 shared .mrl in another archive resolved: texture slot='models/tex_shared'
PASS: cross-archive .tex resolves through the model's own archive
PASS: model's own archive .rtex wins over another archive's .tex
PASS: texture only present in another archive still resolves (no regression)
PASS: cross-archive .mrl resolves through the model's own archive
PASS: model's own archive's 'a shipped .mrl file' beats another archive's '.mrl'
PASS: .mrl only present in another archive still resolves (no regression)

\### BASE (25127af, before the fix) - same script, same archives
mounted roots: 're5::dup.arc' (red tex), 're5::dup.arc#1' (blue tex)
model being imported: re5::models::dup.mod from root 're5::dup.arc#1', bytes=b'MOD-B'
SCENARIO1 imported texture first pixel RGBA=(1.0, 0.0, 0.0, 1.0) bytes_match_root_b=False bytes_match_root_a=True
SCENARIO2 resolved asset: path='a shipped .tex file' ext='tex' (root_c='re5::dup.arc#2' holds .tex, model's own root_d='re5::dup.arc#3' holds only .rtex)
SCENARIO3 shared texture in a different archive resolved: shared.dds pixel=(1.0, 1.0, 0.0, 1.0)
SCENARIO4 mrl resolved for the model in 're1::mrl.arc#1': texture slot='models/tex_from_A' (root 're1::mrl.arc' holds 'models/tex_from_A')
SCENARIO5 mrl resolved: texture slot='models/tex_from_C' ('re1::mrl.arc#2' holds 'suf.mrl', the model's own 're1::mrl.arc#3' holds only 'a shipped .mrl file')
SCENARIO6 shared .mrl in another archive resolved: texture slot='models/tex_shared'
FAIL: cross-archive .tex resolves through the model's own archive
FAIL: model's own archive .rtex wins over another archive's .tex
PASS: texture only present in another archive still resolves (no regression)
FAIL: cross-archive .mrl resolves through the model's own archive
FAIL: model's own archive's 'a shipped .mrl file' beats another archive's '.mrl'
PASS: .mrl only present in another archive still resolves (no regression)
```
</details>
<details>
<summary>Evidence: Perf measurement across 25127af / b9276f2 / 5695b05 on a 20000-entry mount</summary>

<code>base 25127af: 30 unresolved slots -&gt; 178.6 ms (5.95 ms/slot)&#10;b9276f2 (pre-perf-fix): 1074.0 ms (35.80 ms/slot)&#10;target 5695b05: 365.4 ms (12.18 ms/slot)&#10;resolved slots, one mount: 0.08-0.09 ms/slot on all three&#10;resolved slots, two same-named mounts (40006 entries): 0.09 ms/slot on all three</code>

```text
\### base = 25127af (before the fix)
mounted 're5::big.arc': 20003 vfs entries in 1.45s
RESULT one mount, unresolved slots: 30 slots over a 20003-entry VFS took 178.6 ms (5.95 ms/slot), resolved=0
RESULT one mount, resolved slots: 30 slots over a 20003-entry VFS took 2.4 ms (0.08 ms/slot), resolved=30
second same-named archive mounted, 40006 vfs entries
RESULT two same-named mounts, resolved slots: 30 slots over a 40006-entry VFS took 2.6 ms (0.09 ms/slot), resolved=30

\### pre-perf-fix = b9276f2 (fix, before review-1's perf commit)
mounted 're5::big.arc': 20003 vfs entries in 1.41s
RESULT one mount, unresolved slots: 30 slots over a 20003-entry VFS took 1074.0 ms (35.80 ms/slot), resolved=0
RESULT one mount, resolved slots: 30 slots over a 20003-entry VFS took 2.6 ms (0.09 ms/slot), resolved=30
second same-named archive mounted, 40006 vfs entries
RESULT two same-named mounts, resolved slots: 30 slots over a 40006-entry VFS took 2.8 ms (0.09 ms/slot), resolved=30

\### target = 5695b05 (fix + perf commit)
mounted 're5::big.arc': 20003 vfs entries in 1.47s
RESULT one mount, unresolved slots: 30 slots over a 20003-entry VFS took 365.4 ms (12.18 ms/slot), resolved=0
RESULT one mount, resolved slots: 30 slots over a 20003-entry VFS took 2.6 ms (0.09 ms/slot), resolved=30
second same-named archive mounted, 40006 vfs entries
RESULT two same-named mounts, resolved slots: 30 slots over a 40006-entry VFS took 2.7 ms (0.09 ms/slot), resolved=30
```
</details>
<details>
<summary>Evidence: Driver script used to produce the scenario evidence</summary>

```text
"""Drive albam (real Blender/bpy session, real addon, real .arc archives) for
issue #294: two same-named archives mounted, textures/materials must resolve
through the model's own archive.

Run:  LD_LIBRARY_PATH=... python drive_issue294.py <out_dir>
Works against both the fixed code and the base commit (it adapts to
build_blender_textures' signature), so the same script produces before/after
evidence.
"""
import inspect
import io
import os
import shutil
import sys
import types

import bpy

OUT = sys.argv[1]
ARCDIR = os.path.join(OUT, "arcs")

from albam import register  # noqa: E402
register()

from albam.engines.mtfw import texture as mtfw_texture  # noqa: E402
from albam.engines.mtfw import material as mtfw_material  # noqa: E402
from albam.engines.mtfw.archive import _serialize_arc  # noqa: E402
from albam.vfs import VirtualFileData, ALBAM_OT_VirtualFileSystemAddFiles  # noqa: E402
from albam.engines.mtfw.archive import _get_file_entry  # noqa: E402

APP_ID = "re5"
ctx = bpy.context
ctx.scene.albam.apps.app_selected = APP_ID

def _dxt5_block(rgb565):
    """One 4x4 DXT5 block of a single flat color, fully opaque."""
    import struct
    return (bytes([255, 255, 0, 0, 0, 0, 0, 0]) +
            struct.pack("<HH", rgb565, rgb565) + b"\x00\x00\x00\x00")

COLORS = {  # name -> (rgb565 for the real DXT5 payload, expected RGBA on import)
    "red": (0xF800, (1.0, 0.0, 0.0)),
    "blue": (0x001F, (0.0, 0.0, 1.0)),
    "green": (0x07E0, (0.0, 1.0, 0.0)),
    "yellow": (0xFFE0, (1.0, 1.0, 0.0)),
}

def make_tex_bytes(name, color_name, relative_path="models/dup", render_target=False):
    """Real Tex112/Rtex112 bytes (albam's own generated struct writer), 4x4,
    one DXT5 mipmap of a flat color."""
    from kaitaistruct import KaitaiStream
    from albam.engines.mtfw.structs.tex_112 import Tex112
    from albam.engines.mtfw.structs.rtex_112 import Rtex112
    from albam.lib.kaitai_utils import check_recursive

    cls = Rtex112 if render_target else Tex112
    tex = cls(APP_ID)
    tex.id_magic = b"RTX\x00" if render_target else b"TEX\x00"
    tex.version = 112
    tex.texture_type = 0
    tex.encoded_type = 0
    tex.depend_screen = False
    tex.render_target = render_target
    tex.attr = 0
    tex.num_mipmaps_per_image = 1
    tex.num_images = 1
    tex.padding = 0
    tex.width = 4
    tex.height = 4
    tex.depth = 1
    tex.compression_format = "DXT5"
    tex.red = tex.green = tex.blue = tex.alpha = 0.0
    if not render_target:
        tex.mipmap_offsets = [tex.size_before_data_]
        tex.dds_data = _dxt5_block(COLORS[color_name][0])
    check_recursive(tex)
    size = tex.size_before_data_ + (0 if render_target else len(tex.dds_data))
    stream = KaitaiStream(io.BytesIO(bytearray(size)))
    tex._write(stream)
    return stream.to_byte_array()

def write_arc(dirname, entries, arc_name="dup.arc", app_id=APP_ID):
    """entries: {relative_path: bytes} -> a real .arc on disk"""
    d = os.path.join(ARCDIR, dirname)
    os.makedirs(d, exist_ok=True)
    exported = {}
    for rel, data in entries.items():
        vfd = VirtualFileData(app_id, rel, data_bytes=data)
        vfd.get_bytes = lambda d=data: d  # what _get_file_entry() reads off a vfile
        exported[rel] = _get_file_entry(vfd)
    arc_bytes = _serialize_arc(exported)
    path = os.path.join(d, arc_name)
    with open(path, "wb") as f:
        f.write(arc_bytes)
    return d

def mount(directory, arc_name="dup.arc"):
    """The real 'Add Files' operator path an end user clicks."""
    before = set(vf.name for vf in ctx.scene.albam.vfs.file_list if vf.is_root)
    ALBAM_OT_VirtualFileSystemAddFiles._execute(
        ctx, directory, [types.SimpleNamespace(name=arc_name)])
    after = [vf.name for vf in ctx.scene.albam.vfs.file_list if vf.is_root and vf.name not in before]
    return after[0]

def find_vfile(file_id, root_id):
    for vf in ctx.scene.albam.vfs.file_list:
        if vf.name == file_id and vf.tree_node.root_id == root_id:
            return vf
    raise KeyError((file_id, root_id))

def build_textures(root_id, texture_paths=("models/dup",)):
    class _MaterialsData:
        textures = list(texture_paths)

    class _ParsedMod:
        materials_data = _MaterialsData()

    kwargs = {}
    if "root_id" in inspect.signature(mtfw_texture.build_blender_textures).parameters:
        kwargs["root_id"] = root_id
    return mtfw_texture.build_blender_textures(APP_ID, ctx, _ParsedMod(), **kwargs)

def save_png(bl_image, path):
    im = bl_image
    tmp = bpy.data.images.new(im.name + "_png", im.size[0], im.size[1], alpha=True)
    tmp.pixels = list(im.pixels)
    tmp.filepath_raw = path
    tmp.file_format = "PNG"
    tmp.save()

def px(bl_image):
    p = list(bl_image.pixels[:4])
    return tuple(round(v, 2) for v in p)

results = []
shutil.rmtree(ARCDIR, ignore_errors=True)

# --- Scenario 1: two same-named archives, both hold a shipped .tex file ---
red = make_tex_bytes("red", "red")
blue = make_tex_bytes("blue", "blue")
dir_a = write_arc("archive_a", {"a shipped .tex file": red, "a shipped .mod file": b"MOD-A" * 8})
dir_b = write_arc("archive_b", {"a shipped .tex file": blue, "a shipped .mod file": b"MOD-B" * 8})
root_a = mount(dir_a)
root_b = mount(dir_b)
print(f"mounted roots: {root_a!r} (red tex), {root_b!r} (blue tex)")

mod_b = find_vfile(f"{APP_ID}::models::dup.mod", root_b)
print(f"model being imported: {mod_b.name} from root {mod_b.tree_node.root_id!r}, "
      f"bytes={mod_b.get_bytes()[:5]!r}")

textures = build_textures(mod_b.tree_node.root_id)
img = textures[0]
color = px(img)
save_png(img, os.path.join(OUT, "scenario1_texture_from_model_own_archive.png"))
same_as_b = bytes(img.albam_asset.original_bytes) == blue
print(f"SCENARIO1 imported texture first pixel RGBA={color} "
      f"bytes_match_root_b={same_as_b} bytes_match_root_a={bytes(img.albam_asset.original_bytes) == red}")
results.append(("cross-archive .tex resolves through the model's own archive",
                same_as_b and color[2] == 1.0 and color[0] == 0.0))

# --- Scenario 2: model's own archive only has .rtex, the other has .tex ---
rtex_b = make_tex_bytes("rtex_b", "green", relative_path="models/other", render_target=True)
tex_a = make_tex_bytes("tex_a2", "red", relative_path="models/other")
dir_c = write_arc("archive_c", {"a shipped .tex file": tex_a})
dir_d = write_arc("archive_d", {"models/other.rtex": rtex_b, "a shipped .mod file": b"MOD-D" * 8})
root_c = mount(dir_c)
root_d = mount(dir_d)
mod_d = find_vfile(f"{APP_ID}::models::other.mod", root_d)
textures2 = build_textures(mod_d.tree_node.root_id, texture_paths=("models/other",))
img2 = textures2[0]
print(f"SCENARIO2 resolved asset: path={img2.albam_asset.relative_path!r} ext={img2.albam_asset.extension!r} "
      f"(root_c={root_c!r} holds .tex, model's own root_d={root_d!r} holds only .rtex)")
results.append(("model's own archive .rtex wins over another archive's .tex",
                img2.albam_asset.relative_path == "models/other.rtex"))

# --- Scenario 3: shared texture mounted as its own archive still resolves ---
shared = make_tex_bytes("shared", "yellow", relative_path="models/shared")
dir_e = write_arc("archive_e", {"a shipped .tex file": shared})
dir_f = write_arc("archive_f", {"a shipped .mod file": b"MOD-F" * 8})
mount(dir_e)
root_f = mount(dir_f)
mod_f = find_vfile(f"{APP_ID}::models::model.mod", root_f)
textures3 = build_textures(mod_f.tree_node.root_id, texture_paths=("models/shared",))
ok3 = textures3[0] is not None and px(textures3[0])[:3] == (1.0, 1.0, 0.0)
print(f"SCENARIO3 shared texture in a different archive resolved: "
      f"{textures3[0] and textures3[0].name} pixel={textures3[0] and px(textures3[0])}")
results.append(("texture only present in another archive still resolves (no regression)", ok3))

# ---------------- .mrl scenarios (re1: the apps whose materials live in .mrl)
MRL_APP = "re1"

def make_mrl_bytes(texture_path):
    """Real .mrl bytes, written by albam's own generated Mrl struct writer:
    one texture slot (named so we can tell the two archives' copies apart)
    and one material."""
    from kaitaistruct import KaitaiStream
    from albam.engines.mtfw.structs.mrl import Mrl
    from albam.engines.mtfw.material import MRL_DEFAULT_VERSION, MRL_SHADER_VERSION

    mrl = Mrl(MRL_APP)
    mrl.id_magic = b"MRL\x00"
    mrl.version = MRL_DEFAULT_VERSION[MRL_APP]
    mrl.shader_version = MRL_SHADER_VERSION[MRL_APP]
    ts = Mrl.TextureSlot(_parent=mrl, _root=mrl._root)
    ts.type_hash = 0x241f5deb
    ts.unk_02 = 0
    ts.unk_03 = 0
    ts.texture_path = texture_path
    ts.filler = [0] * (64 - len(texture_path) - 1)
    mrl.textures = [ts]
    mat = Mrl.Material(_parent=mrl, _root=mrl._root)
    mat.type_hash = 1605430244
    mat.name_hash_crcjam32 = 1
    mat.cmd_buffer_size = 0
    mat.blend_state_hash = mat.depth_stencil_state_hash = mat.rasterizer_state_hash = 0
    mat.num_resources = 0
    mat.reserverd1 = mat.id = 0
    mat.fog = mat.tangent = mat.half_lambert = False
    mat.stencil_ref = mat.alphatest_ref = mat.polygon_offset = 0
    mat.alphatest = False
    mat.alphatest_func = mat.draw_pass = mat.layer_id = 0
    mat.deffered_lighting = False
    mat.blend_factor = [0.0] * 4
    mat.anim_data_size = mat.ofs_anim_data = 0
    mat.resources = []
    mrl.materials = [mat]
    mrl.num_textures = 1
    mrl.num_materials = 1
    mrl.ofs_textures = mrl.ofs_textures_calculated
    mrl.ofs_materials = mrl.ofs_materials_calculated
    mat.ofs_cmd = mrl.ofs_resources_calculated
    ts._check()
    mat._check()
    mrl._check()
    stream = KaitaiStream(io.BytesIO(bytearray(mrl.size_todo_)))
    mrl._write(stream)
    return stream.to_byte_array()

def infer_mrl(mod_vfile):
    kwargs = {}
    if "root_id" in inspect.signature(mtfw_material._infer_mrl).parameters:
        kwargs["root_id"] = mod_vfile.tree_node.root_id
    return mtfw_material._infer_mrl(ctx, mod_vfile, MRL_APP, **kwargs)

ctx.scene.albam.apps.app_selected = MRL_APP

# Scenario 4: both same-named archives hold a shipped .mrl file
g = write_arc("mrl_a", {"a shipped .mrl file": make_mrl_bytes("models/tex_from_A"),
                        "a shipped .mod file": b"MOD-A" * 8}, arc_name="mrl.arc", app_id=MRL_APP)
h = write_arc("mrl_b", {"a shipped .mrl file": make_mrl_bytes("models/tex_from_B"),
                        "a shipped .mod file": b"MOD-B" * 8}, arc_name="mrl.arc", app_id=MRL_APP)
root_g = mount(g, "mrl.arc")
root_h = mount(h, "mrl.arc")
mod_h = find_vfile(f"{MRL_APP}::models::mdl.mod", root_h)
mrl4 = infer_mrl(mod_h)
print(f"SCENARIO4 mrl resolved for the model in {root_h!r}: "
      f"texture slot={mrl4 and mrl4.textures[0].texture_path!r} (root {root_g!r} holds 'models/tex_from_A')")
results.append(("cross-archive .mrl resolves through the model's own archive",
                bool(mrl4) and mrl4.textures[0].texture_path == "models/tex_from_B"))

# Scenario 5: first archive has dup.mrl, the model's own archive only a shipped .mrl file
i_ = write_arc("mrl_c", {"a shipped .mrl file": make_mrl_bytes("models/tex_from_C")},
               arc_name="mrl.arc", app_id=MRL_APP)
j_ = write_arc("mrl_d", {"a shipped .mod file": b"MOD-D" * 8,
                         "a shipped .mrl file": make_mrl_bytes("models/tex_from_D")},
               arc_name="mrl.arc", app_id=MRL_APP)
root_i = mount(i_, "mrl.arc")
root_j = mount(j_, "mrl.arc")
mod_j = find_vfile(f"{MRL_APP}::models::suf.mod", root_j)
mrl5 = infer_mrl(mod_j)
print(f"SCENARIO5 mrl resolved: texture slot={mrl5 and mrl5.textures[0].texture_path!r} "
      f"({root_i!r} holds 'suf.mrl', the model's own {root_j!r} holds only 'a shipped .mrl file')")
results.append(("model's own archive's 'a shipped .mrl file' beats another archive's '.mrl'",
                bool(mrl5) and mrl5.textures[0].texture_path == "models/tex_from_D"))

# Scenario 6: shared .mrl mounted as its own archive still resolves
k_ = write_arc("mrl_e", {"a shipped .mrl file": make_mrl_bytes("models/tex_shared")},
               arc_name="shared.arc", app_id=MRL_APP)
l_ = write_arc("mrl_f", {"a shipped .mod file": b"MOD-F" * 8}, arc_name="model.arc", app_id=MRL_APP)
mount(k_, "shared.arc")
root_l = mount(l_, "model.arc")
mod_l = find_vfile(f"{MRL_APP}::models::shared.mod", root_l)
mrl6 = infer_mrl(mod_l)
print(f"SCENARIO6 shared .mrl in another archive resolved: "
      f"texture slot={mrl6 and mrl6.textures[0].texture_path!r}")
results.append((".mrl only present in another archive still resolves (no regression)",
                bool(mrl6) and mrl6.textures[0].texture_path == "models/tex_shared"))

print()
for name, ok in results:
    print(f"{'PASS' if ok else 'FAIL'}: {name}")
sys.exit(0 if all(ok for _, ok in results) else 1)
```
</details>
<details>
<summary>Evidence: Perf driver script</summary>

```text
"""Perf check for the review-1 fix (commit 5695b05, "take fast hash path in
get_vfile unless roots conflict"): a realistic single large mount must not
pay a linear scan of the whole VFS per texture lookup.

Real Blender session, real addon, one real .arc with 20000 entries mounted
through the real "Add Files" operator, then the real
build_blender_textures() for a 30-slot model. Run against different
PYTHONPATHs to compare revisions.
"""
import inspect
import io
import os
import sys
import time
import types
import zlib

import bpy

OUT = sys.argv[1]
os.makedirs(OUT, exist_ok=True)

from albam import register  # noqa: E402
register()

from albam.engines.mtfw import texture as mtfw_texture  # noqa: E402
from albam.engines.mtfw.archive import _serialize_arc, _get_file_entry  # noqa: E402
from albam.vfs import VirtualFileData, ALBAM_OT_VirtualFileSystemAddFiles  # noqa: E402

APP_ID = "re5"
N_FILES = 20000
N_SLOTS = 30
ctx = bpy.context
ctx.scene.albam.apps.app_selected = APP_ID

def _dxt5_tex_bytes():
    """Real 4x4 DXT5 Tex112 bytes, so a resolved slot really imports."""
    import struct
    from kaitaistruct import KaitaiStream
    from albam.engines.mtfw.structs.tex_112 import Tex112

    tex = Tex112(APP_ID)
    tex.id_magic = b"TEX\x00"
    tex.version = 112
    tex.texture_type = tex.encoded_type = 0
    tex.depend_screen = tex.render_target = False
    tex.attr = 0
    tex.num_mipmaps_per_image = 1
    tex.num_images = 1
    tex.padding = 0
    tex.width = tex.height = 4
    tex.depth = 1
    tex.compression_format = "DXT5"
    tex.red = tex.green = tex.blue = tex.alpha = 0.0
    tex.mipmap_offsets = [tex.size_before_data_]
    tex.dds_data = (bytes([255, 255, 0, 0, 0, 0, 0, 0]) +
                    struct.pack("<HH", 0x001F, 0x001F) + b"\x00\x00\x00\x00")
    tex._check()
    stream = KaitaiStream(io.BytesIO(bytearray(tex.size_before_data_ + len(tex.dds_data))))
    tex._write(stream)
    return stream.to_byte_array()

TEX_BYTES = _dxt5_tex_bytes()

arc_dir = os.path.join(OUT, "bigarc")
os.makedirs(arc_dir, exist_ok=True)
arc_path = os.path.join(arc_dir, "big.arc")
if not os.path.exists(arc_path):
    exported = {}
    for i in range(N_FILES):
        rel = f"models/pl/pl{i:05d}.tex"
        data = TEX_BYTES
        vfd = VirtualFileData(APP_ID, rel, data_bytes=data)
        vfd.get_bytes = lambda d=data: d
        exported[rel] = _get_file_entry(vfd)
    with open(arc_path, "wb") as f:
        f.write(_serialize_arc(exported))

t0 = time.perf_counter()
ALBAM_OT_VirtualFileSystemAddFiles._execute(
    ctx, arc_dir, [types.SimpleNamespace(name="big.arc")])
mount_secs = time.perf_counter() - t0
vfs = ctx.scene.albam.vfs
root_id = [vf.name for vf in vfs.file_list if vf.is_root][0]
print(f"mounted {root_id!r}: {len(vfs.file_list)} vfs entries in {mount_secs:.2f}s")

def measure(label, paths):
    class _MaterialsData:
        textures = list(paths)

    class _ParsedMod:
        materials_data = _MaterialsData()

    kwargs = {}
    if "root_id" in inspect.signature(mtfw_texture.build_blender_textures).parameters:
        kwargs["root_id"] = root_id
    best = None
    for _ in range(3):
        t0 = time.perf_counter()
        textures = mtfw_texture.build_blender_textures(APP_ID, ctx, _ParsedMod(), **kwargs)
        secs = time.perf_counter() - t0
        best = secs if best is None else min(best, secs)
    print(f"RESULT {label}: {len(paths)} slots over a {len(vfs.file_list)}-entry VFS took "
          f"{best * 1000:.1f} ms ({best / len(paths) * 1000:.2f} ms/slot), "
          f"resolved={sum(1 for t in textures if t)}")

MISSING = [f"models/pl/missing{i:03d}" for i in range(N_SLOTS)]
PRESENT = [f"models/pl/pl{i:05d}" for i in range(N_SLOTS)]

measure("one mount, unresolved slots", MISSING)
measure("one mount, resolved slots", PRESENT)

# Now mount a second, same-named archive: the ambiguous case the fix has to
# resolve correctly (and the only one allowed to cost a scan).
arc_dir2 = os.path.join(OUT, "bigarc2")
os.makedirs(arc_dir2, exist_ok=True)
import shutil
shutil.copy(arc_path, os.path.join(arc_dir2, "big.arc"))
ALBAM_OT_VirtualFileSystemAddFiles._execute(
    ctx, arc_dir2, [types.SimpleNamespace(name="big.arc")])
print(f"second same-named archive mounted, {len(vfs.file_list)} vfs entries")
measure("two same-named mounts, resolved slots", PRESENT)
```
</details>
- Outcome: ⚠️ 1 info across 1 run (10m44s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"98c981b062fd9dc314471d0f097de3a344907d23","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `albam/engines/mtfw/texture.py:327` - Texture resolution now costs a Python-level linear scan of the entire VFS file_list per candidate path. get_vfile only takes the fast CollectionProperty hash path when root_id is None (albam/vfs.py:177); with root_id set it iterates every vfile reading .name and .tree_node.root_id through RNA. build_blender_textures now runs that up to 4 times per texture slot (2 passes x 2 candidates) and, worst case, all 4 full scans happen for every *unresolved* slot - which is routine, since the function has explicit handling for dummy/absent texture paths. Concrete case: a game folder mounted via _expand_directory can hold up to 60000 entries (albam/vfs.py max_files), so a model with ~30 texture slots of which several are missing costs several million RNA attribute reads on top of _infer_mrl&#39;s up-to-5 strict scans - seconds of added import time where before each lookup was a single C-level name lookup. Flagging as ask-user because the smallest honest remedy (a root-scoped id index or per-import lookup cache inside get_vfile) adds new durable state beyond this change&#39;s stated scope; keeping the current cost may well be an acceptable trade, but that&#39;s the author&#39;s call.
- ⚠️ `albam/vfs.py:147` - Simplification: the change introduces a new `strict` mode on the shared VirtualFileSystemBase.get_vfile API plus a two-pass (strict-then-tolerant) loop at each of the two mtfw call sites (albam/engines/mtfw/material.py:1230, albam/engines/mtfw/texture.py:324). The stated intent requires only threading the model&#39;s own root_id into _infer_mrl() and build_blender_textures(), &#34;mirroring what hexn does&#34; - and hexn (albam/engines/hexn/material.py:52, texture.py:107) uses plain root_id preference with no strict flag. The narrower form that satisfies the intent is a single tolerant `root_id=` lookup at both sites. The strict mode does close a further real sub-case (own root holds only a later suffix, e.g. &#34;a shipped .mrl file&#34;, while a same-named first-mounted root holds &#34;dup.mrl&#34;), so removing it is a genuine behavior decision rather than a mechanical cleanup - hence ask-user: either keep it deliberately, or drop the flag and the double loops and accept that sub-case. It is also the component that makes the performance finding above 4x worse, so removal is the smallest remedy there too.
- ℹ️ `albam/vfs.py:184` - Informational: get_vfile(..., strict=True) with root_id left None silently ignores strict - the root_id is None branch returns file_list[file_id] (first match across roots) before the strict check is ever reached, which is precisely the resolution strict exists to prevent. No current caller does this (both new call sites always pass root_id), so nothing is broken today; noting it only because the parameter combination reads as safe and is not.

🔧 Fix applied.
1 info still open:

- ℹ️ `albam/engines/mtfw/texture.py:325` - Residual (accepted-scope) cost: when the fast path in get_vfile misses, the strict and tolerant passes each re-run the identical full scan for the same file_id. Concrete case: model mounted as its own .arc root while shared textures live in a separately mounted game-folder root (the exact &#39;shared texture mounted as its own archive&#39; case get_vfile&#39;s docstring says the tolerant fallback exists for). Per texture slot, strict candidate &#39;.tex&#39; finds `first` in the folder root, scans all entries, finds no own-root match, raises KeyError; the tolerant pass then scans the identical unchanged file_list again before returning that same `first`. file_list is not mutated between the passes, so the second scan is provably redundant - 2 full scans per resolved texture instead of 1. _infer_mrl has the same shape and additionally re-parses any own-root .mrl that already failed its `assert mrl.materials and mrl.textures` in the strict pass. Reporting as no-op rather than prescribing a repair: eliminating it would need get_vfile to report whether the returned vfile was an own-root hit (API change) or to memoize the miss (new state, which the round-1 instruction forbade), and the user explicitly chose to keep the two-pass structure. The change does satisfy the instruction&#39;s stated boundary - the scan now happens only when the first match genuinely belongs to another root.
</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `albam/engines/mtfw/texture.py:327` - Perf note (informational, no action needed unless the author wants it): the review-1 fast-hash-path commit brings the worst case back most of the way, but not all the way to baseline. Driving build_blender_textures over a real 20000-entry .arc mount with 30 *unresolved* texture slots: 178 ms at base 25127af, 1074 ms at b9276f2 (the fix before the perf commit), 365 ms at the target 5695b05 — a 2.9x improvement over the pre-perf-fix state, still ~2x baseline. The residual 2x is not a scan: every lookup now takes the CollectionProperty hash path, and the extra cost is exactly the 4 miss-lookups per slot (2 strict/tolerant passes x 2 .tex/.rtex candidates) versus 2 before, i.e. the strict-then-tolerant double loop the user deliberately chose to keep in review-2. Resolved slots and the two-same-named-mounts case are unchanged from baseline (0.08-0.09 ms/slot everywhere).
- Live validation: ✅ go - 7 of 8 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Two same-named archives mounted; importing the second one&#39;s model loads that archive&#39;s .tex (blue), not the first archive&#39;s (red) | ✅ pass | live | issue294_before_after.txt SCENARIO1 + before_after_scenario1.png: target RGBA=(0,0,1,1) bytes match archive B; base RGBA=(1,0,0,1) bytes match archive A |
| Model&#39;s own archive holds only .rtex while a same-named archive holds .tex — the .rtex from the model&#39;s own archive is used | ✅ pass | live | issue294_before_after.txt SCENARIO2: target resolves models/other.rtex (ext rtex); base resolves a shipped .tex file |
| Adversarial: a texture that exists only in a different archive still resolves (root_id must stay a preference, not a restriction) | ✅ pass | live | issue294_before_after.txt SCENARIO3: shared.dds imported, pixel (1,1,0,1) — passes on both base and target |
| Two same-named archives both holding the model&#39;s .mrl — materials come from the model&#39;s own archive | ✅ pass | live | issue294_before_after.txt SCENARIO4: target mrl texture slot &#39;models/tex_from_B&#39; (own archive); base &#39;models/tex_from_A&#39; (wrong archive) |
| Adversarial suffix case: first-mounted archive has &#39;suf.mrl&#39;, the model&#39;s own archive only &#39;a shipped .mrl file&#39; — the own archive&#39;s later suffix wins | ✅ pass | live | issue294_before_after.txt SCENARIO5: target &#39;models/tex_from_D&#39; (own archive&#39;s a shipped .mrl file); base &#39;models/tex_from_C&#39; |
| Adversarial: an .mrl mounted as its own separate archive still resolves for a model that lacks one | ✅ pass | live | issue294_before_after.txt SCENARIO6: &#39;models/tex_shared&#39; resolved on both base and target |
| Large single mount stays cheap: 20000-entry archive, 30-slot model — no full file_list scan per lookup | ✅ pass | live | perf_before_after.txt: unresolved slots 1074 ms (pre-perf-fix) -&gt; 365 ms (target); resolved slots 0.08-0.09 ms/slot unchanged from base |
| Full .mod import through the albam import operator with two same-named real game archives mounted | ⏸️ untested | no | Requires real MT Framework game archives: either a local install passed as --game-dir &lt;app-id&gt;::&lt;path&gt;, or R2 credentials (R2_ACCOUNT_ID/R2_ACCESS_KEY_ID/R2_SECRET_ACCESS_KEY/R2_BUCKET_NAME in .env, s… |

- <code>`drive_issue294.py` — real bpy session + albam register(); real .arc files built with albam&#39;s own `_serialize_arc`, mounted via `ALBAM_OT_VirtualFileSystemAddFiles._execute`; real Tex112/Rtex112 and Mrl bytes written with albam&#39;s generated struct writers; run against the target and against base 25127af for before/after</code>
- <code>`drive_perf.py` — same real mount path with a 20000-entry .arc, timing `build_blender_textures` for 30 slots, run against 25127af, b9276f2 and 5695b05</code>
- <code>`pytest tests/mtfw/test_root_id_resolution.py tests/test_vfs_duplicate_root_names.py tests/test_vfs_fs_backed.py tests/hexn -q` (38 passed, 152 skipped — skips are the game-asset tests with no --game-dir)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

