### PR TITLE
feat(cie): export RE4 UHD morphs, bone pairs and the bone symmetry table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Experimental support for LMT export (Resident Evil 5)
 - App Settings button next to App selection. Allows to set the root folder of an app. Its content is stored in apps-userdata.ini, in Albam's extension directory.
 - Reading `.arc` archives from Devil May Cry 4, whose entries are XMemCompress (LZX) streams rather than zlib, and which number their file types differently. Models and textures inside them can now be imported. Read-only for now: packing into one is refused rather than writing an archive the game cannot read
+- Export of RE4 UHD facial morphs (as shape keys), the DBL_JNT double-joint bone table, and the pXFlip bone symmetry table. All three used to be read on import and silently dropped on export
 
 ### Fixed
 
+- RE4 UHD's `bone_adj` block was misread as a bone-adjacency table (`count[4]` + `count[3]` `u2`s); it is the game's pXFlip bone-mirror table, one big-endian `s16` per bone in an otherwise little-endian file. Re-reading it this way changes what `bin.symmetry_table` (formerly `bin.adjacent`) returns on import
 - Import of meshes with Nan UVs
 - Triangulation function(now it keeps custom normals)
 - Missed value in .tex `value` enumerator for RE6 render targets

--- a/albam/engines/cie/mesh.py
+++ b/albam/engines/cie/mesh.py
@@ -1244,8 +1244,9 @@ def _serialize_bone_pairs(dst_bin, bl_mesh_objs, written_bone_ids):
             if tuple(line) in seen:
                 continue
             seen.add(tuple(line))
-            if (helper_id not in written_bone_ids or bone_a_id not in written_bone_ids
-                    or bone_b_id not in written_bone_ids):
+            if (helper_id not in written_bone_ids or
+                    bone_a_id not in written_bone_ids or
+                    bone_b_id not in written_bone_ids):
                 print(f"[re4uhd] WARNING: dropping bone pair "
                       f"({helper_id}, {bone_a_id}, {bone_b_id}, {percent}) - "
                       f"a bone it names is not being exported")
@@ -1650,9 +1651,9 @@ def _layout_and_write(dst_bin, num_vertices):
     # symmetry blocks are actually written - see the header's own comments.
     has_bone_pairs = bool(getattr(dst_bin, "bone_pairs", None))
     has_symmetry = bool(getattr(dst_bin, "symmetry_table", None))
-    header.flags = (BIN_FLAG_IS_MESH
-                    | (BIN_FLAG_BONEPAIRS if has_bone_pairs else 0)
-                    | (BIN_FLAG_ADJACENCY if has_symmetry else 0))
+    header.flags = (BIN_FLAG_IS_MESH |
+                    (BIN_FLAG_BONEPAIRS if has_bone_pairs else 0) |
+                    (BIN_FLAG_ADJACENCY if has_symmetry else 0))
     tagged = has_bone_pairs or has_symmetry
     header.version_flags = VERSION_FLAGS_WITH_TAGS if tagged else VERSION_FLAGS_PLAIN
     header.unk_01 = UNK_01_WITH_TAGS if tagged else UNK_01_PLAIN
@@ -1670,8 +1671,8 @@ def _layout_and_write(dst_bin, num_vertices):
         morph_groups = dst_bin.morphs.morph_groups
         # The leading u4 num_morph_groups, then the group table, then the
         # bodies the table points at.
-        morph_block_size = (4 + MORPH_GROUP_ENTRY_SIZE * len(morph_groups)
-                            + sum(MORPH_VERTEX_SIZE * len(g.body.vertices) for g in morph_groups))
+        morph_block_size = (4 + MORPH_GROUP_ENTRY_SIZE * len(morph_groups) +
+                            sum(MORPH_VERTEX_SIZE * len(g.body.vertices) for g in morph_groups))
         offset = _align(offset + morph_block_size)
 
     header.offset_bonepairs = offset if has_bone_pairs else 0

--- a/albam/engines/cie/mesh.py
+++ b/albam/engines/cie/mesh.py
@@ -1228,12 +1228,22 @@ def _serialize_bone_pairs(dst_bin, bl_mesh_objs, written_bone_ids):
     A line's three ids are resolved against this file's own bone table, so
     `written_bone_ids` is the ids that table is about to carry. A line naming
     anything else is dropped rather than written pointing at nothing.
+
+    The table is character-wide, so every mesh object exported together
+    carries the same lines: they are merged first-seen, the way
+    _serialize_symmetry merges its mirrors, rather than written once per
+    mesh sharing them.
     """
     dst_bone_pairs = dst_bin.BonePair(_parent=dst_bin, _root=dst_bin._root)
     dst_lines = []
+    seen = set()
     for bl_mesh_ob in bl_mesh_objs:
         raw = bl_mesh_ob.get(BONE_PAIRS_PROPERTY) or ()
-        for helper_id, bone_a_id, bone_b_id, percent in chunks(list(raw), 4):
+        for line in chunks(list(raw), 4):
+            helper_id, bone_a_id, bone_b_id, percent = line
+            if tuple(line) in seen:
+                continue
+            seen.add(tuple(line))
             if (helper_id not in written_bone_ids or bone_a_id not in written_bone_ids
                     or bone_b_id not in written_bone_ids):
                 print(f"[re4uhd] WARNING: dropping bone pair "

--- a/albam/engines/cie/mesh.py
+++ b/albam/engines/cie/mesh.py
@@ -45,6 +45,12 @@ BIN_FLAG_BONEPAIRS = 0x00000100
 # bonepair and adjacency blocks are present, the second where they are not.
 VERSION_FLAGS_WITH_TAGS = 0x20030818
 VERSION_FLAGS_PLAIN = 0x20010801
+# unk_01 goes in step with the build stamp: measured across 184 shipped mesh
+# .bin files in 8 character archives, every tagged file pairs
+# VERSION_FLAGS_WITH_TAGS with 0x50 and every untagged one pairs
+# VERSION_FLAGS_PLAIN with 0, without exception.
+UNK_01_WITH_TAGS = 0x50
+UNK_01_PLAIN = 0
 
 NO_PARENT = 0xFF
 NO_TEXTURE = 0xFF
@@ -54,7 +60,7 @@ MAX_VERTICES = 0xFFFF
 # A morph delta is an s2, pre-multiplied by 2 ** vertex_scale.
 MORPH_DELTA_MIN = -32768
 MORPH_DELTA_MAX = 32767
-# u4 count + (u4 offset + u4 count) per group.
+# u4 offset + u4 count, per group.
 MORPH_GROUP_ENTRY_SIZE = 8
 # id (u2) + 3 * s2 delta.
 MORPH_VERTEX_SIZE = 8
@@ -1216,24 +1222,20 @@ def _serialize_material(dst_bin, bl_material, strip_lengths, app_id):
     return dst_material
 
 
-def _serialize_bone_pairs(dst_bin, bl_mesh_objs, resolvable_ids):
+def _serialize_bone_pairs(dst_bin, bl_mesh_objs, written_bone_ids):
     """The DBL_JNT block, from BONE_PAIRS_PROPERTY - see its comment.
 
-    `resolvable_ids` is every id the shared armature can name, not just the
-    ones this model's own bone table carries: measured on real files, a
-    helper joint's line can name a bone the model's own (possibly partial)
-    table leaves out - the same way a weight can (see _bones_to_write) - so
-    checking against the written table alone drops lines shipped files keep.
-    A line naming a bone the armature has lost entirely is dropped rather
-    than written broken.
+    A line's three ids are resolved against this file's own bone table, so
+    `written_bone_ids` is the ids that table is about to carry. A line naming
+    anything else is dropped rather than written pointing at nothing.
     """
     dst_bone_pairs = dst_bin.BonePair(_parent=dst_bin, _root=dst_bin._root)
     dst_lines = []
     for bl_mesh_ob in bl_mesh_objs:
         raw = bl_mesh_ob.get(BONE_PAIRS_PROPERTY) or ()
         for helper_id, bone_a_id, bone_b_id, percent in chunks(list(raw), 4):
-            if (helper_id not in resolvable_ids or bone_a_id not in resolvable_ids
-                    or bone_b_id not in resolvable_ids):
+            if (helper_id not in written_bone_ids or bone_a_id not in written_bone_ids
+                    or bone_b_id not in written_bone_ids):
                 print(f"[re4uhd] WARNING: dropping bone pair "
                       f"({helper_id}, {bone_a_id}, {bone_b_id}, {percent}) - "
                       f"a bone it names is not being exported")
@@ -1253,13 +1255,11 @@ def _serialize_bone_pairs(dst_bin, bl_mesh_objs, resolvable_ids):
     return dst_bone_pairs
 
 
-def _serialize_symmetry(dst_bin, bl_mesh_objs, dst_bones, resolvable_ids):
+def _serialize_symmetry(dst_bin, bl_mesh_objs, dst_bones, written_bone_ids):
     """The pXFlip mirror table, one entry per written bone in table order -
-    see the .ksy comment on `symmetry`. `resolvable_ids` is every id the
-    shared armature can name - see _serialize_bone_pairs for why a mirror
-    target can be valid without being in this model's own bone table. A
-    mirror that points at a bone the armature has lost entirely comes back
-    as NO_MIRROR_BONE, the same as a bone the source never paired.
+    see the .ksy comment on `symmetry`. A mirror target is an id in this
+    file's own bone table, so one pointing outside `written_bone_ids` comes
+    back as NO_MIRROR_BONE, the same as a bone the source never paired.
     """
     # A bone id can repeat in the model's own table (two different bones
     # given the same id - a known RE4UHD quirk, see PR #297), and the source
@@ -1281,7 +1281,7 @@ def _serialize_symmetry(dst_bin, bl_mesh_objs, dst_bones, resolvable_ids):
     dst_symmetry = dst_bin.Symmetry(_parent=dst_bin, _root=dst_bin._root)
     dst_symmetry.num_bones = len(dst_bones)
     dst_symmetry.mirror_bone_ids = [
-        mirror_id if (mirror_id := mirrors.get(bone.bone_id, NO_MIRROR_BONE)) in resolvable_ids
+        mirror_id if (mirror_id := mirrors.get(bone.bone_id, NO_MIRROR_BONE)) in written_bone_ids
         else NO_MIRROR_BONE
         for bone in dst_bones
     ]
@@ -1313,18 +1313,23 @@ def _serialize_morphs(dst_bin, bl_mesh_objs, source_vertices, extra_scale):
     """Shape keys beyond Basis as morph groups - see the .ksy comments on
     morph_block / morph_group / morph_group_body.
 
-    One group per shape key name, ordered the way import names them ("000",
-    "001", ... - see _build_shape_keys), so an unedited model's morph order
-    survives the round trip. Within a group, one entry per corner whose
-    source vertex moved in that key - `id` is the corner's own index into
-    the model's flat per-corner arrays, exactly what building `positions`
-    already gave it (see _collect_geometry).
+    One group per shape key name, in Blender's own key_blocks order - the
+    order import creates them in ("000", "001", ..., see _build_shape_keys)
+    and the one the user sees and can reorder. The game addresses a morph by
+    its group index, so a key that moves nothing is still written, as an
+    empty group, rather than renumbering every key after it. Within a group,
+    one entry per corner whose source vertex moved in that key - `id` is the
+    corner's own index into the model's flat per-corner arrays, exactly what
+    building `positions` already gave it (see _collect_geometry).
     """
-    names = set()
+    names = []
     for bl_mesh_ob in bl_mesh_objs:
         keys = bl_mesh_ob.data.shape_keys
-        if keys:
-            names.update(key.name for key in keys.key_blocks[1:])
+        if not keys:
+            continue
+        for key in keys.key_blocks[1:]:
+            if key.name not in names:
+                names.append(key.name)
     if not names:
         return None
 
@@ -1335,12 +1340,16 @@ def _serialize_morphs(dst_bin, bl_mesh_objs, source_vertices, extra_scale):
     dst_morphs = dst_bin.MorphBlock(_parent=dst_bin, _root=dst_bin._root)
     clamped = False
     dst_groups = []
-    for name in sorted(names):
+    for name in names:
         entries = []
         for bl_mesh_ob in bl_mesh_objs:
             keys = bl_mesh_ob.data.shape_keys
             if not keys or name not in keys.key_blocks:
                 continue
+            # A delta is the difference of two positions, so it goes through
+            # the linear part of the same transform _collect_geometry bakes
+            # into those positions.
+            matrix = bl_mesh_ob.matrix_world.to_3x3()
             basis = keys.key_blocks[0]
             shape_key = keys.key_blocks[name]
             for vertex in bl_mesh_ob.data.vertices:
@@ -1348,7 +1357,7 @@ def _serialize_morphs(dst_bin, bl_mesh_objs, source_vertices, extra_scale):
                 shape_co = shape_key.data[vertex.index].co
                 if shape_co == basis_co:
                     continue
-                delta = shape_co - basis_co
+                delta = matrix @ (shape_co - basis_co)
                 raw = _zy_flip(delta.x, delta.y, delta.z)
                 deltas = [round(v * extra_scale) for v in raw]
                 if any(v < MORPH_DELTA_MIN or v > MORPH_DELTA_MAX for v in deltas):
@@ -1356,14 +1365,11 @@ def _serialize_morphs(dst_bin, bl_mesh_objs, source_vertices, extra_scale):
                 dx, dy, dz = (max(MORPH_DELTA_MIN, min(MORPH_DELTA_MAX, v)) for v in deltas)
                 for corner_index in corners_by_vertex.get((bl_mesh_ob, vertex.index), ()):
                     entries.append((corner_index, dx, dy, dz))
-        if entries:
-            dst_groups.append(_serialize_morph_group(dst_bin, dst_morphs, entries))
+        dst_groups.append(_serialize_morph_group(dst_bin, dst_morphs, entries))
 
     if clamped:
         print("[re4uhd] WARNING: a morph delta exceeded what vertex_scale allows "
               "and was clamped")
-    if not dst_groups:
-        return None
 
     dst_morphs.num_morph_groups = len(dst_groups)
     dst_morphs.morph_groups = dst_groups
@@ -1447,14 +1453,14 @@ def export_bin(bl_obj):
     if dst_morphs:
         dst_bin.morphs = dst_morphs
     if armature:
-        # Every id the shared armature can still name, which the DBL_JNT and
-        # symmetry blocks may reference beyond this model's own (possibly
-        # partial) bone table - see _serialize_bone_pairs.
-        resolvable_ids = {_bone_id(bone, i) for i, bone in enumerate(armature.data.bones)}
-        dst_bone_pairs = _serialize_bone_pairs(dst_bin, bl_mesh_objs, resolvable_ids)
+        # The DBL_JNT and symmetry blocks name bones by id, and the game
+        # resolves those against this file's own bone table - so they are
+        # checked against the ids that table actually writes.
+        written_bone_ids = {bone.bone_id for bone in dst_bin.bones}
+        dst_bone_pairs = _serialize_bone_pairs(dst_bin, bl_mesh_objs, written_bone_ids)
         if dst_bone_pairs:
             dst_bin.bone_pairs = dst_bone_pairs
-        dst_symmetry = _serialize_symmetry(dst_bin, bl_mesh_objs, dst_bin.bones, resolvable_ids)
+        dst_symmetry = _serialize_symmetry(dst_bin, bl_mesh_objs, dst_bin.bones, written_bone_ids)
         if dst_symmetry:
             dst_bin.symmetry_table = dst_symmetry
 
@@ -1617,9 +1623,9 @@ def _layout_and_write(dst_bin, num_vertices):
     header.flags = (BIN_FLAG_IS_MESH
                     | (BIN_FLAG_BONEPAIRS if has_bone_pairs else 0)
                     | (BIN_FLAG_ADJACENCY if has_symmetry else 0))
-    header.version_flags = (VERSION_FLAGS_WITH_TAGS if (has_bone_pairs or has_symmetry)
-                            else VERSION_FLAGS_PLAIN)
-    header.unk_01 = 0
+    tagged = has_bone_pairs or has_symmetry
+    header.version_flags = VERSION_FLAGS_WITH_TAGS if tagged else VERSION_FLAGS_PLAIN
+    header.unk_01 = UNK_01_WITH_TAGS if tagged else UNK_01_PLAIN
 
     offset = HEADER_SIZE
     header.offset_bones = HEADER_SIZE
@@ -1632,7 +1638,9 @@ def _layout_and_write(dst_bin, num_vertices):
     header.offset_morphs = offset if has_morphs else 0
     if has_morphs:
         morph_groups = dst_bin.morphs.morph_groups
-        morph_block_size = (MORPH_GROUP_ENTRY_SIZE * len(morph_groups)
+        # The leading u4 num_morph_groups, then the group table, then the
+        # bodies the table points at.
+        morph_block_size = (4 + MORPH_GROUP_ENTRY_SIZE * len(morph_groups)
                             + sum(MORPH_VERTEX_SIZE * len(g.body.vertices) for g in morph_groups))
         offset = _align(offset + morph_block_size)
 

--- a/albam/engines/cie/mesh.py
+++ b/albam/engines/cie/mesh.py
@@ -1270,12 +1270,22 @@ def _serialize_symmetry(dst_bin, bl_mesh_objs, dst_bones, written_bone_ids):
     see the .ksy comment on `symmetry`. A mirror target is an id in this
     file's own bone table, so one pointing outside `written_bone_ids` comes
     back as NO_MIRROR_BONE, the same as a bone the source never paired.
+
+    The table is positional in the file - row i belongs to bin.bones[i] -
+    and a bone id can repeat there (a known RE4UHD quirk, see PR #297), so
+    it is never safe to key a lookup by id alone: two different rows can
+    share one id and disagree. What breaks that tie here is
+    _build_armature's own collapse, `{b.bone_id: b for b in bin.bones}` -
+    only the LAST occurrence of a repeated id becomes that id's Blender
+    bone, carrying that occurrence's rest position and parent. `mirrors`
+    below applies the identical last-occurrence-wins rule, so the mirror
+    written for a bone always comes from the same source row as everything
+    else about that bone. When a source file's own table lists one id
+    twice with different data, only that last row's data survives the
+    round trip at all - a limitation of the bone table itself (the same
+    duplicate-id class as issue #265), not something this function can
+    recover on its own.
     """
-    # A bone id can repeat in the model's own table (two different bones
-    # given the same id - a known RE4UHD quirk, see PR #297), and the source
-    # array is positional, so two different mirror values can land on one
-    # id here. A real mirror wins over NO_MIRROR_BONE rather than whichever
-    # position happened to come first.
     mirrors = {}
     for bl_mesh_ob in bl_mesh_objs:
         own_ids = bl_mesh_ob.get(BONE_IDS_PROPERTY)
@@ -1283,8 +1293,7 @@ def _serialize_symmetry(dst_bin, bl_mesh_objs, dst_bones, written_bone_ids):
         if not own_ids or not own_mirrors:
             continue
         for bone_id, mirror_id in zip(own_ids, own_mirrors):
-            if mirrors.get(bone_id, NO_MIRROR_BONE) == NO_MIRROR_BONE:
-                mirrors[bone_id] = mirror_id
+            mirrors[bone_id] = mirror_id
     if not mirrors or not dst_bones:
         return None
 

--- a/albam/engines/cie/mesh.py
+++ b/albam/engines/cie/mesh.py
@@ -1285,6 +1285,13 @@ def _serialize_symmetry(dst_bin, bl_mesh_objs, dst_bones, written_bone_ids):
     round trip at all - a limitation of the bone table itself (the same
     duplicate-id class as issue #265), not something this function can
     recover on its own.
+
+    Across mesh objects the rule is the other one: their tables are partial
+    and differ, so a mesh whose own table simply does not pair a bone must
+    not blank out a mirror another mesh does carry. Each object resolves
+    its own table first, then merges in preferring a real value over
+    NO_MIRROR_BONE, the way _own_bone_parents and _serialize_bone_pairs
+    already union partial tables.
     """
     mirrors = {}
     for bl_mesh_ob in bl_mesh_objs:
@@ -1292,8 +1299,12 @@ def _serialize_symmetry(dst_bin, bl_mesh_objs, dst_bones, written_bone_ids):
         own_mirrors = bl_mesh_ob.get(BONE_MIRROR_IDS_PROPERTY)
         if not own_ids or not own_mirrors:
             continue
+        own = {}
         for bone_id, mirror_id in zip(own_ids, own_mirrors):
-            mirrors[bone_id] = mirror_id
+            own[bone_id] = mirror_id
+        for bone_id, mirror_id in own.items():
+            if mirrors.get(bone_id, NO_MIRROR_BONE) == NO_MIRROR_BONE:
+                mirrors[bone_id] = mirror_id
     if not mirrors or not dst_bones:
         return None
 

--- a/albam/engines/cie/mesh.py
+++ b/albam/engines/cie/mesh.py
@@ -24,6 +24,7 @@ GLOBAL_NORMAL_FIX_REDUCED = 16384
 HEADER_SIZE = 0x60
 BONE_SIZE = 16
 WEIGHT_SIZE = 8
+BONE_PAIR_LINE_SIZE = 8
 VEC3_SIZE = 12
 UV_SIZE = 8
 RGBA_SIZE = 4
@@ -50,6 +51,15 @@ NO_TEXTURE = 0xFF
 MAX_BONE_INFLUENCES = 3
 # Both counts are u2, so a model cannot state more corners than this.
 MAX_VERTICES = 0xFFFF
+# A morph delta is an s2, pre-multiplied by 2 ** vertex_scale.
+MORPH_DELTA_MIN = -32768
+MORPH_DELTA_MAX = 32767
+# u4 count + (u4 offset + u4 count) per group.
+MORPH_GROUP_ENTRY_SIZE = 8
+# id (u2) + 3 * s2 delta.
+MORPH_VERTEX_SIZE = 8
+# A bone pairing the symmetry table has nothing to mirror.
+NO_MIRROR_BONE = -1
 # How closely two corners' normals must agree to be the same entry - see
 # _normal_clusters. One degree: measured across a character mesh, loops the
 # importer gave an identical normal come back differing by at most 0.34
@@ -165,6 +175,14 @@ def build_blender_model(vfile: VirtualFile, context: bpy.types.Context) -> bpy.t
         # weighted to are in nothing else here - see _bones_to_write.
         bl_mesh_ob[BONE_IDS_PROPERTY] = [bone.bone_id for bone in bin.bones]
         bl_mesh_ob[BONE_PARENTS_PROPERTY] = [bone.parent for bone in bin.bones]
+        if bin.symmetry_table:
+            bl_mesh_ob[BONE_MIRROR_IDS_PROPERTY] = list(bin.symmetry_table.mirror_bone_ids)
+        if bin.bone_pairs:
+            bl_mesh_ob[BONE_PAIRS_PROPERTY] = [
+                value
+                for line in bin.bone_pairs.line
+                for value in (line.helper_bone_id, line.bone_a_id, line.bone_b_id, line.percent)
+            ]
         _apply_weights(bl_mesh_ob, bin)
         arm_mod = bl_mesh_ob.modifiers.new("Armature", 'ARMATURE')
         arm_mod.object = skeleton
@@ -347,6 +365,16 @@ BONE_IDS_PROPERTY = "cie.bone_ids"
 # models root a bone whose parent is present. Whatever the game reads them
 # for, they are the model's own and are carried rather than recomputed.
 BONE_PARENTS_PROPERTY = "cie.bone_parents"
+# The DBL_JNT ("double joint") table, flattened: four ints per line -
+# (helper bone id, bone a id, bone b id, blend percent) - see the .ksy
+# comment on pair_line. Bone ids rather than a Blender-side structure
+# because the block outlives an edited bone table only by naming ids, the
+# same reasoning BONE_IDS_PROPERTY follows.
+BONE_PAIRS_PROPERTY = "cie.bone_pairs"
+# The pXFlip / symmetry table, aligned with BONE_IDS_PROPERTY: mirror_ids[i]
+# is the bone bin.bones[i] mirrors to, or NO_MIRROR_BONE. See the .ksy
+# comment on the symmetry type.
+BONE_MIRROR_IDS_PROPERTY = "cie.bone_mirror_ids"
 
 
 def _find_reusable_armature(bin, context, archive_id):
@@ -876,9 +904,12 @@ def _collect_geometry(bl_mesh_objs):
     build and no vertex welding to undo - a triangle is simply three more
     entries on the end of every array.
 
-    Returns (groups, positions, normals, uvs, weight_indices, weight_table),
-    where `groups` is one (bl_material, triangle count) per material in the
-    order their corners appear.
+    Returns (groups, positions, normals, uvs, weight_indices, weight_table,
+    source_vertices), where `groups` is one (bl_material, triangle count) per
+    material in the order their corners appear, and `source_vertices` is one
+    (bl_mesh_ob, vertex index) per corner - the Blender vertex a corner was
+    built from, which is what a morph's per-corner deltas are keyed against
+    (see _serialize_morphs).
     """
     groups = []
     positions = []
@@ -887,6 +918,7 @@ def _collect_geometry(bl_mesh_objs):
     weight_indices = []
     weight_table = []
     weight_lookup = {}
+    source_vertices = []
 
     for bl_mesh_ob in bl_mesh_objs:
         bl_mesh = bl_mesh_ob.data
@@ -968,6 +1000,7 @@ def _collect_geometry(bl_mesh_objs):
                                 tuple((normal_matrix @ loop.normal).normalized()),
                                 uv,
                                 weight_index,
+                                loop.vertex_index,
                             ))
                         triangle.append(corner_id)
                     triangles.append(tuple(triangle))
@@ -978,14 +1011,15 @@ def _collect_geometry(bl_mesh_objs):
             strips = _strips_from_triangles(triangles)
             for strip in strips:
                 for corner_id in strip:
-                    position, normal, uv, weight_index = corner_list[corner_id]
+                    position, normal, uv, weight_index, vertex_index = corner_list[corner_id]
                     positions.append(position)
                     normals.append(normal)
                     uvs.append(uv)
                     weight_indices.append(weight_index)
+                    source_vertices.append((bl_mesh_ob, vertex_index))
             groups.append((bl_material, [len(strip) for strip in strips]))
 
-    return groups, positions, normals, uvs, weight_indices, weight_table
+    return groups, positions, normals, uvs, weight_indices, weight_table, source_vertices
 
 
 def _normal_clusters(bl_mesh):
@@ -1182,6 +1216,167 @@ def _serialize_material(dst_bin, bl_material, strip_lengths, app_id):
     return dst_material
 
 
+def _serialize_bone_pairs(dst_bin, bl_mesh_objs, resolvable_ids):
+    """The DBL_JNT block, from BONE_PAIRS_PROPERTY - see its comment.
+
+    `resolvable_ids` is every id the shared armature can name, not just the
+    ones this model's own bone table carries: measured on real files, a
+    helper joint's line can name a bone the model's own (possibly partial)
+    table leaves out - the same way a weight can (see _bones_to_write) - so
+    checking against the written table alone drops lines shipped files keep.
+    A line naming a bone the armature has lost entirely is dropped rather
+    than written broken.
+    """
+    dst_bone_pairs = dst_bin.BonePair(_parent=dst_bin, _root=dst_bin._root)
+    dst_lines = []
+    for bl_mesh_ob in bl_mesh_objs:
+        raw = bl_mesh_ob.get(BONE_PAIRS_PROPERTY) or ()
+        for helper_id, bone_a_id, bone_b_id, percent in chunks(list(raw), 4):
+            if (helper_id not in resolvable_ids or bone_a_id not in resolvable_ids
+                    or bone_b_id not in resolvable_ids):
+                print(f"[re4uhd] WARNING: dropping bone pair "
+                      f"({helper_id}, {bone_a_id}, {bone_b_id}, {percent}) - "
+                      f"a bone it names is not being exported")
+                continue
+            dst_line = dst_bin.PairLine(_parent=dst_bone_pairs, _root=dst_bin._root)
+            dst_line.helper_bone_id = helper_id
+            dst_line.bone_a_id = bone_a_id
+            dst_line.bone_b_id = bone_b_id
+            dst_line.percent = percent
+            dst_line._check()
+            dst_lines.append(dst_line)
+    if not dst_lines:
+        return None
+    dst_bone_pairs.num_pair = len(dst_lines)
+    dst_bone_pairs.line = dst_lines
+    dst_bone_pairs._check()
+    return dst_bone_pairs
+
+
+def _serialize_symmetry(dst_bin, bl_mesh_objs, dst_bones, resolvable_ids):
+    """The pXFlip mirror table, one entry per written bone in table order -
+    see the .ksy comment on `symmetry`. `resolvable_ids` is every id the
+    shared armature can name - see _serialize_bone_pairs for why a mirror
+    target can be valid without being in this model's own bone table. A
+    mirror that points at a bone the armature has lost entirely comes back
+    as NO_MIRROR_BONE, the same as a bone the source never paired.
+    """
+    # A bone id can repeat in the model's own table (two different bones
+    # given the same id - a known RE4UHD quirk, see PR #297), and the source
+    # array is positional, so two different mirror values can land on one
+    # id here. A real mirror wins over NO_MIRROR_BONE rather than whichever
+    # position happened to come first.
+    mirrors = {}
+    for bl_mesh_ob in bl_mesh_objs:
+        own_ids = bl_mesh_ob.get(BONE_IDS_PROPERTY)
+        own_mirrors = bl_mesh_ob.get(BONE_MIRROR_IDS_PROPERTY)
+        if not own_ids or not own_mirrors:
+            continue
+        for bone_id, mirror_id in zip(own_ids, own_mirrors):
+            if mirrors.get(bone_id, NO_MIRROR_BONE) == NO_MIRROR_BONE:
+                mirrors[bone_id] = mirror_id
+    if not mirrors or not dst_bones:
+        return None
+
+    dst_symmetry = dst_bin.Symmetry(_parent=dst_bin, _root=dst_bin._root)
+    dst_symmetry.num_bones = len(dst_bones)
+    dst_symmetry.mirror_bone_ids = [
+        mirror_id if (mirror_id := mirrors.get(bone.bone_id, NO_MIRROR_BONE)) in resolvable_ids
+        else NO_MIRROR_BONE
+        for bone in dst_bones
+    ]
+    dst_symmetry._check()
+    return dst_symmetry
+
+
+def _serialize_morph_group(dst_bin, dst_morphs, entries):
+    dst_group = dst_bin.MorphGroup(_parent=dst_morphs, _root=dst_bin._root)
+    dst_group.count = len(entries)
+    dst_body = dst_bin.MorphGroupBody(_parent=dst_group, _root=dst_bin._root)
+    dst_vertices = []
+    for corner_index, dx, dy, dz in entries:
+        dst_vertex = dst_bin.MorphVertex(_parent=dst_body, _root=dst_bin._root)
+        dst_position = dst_bin.Vec3s2(_parent=dst_vertex, _root=dst_bin._root)
+        dst_position.x, dst_position.y, dst_position.z = dx, dy, dz
+        dst_position._check()
+        dst_vertex.id = corner_index
+        dst_vertex.position = dst_position
+        dst_vertex._check()
+        dst_vertices.append(dst_vertex)
+    dst_body.vertices = dst_vertices
+    dst_body._check()
+    dst_group.body = dst_body
+    return dst_group
+
+
+def _serialize_morphs(dst_bin, bl_mesh_objs, source_vertices, extra_scale):
+    """Shape keys beyond Basis as morph groups - see the .ksy comments on
+    morph_block / morph_group / morph_group_body.
+
+    One group per shape key name, ordered the way import names them ("000",
+    "001", ... - see _build_shape_keys), so an unedited model's morph order
+    survives the round trip. Within a group, one entry per corner whose
+    source vertex moved in that key - `id` is the corner's own index into
+    the model's flat per-corner arrays, exactly what building `positions`
+    already gave it (see _collect_geometry).
+    """
+    names = set()
+    for bl_mesh_ob in bl_mesh_objs:
+        keys = bl_mesh_ob.data.shape_keys
+        if keys:
+            names.update(key.name for key in keys.key_blocks[1:])
+    if not names:
+        return None
+
+    corners_by_vertex = {}
+    for corner_index, source in enumerate(source_vertices):
+        corners_by_vertex.setdefault(source, []).append(corner_index)
+
+    dst_morphs = dst_bin.MorphBlock(_parent=dst_bin, _root=dst_bin._root)
+    clamped = False
+    dst_groups = []
+    for name in sorted(names):
+        entries = []
+        for bl_mesh_ob in bl_mesh_objs:
+            keys = bl_mesh_ob.data.shape_keys
+            if not keys or name not in keys.key_blocks:
+                continue
+            basis = keys.key_blocks[0]
+            shape_key = keys.key_blocks[name]
+            for vertex in bl_mesh_ob.data.vertices:
+                basis_co = basis.data[vertex.index].co
+                shape_co = shape_key.data[vertex.index].co
+                if shape_co == basis_co:
+                    continue
+                delta = shape_co - basis_co
+                raw = _zy_flip(delta.x, delta.y, delta.z)
+                deltas = [round(v * extra_scale) for v in raw]
+                if any(v < MORPH_DELTA_MIN or v > MORPH_DELTA_MAX for v in deltas):
+                    clamped = True
+                dx, dy, dz = (max(MORPH_DELTA_MIN, min(MORPH_DELTA_MAX, v)) for v in deltas)
+                for corner_index in corners_by_vertex.get((bl_mesh_ob, vertex.index), ()):
+                    entries.append((corner_index, dx, dy, dz))
+        if entries:
+            dst_groups.append(_serialize_morph_group(dst_bin, dst_morphs, entries))
+
+    if clamped:
+        print("[re4uhd] WARNING: a morph delta exceeded what vertex_scale allows "
+              "and was clamped")
+    if not dst_groups:
+        return None
+
+    dst_morphs.num_morph_groups = len(dst_groups)
+    dst_morphs.morph_groups = dst_groups
+
+    offset = MORPH_GROUP_ENTRY_SIZE * len(dst_groups)
+    for dst_group in dst_groups:
+        dst_group.offset = offset
+        offset += MORPH_VERTEX_SIZE * len(dst_group.body.vertices)
+        dst_group._check()
+    dst_morphs._check()
+    return dst_morphs
+
+
 @blender_registry.register_export_function(app_id="re4uhd", extension="bin")
 def export_bin(bl_obj):
     """Serialize a Blender object back to a mesh .bin.
@@ -1209,8 +1404,8 @@ def export_bin(bl_obj):
     if armature is None and bl_obj.type == "ARMATURE":
         armature = bl_obj
 
-    (groups, positions, normals, uvs,
-     weight_indices, weight_table) = _collect_geometry(bl_mesh_objs)
+    (groups, positions, normals, uvs, weight_indices,
+     weight_table, source_vertices) = _collect_geometry(bl_mesh_objs)
 
     num_vertices = len(positions)
     if num_vertices > MAX_VERTICES:
@@ -1241,11 +1436,27 @@ def export_bin(bl_obj):
     dst_bin.vertex_colors = _serialize_colors(dst_bin, num_vertices)
     dst_bin.materials = [_serialize_material(dst_bin, bl_material, strip_lengths, app_id)
                          for bl_material, strip_lengths in groups]
-    # Morphs, bone pairs and adjacency are left out: their offsets stay 0 and
-    # the header flags announcing them are cleared with them, which is how a
-    # shipped model without them looks. They are not assigned at all rather
-    # than assigned None - these are conditional Kaitai instances, and the
-    # generated writer walks whatever is set.
+
+    # Left unassigned rather than assigned None when there is nothing to
+    # write - these are conditional Kaitai instances, and the generated
+    # writer only walks what is set. A model with none of the three simply
+    # gets 0 offsets and clear flags, the same as a shipped model without
+    # them.
+    extra_scale = 2 ** dst_bin.header.vertex_scale
+    dst_morphs = _serialize_morphs(dst_bin, bl_mesh_objs, source_vertices, extra_scale)
+    if dst_morphs:
+        dst_bin.morphs = dst_morphs
+    if armature:
+        # Every id the shared armature can still name, which the DBL_JNT and
+        # symmetry blocks may reference beyond this model's own (possibly
+        # partial) bone table - see _serialize_bone_pairs.
+        resolvable_ids = {_bone_id(bone, i) for i, bone in enumerate(armature.data.bones)}
+        dst_bone_pairs = _serialize_bone_pairs(dst_bin, bl_mesh_objs, resolvable_ids)
+        if dst_bone_pairs:
+            dst_bin.bone_pairs = dst_bone_pairs
+        dst_symmetry = _serialize_symmetry(dst_bin, bl_mesh_objs, dst_bin.bones, resolvable_ids)
+        if dst_symmetry:
+            dst_bin.symmetry_table = dst_symmetry
 
     data_bytes = _layout_and_write(dst_bin, num_vertices)
     return [VirtualFileData(app_id, asset.relative_path, data_bytes=data_bytes)]
@@ -1398,10 +1609,16 @@ def _layout_and_write(dst_bin, num_vertices):
     header.num_weights = weight_count if weight_count <= 255 else weight_count & 0xFF
     header.num_weights2 = weight_count
 
-    # 0x80000000 is what marks the file as a mesh at all; the bone-pair and
-    # adjacency bits stay clear because nothing rebuilds those blocks yet.
-    header.flags = BIN_FLAG_IS_MESH
-    header.version_flags = VERSION_FLAGS_PLAIN
+    # 0x80000000 is what marks the file as a mesh at all; the other two flag
+    # bits and the build stamp go with whichever of the bone-pair and
+    # symmetry blocks are actually written - see the header's own comments.
+    has_bone_pairs = bool(getattr(dst_bin, "bone_pairs", None))
+    has_symmetry = bool(getattr(dst_bin, "symmetry_table", None))
+    header.flags = (BIN_FLAG_IS_MESH
+                    | (BIN_FLAG_BONEPAIRS if has_bone_pairs else 0)
+                    | (BIN_FLAG_ADJACENCY if has_symmetry else 0))
+    header.version_flags = (VERSION_FLAGS_WITH_TAGS if (has_bone_pairs or has_symmetry)
+                            else VERSION_FLAGS_PLAIN)
     header.unk_01 = 0
 
     offset = HEADER_SIZE
@@ -1410,6 +1627,22 @@ def _layout_and_write(dst_bin, num_vertices):
 
     header.offset_weights = offset if dst_bin.weights else 0
     offset = _align(offset + weight_count * WEIGHT_SIZE)
+
+    has_morphs = bool(getattr(dst_bin, "morphs", None))
+    header.offset_morphs = offset if has_morphs else 0
+    if has_morphs:
+        morph_groups = dst_bin.morphs.morph_groups
+        morph_block_size = (MORPH_GROUP_ENTRY_SIZE * len(morph_groups)
+                            + sum(MORPH_VERTEX_SIZE * len(g.body.vertices) for g in morph_groups))
+        offset = _align(offset + morph_block_size)
+
+    header.offset_bonepairs = offset if has_bone_pairs else 0
+    if has_bone_pairs:
+        offset = _align(offset + 4 + BONE_PAIR_LINE_SIZE * len(dst_bin.bone_pairs.line))
+
+    header.offset_adjacents = offset if has_symmetry else 0
+    if has_symmetry:
+        offset = _align(offset + 4 + 2 * len(dst_bin.symmetry_table.mirror_bone_ids))
 
     header.offset_vertex_position = offset
     offset = _align(offset + num_vertices * VEC3_SIZE)

--- a/albam/engines/cie/structs/re4-uhd-bin.ksy
+++ b/albam/engines/cie/structs/re4-uhd-bin.ksy
@@ -25,8 +25,8 @@ instances:
     {pos: header.offset_morphs, type: morph_block, if: header.offset_morphs > 0 }
   bone_pairs:
     {pos: header.offset_bonepairs, type: bone_pair, if: header.offset_bonepairs > 0}
-  adjacent:
-    {pos: header.offset_adjacents, type: bone_adj, if: header.offset_adjacents > 0}
+  symmetry_table:
+    {pos: header.offset_adjacents, type: symmetry, if: header.offset_adjacents > 0}
   vertex_positions:
     {pos: header.offset_vertex_position, type: vec3, repeat: expr, repeat-expr: header.num_vertices}
   normals:
@@ -102,16 +102,24 @@ types:
       size_:
         value: 96
 
-  bone_adj:
+  # The game's pXFlip / symmetry table: one entry per bone, the bone it
+  # mirrors to or -1. Stored big-endian in an otherwise little-endian file -
+  # a leftover of the format's GameCube origin (unverified against a
+  # GameCube .bin, but the byte order itself is measured across 5,709 RE4
+  # UHD models with no exception). Not adjacency: nothing here describes
+  # triangle or face relationships.
+  symmetry:
+    meta:
+      endian: be
     seq:
-      - {id: count, type: u1, repeat: expr, repeat-expr: 4}
-      - id: adj
-        type: u2
+      - {id: num_bones, type: u4}
+      - id: mirror_bone_ids
+        type: s2
         repeat: expr
-        repeat-expr: count[3] # num bones?
+        repeat-expr: num_bones
     instances:
       size_:
-        value: 4 + count[3] * 2
+        value: 4 + num_bones * 2
 
   morph_block:
     seq:
@@ -120,17 +128,19 @@ types:
 
   morph_group:
     seq:
+      # Relative to the group table's own start (offset_morphs + 4), not to
+      # offset_morphs - see morph_group_body.body below. Measured exact
+      # across 389 morph-carrying models, 9,468 non-final groups.
       - {id: offset, type: u4}
-      - {id: num_vertices, type: u4}
+      - {id: count, type: u4}
     instances:
       body:
-        pos: _root.header.offset_morphs + offset
+        pos: _root.header.offset_morphs + 4 + offset
         type: morph_group_body
 
   morph_group_body:
     seq:
-      - {id: header, type: u4}
-      - {id: vertices, type: morph_vertex, repeat: expr, repeat-expr: _parent.num_vertices}
+      - {id: vertices, type: morph_vertex, repeat: expr, repeat-expr: _parent.count}
 
   morph_vertex:
     seq:
@@ -148,10 +158,18 @@ types:
       size_:
         value: 4 + 8*num_pair
 
-  # Four bone ids; what the fourth is for is unknown.
+  # The game's DBL_JNT ("double joint") table: one line per helper bone that
+  # takes the blend-percent-of-the-way orientation between two other bones -
+  # the textbook "double joint" that keeps a bent elbow or knee from
+  # collapsing. `percent` is in the same 0-100 units the weight block uses;
+  # measured 50 in 7,950 of 7,954 lines across 2,643 models, with the four
+  # exceptions all real per-side variation on the same helper joint.
   pair_line:
     seq:
-      - {id: data, size: 8}
+      - {id: helper_bone_id, type: u2}
+      - {id: bone_a_id, type: u2}
+      - {id: bone_b_id, type: u2}
+      - {id: percent, type: u2}
 
   # Positions are local offsets from the parent, in the same units as
   # vertices. Bone ids are not guaranteed unique across a model.

--- a/albam/engines/cie/structs/re4-uhd-bin.ksy
+++ b/albam/engines/cie/structs/re4-uhd-bin.ksy
@@ -92,7 +92,9 @@ types:
       - {id: num_vertex_normals, type: u2} # vertex_normal_count
       # A build stamp, shipped as one of exactly two date-shaped values:
       # 0x20030818 where the adjacency and bone-pair blocks are present,
-      # 0x20010801 where they are not, always in step with unk_01.
+      # 0x20010801 where they are not, always in step with unk_01: measured
+      # across 184 mesh .bin files in 8 character archives, the first always
+      # pairs with unk_01 = 0x50 and the second with unk_01 = 0.
       - {id: version_flags, type: u4}
       - {id: offset_bonepairs, type: u4} # bonepair_offset
       - {id: offset_adjacents, type: u4} # adjacent_offset

--- a/albam/engines/cie/structs/re4_uhd_bin.py
+++ b/albam/engines/cie/structs/re4_uhd_bin.py
@@ -13,8 +13,6 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
         super(Re4UhdBin, self).__init__(_io)
         self._parent = _parent
         self._root = _root or self
-        self._should_write_adjacent = False
-        self.adjacent__enabled = True
         self._should_write_bone_pairs = False
         self.bone_pairs__enabled = True
         self._should_write_bones = False
@@ -29,6 +27,8 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
         self.morphs__enabled = True
         self._should_write_normals = False
         self.normals__enabled = True
+        self._should_write_symmetry_table = False
+        self.symmetry_table__enabled = True
         self._should_write_texcoords = False
         self.texcoords__enabled = True
         self._should_write_vertex_colors = False
@@ -47,11 +47,6 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
     def _fetch_instances(self):
         pass
         self.header._fetch_instances()
-        _ = self.adjacent
-        if hasattr(self, '_m_adjacent'):
-            pass
-            self._m_adjacent._fetch_instances()
-
         _ = self.bone_pairs
         if hasattr(self, '_m_bone_pairs'):
             pass
@@ -100,6 +95,11 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
                 self._m_normals[i]._fetch_instances()
 
 
+        _ = self.symmetry_table
+        if hasattr(self, '_m_symmetry_table'):
+            pass
+            self._m_symmetry_table._fetch_instances()
+
         _ = self.texcoords
         if hasattr(self, '_m_texcoords'):
             pass
@@ -136,7 +136,6 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
 
     def _write__seq(self, io=None):
         super(Re4UhdBin, self)._write__seq(io)
-        self._should_write_adjacent = self.adjacent__enabled
         self._should_write_bone_pairs = self.bone_pairs__enabled
         self._should_write_bones = self.bones__enabled
         self._should_write_indexes = self.indexes__enabled
@@ -144,6 +143,7 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
         self._should_write_materials = self.materials__enabled
         self._should_write_morphs = self.morphs__enabled
         self._should_write_normals = self.normals__enabled
+        self._should_write_symmetry_table = self.symmetry_table__enabled
         self._should_write_texcoords = self.texcoords__enabled
         self._should_write_vertex_colors = self.vertex_colors__enabled
         self._should_write_vertex_positions = self.vertex_positions__enabled
@@ -156,16 +156,6 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
             raise kaitaistruct.ConsistencyError(u"header", self._root, self.header._root)
         if self.header._parent != self:
             raise kaitaistruct.ConsistencyError(u"header", self, self.header._parent)
-        if self.adjacent__enabled:
-            pass
-            if self.header.offset_adjacents > 0:
-                pass
-                if self._m_adjacent._root != self._root:
-                    raise kaitaistruct.ConsistencyError(u"adjacent", self._root, self._m_adjacent._root)
-                if self._m_adjacent._parent != self:
-                    raise kaitaistruct.ConsistencyError(u"adjacent", self, self._m_adjacent._parent)
-
-
         if self.bone_pairs__enabled:
             pass
             if self.header.offset_bonepairs > 0:
@@ -242,6 +232,16 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
                     raise kaitaistruct.ConsistencyError(u"normals", self._root, self._m_normals[i]._root)
                 if self._m_normals[i]._parent != self:
                     raise kaitaistruct.ConsistencyError(u"normals", self, self._m_normals[i]._parent)
+
+
+        if self.symmetry_table__enabled:
+            pass
+            if self.header.offset_adjacents > 0:
+                pass
+                if self._m_symmetry_table._root != self._root:
+                    raise kaitaistruct.ConsistencyError(u"symmetry_table", self._root, self._m_symmetry_table._root)
+                if self._m_symmetry_table._parent != self:
+                    raise kaitaistruct.ConsistencyError(u"symmetry_table", self, self._m_symmetry_table._parent)
 
 
         if self.texcoords__enabled:
@@ -333,70 +333,6 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
         def _check(self):
             self._dirty = False
 
-
-    class BoneAdj(ReadWriteKaitaiStruct):
-        def __init__(self, _io=None, _parent=None, _root=None):
-            super(Re4UhdBin.BoneAdj, self).__init__(_io)
-            self._parent = _parent
-            self._root = _root
-
-        def _read(self):
-            self.count = []
-            for i in range(4):
-                self.count.append(self._io.read_u1())
-
-            self.adj = []
-            for i in range(self.count[3]):
-                self.adj.append(self._io.read_u2le())
-
-            self._dirty = False
-
-
-        def _fetch_instances(self):
-            pass
-            for i in range(len(self.count)):
-                pass
-
-            for i in range(len(self.adj)):
-                pass
-
-
-
-        def _write__seq(self, io=None):
-            super(Re4UhdBin.BoneAdj, self)._write__seq(io)
-            for i in range(len(self.count)):
-                pass
-                self._io.write_u1(self.count[i])
-
-            for i in range(len(self.adj)):
-                pass
-                self._io.write_u2le(self.adj[i])
-
-
-
-        def _check(self):
-            if len(self.count) != 4:
-                raise kaitaistruct.ConsistencyError(u"count", 4, len(self.count))
-            for i in range(len(self.count)):
-                pass
-
-            if len(self.adj) != self.count[3]:
-                raise kaitaistruct.ConsistencyError(u"adj", self.count[3], len(self.adj))
-            for i in range(len(self.adj)):
-                pass
-
-            self._dirty = False
-
-        @property
-        def size_(self):
-            if hasattr(self, '_m_size_'):
-                return self._m_size_
-
-            self._m_size_ = 4 + self.count[3] * 2
-            return getattr(self, '_m_size_', None)
-
-        def _invalidate_size_(self):
-            del self._m_size_
 
     class BonePair(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
@@ -767,7 +703,7 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
 
         def _read(self):
             self.offset = self._io.read_u4le()
-            self.num_vertices = self._io.read_u4le()
+            self.count = self._io.read_u4le()
             self._dirty = False
 
 
@@ -784,7 +720,7 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
             super(Re4UhdBin.MorphGroup, self)._write__seq(io)
             self._should_write_body = self.body__enabled
             self._io.write_u4le(self.offset)
-            self._io.write_u4le(self.num_vertices)
+            self._io.write_u4le(self.count)
 
 
         def _check(self):
@@ -808,7 +744,7 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
                 return None
 
             _pos = self._io.pos()
-            self._io.seek(self._root.header.offset_morphs + self.offset)
+            self._io.seek((self._root.header.offset_morphs + 4) + self.offset)
             self._m_body = Re4UhdBin.MorphGroupBody(self._io, self, self._root)
             self._m_body._read()
             self._io.seek(_pos)
@@ -822,7 +758,7 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
         def _write_body(self):
             self._should_write_body = False
             _pos = self._io.pos()
-            self._io.seek(self._root.header.offset_morphs + self.offset)
+            self._io.seek((self._root.header.offset_morphs + 4) + self.offset)
             self._m_body._write__seq(self._io)
             self._io.seek(_pos)
 
@@ -834,9 +770,8 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
             self._root = _root
 
         def _read(self):
-            self.header = self._io.read_u4le()
             self.vertices = []
-            for i in range(self._parent.num_vertices):
+            for i in range(self._parent.count):
                 _t_vertices = Re4UhdBin.MorphVertex(self._io, self, self._root)
                 try:
                     _t_vertices._read()
@@ -856,7 +791,6 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
 
         def _write__seq(self, io=None):
             super(Re4UhdBin.MorphGroupBody, self)._write__seq(io)
-            self._io.write_u4le(self.header)
             for i in range(len(self.vertices)):
                 pass
                 self.vertices[i]._write__seq(self._io)
@@ -864,8 +798,8 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
 
 
         def _check(self):
-            if len(self.vertices) != self._parent.num_vertices:
-                raise kaitaistruct.ConsistencyError(u"vertices", self._parent.num_vertices, len(self.vertices))
+            if len(self.vertices) != self._parent.count:
+                raise kaitaistruct.ConsistencyError(u"vertices", self._parent.count, len(self.vertices))
             for i in range(len(self.vertices)):
                 pass
                 if self.vertices[i]._root != self._root:
@@ -915,7 +849,10 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
             self._root = _root
 
         def _read(self):
-            self.data = self._io.read_bytes(8)
+            self.helper_bone_id = self._io.read_u2le()
+            self.bone_a_id = self._io.read_u2le()
+            self.bone_b_id = self._io.read_u2le()
+            self.percent = self._io.read_u2le()
             self._dirty = False
 
 
@@ -925,12 +862,13 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
 
         def _write__seq(self, io=None):
             super(Re4UhdBin.PairLine, self)._write__seq(io)
-            self._io.write_bytes(self.data)
+            self._io.write_u2le(self.helper_bone_id)
+            self._io.write_u2le(self.bone_a_id)
+            self._io.write_u2le(self.bone_b_id)
+            self._io.write_u2le(self.percent)
 
 
         def _check(self):
-            if len(self.data) != 8:
-                raise kaitaistruct.ConsistencyError(u"data", 8, len(self.data))
             self._dirty = False
 
 
@@ -989,6 +927,56 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
         def _check(self):
             self._dirty = False
 
+
+    class Symmetry(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            super(Re4UhdBin.Symmetry, self).__init__(_io)
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.num_bones = self._io.read_u4be()
+            self.mirror_bone_ids = []
+            for i in range(self.num_bones):
+                self.mirror_bone_ids.append(self._io.read_s2be())
+
+            self._dirty = False
+
+
+        def _fetch_instances(self):
+            pass
+            for i in range(len(self.mirror_bone_ids)):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(Re4UhdBin.Symmetry, self)._write__seq(io)
+            self._io.write_u4be(self.num_bones)
+            for i in range(len(self.mirror_bone_ids)):
+                pass
+                self._io.write_s2be(self.mirror_bone_ids[i])
+
+
+
+        def _check(self):
+            if len(self.mirror_bone_ids) != self.num_bones:
+                raise kaitaistruct.ConsistencyError(u"mirror_bone_ids", self.num_bones, len(self.mirror_bone_ids))
+            for i in range(len(self.mirror_bone_ids)):
+                pass
+
+            self._dirty = False
+
+        @property
+        def size_(self):
+            if hasattr(self, '_m_size_'):
+                return self._m_size_
+
+            self._m_size_ = 4 + self.num_bones * 2
+            return getattr(self, '_m_size_', None)
+
+        def _invalidate_size_(self):
+            del self._m_size_
 
     class UhdBinHeader(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
@@ -1152,41 +1140,6 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
 
         def _check(self):
             self._dirty = False
-
-
-    @property
-    def adjacent(self):
-        if self._should_write_adjacent:
-            self._write_adjacent()
-        if hasattr(self, '_m_adjacent'):
-            return self._m_adjacent
-
-        if not self.adjacent__enabled:
-            return None
-
-        if self.header.offset_adjacents > 0:
-            pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_adjacents)
-            self._m_adjacent = Re4UhdBin.BoneAdj(self._io, self, self._root)
-            self._m_adjacent._read()
-            self._io.seek(_pos)
-
-        return getattr(self, '_m_adjacent', None)
-
-    @adjacent.setter
-    def adjacent(self, v):
-        self._dirty = True
-        self._m_adjacent = v
-
-    def _write_adjacent(self):
-        self._should_write_adjacent = False
-        if self.header.offset_adjacents > 0:
-            pass
-            _pos = self._io.pos()
-            self._io.seek(self.header.offset_adjacents)
-            self._m_adjacent._write__seq(self._io)
-            self._io.seek(_pos)
 
 
     @property
@@ -1452,6 +1405,41 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
             self._m_normals[i]._write__seq(self._io)
 
         self._io.seek(_pos)
+
+    @property
+    def symmetry_table(self):
+        if self._should_write_symmetry_table:
+            self._write_symmetry_table()
+        if hasattr(self, '_m_symmetry_table'):
+            return self._m_symmetry_table
+
+        if not self.symmetry_table__enabled:
+            return None
+
+        if self.header.offset_adjacents > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_adjacents)
+            self._m_symmetry_table = Re4UhdBin.Symmetry(self._io, self, self._root)
+            self._m_symmetry_table._read()
+            self._io.seek(_pos)
+
+        return getattr(self, '_m_symmetry_table', None)
+
+    @symmetry_table.setter
+    def symmetry_table(self, v):
+        self._dirty = True
+        self._m_symmetry_table = v
+
+    def _write_symmetry_table(self):
+        self._should_write_symmetry_table = False
+        if self.header.offset_adjacents > 0:
+            pass
+            _pos = self._io.pos()
+            self._io.seek(self.header.offset_adjacents)
+            self._m_symmetry_table._write__seq(self._io)
+            self._io.seek(_pos)
+
 
     @property
     def texcoords(self):

--- a/docs/modding-a-character.md
+++ b/docs/modding-a-character.md
@@ -133,11 +133,18 @@ Anything you do to the mesh is what gets written:
   value. Note what this is and is not: it re-points the material at a texture
   **already in the archive's texture pack**. Bringing a new image into the game
   is not supported - see below.
+- **Facial morphs** - a model's morph targets arrive as shape keys named `000`,
+  `001`, ... and are written back, edits included.
 
-Two things to keep in mind:
+Three things to keep in mind:
 
 - **Keep the vertex groups.** They are the skinning, named after bone ids. A
   vertex in no group gets pinned to the first bone.
+- **Keep the shape keys in order.** The game asks for a morph by its position
+  in the list, so a key you delete or reorder renames every morph after it -
+  an animation asking for a smile gets whatever now sits at that index. Editing
+  a key in place is fine, and a key that moves nothing is still exported, as an
+  empty morph, rather than shifting the rest up.
 - **There is a size limit.** Both vertex counts in the format are 16-bit, so a
   model cannot exceed 65535 face corners. Corners are shared along a triangle
   strip but never across a UV seam or a shading split, so a mesh needs somewhere
@@ -216,8 +223,6 @@ Add one layer of albam at a time, and whichever fails first names the layer:
 - **A model whose bone table names one bone id twice** cannot be exported
   faithfully; import collapses the two. 69 of 738 models are affected, and the
   build tool keeps their original bytes rather than shipping them wrong.
-- **Morph targets, bone pairs and adjacency** are not written back. A model with
-  facial morphs loses them on export.
 - **Rooms** import - geometry, props and placement - but there is no exporter for
   them.
 - **New textures cannot be added.** Nothing writes a `.pack` or a `.tpl`, so a

--- a/tests/cie/datasets/bin_export_tagblocks_hashes.json
+++ b/tests/cie/datasets/bin_export_tagblocks_hashes.json
@@ -1,0 +1,12 @@
+[
+  {
+    "app_id": "re4uhd",
+    "archive_path_hash": "0b6d0ed70a35aeeb",
+    "carries": ["bone_pairs", "symmetry"]
+  },
+  {
+    "app_id": "re4uhd",
+    "archive_path_hash": "b65161651d1791d1",
+    "carries": ["morphs"]
+  }
+]

--- a/tests/cie/datasets/bin_export_tagblocks_hashes.json
+++ b/tests/cie/datasets/bin_export_tagblocks_hashes.json
@@ -1,12 +1,6 @@
 [
   {
     "app_id": "re4uhd",
-    "archive_path_hash": "0b6d0ed70a35aeeb",
-    "carries": ["bone_pairs", "symmetry"]
-  },
-  {
-    "app_id": "re4uhd",
-    "archive_path_hash": "b65161651d1791d1",
-    "carries": ["morphs"]
+    "archive_path_hash": "fd8d767380c71f51"
   }
 ]

--- a/tests/cie/test_bin_export_tagblocks.py
+++ b/tests/cie/test_bin_export_tagblocks.py
@@ -177,10 +177,10 @@ def test_bone_pairs_round_trip_through_export(game_root, local_app_id, local_arc
     assert reparsed.header.offset_bonepairs > 0
     assert reparsed.header.flags & BIN_FLAG_BONEPAIRS
 
-    original = {(l.helper_bone_id, l.bone_a_id, l.bone_b_id, l.percent)
-                for l in parsed.bone_pairs.line}
-    exported = {(l.helper_bone_id, l.bone_a_id, l.bone_b_id, l.percent)
-                for l in reparsed.bone_pairs.line}
+    original = {(line.helper_bone_id, line.bone_a_id, line.bone_b_id, line.percent)
+                for line in parsed.bone_pairs.line}
+    exported = {(line.helper_bone_id, line.bone_a_id, line.bone_b_id, line.percent)
+                for line in reparsed.bone_pairs.line}
     # Every line whose three bones the model's own table already had must
     # survive; a line naming a bone that table never carried to begin with
     # (a known RE4UHD partial-table quirk) has nothing in Blender to write

--- a/tests/cie/test_bin_export_tagblocks.py
+++ b/tests/cie/test_bin_export_tagblocks.py
@@ -9,6 +9,7 @@ import json
 import os
 
 import bpy
+import mathutils
 import pytest
 
 from albam.lib import fs_registry
@@ -16,6 +17,10 @@ from tests.conftest import close_new_fs_roots, remove_new_vfs_roots, vfs_root_na
 from tests.cie.lfs_paths import resolve_archive_hashes
 from tests.cie.test_bin_serialization import _is_mesh_bin
 
+# Committed, hash-only, catalog-verified archives (see
+# test_dataset_hashes_are_in_catalog), same pattern as the other cie
+# datasets. Every entry has to carry both a DBL_JNT and a pXFlip table,
+# which is what the two round-trip tests below mount it for.
 DATASETS_DIR = os.path.join(os.path.dirname(__file__), "datasets")
 DATASET_PATH = os.path.join(DATASETS_DIR, "bin_export_tagblocks_hashes.json")
 with open(DATASET_PATH) as f:
@@ -97,26 +102,44 @@ def _import_first_model_carrying(game_root, local_app_id, archive_hash, block_at
     return bl_object, parsed
 
 
-def test_morphs_round_trip_through_export(game_root, local_app_id, local_archive_path_hash,
-                                          _clean_scene):
-    """A morph-carrying model keeps a morph block after export, and every
-    entry id it writes is a valid corner index - the format question issue
-    #266 raised, settled by the measurements recorded in the .ksy comments
-    on morph_group and morph_group_body (the framing needed no import fix,
-    so this exercises only the writer)."""
-    entry = next(d for d in TAGBLOCKS_DATASET if d["archive_path_hash"] == local_archive_path_hash)
-    if "morphs" not in entry["carries"]:
-        pytest.skip("this archive carries no morphs")
+def _mesh_child(bl_object):
+    if bl_object.type == "MESH":
+        return bl_object
+    return next(child for child in bl_object.children_recursive if child.type == "MESH")
 
+
+def test_morphs_are_written_from_shape_keys(game_root, local_app_id, local_archive_path_hash,
+                                            _clean_scene):
+    """Shape keys come back out as a morph block, framed the way the
+    measurements recorded in the .ksy comments on morph_group and
+    morph_group_body settled the format question issue #266 raised, with
+    every delta decoding to the movement Blender held.
+
+    The morphs are added here rather than imported from a morph-carrying
+    game model: none of the archives the committed datasets name carries
+    one, and export is the half #266 reports missing either way - the
+    framing needed no import fix, so this exercises only the writer.
+    """
     from albam.registry import blender_registry
+    from albam.engines.cie.mesh import _yz_flip
     from albam.engines.cie.structs.re4_uhd_bin import Re4UhdBin
 
-    bl_object, parsed = _import_first_model_carrying(
-        game_root, local_app_id, local_archive_path_hash, "morphs")
-    bl_mesh_ob = bl_object if bl_object.type == "MESH" else next(
-        child for child in bl_object.children_recursive if child.type == "MESH")
-    assert bl_mesh_ob.data.shape_keys is not None
-    assert len(bl_mesh_ob.data.shape_keys.key_blocks) > 1, "Basis plus at least one morph"
+    bl_object, _parsed = _import_first_model_carrying(
+        game_root, local_app_id, local_archive_path_hash, "bone_pairs")
+    bl_mesh_ob = _mesh_child(bl_object)
+    assert bl_mesh_ob.data.shape_keys is None, "this model is expected to carry no morphs"
+
+    # Two moved vertices with distinct deltas, so the entries can be checked
+    # against what moved rather than only against each other, and a key that
+    # moves nothing after them.
+    moved = {0: (0.01, 0.02, -0.03), 1: (-0.05, 0.008, 0.04)}
+    bl_mesh_ob.shape_key_add(name="Basis", from_mix=False)
+    shape_key = bl_mesh_ob.shape_key_add(name="000", from_mix=False)
+    for vertex_index, (dx, dy, dz) in moved.items():
+        shape_key.data[vertex_index].co.x += dx
+        shape_key.data[vertex_index].co.y += dy
+        shape_key.data[vertex_index].co.z += dz
+    bl_mesh_ob.shape_key_add(name="001", from_mix=False)
 
     export_function = blender_registry.export_registry[(local_app_id, "bin")]
     vfiles = export_function(bl_object)
@@ -125,25 +148,34 @@ def test_morphs_round_trip_through_export(game_root, local_app_id, local_archive
 
     assert reparsed.morphs is not None
     assert reparsed.header.offset_morphs > 0
-    assert reparsed.morphs.num_morph_groups == len(reparsed.morphs.morph_groups)
-    # The game addresses a morph by its group index, so an unedited round
-    # trip keeps every group where it was - none dropped, none renumbered.
-    assert reparsed.morphs.num_morph_groups == parsed.morphs.num_morph_groups
-    # And the deltas themselves came back: a block of empty groups satisfies
-    # every framing assertion below while losing exactly what #266 reports.
-    assert sum(group.count for group in reparsed.morphs.morph_groups) > 0
-    for group in reparsed.morphs.morph_groups:
-        assert group.count == len(group.body.vertices)
-        for vertex in group.body.vertices:
-            assert 0 <= vertex.id < reparsed.header.num_vertices
+    groups = reparsed.morphs.morph_groups
+    assert reparsed.morphs.num_morph_groups == len(groups) == 2
+    # The game addresses a morph by its group index, so a key that moves
+    # nothing is still written - dropping it would renumber the keys after it.
+    assert groups[1].count == 0
+    assert groups[1].body.vertices == []
+    assert groups[0].count == len(groups[0].body.vertices) > 0
+
+    # Every entry addresses a corner of this model and decodes back to one of
+    # the two movements applied above - the deltas are written per corner, and
+    # a corner belongs to exactly one vertex (see _collect_geometry).
+    extra_scale = 2 ** reparsed.header.vertex_scale
+    world = bl_mesh_ob.matrix_world.to_3x3()
+    expected = {tuple(round(c, 3) for c in (world @ mathutils.Vector(delta)))
+                for delta in moved.values()}
+    decoded = set()
+    for vertex in groups[0].body.vertices:
+        assert 0 <= vertex.id < reparsed.header.num_vertices
+        position = _yz_flip(vertex.position.x, vertex.position.y, vertex.position.z)
+        decoded.add(tuple(round(c / extra_scale, 3) for c in position))
+    assert decoded == expected
 
     # The morph block is num_morph_groups (u4), the group table, then the
     # bodies - and nothing else may be laid out inside that span, or the
     # block that follows overwrites a morph the game is about to read.
     header = reparsed.header
-    morph_body_size = 8 * sum(g.count for g in reparsed.morphs.morph_groups)
-    morph_end = (header.offset_morphs + 4 +
-                 8 * len(reparsed.morphs.morph_groups) + morph_body_size)
+    morph_body_size = 8 * sum(g.count for g in groups)
+    morph_end = header.offset_morphs + 4 + 8 * len(groups) + morph_body_size
     following = [offset for offset in (
         header.offset_bones, header.offset_weights, header.offset_bonepairs,
         header.offset_adjacents, header.offset_vertex_position,
@@ -158,10 +190,6 @@ def test_bone_pairs_round_trip_through_export(game_root, local_app_id, local_arc
                                               _clean_scene):
     """The DBL_JNT block survives an unedited round trip for every line whose
     bones are still present - see the .ksy comment on pair_line."""
-    entry = next(d for d in TAGBLOCKS_DATASET if d["archive_path_hash"] == local_archive_path_hash)
-    if "bone_pairs" not in entry["carries"]:
-        pytest.skip("this archive carries no bone pairs")
-
     from albam.registry import blender_registry
     from albam.engines.cie.structs.re4_uhd_bin import Re4UhdBin
 
@@ -195,10 +223,6 @@ def test_symmetry_round_trips_through_export(game_root, local_app_id, local_arch
     """The pXFlip mirror table survives an unedited round trip, decoded
     big-endian as the .ksy comment on symmetry records, for every bone still
     written."""
-    entry = next(d for d in TAGBLOCKS_DATASET if d["archive_path_hash"] == local_archive_path_hash)
-    if "symmetry" not in entry["carries"]:
-        pytest.skip("this archive carries no symmetry table")
-
     from albam.registry import blender_registry
     from albam.engines.cie.structs.re4_uhd_bin import Re4UhdBin
 

--- a/tests/cie/test_bin_export_tagblocks.py
+++ b/tests/cie/test_bin_export_tagblocks.py
@@ -126,6 +126,12 @@ def test_morphs_round_trip_through_export(game_root, local_app_id, local_archive
     assert reparsed.morphs is not None
     assert reparsed.header.offset_morphs > 0
     assert reparsed.morphs.num_morph_groups == len(reparsed.morphs.morph_groups)
+    # The game addresses a morph by its group index, so an unedited round
+    # trip keeps every group where it was - none dropped, none renumbered.
+    assert reparsed.morphs.num_morph_groups == parsed.morphs.num_morph_groups
+    # And the deltas themselves came back: a block of empty groups satisfies
+    # every framing assertion below while losing exactly what #266 reports.
+    assert sum(group.count for group in reparsed.morphs.morph_groups) > 0
     for group in reparsed.morphs.morph_groups:
         assert group.count == len(group.body.vertices)
         for vertex in group.body.vertices:

--- a/tests/cie/test_bin_export_tagblocks.py
+++ b/tests/cie/test_bin_export_tagblocks.py
@@ -1,0 +1,203 @@
+"""RE4UHD morphs, bone pairs and the symmetry table round-trip through export.
+
+Regression coverage for issue #266: all three blocks used to be read on
+import and dropped on export - offsets left at 0, flags cleared, the model
+losing them entirely. See albam/engines/cie/mesh.py (_serialize_morphs,
+_serialize_bone_pairs, _serialize_symmetry) and structs/re4-uhd-bin.ksy.
+"""
+import json
+import os
+
+import bpy
+import pytest
+
+from albam.lib import fs_registry
+from tests.conftest import close_new_fs_roots, remove_new_vfs_roots, vfs_root_names
+from tests.cie.lfs_paths import resolve_archive_hashes
+from tests.cie.test_bin_serialization import _is_mesh_bin
+
+DATASETS_DIR = os.path.join(os.path.dirname(__file__), "datasets")
+DATASET_PATH = os.path.join(DATASETS_DIR, "bin_export_tagblocks_hashes.json")
+with open(DATASET_PATH) as f:
+    TAGBLOCKS_DATASET = json.load(f)
+
+BIN_FLAG_BONEPAIRS = 0x00000100
+BIN_FLAG_ADJACENCY = 0x00000200
+
+
+def pytest_generate_tests(metafunc):
+    if ("local_app_id" in metafunc.fixturenames and
+            "local_archive_path_hash" in metafunc.fixturenames):
+        argnames = ("local_app_id", "local_archive_path_hash")
+        argvalues = [(d["app_id"], d["archive_path_hash"]) for d in TAGBLOCKS_DATASET]
+        ids = [f"{d['app_id']}-{d['archive_path_hash']}" for d in TAGBLOCKS_DATASET]
+        metafunc.parametrize(argnames, argvalues, ids=ids, scope="session")
+
+
+def test_dataset_hashes_are_in_catalog():
+    """No plaintext game asset path is ever committed - see
+    tests/cie/test_lfs_fs.py, same check. CI-safe."""
+    for entry in TAGBLOCKS_DATASET:
+        catalog_path = os.path.join(DATASETS_DIR, f"{entry['app_id']}_catalog.json")
+        with open(catalog_path) as f:
+            catalog = {e["path_hash"]: e for e in json.load(f)}
+        assert entry["archive_path_hash"] in catalog, (
+            f"{entry['archive_path_hash']!r} is not in {catalog_path!r}"
+        )
+
+
+@pytest.fixture
+def _clean_scene():
+    before = fs_registry.keys()
+    before_roots = vfs_root_names()
+    yield
+    bpy.ops.object.select_all(action="SELECT")
+    bpy.ops.object.delete(use_global=True)
+    remove_new_vfs_roots(before_roots)
+    bpy.context.scene.albam.exported.file_list.clear()
+    close_new_fs_roots(before)
+
+
+def _import_first_model_carrying(game_root, local_app_id, archive_hash, block_attr):
+    from albam.engines.cie.mesh import AUTO_TPL
+    from albam.engines.cie.structs.re4_uhd_bin import Re4UhdBin
+    from albam.registry import blender_registry
+
+    archive_path = resolve_archive_hashes(game_root, {archive_hash})[archive_hash]
+
+    vfs = bpy.context.scene.albam.vfs
+    bpy.context.scene.albam.apps.app_selected = local_app_id
+    root = vfs.add_real_file(local_app_id, archive_path)
+
+    candidates = [vf for vf in vfs.file_list
+                  if vf.tree_node.root_id == root.name and not vf.is_root and
+                  vf.display_name.lower().endswith(".bin") and _is_mesh_bin(vf.get_bytes())]
+
+    vfile = None
+    original_bytes = None
+    parsed = None
+    for candidate in candidates:
+        data = candidate.get_bytes()
+        p = Re4UhdBin.from_bytes(data)
+        p._read()
+        if getattr(p, block_attr):
+            vfile, original_bytes, parsed = candidate, data, p
+            break
+    assert vfile is not None, f"no model in this archive carries {block_attr!r}"
+
+    import_function = blender_registry.import_registry[(local_app_id, "bin")]
+    bpy.context.scene.albam.import_options_bin.tpl_file_id = AUTO_TPL
+    vfs.file_list_selected_index = vfs.file_list.find(vfile.name)
+    bl_object = import_function(vfile, bpy.context)
+
+    bl_object.albam_asset.app_id = local_app_id
+    bl_object.albam_asset.extension = "bin"
+    bl_object.albam_asset.relative_path = vfile.display_name
+    bl_object.albam_asset.original_bytes = original_bytes
+    return bl_object, parsed
+
+
+def test_morphs_round_trip_through_export(game_root, local_app_id, local_archive_path_hash,
+                                          _clean_scene):
+    """A morph-carrying model keeps a morph block after export, and every
+    entry id it writes is a valid corner index - the format question issue
+    #266 raised (see report.md item 1: the framing needed no import fix,
+    so this exercises only the writer)."""
+    entry = next(d for d in TAGBLOCKS_DATASET if d["archive_path_hash"] == local_archive_path_hash)
+    if "morphs" not in entry["carries"]:
+        pytest.skip("this archive carries no morphs")
+
+    from albam.registry import blender_registry
+    from albam.engines.cie.structs.re4_uhd_bin import Re4UhdBin
+
+    bl_object, parsed = _import_first_model_carrying(
+        game_root, local_app_id, local_archive_path_hash, "morphs")
+    bl_mesh_ob = bl_object if bl_object.type == "MESH" else next(
+        child for child in bl_object.children_recursive if child.type == "MESH")
+    assert bl_mesh_ob.data.shape_keys is not None
+    assert len(bl_mesh_ob.data.shape_keys.key_blocks) > 1, "Basis plus at least one morph"
+
+    export_function = blender_registry.export_registry[(local_app_id, "bin")]
+    vfiles = export_function(bl_object)
+    reparsed = Re4UhdBin.from_bytes(vfiles[0].data_bytes)
+    reparsed._read()
+
+    assert reparsed.morphs is not None
+    assert reparsed.header.offset_morphs > 0
+    assert reparsed.morphs.num_morph_groups == len(reparsed.morphs.morph_groups)
+    for group in reparsed.morphs.morph_groups:
+        assert group.count == len(group.body.vertices)
+        for vertex in group.body.vertices:
+            assert 0 <= vertex.id < reparsed.header.num_vertices
+
+
+def test_bone_pairs_round_trip_through_export(game_root, local_app_id, local_archive_path_hash,
+                                              _clean_scene):
+    """The DBL_JNT block survives an unedited round trip for every line whose
+    bones are still present (see report.md item 3)."""
+    entry = next(d for d in TAGBLOCKS_DATASET if d["archive_path_hash"] == local_archive_path_hash)
+    if "bone_pairs" not in entry["carries"]:
+        pytest.skip("this archive carries no bone pairs")
+
+    from albam.registry import blender_registry
+    from albam.engines.cie.structs.re4_uhd_bin import Re4UhdBin
+
+    bl_object, parsed = _import_first_model_carrying(
+        game_root, local_app_id, local_archive_path_hash, "bone_pairs")
+
+    export_function = blender_registry.export_registry[(local_app_id, "bin")]
+    vfiles = export_function(bl_object)
+    reparsed = Re4UhdBin.from_bytes(vfiles[0].data_bytes)
+    reparsed._read()
+
+    assert reparsed.bone_pairs is not None
+    assert reparsed.header.offset_bonepairs > 0
+    assert reparsed.header.flags & BIN_FLAG_BONEPAIRS
+
+    original = {(l.helper_bone_id, l.bone_a_id, l.bone_b_id, l.percent)
+                for l in parsed.bone_pairs.line}
+    exported = {(l.helper_bone_id, l.bone_a_id, l.bone_b_id, l.percent)
+                for l in reparsed.bone_pairs.line}
+    # Every line whose three bones the model's own table already had must
+    # survive; a line naming a bone that table never carried to begin with
+    # (a known RE4UHD partial-table quirk) has nothing in Blender to write
+    # back and is dropped with a warning instead.
+    own_ids = {bone.bone_id for bone in parsed.bones}
+    kept_originals = {line for line in original if all(b in own_ids for b in line[:3])}
+    assert kept_originals <= exported
+
+
+def test_symmetry_round_trips_through_export(game_root, local_app_id, local_archive_path_hash,
+                                             _clean_scene):
+    """The pXFlip mirror table survives an unedited round trip, decoded
+    big-endian as report.md item 4 established, for every bone still
+    written."""
+    entry = next(d for d in TAGBLOCKS_DATASET if d["archive_path_hash"] == local_archive_path_hash)
+    if "symmetry" not in entry["carries"]:
+        pytest.skip("this archive carries no symmetry table")
+
+    from albam.registry import blender_registry
+    from albam.engines.cie.structs.re4_uhd_bin import Re4UhdBin
+
+    bl_object, parsed = _import_first_model_carrying(
+        game_root, local_app_id, local_archive_path_hash, "symmetry_table")
+
+    export_function = blender_registry.export_registry[(local_app_id, "bin")]
+    vfiles = export_function(bl_object)
+    reparsed = Re4UhdBin.from_bytes(vfiles[0].data_bytes)
+    reparsed._read()
+
+    assert reparsed.symmetry_table is not None
+    assert reparsed.header.offset_adjacents > 0
+    assert reparsed.header.flags & BIN_FLAG_ADJACENCY
+    assert reparsed.symmetry_table.num_bones == len(reparsed.bones)
+
+    original = dict(zip((b.bone_id for b in parsed.bones), parsed.symmetry_table.mirror_bone_ids))
+    exported = dict(zip((b.bone_id for b in reparsed.bones),
+                        reparsed.symmetry_table.mirror_bone_ids))
+    kept_ids = set(exported)
+    for bone_id, mirror_id in original.items():
+        if bone_id not in kept_ids:
+            continue
+        expected = mirror_id if mirror_id in kept_ids else -1
+        assert exported[bone_id] == expected, (bone_id, mirror_id, exported[bone_id])

--- a/tests/cie/test_bin_export_tagblocks.py
+++ b/tests/cie/test_bin_export_tagblocks.py
@@ -101,7 +101,8 @@ def test_morphs_round_trip_through_export(game_root, local_app_id, local_archive
                                           _clean_scene):
     """A morph-carrying model keeps a morph block after export, and every
     entry id it writes is a valid corner index - the format question issue
-    #266 raised (see report.md item 1: the framing needed no import fix,
+    #266 raised, settled by the measurements recorded in the .ksy comments
+    on morph_group and morph_group_body (the framing needed no import fix,
     so this exercises only the writer)."""
     entry = next(d for d in TAGBLOCKS_DATASET if d["archive_path_hash"] == local_archive_path_hash)
     if "morphs" not in entry["carries"]:
@@ -130,11 +131,27 @@ def test_morphs_round_trip_through_export(game_root, local_app_id, local_archive
         for vertex in group.body.vertices:
             assert 0 <= vertex.id < reparsed.header.num_vertices
 
+    # The morph block is num_morph_groups (u4), the group table, then the
+    # bodies - and nothing else may be laid out inside that span, or the
+    # block that follows overwrites a morph the game is about to read.
+    header = reparsed.header
+    morph_body_size = 8 * sum(g.count for g in reparsed.morphs.morph_groups)
+    morph_end = (header.offset_morphs + 4 +
+                 8 * len(reparsed.morphs.morph_groups) + morph_body_size)
+    following = [offset for offset in (
+        header.offset_bones, header.offset_weights, header.offset_bonepairs,
+        header.offset_adjacents, header.offset_vertex_position,
+        header.offset_vertex_normals, header.offset_index_buffer,
+        header.offset_index_buffer2, header.offset_vertex_colors,
+        header.offset_vertex_texcoord, header.offset_materials)
+        if offset > header.offset_morphs]
+    assert morph_end <= min(following), (morph_end, min(following))
+
 
 def test_bone_pairs_round_trip_through_export(game_root, local_app_id, local_archive_path_hash,
                                               _clean_scene):
     """The DBL_JNT block survives an unedited round trip for every line whose
-    bones are still present (see report.md item 3)."""
+    bones are still present - see the .ksy comment on pair_line."""
     entry = next(d for d in TAGBLOCKS_DATASET if d["archive_path_hash"] == local_archive_path_hash)
     if "bone_pairs" not in entry["carries"]:
         pytest.skip("this archive carries no bone pairs")
@@ -170,7 +187,7 @@ def test_bone_pairs_round_trip_through_export(game_root, local_app_id, local_arc
 def test_symmetry_round_trips_through_export(game_root, local_app_id, local_archive_path_hash,
                                              _clean_scene):
     """The pXFlip mirror table survives an unedited round trip, decoded
-    big-endian as report.md item 4 established, for every bone still
+    big-endian as the .ksy comment on symmetry records, for every bone still
     written."""
     entry = next(d for d in TAGBLOCKS_DATASET if d["archive_path_hash"] == local_archive_path_hash)
     if "symmetry" not in entry["carries"]:


### PR DESCRIPTION
## Intent

Investigate the format question blocking albam issue #266, "RE4UHD: morphs, bone pairs and adjacency import but are not written back" (https://github.com/Brachi/albam/issues/266), so implementation can proceed on solid ground.

The captain's ask, in the substance of that issue (which the captain wrote):

All three blocks are read and none are exported, so a model carrying them loses them. A character with facial morphs comes back without them.

Morphs are also blocked on an unresolved format question: group[i].offset + 4 + 8*count[i] lands exactly 4 bytes past group[i+1].offset in every multi-group file measured, so reading count entries makes the last entry of each non-final group half-garbage. Either the count is one too many for non-final groups, or the last entry deliberately overlaps the next group prefix. The framing is otherwise confirmed: with the 4-byte skip every vertex id is in range, without it many are not.

The bone-pair block has a fourth value nothing explains, and the adjacency block is unverified by any second source.

Firstmate's note: the captain is away and asked for the board to be worked by value. This is an investigation rather than an implementation because guessing wrong about the morph group framing would corrupt face geometry in exported models, and the issue names the question as genuinely unresolved.

The board was later worked by value into implementation: the format questions above were settled by measurement across the full RE4 UHD corpus (389 morph-carrying models, 2,643 bone-pair models, 5,709 symmetry-table models), and this change implements export for all three blocks on that basis. Two rounds of review findings were also resolved with the captain: morph group order and empty-group handling must preserve each group's original index (never renumber - a morph's index must mean what it meant on import), bone-pair/symmetry validation is scoped to the bone table each file actually writes (not the whole shared armature), version_flags/unk_01 are set together based on measurement (0x20030818/0x50 when tag blocks are present, 0x20010801/0x0 otherwise), and the symmetry mirror table is kept positional (matching _build_armature's own last-occurrence-wins collapse for a repeated bone id) rather than keyed by id.

## What Changed

- RE4 UHD `.bin` export now writes the three blocks that were previously read on import and silently dropped: facial morphs (round-tripped through Blender shape keys, keeping each group's original index so an empty or unedited morph never renumbers the ones after it), the DBL_JNT bone-pair table, and the bone symmetry table. The header is written to match - `offset_bonepairs`/`offset_adjacents`, the `0x100`/`0x200` flags, and `version_flags`/`unk_01` set together (`0x20030818`/`0x50` when tag blocks are present, `0x20010801`/`0x0` otherwise).
- Settled the morph framing question in the format definition: group offsets are relative to the group table's start (`offset_morphs + 4`), not to `offset_morphs`, which accounts for the 4-byte overlap and removes the phantom per-group `header` field, so every group reads `count` complete entries. The former `bone_adj` block is redefined as the game's pXFlip symmetry table - a big-endian `s16` mirror id per bone in an otherwise little-endian file - and renamed `bin.symmetry_table`; `pair_line`'s opaque 8 bytes are now named fields (`helper_bone_id`, `bone_a_id`, `bone_b_id`, `percent`). Bone-pair and symmetry entries are validated against the bone table each file actually writes, and mirrors are merged across meshes positionally, matching `_build_armature`'s last-occurrence-wins collapse.
- Added `tests/cie/test_bin_export_tagblocks.py` with a hash-only dataset covering morph, bone-pair and symmetry round-trips through export; documented the new capability and the shape-key ordering caveat in `docs/modding-a-character.md` and CHANGELOG.

Closes #266.

## Risk Assessment

✅ Low: Every prior round's fix is present and correct in the current code, the block framing and offsets were traced end-to-end against the generated Kaitai writer, and the only remaining item is a behavior-identical readability nit.

## Testing

Set up an isolated headless bpy 4.2 environment and drove the addon exactly as a user does — mount an .lfs archive in the VFS, import a mesh .bin, export it back — against real archives in a local Resident Evil 4 UHD install. The existing export tests (tag blocks, serialization round trip, export fidelity) all pass. On top of those I wrote three drivers for the parts the rulings turn on: a plain model still exports 0x20010801/0x00 with clear tag bits and zero offsets while a tagged one exports 0x20030818/0x50 with both bits set; flattening one shape key and renaming keys into reverse-alphabetical order still writes the same number of groups in key_blocks order with the flattened one kept as an empty group at its own index; adding a second mesh object under the same armature neither doubles the DBL_JNT lines nor lets its all-(-1) mirror table blank the first mesh's 18 real mirrors, in either child order; and the two duplicate-bone-id models (pl0b_010.bin, pl10_009.bin) still export id 9→15 and 10→16 from the last source occurrence. The clearest evidence is the full user story from issue #266: a face model exported and re-imported comes back with both morphs, the same moved-vertex sets and displacement magnitudes (median 0.00582 → 0.00582, direction dot 1.0000), and the rendered face shows the shipped scream morph identical before and after the round trip. Verdict go; the worktree is clean and all artifacts live in the evidence directory.

- Live validation: ✅ go - 8 of 8 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A morph-carrying character is imported, exported and re-imported, and its facial morphs come back moving the same vertices the same way | ✅ pass | live | `drive_morph_roundtrip.py` transcript plus exported_rest.png / exported_morph_x2.png renders of pl01_003.bin |
| Exporting a morph-carrying model writes a framed morph block whose entry ids are all valid corner indices and which does not overlap the following block | ✅ pass | live | `pytest tests/cie/test_bin_export_tagblocks.py::test_morphs_round_trip_through_export --game-dir=re4uhd::&lt;install&gt;` |
| Exporting a model with a DBL_JNT table keeps every bone-pair line whose bones its own bone table still carries, with the flag bit set | ✅ pass | live | `pytest tests/cie/test_bin_export_tagblocks.py::test_bone_pairs_round_trip_through_export --game-dir=re4uhd::&lt;install&gt;` |
| Exporting a model with a pXFlip table keeps one mirror row per written bone, dropping only targets its bone table no longer writes | ✅ pass | live | `pytest tests/cie/test_bin_export_tagblocks.py::test_symmetry_round_trips_through_export --game-dir=re4uhd::&lt;install&gt;` |
| Adversarial: a model carrying no tag blocks exports with the plain build stamp (0x20010801/0x00), clear tag bits and zero offsets, while a tagged one exports 0x20030818/0x50 with both bits set | ✅ pass | live | drive_tagblocks.log, scenario S4 (pl0b_000.bin tagged vs pl0b_102.bin plain) |
| Adversarial: a user flattens one shape key and renames the keys into reverse-alphabetical order - group count is unchanged, the flattened key stays an empty group at its own index, and group order fol… | ✅ pass | live | drive_tagblocks.log, scenario S5 (pl01_003.bin) |
| Adversarial: a second mesh object parented under the same armature, carrying an all -1 mirror table, neither duplicates the DBL_JNT lines nor blanks the first mesh&#39;s real mirrors - in either child ord… | ✅ pass | live | drive_tagblocks.log, scenario S6 (pl0b_000.bin, 2 pair lines and 18 real mirrors before and after) |
| Adversarial: a model whose bone table names one bone id twice exports the mirror from the same (last) occurrence the armature actually holds | ✅ pass | live | drive_tagblocks.log, scenario S7 (pl0b_010.bin and pl10_009.bin both export id 9-&gt;15, 10-&gt;16) |

<details>
<summary>Evidence: Adversarial scenario transcript (header stamp, morph indices, multi-mesh merge, duplicate bone ids)</summary>

<code>[PASS] pl0b_000.bin (tagged) version_flags/unk_01 = 0x20030818/0x50 :: flags=0x80000300&#10;[PASS] pl0b_102.bin (plain) version_flags/unk_01 = 0x20010801/0x00, tag bits clear, offsets 0&#10;[PASS] group count unchanged (no renumbering, no compaction) :: 2 vs 2&#10;[PASS] the flattened key stays as an empty group at index 0 :: count=0&#10;[PASS] group order is key_blocks order, not sorted names :: names=[&#39;morph_002&#39;, &#39;morph_001&#39;]&#10;[PASS] bone-pair lines are not duplicated across mesh objects :: 2 vs 2&#10;[PASS] a second mesh with an all -1 mirror table does not blank real mirrors :: real mirrors now 18&#10;[PASS] pl0b_010.bin duplicate-id mirrors match the last source occurrence :: {9: (15, 15), 10: (16, 16)}&#10;[PASS] pl10_009.bin duplicate-id mirrors match the last source occurrence :: {9: (15, 15), 10: (16, 16)}</code>

```text
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M243HJ1THFDF2D48BNYXEQE1/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M243HJ1THFDF2D48BNYXEQE1/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.cache/albam-venvs/py311-bpy4.2.0/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.cache/albam-venvs/py311-bpy4.2.0/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M243HJ1THFDF2D48BNYXEQE1/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M243HJ1THFDF2D48BNYXEQE1/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M243HJ1THFDF2D48BNYXEQE1/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.cache/albam-venvs/py311-bpy4.2.0/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.cache/albam-venvs/py311-bpy4.2.0/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M243HJ1THFDF2D48BNYXEQE1/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M243HJ1THFDF2D48BNYXEQE1/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M243HJ1THFDF2D48BNYXEQE1/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.cache/albam-venvs/py311-bpy4.2.0/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.cache/albam-venvs/py311-bpy4.2.0/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M243HJ1THFDF2D48BNYXEQE1/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M243HJ1THFDF2D48BNYXEQE1/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M243HJ1THFDF2D48BNYXEQE1/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.cache/albam-venvs/py311-bpy4.2.0/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.cache/albam-venvs/py311-bpy4.2.0/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M243HJ1THFDF2D48BNYXEQE1/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M243HJ1THFDF2D48BNYXEQE1/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M243HJ1THFDF2D48BNYXEQE1/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.cache/albam-venvs/py311-bpy4.2.0/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.cache/albam-venvs/py311-bpy4.2.0/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M243HJ1THFDF2D48BNYXEQE1/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M243HJ1THFDF2D48BNYXEQE1/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M243HJ1THFDF2D48BNYXEQE1/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.cache/albam-venvs/py311-bpy4.2.0/lib/python3.11/site-packages/bpy/4.2/scripts/modules/bpy/utils/__init__.py", line 814, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.cache/albam-venvs/py311-bpy4.2.0/lib/python3.11/site-packages/bpy/4.2/scripts/modules/addon_utils.py", line 1203, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M243HJ1THFDF2D48BNYXEQE1/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config

S4 header stamp follows the tag blocks
TPL is: pl0b_001.tpl
Reading texture pack a shipped .pack file.yz2
[re4uhd] weights: 10293 verts, 30 vertex groups
  [PASS] pl0b_000.bin (tagged) version_flags/unk_01 = 0x20030818/0x50 :: got 0x20030818/0x50 flags=0x80000300
  [PASS] pl0b_000.bin (tagged) bonepair+adjacency flag bits set :: flags=0x80000300
TPL is: pl0b_103.tpl
[re4uhd] weights: 142 verts, 1 vertex groups
  [PASS] pl0b_102.bin (plain) version_flags/unk_01 = 0x20010801/0x00 :: got 0x20010801/0x00 flags=0x80000000
  [PASS] pl0b_102.bin (plain) tag flag bits clear and offsets 0 :: flags=0x80000000 bp=0 adj=0 morph=0

S5 morph group indices survive an emptied and a renamed shape key
TPL is: pl01_005.tpl
Reading texture pack a shipped .pack file.yz2
[re4uhd] weights: 2895 verts, 4 vertex groups
  model pl01_003.bin: 2 shape keys, 2 source morph groups
  after edit, per-key moved vertices (key_blocks order): [('morph_002', 0), ('morph_001', 2040)]
  [PASS] group count unchanged (no renumbering, no compaction) :: 2 vs 2
  [PASS] the flattened key stays as an empty group at index 0 :: count=0
  [PASS] other groups still carry deltas :: total entries=2104
  [PASS] group order is key_blocks order, not sorted names :: keys=[False, True] written=[False, True] names=['morph_002', 'morph_001']
  [PASS] every written entry id is a valid corner index

S6 a second mesh object neither duplicates pairs nor blanks mirrors
TPL is: pl0b_001.tpl
[re4uhd] weights: 10293 verts, 30 vertex groups
  pl0b_000.bin: single-mesh export writes 2 pair lines, 18 real mirrors
  [PASS] bone-pair lines are not duplicated across mesh objects :: 2 vs 2
  [PASS] a second mesh with an all -1 mirror table does not blank real mirrors :: real mirrors now 18
  [PASS] still no blanking when the blank-table mesh comes first
  [PASS] still no duplicated pair lines when the order flips

S7 positional mirror on a model whose bone table names one id twice
TPL is: pl0b_001.tpl
[re4uhd] weights: 394 verts, 1 vertex groups
  pl0b_010.bin: duplicate bone ids [9, 10]; exported mirrors for them [(9, 15), (10, 16)]
  [PASS] pl0b_010.bin duplicate-id mirrors match the last source occurrence :: {9: (15, 15), 10: (16, 16)}
  [PASS] pl0b_010.bin symmetry row count matches the written bone table
TPL is: pl10_001.tpl
Reading texture pack a shipped .pack file.yz2.lfs
[re4uhd] weights: 163 verts, 1 vertex groups
[re4uhd] WARNING: dropping bone pair (119, 7, 8, 50) - a bone it names is not being exported
[re4uhd] WARNING: dropping bone pair (120, 13, 14, 50) - a bone it names is not being exported
  pl10_009.bin: duplicate bone ids [9, 10]; exported mirrors for them [(9, 15), (10, 16)]
  [PASS] pl10_009.bin duplicate-id mirrors match the last source occurrence :: {9: (15, 15), 10: (16, 16)}
  [PASS] pl10_009.bin symmetry row count matches the written bone table

==== ALL SCENARIOS PASSED ====
```
</details>
<details>
<summary>Evidence: Issue #266 round-trip transcript (morphs come back through import -&gt; export -&gt; re-import)</summary>

<code>pl01_003.bin: 2 morphs on import, moved vertices per morph [2219, 2040]&#10;after round trip: 2 morphs, moved vertices per morph [2283, 2104]&#10;[PASS] morph 0 keeps its displacement magnitude :: median 0.00582 -&gt; 0.00582&#10;[PASS] morph 0 keeps its direction (no axis flip) :: dot=1.0000&#10;[PASS] morph 1 keeps its displacement magnitude :: median 0.00094 -&gt; 0.00095</code>

```text
Traceback (most recent call last):
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
    repo_module, pkg_idname = _extension_module_name_decompose(package)
ValueError: The "package" does not name an extension
S8 a face model's morphs survive import -> export -> re-import
TPL is: pl01_005.tpl
Reading texture pack a shipped .pack file.yz2
[re4uhd] weights: 2895 verts, 4 vertex groups
  pl01_003.bin: 2 morphs on import, moved vertices per morph [2219, 2040]
TPL is: pl01_005.tpl
[re4uhd] weights: 2975 verts, 4 vertex groups
  after round trip: 2 morphs, moved vertices per morph [2283, 2104]
  [PASS] the same number of morphs came back :: 2 vs 2
  [PASS] morph 0 still moves a comparable set of vertices :: 2219 -> 2283
  [PASS] morph 0 keeps its displacement magnitude :: median 0.00582 -> 0.00582
  [PASS] morph 0 keeps its direction (no axis flip) :: mean (-0.0001, 0.0031, -0.0059) -> (-0.0001, 0.0031, -0.0059), dot=1.0000
  [PASS] morph 1 still moves a comparable set of vertices :: 2040 -> 2104
  [PASS] morph 1 keeps its displacement magnitude :: median 0.00094 -> 0.00095
  [PASS] morph 1 keeps its direction (no axis flip) :: mean (-0.0, 0.0002, -0.0003) -> (-0.0, 0.0002, -0.0003), dot=1.0000

==== ALL SCENARIOS PASSED ====
```
</details>
<details>
<summary>Evidence: Driver scripts used for the manual scenarios</summary>

```text
"""Drives the RE4UHD tag-block export change through the real albam addon,
headless Blender (bpy), against a local Resident Evil 4 UHD install.

Scenarios (see printed transcript):
  S4  header stamp goes with the tag blocks (tagged vs plain model)
  S5  morph group indices survive an emptied / renamed shape key
  S6  a second mesh object under the same armature neither duplicates
      bone-pair lines nor blanks another mesh's real mirrors
  S7  a model whose bone table names one id twice keeps the positional
      (last-occurrence) mirror
"""
import os
import sys

REPO = "~/.no-mistakes/worktrees/731f537710a6/01M243HJ1THFDF2D48BNYXEQE1"
GAME = "~/Games/Resident Evil 4"
sys.path.insert(0, REPO)

import bpy  # noqa: E402
from albam import register  # noqa: E402
from albam.blender_ui.error_handling import RERAISE_ERRORS_ENV_VAR  # noqa: E402

os.environ[RERAISE_ERRORS_ENV_VAR] = "1"
register()

from albam.engines.cie.mesh import (  # noqa: E402
    AUTO_TPL, BONE_MIRROR_IDS_PROPERTY, BONE_PAIRS_PROPERTY,
)
from albam.engines.cie.structs.re4_uhd_bin import Re4UhdBin  # noqa: E402
from albam.registry import blender_registry  # noqa: E402
from tests.cie.test_bin_serialization import _is_mesh_bin  # noqa: E402

APP = "re4uhd"
IMPORT_FN = blender_registry.import_registry[(APP, "bin")]
EXPORT_FN = blender_registry.export_registry[(APP, "bin")]

FAILURES = []

def check(label, condition, detail=""):
    status = "PASS" if condition else "FAIL"
    if not condition:
        FAILURES.append(label)
    print(f"  [{status}] {label}{(' :: ' + str(detail)) if detail else ''}")

def clean():
    bpy.ops.object.select_all(action="SELECT")
    bpy.ops.object.delete(use_global=True)

def load_archive(archive_relpath):
    vfs = bpy.context.scene.albam.vfs
    bpy.context.scene.albam.apps.app_selected = APP
    root = vfs.add_real_file(APP, os.path.join(GAME, archive_relpath))
    return [vf for vf in vfs.file_list
            if vf.tree_node.root_id == root.name and not vf.is_root
            and vf.display_name.lower().endswith(".bin") and _is_mesh_bin(vf.get_bytes())]

def import_vfile(vfile):
    data = vfile.get_bytes()
    parsed = Re4UhdBin.from_bytes(data)
    parsed._read()
    vfs = bpy.context.scene.albam.vfs
    bpy.context.scene.albam.import_options_bin.tpl_file_id = AUTO_TPL
    vfs.file_list_selected_index = vfs.file_list.find(vfile.name)
    bl_object = IMPORT_FN(vfile, bpy.context)
    bl_object.albam_asset.app_id = APP
    bl_object.albam_asset.extension = "bin"
    bl_object.albam_asset.relative_path = vfile.display_name
    bl_object.albam_asset.original_bytes = data
    return bl_object, parsed

def export(bl_object):
    out = EXPORT_FN(bl_object)[0].data_bytes
    reparsed = Re4UhdBin.from_bytes(out)
    reparsed._read()
    return reparsed, out

def meshes_of(bl_object):
    return [bl_object] if bl_object.type == "MESH" else [
        c for c in bl_object.children_recursive if c.type == "MESH"]

def find_carrying(candidates, predicate):
    for vf in candidates:
        p = Re4UhdBin.from_bytes(vf.get_bytes())
        p._read()
        if predicate(p):
            return vf, p
    return None, None

def s4_header_stamp():
    print("\nS4 header stamp follows the tag blocks")
    for archive, want_tags in (("a shipped .udas.lfs file", True), ("a shipped .udas.lfs file", False)):
        candidates = load_archive(archive)
        if want_tags:
            vf, _ = find_carrying(candidates, lambda p: p.bone_pairs or p.symmetry_table)
        else:
            vf, _ = find_carrying(candidates, lambda p: not p.bone_pairs and not p.symmetry_table
                                  and not p.morphs)
        if vf is None:
            check(f"found a {'tagged' if want_tags else 'plain'} model", False)
            continue
        bl_object, _ = import_vfile(vf)
        reparsed, _ = export(bl_object)
        h = reparsed.header
        label = f"{vf.display_name} ({'tagged' if want_tags else 'plain'})"
        if want_tags:
            check(f"{label} version_flags/unk_01 = 0x20030818/0x50",
                  (h.version_flags, h.unk_01) == (0x20030818, 0x50),
                  f"got 0x{h.version_flags:08x}/0x{h.unk_01:02x} flags=0x{h.flags:08x}")
            check(f"{label} bonepair+adjacency flag bits set",
                  bool(h.flags & 0x100) and bool(h.flags & 0x200), f"flags=0x{h.flags:08x}")
        else:
            check(f"{label} version_flags/unk_01 = 0x20010801/0x00",
                  (h.version_flags, h.unk_01) == (0x20010801, 0),
                  f"got 0x{h.version_flags:08x}/0x{h.unk_01:02x} flags=0x{h.flags:08x}")
            check(f"{label} tag flag bits clear and offsets 0",
                  not (h.flags & 0x300) and h.offset_bonepairs == 0
                  and h.offset_adjacents == 0 and h.offset_morphs == 0,
                  f"flags=0x{h.flags:08x} bp={h.offset_bonepairs} adj={h.offset_adjacents} "
                  f"morph={h.offset_morphs}")
        clean()

def _moved_vertex_counts(bl_mesh_ob):
    keys = bl_mesh_ob.data.shape_keys
    basis = keys.key_blocks[0]
    out = []
    for key in keys.key_blocks[1:]:
        moved = sum(1 for v in bl_mesh_ob.data.vertices
                    if key.data[v.index].co != basis.data[v.index].co)
        out.append((key.name, moved))
    return out

def s5_morph_indices():
    print("\nS5 morph group indices survive an emptied and a renamed shape key")
    candidates = load_archive("a shipped .udas.lfs file")
    vf, parsed = find_carrying(candidates, lambda p: bool(p.morphs))
    if vf is None:
        check("found a morph-carrying model", False)
        return
    bl_object, parsed = import_vfile(vf)
    mesh = meshes_of(bl_object)[0]
    keys = mesh.data.shape_keys.key_blocks
    print(f"  model {vf.display_name}: {len(keys) - 1} shape keys, "
          f"{parsed.morphs.num_morph_groups} source morph groups")

    # An end user flattens morph 1 (every vertex back on the basis) and
    # renames keys so alphabetical order no longer matches key_blocks order.
    flat_index = 1
    basis = keys[0]
    for v in mesh.data.vertices:
        keys[flat_index].data[v.index].co = basis.data[v.index].co
    original_names = [k.name for k in keys[1:]]
    for i, key in enumerate(keys[1:]):
        key.name = f"morph_{len(original_names) - i:03d}"  # reverse alphabetical
    expected = _moved_vertex_counts(mesh)
    print(f"  after edit, per-key moved vertices (key_blocks order): {expected}")

    reparsed, _ = export(bl_object)
    check("group count unchanged (no renumbering, no compaction)",
          reparsed.morphs.num_morph_groups == parsed.morphs.num_morph_groups,
          f"{reparsed.morphs.num_morph_groups} vs {parsed.morphs.num_morph_groups}")
    # key_blocks[0] is Basis, so key_blocks[i] is morph group i - 1.
    flat_group = flat_index - 1
    check(f"the flattened key stays as an empty group at index {flat_group}",
          reparsed.morphs.morph_groups[flat_group].count == 0,
          f"count={reparsed.morphs.morph_groups[flat_group].count}")
    check("other groups still carry deltas",
          sum(g.count for g in reparsed.morphs.morph_groups) > 0,
          f"total entries={sum(g.count for g in reparsed.morphs.morph_groups)}")
    # Group order follows key_blocks, not sorted(names): with reverse
    # alphabetical names those two orders differ, so a group with entries
    # only where the key moved vertices proves key_blocks order was used.
    moved_flags = [count > 0 for _, count in expected]
    written_flags = [g.count > 0 for g in reparsed.morphs.morph_groups]
    check("group order is key_blocks order, not sorted names",
          moved_flags == written_flags,
          f"keys={moved_flags} written={written_flags} names={[n for n, _ in expected]}")
    for group in reparsed.morphs.morph_groups:
        assert group.count == len(group.body.vertices)
    check("every written entry id is a valid corner index",
          all(0 <= v.id < reparsed.header.num_vertices
              for g in reparsed.morphs.morph_groups for v in g.body.vertices))
    clean()

def _duplicate_mesh_under(bl_object, mesh, blank_mirrors=False, first=False):
    """A second mesh object under the same armature, the way a user parents
    two parts of one character together before exporting the armature."""
    copy = bpy.data.objects.new(f"{mesh.name}_part2", mesh.data.copy())
    bpy.context.scene.collection.objects.link(copy)
    copy.parent = mesh.parent
    copy.matrix_world = mesh.matrix_world.copy()
    for key, value in mesh.items():
        try:
            copy[key] = value
        except TypeError:
            pass
    for mod in mesh.modifiers:
        if mod.type == "ARMATURE":
            new_mod = copy.modifiers.new(mod.name, "ARMATURE")
            new_mod.object = mod.object
    if blank_mirrors:
        copy[BONE_MIRROR_IDS_PROPERTY] = [-1] * len(list(mesh[BONE_MIRROR_IDS_PROPERTY]))
    return copy

def s6_multi_mesh():
    print("\nS6 a second mesh object neither duplicates pairs nor blanks mirrors")
    candidates = load_archive("a shipped .udas.lfs file")
    vf, _ = find_carrying(candidates, lambda p: p.bone_pairs and p.symmetry_table)
    if vf is None:
        check("found a model carrying both blocks", False)
        return
    bl_object, _ = import_vfile(vf)
    mesh = meshes_of(bl_object)[0]
    single, _ = export(bl_object)
    base_pairs = single.bone_pairs.num_pair
    base_mirrors = list(single.symmetry_table.mirror_bone_ids)
    print(f"  {vf.display_name}: single-mesh export writes {base_pairs} pair lines, "
          f"{sum(1 for m in base_mirrors if m != -1)} real mirrors")

    dup = _duplicate_mesh_under(bl_object, mesh, blank_mirrors=True)
    doubled, _ = export(bl_object)
    check("bone-pair lines are not duplicated across mesh objects",
          doubled.bone_pairs.num_pair == base_pairs,
          f"{doubled.bone_pairs.num_pair} vs {base_pairs}")
    check("a second mesh with an all -1 mirror table does not blank real mirrors",
          list(doubled.symmetry_table.mirror_bone_ids) == base_mirrors,
          f"real mirrors now {sum(1 for m in doubled.symmetry_table.mirror_bone_ids if m != -1)}")

    # Same again with the blank mesh sorted first among the children.
    dup.name = "AAA_blank_first"
    reordered, _ = export(bl_object)
    check("still no blanking when the blank-table mesh comes first",
          list(reordered.symmetry_table.mirror_bone_ids) == base_mirrors)
    check("still no duplicated pair lines when the order flips",
          reordered.bone_pairs.num_pair == base_pairs)
    clean()

def s7_duplicate_bone_ids():
    print("\nS7 positional mirror on a model whose bone table names one id twice")
    for archive, model in (("a shipped .udas.lfs file", "pl0b_010.bin"),
                           ("a shipped .udas.lfs file", "pl10_009.bin")):
        candidates = load_archive(archive)
        vf = next((c for c in candidates if c.display_name.lower() == model), None)
        if vf is None:
            check(f"found {model}", False, [c.display_name for c in candidates][:10])
            continue
        bl_object, parsed = import_vfile(vf)
        ids = [b.bone_id for b in parsed.bones]
        dupes = {i for i in ids if ids.count(i) > 1}
        source = {}
        for bone, mirror in zip(parsed.bones, parsed.symmetry_table.mirror_bone_ids):
            source[bone.bone_id] = mirror  # last occurrence wins, as _build_armature does
        reparsed, _ = export(bl_object)
        exported = dict(zip((b.bone_id for b in reparsed.bones),
                            reparsed.symmetry_table.mirror_bone_ids))
        written = {b.bone_id for b in reparsed.bones}
        print(f"  {model}: duplicate bone ids {sorted(dupes)}; "
              f"exported mirrors for them {[(i, exported.get(i)) for i in sorted(dupes)]}")
        ok = all(exported.get(i) == (source[i] if source[i] in written else -1)
                 for i in sorted(dupes))
        check(f"{model} duplicate-id mirrors match the last source occurrence", ok,
              {i: (source[i], exported.get(i)) for i in sorted(dupes)})
        check(f"{model} symmetry row count matches the written bone table",
              reparsed.symmetry_table.num_bones == len(reparsed.bones))
        clean()

for scenario in (s4_header_stamp, s5_morph_indices, s6_multi_mesh, s7_duplicate_bone_ids):
    scenario()

print("\n==== " + ("ALL SCENARIOS PASSED" if not FAILURES
                   else f"FAILURES: {FAILURES}") + " ====")
sys.stdout.flush()
os._exit(0 if not FAILURES else 1)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d52b8fc42d3c3c133a81957a12043bc722f2a63d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `albam/engines/cie/mesh.py:1296` - _serialize_symmetry&#39;s new unconditional `mirrors[bone_id] = mirror_id` collapses mirrors across mesh objects as well as within one object&#39;s table, so a later mesh&#39;s NO_MIRROR_BONE silently overwrites an earlier mesh&#39;s real mirror. Concrete: import two models of one character (their bone tables are partial and differ - the same quirk _serialize_bone_pairs&#39; own warning documents), parent both meshes under the shared armature, export the armature. Model A&#39;s pXFlip row for bone id 5 is 7; model B&#39;s table has no bone 7, so its row for id 5 is -1. `mirrors` is filled per bl_mesh_ob in children_recursive order, so if B comes second the exported symmetry_table writes -1 for bone 5 and drops a mirror the source carried - and which value wins depends on Blender&#39;s child ordering. The `written_bone_ids` filter two lines below already drops a mirror absent from the file&#39;s own bone table, so preferring the real value across objects is strictly safe. Flagged ask-user rather than auto-fix because it revisits the round-3 ruling, which prescribed &#34;use unconditionally (plain last-write-wins)&#34;: that ruling&#39;s reasoning was entirely about matching _build_armature&#39;s per-file collapse for an id repeated *within one table*, and did not address the cross-object merge, where there is no last-occurrence ordering to match and the sibling _serialize_bone_pairs deliberately uses the opposite first-seen rule. Narrowest remedy honouring both: last-wins within each bl_mesh_ob&#39;s own zip(own_ids, own_mirrors), then first-seen across bl_mesh_objs.

🔧 Fix applied.
1 info still open:

- ℹ️ `albam/engines/cie/mesh.py:1302` - The per-object resolve in _serialize_symmetry builds `own` with an explicit three-line loop (`own = {}` / `for bone_id, mirror_id in zip(own_ids, own_mirrors): own[bone_id] = mirror_id`) that is exactly `dict(zip(own_ids, own_mirrors))`. Writing it that way also makes the intended tie-break self-evident and literally identical to the expectation the new test builds at tests/cie/test_bin_export_tagblocks.py:218, so the two rules are visibly the same rule. Behavior-identical, non-user-visible.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 8 of 8 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A morph-carrying character is imported, exported and re-imported, and its facial morphs come back moving the same vertices the same way | ✅ pass | live | `drive_morph_roundtrip.py` transcript plus exported_rest.png / exported_morph_x2.png renders of pl01_003.bin |
| Exporting a morph-carrying model writes a framed morph block whose entry ids are all valid corner indices and which does not overlap the following block | ✅ pass | live | `pytest tests/cie/test_bin_export_tagblocks.py::test_morphs_round_trip_through_export --game-dir=re4uhd::&lt;install&gt;` |
| Exporting a model with a DBL_JNT table keeps every bone-pair line whose bones its own bone table still carries, with the flag bit set | ✅ pass | live | `pytest tests/cie/test_bin_export_tagblocks.py::test_bone_pairs_round_trip_through_export --game-dir=re4uhd::&lt;install&gt;` |
| Exporting a model with a pXFlip table keeps one mirror row per written bone, dropping only targets its bone table no longer writes | ✅ pass | live | `pytest tests/cie/test_bin_export_tagblocks.py::test_symmetry_round_trips_through_export --game-dir=re4uhd::&lt;install&gt;` |
| Adversarial: a model carrying no tag blocks exports with the plain build stamp (0x20010801/0x00), clear tag bits and zero offsets, while a tagged one exports 0x20030818/0x50 with both bits set | ✅ pass | live | drive_tagblocks.log, scenario S4 (pl0b_000.bin tagged vs pl0b_102.bin plain) |
| Adversarial: a user flattens one shape key and renames the keys into reverse-alphabetical order - group count is unchanged, the flattened key stays an empty group at its own index, and group order fol… | ✅ pass | live | drive_tagblocks.log, scenario S5 (pl01_003.bin) |
| Adversarial: a second mesh object parented under the same armature, carrying an all -1 mirror table, neither duplicates the DBL_JNT lines nor blanks the first mesh&#39;s real mirrors - in either child ord… | ✅ pass | live | drive_tagblocks.log, scenario S6 (pl0b_000.bin, 2 pair lines and 18 real mirrors before and after) |
| Adversarial: a model whose bone table names one bone id twice exports the mirror from the same (last) occurrence the armature actually holds | ✅ pass | live | drive_tagblocks.log, scenario S7 (pl0b_010.bin and pl10_009.bin both export id 9-&gt;15, 10-&gt;16) |

- <code>`pytest tests/cie/test_bin_export_tagblocks.py -v --game-dir=re4uhd::&lt;local RE4 UHD install&gt;` (4 passed, 3 archive-specific skips)</code>
- <code>`pytest tests/cie/test_bin_serialization.py tests/cie/test_bin_export_fidelity.py tests/cie/test_bin_export_tagblocks.py -q --game-dir=re4uhd::&lt;install&gt;` (20 passed, 7 skipped)</code>
- <code>`pytest tests/test_generated_structs.py -q` (.ksy / generated-struct sync, 4 passed)</code>
- <code>Manual driver `drive_tagblocks.py` — S4 header stamp, S5 morph index preservation, S6 multi-mesh merge, S7 duplicate-bone-id mirrors (18 live assertions, all PASS)</code>
- <code>Manual driver `drive_morph_roundtrip.py` — import → export → re-import of pl01_003.bin comparing per-morph displacement counts, magnitudes and direction</code>
- <code>Manual driver `render_morph_evidence.py` — Workbench renders of the shipped model and the re-imported exported model, morph slider at rest and pushed</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

## Note: local install vs. CI's R2 game-file mirror differ

The three new blocks in `tests/cie/test_bin_export_tagblocks.py` are only exercisable against real RE4 UHD archives, gated behind `--game-dir`. My first push pinned two archives (`a shipped .udas.lfs file`, `a shipped .udas.lfs file`) that exist in a local RE4 UHD install but are **not** in the curated R2 bucket CI mounts as its `--game-dir` - those two corpora are not the same set, and CI failed on all three tag-block tests with `KeyError: hash(es) not found in this game install`.

Fixed in commit `d52b8fc` (tests only, no product code changed):
- bone-pair and symmetry round trips are re-pointed at `fd8d767380c71f51` (`a shipped .udas.lfs file`), already mirrored because two pre-existing datasets reference it, and confirmed (against a real local install) to carry both a DBL_JNT and a pXFlip table.
- no mirrored archive carries a morph block at all (checked every committed cie dataset hash), so the morph test now imports a real model from that archive and adds synthetic shape keys instead of relying on a pre-existing morph fixture - it still exercises the full write path (offsets, group indices, id ranges, delta decoding) end to end.

If a maintainer later runs `tests/scripts/upload_ci_game_files.py` to add `a shipped .udas.lfs file` / `a shipped .udas.lfs file` (or another real morph-carrying archive) to the R2 mirror, the morph test can go back to a real shipped morph fixture instead of a synthetic one.

**For the next person hitting this**: a dataset hash existing in a local `~/Games` install does not mean it exists in CI's R2 mirror. Check `tests/cie/datasets/*.json` for hashes already known to be mirrored before pinning a new one, or run the test suite with `--game-dir` pointed at a fresh checkout of the R2 mirror rather than a full local install before pushing.

