### PR TITLE
feat(cie): write RE4 UHD texture packs so a shipped texture can be replaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Autosorter tool to automatically set `alpha priority` values for hair cards
 - Experimental support for LMT export (Resident Evil 5)
 - App Settings button next to App selection. Allows to set the root folder of an app. Its content is stored in apps-userdata.ini, in Albam's extension directory.
+- Writing Resident Evil 4 UHD texture packs: a `.pack` archive rebuilt with one
+  texture's bytes replaced by a supplied DDS, leaving every other texture in it
+  byte for byte. Not reachable from the panels yet, since nothing puts a
+  replacement DDS into the export list; see `docs/modding-a-character.md`
 - Reading `.arc` archives from Devil May Cry 4, whose entries are XMemCompress (LZX) streams rather than zlib, and which number their file types differently. Models and textures inside them can now be imported. Read-only for now: packing into one is refused rather than writing an archive the game cannot read
 
 ### Fixed

--- a/albam/engines/cie/archive.py
+++ b/albam/engines/cie/archive.py
@@ -4,6 +4,12 @@ Reading is the fs_root_loader below, which hands the VFS an LfsFS (see fs.py).
 Writing is update_lfs(): an archive with some of its files replaced by what
 albam exported, rebuilt and recompressed into a file the game can load.
 
+Two containers are rebuilt - a .udas, which is what a model archive is, and a
+.pack, which is what a texture archive is. A pack lives in its own archive
+(ImagePack/ImagePackHD) rather than beside the model that uses it, so
+replacing a texture repacks that archive and nothing else: the .tpl naming the
+slot keeps pointing at the same pack id and index.
+
 Compression is lfs_compress's, by way of lfs_decompress.xcompress_compress_re4hd:
 chunks are LZX compressed, bar any that would grow, which the container can
 flag as stored instead.
@@ -11,9 +17,10 @@ flag as stored instead.
 import os
 import struct
 
-from .fs import LfsFS, split_archive_name, udas_byte_order
+from .fs import LfsFS, pack_entry_extension, split_archive_name, udas_byte_order
 from .lfs_decompress import xcompress_compress_re4hd, xcompress_decompress_re4hd
 from .structs.lfs import Lfs
+from .structs.pack import Pack
 from .structs.udas import Udas
 from ...registry import blender_registry
 
@@ -26,6 +33,21 @@ BLOCK_DESCRIPTOR_SIZE = 32
 BLOCK_TABLE_OFFSET = 0x20
 BLOCK_TYPE_DAT = 0
 BLOCK_TERMINATOR = 0xFFFFFFFF
+
+# A pack: an id, a file count, then a u4 offset per file. Each entry is a
+# 16-byte header - the size of what follows, a word every shipped entry sets to
+# 0xFFFFFFFF, the pack's own id split over two u2 fields, and a DDS flag -
+# followed by the file's raw bytes (see structs/pack.ksy).
+PACK_HEADER_SIZE = 8
+PACK_ENTRY_HEADER_SIZE = 16
+# Where a file's raw bytes go. Every one of the 644 uncompressed packs of an
+# install starts the first file's bytes on a 128-byte boundary, at the smallest
+# offset clearing the offset table, and 604 of them put every later file's
+# bytes on one too - the other 40 leave a constant gap between entries instead.
+# So this is both what a shipped layout looks like and what a rebuilt entry is
+# laid out by.
+PACK_DATA_ALIGNMENT = 128
+DDS_MAGIC = b"DDS "
 
 
 @blender_registry.register_fs_root_loader(app_id="re4uhd", extension="lfs")
@@ -161,6 +183,162 @@ def _rebuild_udas(payload, replacements):
     return bytes(out)
 
 
+def _read_pack(payload):
+    """The Pack in `payload`, with what the rebuild rests on checked first.
+
+    An .lfs named for a container does not always hold one (see
+    fs.LfsFS._split), and a payload that is not a pack can still read as one -
+    a plausible count, offsets pointing anywhere. Each entry is carried over as
+    the byte range between its own offset and the next one, so ascending,
+    distinct offsets clearing the table are what makes that range the entry;
+    saying so beats emitting a container built over nonsense.
+
+    The file count is checked before the container is parsed at all: the
+    generated reader reads one offset per file the count claims, so a payload
+    claiming four billion of them would spin rather than fail.
+    """
+    if len(payload) < PACK_HEADER_SIZE:
+        raise ValueError(
+            f"this payload is {len(payload)} bytes, too short to be a pack's own header"
+        )
+    _pack_id, num_files = struct.unpack_from("<II", payload)
+    if PACK_HEADER_SIZE + 4 * num_files > len(payload):
+        raise ValueError(
+            f"this payload claims {num_files} files, more than its {len(payload)} bytes "
+            f"can hold an offset for, so it is not a pack"
+        )
+
+    pack = Pack.from_bytes(payload)
+    pack._read()
+
+    offsets = [entry.offset for entry in pack.file_entries]
+    if not offsets:
+        raise ValueError("this pack lists no files, so there is nothing to replace in it")
+    table_end = PACK_HEADER_SIZE + 4 * len(offsets)
+    if offsets[0] < table_end:
+        raise ValueError(
+            f"this pack puts its first file at {offsets[0]}, inside its own "
+            f"{table_end}-byte offset table, so the payload is not a pack"
+        )
+    if sorted(set(offsets)) != offsets:
+        raise ValueError(
+            "this pack's offsets are not ascending and distinct, so a file does not "
+            "run from its own offset to the next one and albam cannot rebuild it"
+        )
+    return pack
+
+
+def _build_pack_entry(entry, data):
+    """One pack entry: its 16-byte header, and `data`.
+
+    Every header word but the size is the entry's own. `unk_00` is 0xFFFFFFFF
+    in all 12416 entries of an install's uncompressed packs, and `unk_01` /
+    `unk_02` are that pack's own id split over two u2 fields in every one of
+    them - so neither is guessed here, both are simply kept.
+
+    The DDS flag is kept too, and only cleared for a replacement that is not a
+    DDS. A shipped pack never flags an entry that isn't one, but it does leave
+    the flag clear over DDS bytes - 6650 of the 9882 such entries - so setting
+    it from the replacement's own magic would rewrite what those entries say
+    while nothing suggests the game reads it that way.
+    """
+    body = entry.data
+    is_dds = body.is_dds if data[:4] == DDS_MAGIC else 0
+    return struct.pack("<IIHHI", len(data), body.unk_00, body.unk_01, body.unk_02,
+                       is_dds) + bytes(data)
+
+
+def _pack_data_offset(end_of_previous):
+    """Where the next entry goes for its raw bytes to land on
+    PACK_DATA_ALIGNMENT, which is how a shipped pack lays one out."""
+    aligned = _align(end_of_previous + PACK_ENTRY_HEADER_SIZE, PACK_DATA_ALIGNMENT)
+    return aligned - PACK_ENTRY_HEADER_SIZE
+
+
+def _assemble_pack(pack_id, bodies):
+    """A whole pack payload from `bodies`, a list of (bytes, place aligned).
+
+    A body already the size of the range it came from is placed where the
+    previous one ended, which is where it was; one that outgrew that range is
+    placed - and followed - by PACK_DATA_ALIGNMENT instead, and everything
+    after it moves. A body placed last is never followed by padding: no shipped
+    pack has bytes after its final file.
+    """
+    body_start = _pack_data_offset(PACK_HEADER_SIZE + 4 * len(bodies))
+    body = bytearray()
+    offsets = []
+    for index, (data, place_aligned) in enumerate(bodies):
+        offset = body_start + len(body)
+        if place_aligned:
+            body += b"\x00" * (_pack_data_offset(offset) - offset)
+            offset = _pack_data_offset(offset)
+        offsets.append(offset)
+        body += data
+        if place_aligned and index < len(bodies) - 1:
+            end = offset + len(data)
+            body += b"\x00" * (_pack_data_offset(end) - end)
+
+    out = bytearray(struct.pack("<II", pack_id, len(bodies)))
+    for offset in offsets:
+        out += struct.pack("<I", offset)
+    out += b"\x00" * (body_start - len(out))
+    return bytes(out) + bytes(body)
+
+
+def _rebuild_pack(payload, replacements):
+    """A pack with `replacements` ({entry name: bytes}) substituted.
+
+    A pack's entries carry no names either, so a replacement is matched by the
+    numbered name albam exposed the entry under, the same way _rebuild_udas
+    matches one - see fs.pack_entry_extension for the extension half of it.
+
+    An entry keeps the byte range it occupies here - its own padding included -
+    rather than being written out again from the parsed fields, both when
+    nothing replaces it and when the replacement still fits. Only an entry that
+    outgrew its range is laid out afresh, and only what follows that one moves.
+    A pack is 400 textures where a mod changes one, and shipped packs do not all
+    pad the same way (40 of the 644 uncompressed ones of an install leave a
+    constant gap between entries rather than aligning each), so rebuilding every
+    entry would rewrite an archive that only means to have one file substituted.
+    """
+    pack = _read_pack(payload)
+    offsets = [entry.offset for entry in pack.file_entries]
+    ends = offsets[1:] + [len(payload)]
+    last = len(pack.file_entries) - 1
+
+    bodies = []
+    replaced = 0
+    for index, entry in enumerate(pack.file_entries):
+        original = payload[offsets[index]:ends[index]]
+        suffix = f"_{index:03d}.{pack_entry_extension(entry)}"
+        new_bytes = None
+        for name, candidate in replacements.items():
+            if name.lower().endswith(suffix):
+                new_bytes = candidate
+                break
+        if new_bytes is None:
+            bodies.append((original, False))
+            continue
+        replaced += 1
+        rebuilt = _build_pack_entry(entry, new_bytes)
+        if len(rebuilt) > len(original):
+            bodies.append((rebuilt, True))
+        else:
+            # Padded back out to the range it came from so nothing after it
+            # moves - except when it is the last entry, where nothing follows
+            # it to hold in place and padding would be bytes after the final
+            # file that no shipped pack has.
+            padding = 0 if index == last else len(original) - len(rebuilt)
+            bodies.append((rebuilt + b"\x00" * padding, False))
+
+    if not replaced:
+        raise ValueError(
+            f"none of {sorted(replacements)} matched an entry in this pack - a "
+            f"replacement is matched by the numbered name it was imported under"
+        )
+    return _assemble_pack(pack.pack_name, bodies)
+
+
 @blender_registry.register_archive_writer(app_id="re4uhd", extension="lfs")
 def update_lfs(archive_path, exported_vfiles, **options):
     """The archive at `archive_path`, with each exported file substituted for
@@ -175,13 +353,15 @@ def update_lfs(archive_path, exported_vfiles, **options):
 
     if extension == ".udas":
         payload = _rebuild_udas(payload, replacements)
-    elif len(replacements) == 1 and extension not in (".dat", ".pack", ".evd"):
+    elif extension == ".pack":
+        payload = _rebuild_pack(payload, replacements)
+    elif len(replacements) == 1 and extension not in (".dat", ".evd"):
         # A single-file archive: the payload is the file.
         payload = next(iter(replacements.values()))
     else:
         raise NotImplementedError(
-            f"writing a {extension} archive isn't supported yet - only .udas "
-            f"containers and single-file archives"
+            f"writing a {extension} archive isn't supported yet - only .udas and "
+            f".pack containers and single-file archives"
         )
 
     return xcompress_compress_re4hd(payload)

--- a/albam/engines/cie/archive.py
+++ b/albam/engines/cie/archive.py
@@ -47,7 +47,6 @@ PACK_ENTRY_HEADER_SIZE = 16
 # So this is both what a shipped layout looks like and what a rebuilt entry is
 # laid out by.
 PACK_DATA_ALIGNMENT = 128
-DDS_MAGIC = b"DDS "
 
 
 @blender_registry.register_fs_root_loader(app_id="re4uhd", extension="lfs")
@@ -236,16 +235,14 @@ def _build_pack_entry(entry, data):
     `unk_02` are that pack's own id split over two u2 fields in every one of
     them - so neither is guessed here, both are simply kept.
 
-    The DDS flag is kept too, and only cleared for a replacement that is not a
-    DDS. A shipped pack never flags an entry that isn't one, but it does leave
-    the flag clear over DDS bytes - 6650 of the 9882 such entries - so setting
-    it from the replacement's own magic would rewrite what those entries say
-    while nothing suggests the game reads it that way.
+    The DDS flag is the entry's own like every other header word. A shipped
+    pack leaves it clear over DDS bytes - 6650 of the 9882 such entries - so
+    setting it from the replacement's own bytes would rewrite what those
+    entries say while nothing suggests the game reads it that way.
     """
     body = entry.data
-    is_dds = body.is_dds if data[:4] == DDS_MAGIC else 0
     return struct.pack("<IIHHI", len(data), body.unk_00, body.unk_01, body.unk_02,
-                       is_dds) + bytes(data)
+                       body.is_dds) + bytes(data)
 
 
 def _pack_data_offset(end_of_previous):

--- a/albam/engines/cie/fs.py
+++ b/albam/engines/cie/fs.py
@@ -76,6 +76,22 @@ YZ2_HEADER_SIZE = 32
 YZ2_HEADER_PATTERN = re.compile(rb"^[0-9a-f]+\t[0-9a-f]+\n\x00*$")
 
 
+def pack_entry_extension(entry):
+    """The extension one pack entry is exposed under.
+
+    A pack names nothing, so this and the entry's index are the whole of the
+    name a caller ever sees it by (see LfsFS._split_container), which is also
+    what the writer matches a replacement against (see
+    albam.engines.cie.archive._rebuild_pack).
+
+    The flag it reads is not a reliable statement about the bytes: 6650 of the
+    9882 entries holding a DDS across the uncompressed packs of an install
+    leave it clear, so a DDS is often exposed under a ".tga" name. Reader and
+    writer agree on the name anyway by both asking here.
+    """
+    return "dds" if entry.data.is_dds else "tga"
+
+
 def read_udas_block_table(payload, byte_order):
     """The block descriptors of `payload` as [(type, size, offset)], read in
     `byte_order` ("<" or ">"), or None when it holds no table in that order.
@@ -286,7 +302,7 @@ class LfsFS(FS):
                 extension = extensions[i].ext.lower() or "null"
                 raw_data = entry.raw_data
             else:
-                extension = "dds" if entry.data.is_dds else "tga"
+                extension = pack_entry_extension(entry)
                 raw_data = entry.data.raw_data
             data[f"/{self._stem}_{i:03d}.{extension}"] = raw_data
         return data

--- a/docs/modding-a-character.md
+++ b/docs/modding-a-character.md
@@ -79,10 +79,11 @@ Three things follow, and they are what catches people out:
 - **Textures live outside the archive you are modding**, so the archive alone
   is not enough to import a textured model. Step 3 covers what to do when you
   are working from a copy.
-- **A pack is shared by many models**, and about a third carry an extra YZ2
-  compression layer albam cannot read. That, plus there being no `.pack` or
-  `.tpl` writer, is why new textures cannot be added - see the end of this
-  guide.
+- **A pack is shared by many models**, so anything done to a texture is done to
+  every model using it. About a third of the packs are named `*.pack.yz2.lfs`;
+  that extra segment is bookkeeping, and the payload is a plain pack like any
+  other - true of every one in an install. Textures still cannot be changed from
+  the panels, though; see the end of this guide.
 
 The parts of a character also share one skeleton, which is why the order you
 import them in matters - again, step 3.
@@ -220,8 +221,17 @@ Add one layer of albam at a time, and whichever fails first names the layer:
   facial morphs loses them on export.
 - **Rooms** import - geometry, props and placement - but there is no exporter for
   them.
-- **New textures cannot be added.** Nothing writes a `.pack` or a `.tpl`, so a
-  model can only address textures its archive already ships. Retexturing - the
-  usual reason to mod a character - needs that, and it needs a DDS encoder
-  (albam only reads DDS) plus a decoder for the YZ2 layer that about a third of
-  the packs carry.
+- **New textures cannot be added.** Nothing writes a `.tpl`, so a model can only
+  address the slots its texture list already has, and a mod that adds one would
+  also have to renumber the material indices addressing it.
+- **Replacing a texture has no route through the panels yet.** The pack writer
+  itself is done: given a pack archive and a replacement DDS it produces a pack
+  laid out the way the shipped ones are, leaving every other texture in it byte
+  for byte. Unlike the rest of this guide, that last step has not yet been
+  confirmed in the running game. What is missing in front of it is the step that
+  would make it usable: a pack is a different archive from the model, and nothing
+  yet puts a replacement DDS into the export list for **Pack item** to
+  substitute, so the writer is reachable from
+  `albam.engines.cie.archive.update_lfs` and not from the UI. Encoding an
+  arbitrary Blender image as a DDS is a separate gap again: albam only reads DDS
+  today, so the replacement has to be a DDS you supply.

--- a/tests/cie/test_lfs_fs.py
+++ b/tests/cie/test_lfs_fs.py
@@ -217,7 +217,9 @@ def test_repacking_an_archive_unchanged_preserves_every_entry(lfs_fs, local_payl
     carries the archive's own filename.
     """
     if local_payload_extension != ".udas":
-        pytest.skip("only .udas containers are rebuilt")
+        # A .pack is rebuilt too, by tests/cie/test_pack_writer.py; nothing
+        # else is.
+        pytest.skip("this test covers the .udas rebuild")
 
     from albam.engines.cie.archive import _read_payload, _rebuild_udas
     from albam.engines.cie.lfs_decompress import (xcompress_compress_re4hd,

--- a/tests/cie/test_pack_writer.py
+++ b/tests/cie/test_pack_writer.py
@@ -1,0 +1,344 @@
+"""
+Writing RE4UHD texture packs - albam.engines.cie.archive._rebuild_pack, and
+update_lfs dispatching to it.
+
+A pack is the archive a model's textures actually live in: a .tpl entry names
+a pack id and an index into it, and the pack is a separate .lfs under
+ImagePack / ImagePackHD (see albam/engines/cie/textures.py). Replacing a
+texture therefore rebuilds that pack and nothing else - the .tpl keeps
+pointing at the same pack id and the same index.
+
+The first half of this file builds packs by hand and needs no game data. The
+second half rebuilds real ones, which needs --game-dir.
+"""
+import json
+import os
+import struct
+
+import pytest
+
+from albam.engines.cie.archive import (PACK_DATA_ALIGNMENT, PACK_ENTRY_HEADER_SIZE,
+                                       PACK_HEADER_SIZE, _rebuild_pack)
+from tests.cie.lfs_paths import resolve_archive_hashes
+
+# The .pack archives of the shared parsing dataset - already verified against
+# the committed catalog by tests/cie/test_lfs_fs.py, which is where that
+# dataset and its guard live. One is a plain "*.pack.lfs" and one a
+# "*.pack.yz2.lfs", whose payload is a plain pack too (see
+# albam.engines.cie.fs).
+DATASETS_DIR = os.path.join(os.path.dirname(__file__), "datasets")
+with open(os.path.join(DATASETS_DIR, "lfs_parsing_hashes.json")) as f:
+    PACK_DATASET = [d for d in json.load(f) if d["payload_extension"] == ".pack"]
+
+# A DDS albam would never have to decode: the writer only ever looks at the
+# magic, to decide the entry's own DDS flag.
+FAKE_DDS = b"DDS " + b"\x7f" * 220
+FAKE_TGA = b"\x00\x00\x02\x00" + b"\x11" * 180
+
+
+def _build_pack(pack_id, files):
+    """A pack payload holding `files`, a list of (bytes, DDS flag).
+
+    Written here rather than with the writer under test, and laid out the way
+    every shipped pack lays out its first file and 604 of the 644 uncompressed
+    packs of an install lay out all of them: each file's raw bytes start on a
+    PACK_DATA_ALIGNMENT boundary. The header words the writer carries over are
+    given the values every shipped entry has - 0xFFFFFFFF, and the pack's own
+    id split over two u2 fields.
+    """
+    def data_offset(end_of_previous):
+        unaligned = end_of_previous + PACK_ENTRY_HEADER_SIZE
+        aligned = -(-unaligned // PACK_DATA_ALIGNMENT) * PACK_DATA_ALIGNMENT
+        return aligned - PACK_ENTRY_HEADER_SIZE
+
+    offsets = []
+    bodies = bytearray()
+    body_start = data_offset(PACK_HEADER_SIZE + 4 * len(files))
+    for index, (data, is_dds) in enumerate(files):
+        offset = body_start + len(bodies)
+        offsets.append(offset)
+        bodies += struct.pack("<IIHHI", len(data), 0xFFFFFFFF,
+                              pack_id & 0xFFFF, pack_id >> 16, is_dds) + data
+        if index < len(files) - 1:
+            end = offset + PACK_ENTRY_HEADER_SIZE + len(data)
+            bodies += b"\x00" * (data_offset(end) - end)
+
+    header = bytearray(struct.pack("<II", pack_id, len(files)))
+    for offset in offsets:
+        header += struct.pack("<I", offset)
+    header += b"\x00" * (body_start - len(header))
+    return bytes(header) + bytes(bodies)
+
+
+def _entries(payload):
+    """[(name, bytes)] for a pack payload, named the way the VFS names its
+    entries - which is what a replacement is matched against."""
+    from albam.engines.cie.fs import pack_entry_extension
+    from albam.engines.cie.structs.pack import Pack
+
+    pack = Pack.from_bytes(payload)
+    pack._read()
+    return [(f"{pack.pack_name:08x}_{i:03d}.{pack_entry_extension(entry)}",
+             bytes(entry.data.raw_data))
+            for i, entry in enumerate(pack.file_entries)]
+
+
+@pytest.fixture
+def pack():
+    """A three-file pack: a DDS flagged as one, a DDS left unflagged (which is
+    how 6650 of the 9882 DDS entries of an install ship), and a TGA."""
+    return _build_pack(0x0D104000, [(FAKE_DDS, 1), (FAKE_DDS + b"\x01" * 64, 0),
+                                    (FAKE_TGA, 0)])
+
+
+def test_a_handbuilt_pack_reads_back(pack):
+    """The fixture is only worth testing the writer against if the reader
+    agrees it is a pack, since the reader is what a mod is judged by."""
+    assert [name for name, _data in _entries(pack)] == [
+        "0d104000_000.dds", "0d104000_001.tga", "0d104000_002.tga"]
+
+
+def test_rebuilding_unchanged_is_byte_for_byte_identical(pack):
+    """Handing one entry back unchanged gives the pack that went in.
+
+    Nothing may drift when a mod replaces one texture of the four hundred a
+    pack can hold, so the identity case is exact rather than merely
+    equivalent.
+    """
+    name, data = _entries(pack)[1]
+    assert _rebuild_pack(pack, {name: data}) == pack
+
+
+def test_a_same_size_replacement_moves_nothing_else(pack):
+    """A replacement that fits where the entry already sat leaves every other
+    byte of the pack alone - offset table included."""
+    before = _entries(pack)
+    name, data = before[1]
+    replacement = bytes(len(data))
+    rebuilt = _rebuild_pack(pack, {name: replacement})
+
+    assert len(rebuilt) == len(pack)
+    assert struct.unpack_from("<3I", rebuilt, PACK_HEADER_SIZE) == \
+        struct.unpack_from("<3I", pack, PACK_HEADER_SIZE)
+    assert [d for _n, d in _entries(rebuilt)] == [before[0][1], replacement, before[2][1]]
+
+
+def test_a_shorter_replacement_moves_nothing_else(pack):
+    before = _entries(pack)
+    name, data = before[1]
+    replacement = data[:32]
+    rebuilt = _rebuild_pack(pack, {name: replacement})
+
+    assert struct.unpack_from("<3I", rebuilt, PACK_HEADER_SIZE) == \
+        struct.unpack_from("<3I", pack, PACK_HEADER_SIZE)
+    assert [d for _n, d in _entries(rebuilt)] == [before[0][1], replacement, before[2][1]]
+
+
+def test_a_longer_replacement_shifts_only_what_follows_it(pack):
+    """An entry that outgrew its range is laid out afresh and the entries after
+    it move; the ones before it do not."""
+    before = _entries(pack)
+    name, data = before[1]
+    replacement = data + b"\xab" * 4000
+    rebuilt = _rebuild_pack(pack, {name: replacement})
+
+    offsets_before = struct.unpack_from("<3I", pack, PACK_HEADER_SIZE)
+    offsets_after = struct.unpack_from("<3I", rebuilt, PACK_HEADER_SIZE)
+    assert offsets_after[0] == offsets_before[0]
+    assert offsets_after[1] == offsets_before[1]
+    assert offsets_after[2] > offsets_before[2]
+    assert [d for _n, d in _entries(rebuilt)] == [before[0][1], replacement, before[2][1]]
+
+
+def test_every_rebuilt_entry_starts_its_data_on_the_alignment(pack):
+    """What 604 of the 644 uncompressed packs of an install do for every entry,
+    and all 644 do for the first: a file's raw bytes begin on a
+    PACK_DATA_ALIGNMENT boundary."""
+    name, data = _entries(pack)[0]
+    rebuilt = _rebuild_pack(pack, {name: data + b"\x00" * 5000})
+
+    count = struct.unpack_from("<I", rebuilt, 4)[0]
+    offsets = struct.unpack_from(f"<{count}I", rebuilt, PACK_HEADER_SIZE)
+    assert [(o + PACK_ENTRY_HEADER_SIZE) % PACK_DATA_ALIGNMENT for o in offsets] == [0] * count
+
+
+def test_the_last_entry_growing_leaves_no_trailing_bytes(pack):
+    """No shipped pack has bytes after its final file, so a rebuilt one
+    doesn't either."""
+    entries = _entries(pack)
+    name, data = entries[-1]
+    for replacement in (data + b"\x22" * 3000, data[:16]):
+        rebuilt = _rebuild_pack(pack, {name: replacement})
+        count = struct.unpack_from("<I", rebuilt, 4)[0]
+        last = struct.unpack_from(f"<{count}I", rebuilt, PACK_HEADER_SIZE)[-1]
+        assert len(rebuilt) == last + PACK_ENTRY_HEADER_SIZE + len(replacement)
+
+
+def test_the_dds_flag_is_kept_and_only_ever_cleared(pack):
+    """A shipped pack never flags an entry that isn't a DDS, but it does leave
+    the flag clear over DDS bytes - so a DDS replacement keeps whatever the
+    entry said, and only a replacement that isn't one clears it.
+
+    Read back through the entry names, which is what the flag decides.
+    """
+    flagged, unflagged, tga = _entries(pack)
+
+    rebuilt = _rebuild_pack(pack, {flagged[0]: FAKE_DDS + b"\x03" * 8})
+    assert [n for n, _d in _entries(rebuilt)] == [flagged[0], unflagged[0], tga[0]]
+
+    rebuilt = _rebuild_pack(pack, {unflagged[0]: FAKE_DDS})
+    assert [n for n, _d in _entries(rebuilt)] == [flagged[0], unflagged[0], tga[0]]
+
+    rebuilt = _rebuild_pack(pack, {flagged[0]: FAKE_TGA})
+    assert [n for n, _d in _entries(rebuilt)] == \
+        ["0d104000_000.tga", unflagged[0], tga[0]]
+
+
+def test_a_replacement_is_matched_by_its_number_not_its_archive_name(pack):
+    """A pack's entries carry no names, only positions, so the number albam
+    exposed the entry under is the whole of the match - the stem in front of it
+    is whichever archive it was read from, which a mod's own file need not
+    repeat."""
+    replacement = FAKE_TGA[:24]
+    for name in ("0d104000_002.tga", "whatever_002.TGA"):
+        assert _entries(_rebuild_pack(pack, {name: replacement}))[2][1] == replacement
+
+
+def test_a_replacement_matching_nothing_is_an_error(pack):
+    with pytest.raises(ValueError, match="matched an entry"):
+        _rebuild_pack(pack, {"0d104000_009.dds": b""})
+    # The right number, the extension the other flag would have given it.
+    with pytest.raises(ValueError, match="matched an entry"):
+        _rebuild_pack(pack, {"0d104000_000.tga": b""})
+
+
+def test_a_payload_that_is_not_a_pack_is_refused():
+    """An .lfs named for a container does not always hold one (see
+    albam.engines.cie.fs.LfsFS._split), and the writer is handed the payload
+    rather than the mounted files - so it says so rather than emitting a
+    container built over whatever the bytes read as."""
+    # A count of two whose first "offset" points inside the offset table.
+    payload = struct.pack("<IIII", 0, 2, 8, 500) + bytes(500)
+    with pytest.raises(ValueError, match="not a pack"):
+        _rebuild_pack(payload, {"x_000.dds": b""})
+
+
+def test_an_absurd_file_count_is_refused_without_being_parsed():
+    """The generated reader reads one offset per file the count claims, so a
+    count nothing could hold has to be caught before it is handed over."""
+    payload = struct.pack("<II", 0, 0xFFFFFFFF) + bytes(4096)
+    with pytest.raises(ValueError, match="claims 4294967295 files"):
+        _rebuild_pack(payload, {"x_000.dds": b""})
+
+
+def test_aliased_entry_offsets_are_refused():
+    """Two entries at one offset would leave the first with no bytes between
+    its own offset and the next, which is how an entry is carried over. No
+    pack of an install does it; a payload that is not a pack can."""
+    header = struct.pack("<IIIII", 0, 3, 256, 256, 400)
+    payload = header + bytes(1024 - len(header))
+    with pytest.raises(ValueError, match="ascending and distinct"):
+        _rebuild_pack(payload, {"x_000.dds": b""})
+
+
+def pytest_generate_tests(metafunc):
+    if ("local_app_id" in metafunc.fixturenames and
+            "local_archive_path_hash" in metafunc.fixturenames):
+        argnames = ("local_app_id", "local_archive_path_hash")
+        argvalues = [(d["app_id"], d["archive_path_hash"]) for d in PACK_DATASET]
+        ids = [f"{d['app_id']}-pack-{d['archive_path_hash']}" for d in PACK_DATASET]
+        metafunc.parametrize(argnames, argvalues, ids=ids, scope="session")
+
+
+@pytest.fixture(scope="session")
+def shipped_pack(game_root, local_archive_path_hash):
+    """A real pack archive's path, and the files it mounts."""
+    from albam.engines.cie.fs import LfsFS
+
+    path = resolve_archive_hashes(game_root, {local_archive_path_hash})[local_archive_path_hash]
+    fs = LfsFS(path)
+    try:
+        files = {p: fs.readbytes(p) for p in fs.walk.files()}
+    finally:
+        fs.close()
+    assert files
+    return path, files
+
+
+class _ExportedVFile:
+    """What update_lfs takes of an exported file: a name and its bytes."""
+
+    def __init__(self, display_name, data_bytes):
+        self.display_name = display_name
+        self._data_bytes = data_bytes
+
+    def get_bytes(self):
+        return self._data_bytes
+
+
+def test_rebuilding_a_shipped_pack_unchanged_is_byte_for_byte_identical(shipped_pack):
+    """A real pack, one entry handed back unchanged, comes out as the payload
+    that went in - which is what says the writer reproduces a shipped layout
+    rather than merely producing a readable one.
+
+    True of all 644 uncompressed packs of an install, and of the payload of
+    every compressed one sampled, including the "*.pack.yz2.lfs" ones.
+    """
+    from albam.engines.cie.archive import _read_payload
+
+    path, files = shipped_pack
+    payload, extension = _read_payload(path)
+    assert extension == ".pack"
+
+    name = sorted(files)[0]
+    assert _rebuild_pack(payload, {name.lstrip("/"): files[name]}) == payload
+
+
+def test_writing_a_shipped_pack_unchanged_remounts_the_same_files(shipped_pack, tmp_path):
+    """The whole writer - decompress, rebuild, compress - and the archive
+    mounted back off disk, which is the file a mod would ship."""
+    from albam.engines.cie.archive import update_lfs
+    from albam.engines.cie.fs import LfsFS
+
+    path, files = shipped_pack
+    name = sorted(files)[0]
+    archive = update_lfs(path, [_ExportedVFile(name.lstrip("/"), files[name])])
+
+    repacked_path = tmp_path / os.path.basename(path)
+    repacked_path.write_bytes(archive)
+    repacked = LfsFS(str(repacked_path))
+    try:
+        assert {p: repacked.readbytes(p) for p in repacked.walk.files()} == files
+    finally:
+        repacked.close()
+
+
+def test_replacing_a_texture_in_a_shipped_pack(shipped_pack, tmp_path):
+    """The point of the writer: a supplied DDS in place of a shipped texture,
+    read back out of the archive the writer produced.
+
+    The DDS is not decoded by anything here - import keeps the original bytes
+    on the Blender image and this path hands bytes straight through - so a
+    stand-in with the right magic is what a replacement looks like to the
+    writer. Deliberately longer than what it replaces, which is the case that
+    moves every entry after it.
+    """
+    from albam.engines.cie.archive import update_lfs
+    from albam.engines.cie.fs import LfsFS
+
+    path, files = shipped_pack
+    name = sorted(files)[0]
+    replacement = FAKE_DDS + b"\x5a" * (len(files[name]) + 3000)
+    archive = update_lfs(path, [_ExportedVFile(name.lstrip("/"), replacement)])
+
+    repacked_path = tmp_path / os.path.basename(path)
+    repacked_path.write_bytes(archive)
+    repacked = LfsFS(str(repacked_path))
+    try:
+        after = {p: repacked.readbytes(p) for p in repacked.walk.files()}
+    finally:
+        repacked.close()
+
+    expected = dict(files)
+    expected[name] = replacement
+    assert after == expected

--- a/tests/cie/test_pack_writer.py
+++ b/tests/cie/test_pack_writer.py
@@ -30,8 +30,8 @@ DATASETS_DIR = os.path.join(os.path.dirname(__file__), "datasets")
 with open(os.path.join(DATASETS_DIR, "lfs_parsing_hashes.json")) as f:
     PACK_DATASET = [d for d in json.load(f) if d["payload_extension"] == ".pack"]
 
-# A DDS albam would never have to decode: the writer only ever looks at the
-# magic, to decide the entry's own DDS flag.
+# Payloads albam would never have to decode: the writer copies a replacement's
+# bytes through without reading them.
 FAKE_DDS = b"DDS " + b"\x7f" * 220
 FAKE_TGA = b"\x00\x00\x02\x00" + b"\x11" * 180
 
@@ -174,24 +174,21 @@ def test_the_last_entry_growing_leaves_no_trailing_bytes(pack):
         assert len(rebuilt) == last + PACK_ENTRY_HEADER_SIZE + len(replacement)
 
 
-def test_the_dds_flag_is_kept_and_only_ever_cleared(pack):
-    """A shipped pack never flags an entry that isn't a DDS, but it does leave
-    the flag clear over DDS bytes - so a DDS replacement keeps whatever the
-    entry said, and only a replacement that isn't one clears it.
+def test_the_dds_flag_is_always_carried_through_unchanged(pack):
+    """The flag is the entry's own, whatever the replacement's bytes are: a
+    shipped pack leaves it clear over DDS bytes just as often as it sets it, so
+    the replacement never gets a say in it.
 
     Read back through the entry names, which is what the flag decides.
     """
     flagged, unflagged, tga = _entries(pack)
+    names = [flagged[0], unflagged[0], tga[0]]
 
-    rebuilt = _rebuild_pack(pack, {flagged[0]: FAKE_DDS + b"\x03" * 8})
-    assert [n for n, _d in _entries(rebuilt)] == [flagged[0], unflagged[0], tga[0]]
-
-    rebuilt = _rebuild_pack(pack, {unflagged[0]: FAKE_DDS})
-    assert [n for n, _d in _entries(rebuilt)] == [flagged[0], unflagged[0], tga[0]]
-
-    rebuilt = _rebuild_pack(pack, {flagged[0]: FAKE_TGA})
-    assert [n for n, _d in _entries(rebuilt)] == \
-        ["0d104000_000.tga", unflagged[0], tga[0]]
+    for name, replacement in ((flagged[0], FAKE_DDS + b"\x03" * 8),
+                              (unflagged[0], FAKE_DDS),
+                              (flagged[0], FAKE_TGA)):
+        rebuilt = _rebuild_pack(pack, {name: replacement})
+        assert [n for n, _d in _entries(rebuilt)] == names
 
 
 def test_a_replacement_is_matched_by_its_number_not_its_archive_name(pack):


### PR DESCRIPTION
## Intent

Implement step 1 of albam issue #263, "RE4UHD: textures cannot be added, only re-pointed" (https://github.com/Brachi/albam/issues/263).

The captain's ask, in the substance of that issue (which the captain wrote):

Nothing writes a `.pack` or a `.tpl`, so a model can only address textures its archive already ships. Retexturing - the usual reason to mod a character - is not possible.

Needs three things, in increasing order of work:

1. A `.pack` writer. The format is trivial - name, count, a u4 offset per file, then size/flags/raw bytes - and a pack ships as a single-payload `.lfs`, so writing one reuses the existing archive writer. Import already keeps the original DDS bytes on the Blender image, so replacing a texture with a supplied DDS needs no encoding.
2. A DDS encoder, for any Blender image rather than a supplied DDS. albam only reads DDS today.
3. `.tpl` writing, for a mod that adds a slot rather than replacing one - which also means renumbering the material indices that address it.

Two complications: a pack is shared by many models and lives in a different archive from the model, so this is a second repack the Pack operator does not currently express; and 596 of 1717 packs carry a YZ2 layer.

The captain asked firstmate to continue with RE4 work.

Firstmate's note on that last complication: it is no longer true. A separate investigation measured the corpus and found all 1192 `.pack.yz2.lfs` files carry plain pack payloads with no YZ2 headers, and they already mount to real textures - the `.yz2` name segment is bookkeeping, as the project's own `fs.py` docstring and `test_archive_names.py` already state. So the pack writer is not blocked on any codec work.

## What Changed

- `update_lfs` now rebuilds `.pack` payloads instead of refusing them: `_read_pack` validates the header, file count and that offsets are ascending, distinct and clear of the offset table before parsing; `_rebuild_pack` matches a replacement by the numbered name the entry was imported under, keeps every other entry's byte range (padding included) unchanged, and only re-lays-out an entry that outgrew its range plus what follows it, on the 128-byte data alignment shipped packs use. A rebuilt entry keeps its own header words, including the DDS flag, and errors when no replacement matched.
- Extracted the pack entry extension rule into `fs.pack_entry_extension`, so the reader's exposed name and the writer's replacement matching are derived from one place.
- Added `tests/cie/test_pack_writer.py` covering pack reading validation, entry rebuilds, alignment and replacement matching; updated `tests/cie/test_lfs_fs.py`, the CHANGELOG and `docs/modding-a-character.md` (which now records that `*.pack.yz2.lfs` payloads are plain packs, that the writer is not yet reachable from the panels, and that `.tpl` writing and DDS encoding remain missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Risk Assessment

✅ Low: The pack writer is well-bounded new code behind explicit payload validation, its layout math traces correctly through same-size, shorter, longer and last-entry cases, it is covered by both hand-built and shipped-pack byte-for-byte identity tests, and the review-round fix is exactly the minimal prescribed change with a test that genuinely pins the removed branch.

## Testing

Exercised the pack writer through albam's real writer-registry entry against a live RE4 UHD install: shipped-pack identity, DDS replacement in both plain and .yz2-named packs, the DDS-flag carry-through the review round fixed, refusal paths, and the .udas dispatch it touched. Visual evidence is a before/after pair of PNGs decoded out of the rebuilt archive showing slot 000 now holding the supplied texture; there is no UI surface to screenshot because the change is deliberately not reachable from the panels yet (nothing puts a replacement DDS into the export list), which the docs in this change state. Everything drivable passed; the repo's own tests/cie/test_pack_writer.py also passed with --game-dir. Only in-game loading of a modded pack could not be driven.

- Live validation: ✅ go - 8 of 9 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Rebuilding a shipped 34-entry pack with one texture handed back unchanged reproduces the shipped payload byte for byte | ✅ pass | live | `drive_pack.py unchanged-multi a shipped .pack.lfs file 5` — pack-writer-real-archives.log: &#34;pack payload byte-identical to shipped: True (458898 -&gt; 458898 bytes)&#34; |
| Replacing a texture in a plain .pack.lfs with a larger supplied DDS remounts with the new bytes and leaves every other texture byte for byte | ✅ pass | live | `drive_pack.py replace … 5 40960` — 640-byte slot now 41600 bytes, only that entry changed, LfsFS remount of the written archive |
| A *.pack.yz2.lfs archive rebuilds the same way (the corpus claim that the .yz2 segment is bookkeeping) | ✅ pass | live | `drive_pack.py yz2 a shipped .pack.lfs file 3 8192` — 34 textures remount, one replaced, others intact |
| A shipped DDS swapped into another slot decodes to the new image when read back out of the rebuilt archive | ✅ pass | live | 1-shipped-texture-before.png vs 3-same-slot-read-back-from-rebuilt-pack.png, produced by drive_visual.py through Blender&#39;s DDS decode |
| An .lfs named .pack that does not hold a pack is refused rather than producing a corrupt archive | ✅ pass | live | pack-writer-adversarial.log — ValueError naming the offset inside the offset table, no archive emitted |
| A replacement whose name matches no entry (wrong index, or right index under the other extension) is refused | ✅ pass | live | pack-writer-adversarial.log — both cases raise &#34;none of [...] matched an entry in this pack&#34; |
| The entry&#39;s DDS flag is carried through unchanged, so non-DDS bytes do not rename the entry and the same export re-runs against the rebuilt pack | ✅ pass | live | pack-writer-adversarial.log — names unchanged after a non-DDS replacement; second rebuild against the modded archive succeeds; an unflagged entry given a DDS keeps its .tga name |
| The .udas and unsupported-extension dispatch this change edited still behaves | ✅ pass | live | lfs-writer-regression.log — a shipped .udas.lfs file remounts identical; a .dat.lfs is still refused with the updated message |
| A pack rebuilt by albam loads correctly in the running Resident Evil 4 UHD game | ⏸️ untested | no | Requires launching the Windows RE4 UHD executable under Proton with a display and installing the modded archive into the game folder; this environment has no GUI session, no authority to modify the ga… |

<details>
<summary>Evidence: Real archives driven through the writer (identity, replacement, .yz2)</summary>

<code>=== plain .pack.lfs, one texture of many handed back unchanged&#10;pack payload byte-identical to shipped: True (458898 -&gt; 458898 bytes uncompressed)&#10;=== plain .pack.lfs, a supplied DDS replacing a shipped texture (larger)&#10;replaced a shipped .dds file: 640 bytes -&gt; 41600 bytes; entries whose bytes changed: [&#39;a shipped .dds file&#39;]; every other texture byte for byte: True&#10;=== *.pack.yz2.lfs, a supplied DDS replacing a shipped texture&#10;replaced a shipped .dds file: 131200 -&gt; 139392 bytes; every other texture byte for byte: True</code>

```text

=== plain .pack.lfs, one texture of many handed back unchanged
archive: a shipped .pack.lfs file  (294784 bytes on disk)
mounted 34 textures, e.g. ['a shipped .dds file', 'a shipped .tga file', 'a shipped .dds file']
wrote <temp path> (316082 bytes)
pack payload byte-identical to shipped: True (458898 -> 458898 bytes uncompressed)
remounted 34 textures; names unchanged: True
replaced a shipped .dds file: 640 bytes (fd8d929643e09a32) -> 640 bytes (fd8d929643e09a32)
entries whose bytes changed: []
new bytes read back exactly: True
every other texture byte for byte: True

=== plain .pack.lfs, a supplied DDS replacing a shipped texture (larger)
archive: a shipped .pack.lfs file  (294784 bytes on disk)
mounted 34 textures, e.g. ['a shipped .dds file', 'a shipped .tga file', 'a shipped .dds file']
wrote <temp path> (316076 bytes)
pack payload byte-identical to shipped: False (458898 -> 499858 bytes uncompressed)
remounted 34 textures; names unchanged: True
replaced a shipped .dds file: 640 bytes (fd8d929643e09a32) -> 41600 bytes (2e7b0a6ee1c95027)
entries whose bytes changed: ['a shipped .dds file']
new bytes read back exactly: True
every other texture byte for byte: True

=== *.pack.yz2.lfs, a supplied DDS replacing a shipped texture
archive: a shipped .pack.lfs file  (383242 bytes on disk)
mounted 34 textures, e.g. ['a shipped .dds file', 'a shipped .dds file', 'a shipped .tga file']
wrote <temp path> (309474 bytes)
pack payload byte-identical to shipped: False (685952 -> 694144 bytes uncompressed)
remounted 34 textures; names unchanged: True
replaced a shipped .dds file: 131200 bytes (f4ffda715b6e7ff7) -> 139392 bytes (354bf90d83f89b21)
entries whose bytes changed: ['a shipped .dds file']
new bytes read back exactly: True
every other texture byte for byte: True
```
</details>
<details>
<summary>Evidence: Adversarial paths: non-pack payload, unmatched names, DDS flag carry-through</summary>

<code>refused with ValueError: this pack puts its first file at 144, inside its own 1920520-byte offset table, so the payload is not a pack&#10;refused with ValueError: none of [&#39;a shipped .dds file&#39;] matched an entry in this pack - a replacement is matched by the numbered name it was imported under&#10;entry names unchanged after a non-DDS replacement: True&#10;the same export re-run against the rebuilt pack works: True</code>

```text

=== an .lfs named .pack that does not hold a pack
built a shipped .pack.lfs file from a .fix payload (26330896 bytes)
refused with ValueError: this pack puts its first file at 144, inside its own 1920520-byte offset table, so the payload is not a pack
no output archive written by the failed pack: True

=== a replacement whose name matches no entry
refused with ValueError: none of ['a shipped .dds file'] matched an entry in this pack - a replacement is matched by the numbered name it was imported under

... and the right index under the wrong extension
refused with ValueError: none of ['a shipped .tga file'] matched an entry in this pack - a replacement is matched by the numbered name it was imported under

=== the DDS flag is the entry's own: non-DDS bytes into a flagged entry
entry names unchanged after a non-DDS replacement: True
a shipped .dds file still exposed as .dds and holds the supplied bytes: True
the same export re-run against the rebuilt pack works: True
an unflagged entry keeps its .tga name when given a DDS: True (bytes stored: True)
```
</details>
<details>
<summary>Evidence: .udas repack regression and unsupported-extension refusal</summary>

<code>archive: a shipped .udas.lfs file — mounted 2 files; remounted identical: True&#10;a shipped .dat.lfs file refused: writing a .dat archive isn&#39;t supported yet - only .udas and .pack containers and single-file archives</code>

```text

=== a .udas model archive still repacks (the dispatch this change touched)
archive: a shipped .udas.lfs file
mounted 2 files; remounted identical: True

=== an extension with no writer is still refused
a shipped .dat.lfs file refused: writing a .dat archive isn't supported yet - only .udas and .pack containers and single-file archives
```
</details>

## Open question for the captain

**Does the game accept a plain `.pack.lfs` where it shipped `.pack.yz2.lfs`?** One in-game
test settles it, and nothing in the files can.

Measuring the corpus narrows it a long way, though: every shipped `.pack.yz2.lfs` payload
sampled here, and all 105 uncompressed `.pack.yz2` files, hold a **plain pack with no YZ2
header**. So this writer emits the same kind of payload the game already loads from that
name, and keeping the shipped filename (which is what `docs/modding-a-character.md` step 6
already tells users to do, and what the Pack operator defaults to) needs no rename at all.
What remains untested is only whether a *modified* pack loads.

## What is not reachable yet

The writer has **no route through the panels**. A pack is a different archive from the
model, and nothing puts a replacement DDS into the export list for **Pack item** to
substitute, so `update_lfs` is reachable from code and not from the UI. Closing that gap
means an image import function, an image export function, and a fix to
`ExportableItem.is_bl_object_missing` (which filters out any non-object ID, so Export's
`poll` is `False` for an Image) - a new user-facing workflow, deliberately out of scope for
step 1. `docs/modding-a-character.md` and the CHANGELOG both say so plainly.

Worth stating because it changes how the shared-pack complication reads: for a
**replacement**, only the pack archive is rebuilt. The `.tpl` keeps pointing at the same
pack id and index, and the model archive needs no repack, so the "second repack" problem
the issue names belongs to step 3 (adding a slot), not to this change.

## Where the measured format facts live

The header rules this writer follows were measured across the whole install, not inferred:
`unk_00` is `0xFFFFFFFF` in all 12416 entries of the 644 uncompressed packs; `unk_01` /
`unk_02` are that pack's own id split over two u2 fields in every one of them; the DDS flag
is clear over DDS bytes in 6650 of 9882 such entries; every pack starts its first file's raw
bytes on a 128-byte boundary and 604 of 644 do so for every file; none has bytes after its
final file; none aliases an offset.

Those facts currently live in the `_build_pack_entry` docstring in
`albam/engines/cie/archive.py` and in `fs.pack_entry_extension`. **`docs/README.md` makes
the `.ksy` files the owner of a format's own field documentation, so `pack.ksy` is where
they belong.** Moving them needs `kaitai-struct-compiler`, which is not available in this
environment: `structs/pack.py` is generated from the `.ksy` and mirrors its doc block into
the class docstring, so hand-writing that generated docstring would let the file drift from
its source. Tracked as a follow-up: add the doc block to `pack.ksy`, regenerate `pack.py`,
then reduce the `archive.py` paragraph to a pointer.

## Lint: what was actually run

**flake8 was run for real and is clean.** The pipeline's lint step could not find the
linters in its own environment and fell back to manual substitutes; that finding is
superseded. flake8 (`max-line-length 110`, the repo's configured setting) was then run
against the post-fix content of every changed file and reported **0 findings**.

**black was run and deliberately not applied.** It would reformat these files - but it would
also reformat **174 of the 204 Python files** in `albam/` and `tests/`, so the codebase does
not follow black: `[tool.black]` in `pyproject.toml` is dormant config, black is in no
workflow and is not a declared dev dependency, and CI runs flake8 only. Applying it here
would restyle two files this change barely touches and bury a 17-line fix. For the record,
flake8 over black's own output is also clean, so the two do not conflict - the case against
black is dormancy and diff noise, not breakage.

## Known follow-up left in place

`albam/engines/cie/textures.py:239` still inlines `"dds" if entry.data.is_dds else "tga"`
instead of calling the new `fs.pack_entry_extension`, which both the review and document
steps flagged. Behaviour is identical today. It is left for a follow-up rather than folded in
here because the pipeline's test step had already passed by the time it surfaced, and
changing code afterwards would ship behaviour that test evidence never covered.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e3b3b45450b08678621c965a2f3181f5a2c3e26b","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":8,"total":9}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `albam/engines/cie/archive.py:225` - `_build_pack_entry` introduces a branch that clears the entry&#39;s DDS flag when the replacement bytes do not start with `DDS ` (`is_dds = body.is_dds if data[:4] == DDS_MAGIC else 0`). The intent&#39;s step 1 is scoped to &#34;replacing a texture with a supplied DDS&#34; (a DDS encoder is explicitly step 2), so no intent requirement needs a non-DDS replacement path. The branch is also not inert: clearing the flag changes the name the entry is exposed under (`fs.pack_entry_extension` returns &#34;tga&#34; once the flag is 0), so a pack rebuilt with non-DDS bytes renames that entry, and re-running the same export against the rebuilt pack then fails with &#34;none of [...] matched an entry&#34;. Remedy: remove the conditional and keep `body.is_dds` unchanged, matching the stated rule that every header word but the size is the entry&#39;s own.
- ℹ️ `albam/engines/cie/archive.py:333` - Replacing the *last* entry sets `padding = 0`, so the rebuilt payload ends immediately after that entry&#39;s bytes and any bytes the original payload had after the final file are dropped. The docstrings assert no shipped pack has such bytes, but the shipped-pack identity test (`test_rebuilding_a_shipped_pack_unchanged_is_byte_for_byte_identical`) always uses `sorted(files)[0]`, i.e. entry 000, so the unchanged entry keeps `payload[offset:len(payload)]` verbatim and that assumption is never actually exercised against real data. Noting the gap; the assumption is documented as verified, so no change is required.

🔧 Fix applied.
1 info still open:

- ℹ️ `albam/engines/cie/textures.py:239` - The change extracted the pack-entry extension rule into `fs.pack_entry_extension` and routed the reader (`fs.LfsFS._split_container`) and the new writer (`archive._rebuild_pack`) through it, and its docstring states &#34;Reader and writer agree on the name anyway by both asking here.&#34; `_read_plain_pack` in textures.py still carries a third copy inline (`extension = &#34;dds&#34; if entry.data.is_dds else &#34;tga&#34;`) over the same `Pack.FileEntry` type, so it does not ask. Behaviour is currently identical, so this is not a bug - but it is the one call site that would silently diverge if the rule ever changes, and folding it into the helper is mechanical.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 8 of 9 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Rebuilding a shipped 34-entry pack with one texture handed back unchanged reproduces the shipped payload byte for byte | ✅ pass | live | `drive_pack.py unchanged-multi a shipped .pack.lfs file 5` — pack-writer-real-archives.log: &#34;pack payload byte-identical to shipped: True (458898 -&gt; 458898 bytes)&#34; |
| Replacing a texture in a plain .pack.lfs with a larger supplied DDS remounts with the new bytes and leaves every other texture byte for byte | ✅ pass | live | `drive_pack.py replace … 5 40960` — 640-byte slot now 41600 bytes, only that entry changed, LfsFS remount of the written archive |
| A *.pack.yz2.lfs archive rebuilds the same way (the corpus claim that the .yz2 segment is bookkeeping) | ✅ pass | live | `drive_pack.py yz2 a shipped .pack.lfs file 3 8192` — 34 textures remount, one replaced, others intact |
| A shipped DDS swapped into another slot decodes to the new image when read back out of the rebuilt archive | ✅ pass | live | 1-shipped-texture-before.png vs 3-same-slot-read-back-from-rebuilt-pack.png, produced by drive_visual.py through Blender&#39;s DDS decode |
| An .lfs named .pack that does not hold a pack is refused rather than producing a corrupt archive | ✅ pass | live | pack-writer-adversarial.log — ValueError naming the offset inside the offset table, no archive emitted |
| A replacement whose name matches no entry (wrong index, or right index under the other extension) is refused | ✅ pass | live | pack-writer-adversarial.log — both cases raise &#34;none of [...] matched an entry in this pack&#34; |
| The entry&#39;s DDS flag is carried through unchanged, so non-DDS bytes do not rename the entry and the same export re-runs against the rebuilt pack | ✅ pass | live | pack-writer-adversarial.log — names unchanged after a non-DDS replacement; second rebuild against the modded archive succeeds; an unflagged entry given a DDS keeps its .tga name |
| The .udas and unsupported-extension dispatch this change edited still behaves | ✅ pass | live | lfs-writer-regression.log — a shipped .udas.lfs file remounts identical; a .dat.lfs is still refused with the updated message |
| A pack rebuilt by albam loads correctly in the running Resident Evil 4 UHD game | ⏸️ untested | no | Requires launching the Windows RE4 UHD executable under Proton with a display and installing the modded archive into the game folder; this environment has no GUI session, no authority to modify the ga… |

- <code>`python drive_pack.py … unchanged-multi &#34;a shipped .pack.lfs file&#34; 5` — writer via the Pack operator&#39;s registry lookup, payload compared byte for byte with the shipped one</code>
- <code>`python drive_pack.py … replace &#34;a shipped .pack.lfs file&#34; 5 40960` — a 41600-byte supplied DDS into a 640-byte slot, remounted with LfsFS</code>
- <code>`python drive_pack.py … yz2 &#34;a shipped .pack.lfs file&#34; 3 8192` — same against a *.pack.yz2.lfs archive</code>
- <code>`python drive_visual.py` — a shipped 512x512 DXT1 DDS swapped into slot 000 of a shipped .pack file.yz2.lfs, both slots decoded to PNG through Blender</code>
- <code>`python drive_adversarial.py` — non-pack payload in a *.pack.lfs, unmatched replacement names, and the DDS-flag carry-through (incl. re-running the same export against the rebuilt pack)</code>
- <code>`python drive_regression.py` — a real little-endian .udas.lfs repacked and remounted identical; a .dat.lfs still refused by update_lfs</code>
- <code>`pytest tests/cie/test_pack_writer.py --game-dir=re4uhd::&#34;~/Games/Resident Evil 4&#34;` — 19 passed, including the shipped-pack parametrized cases</code>
</details>

<details>
<summary>⚠️ **Document** - 2 infos</summary>

- ℹ️ `albam/engines/cie/structs/pack.ksy:24` - The change measured new format facts about the pack entry header (unk_00 is 0xFFFFFFFF in all 12416 entries of an install, unk_01/unk_02 are the pack id split over two u2 fields, is_dds is clear over DDS bytes in 6650 of 9882 entries) and recorded them in the _build_pack_entry docstring in archive.py and in fs.pack_entry_extension. docs/README.md names the .ksy files as where a format&#39;s own fields are documented, and lfs.ksy/udas.ksy carry exactly that kind of doc block, so pack.ksy is the owner for these facts and currently says nothing. I did not add the doc block because pack.py is generated from the .ksy and mirrors its doc into the class docstring, and no kaitai-struct-compiler is available in this environment to regenerate it - hand-writing the generated docstring would risk drift. Follow-up: add a doc block to pack.ksy naming these fields and regenerate pack.py, then reduce the archive.py docstring paragraph to a pointer.
- ℹ️ `albam/engines/cie/textures.py:239` - The change made fs.pack_entry_extension the owner of the name a pack entry is exposed under, and its docstring states that reader and writer agree &#39;by both asking here&#39;. albam/engines/cie/textures.py:239 still carries the inlined copy (extension = &#34;dds&#34; if entry.data.is_dds else &#34;tga&#34;) for uncompressed packs, so a third caller does not ask. Resolving it means editing code rather than documentation, which is out of scope for this pass; proposing it as a one-line follow-up (call pack_entry_extension there) so the docstring&#39;s claim holds.
</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `pyproject.toml:70` - The repository&#39;s configured linters (flake8 with flake8-pyproject, max-line-length 110, and black at line-length 110) are not installed in this environment and there is no pip, uv, or virtualenv available to install them, so the configured checks could not be executed. Manual substitutes on the changed files (albam/engines/cie/archive.py, albam/engines/cie/fs.py, tests/cie/test_pack_writer.py, tests/cie/test_lfs_fs.py) found no line over 110 characters, no trailing whitespace, no unused imports, and all files byte-compile - but black formatting and the full flake8 rule set remain unverified.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

