### PR TITLE
fix(cie): read short .bin headers, keep bone ids unique and bake meshes armature-relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ one command rather than a per-file split that nothing in a `.ksy` records. It im
 `from_bytes()`) no longer parses anything on its own, so every call site follows it with an
 explicit `_read()`.
 
+One generated parser is not purely generated: `albam/engines/cie/structs/re4_uhd_bin.py`
+carries a hand-written short-header branch the compiler does not produce, because a `.ksy`
+cannot say "this field reads as 0 when it is absent". Regenerating that file drops the branch;
+the comment at the edit itself says what to reapply and why.
+
 A `.ksy` that declares `params:` can't use `from_bytes()` at all - Kaitai's own runtime hardcodes
 a parameterless constructor there. `albam.lib.kaitai_utils.parse(cls, data, *params)` covers both
 cases and does the `_read()` for you. Every MT Framework model and texture struct takes an

--- a/albam/blender_ui/export_panel.py
+++ b/albam/blender_ui/export_panel.py
@@ -366,7 +366,7 @@ class ALBAM_OT_Pack(bpy.types.Operator):
             return {"CANCELLED"}
         return {"FINISHED"}
 
-    def _execute(self, context):  # pragma: no cover
+    def _execute(self, context):
         # FIXME don't import function here, use method in archive type
         # necessary for kaitaistruct unavailable when registering
         # blender types

--- a/albam/engines/cie/mesh.py
+++ b/albam/engines/cie/mesh.py
@@ -721,8 +721,10 @@ def _bone_ids_by_name(all_bones):
     stays inside the u1 the format allows. That position can be the very
     number an id-named bone elsewhere claims - a hand-added bone at index 5
     collides with one named "5" wherever it sits. Claimed ids are therefore
-    reserved up front, and anything colliding with one is nudged to the next
-    free id instead of silently doubling up.
+    reserved up front, and anything colliding with one takes the nearest free
+    id the format allows instead of silently doubling up - a model bound to
+    the upper half of a shared rig leaves the ids below it free, so the
+    search wraps rather than stopping at 254.
     """
     used = {claimed for claimed in (_claimed_id(bone.name) for bone in all_bones)
             if claimed is not None}
@@ -731,14 +733,14 @@ def _bone_ids_by_name(all_bones):
     for i, bone in enumerate(all_bones):
         bone_id = _claimed_id(bone.name)
         if bone_id is None or bone_id in taken:
-            bone_id = min(i, 254)
-            while bone_id in used or bone_id in taken:
-                if bone_id == 254:
-                    raise AlbamCheckFailure(
-                        f"Bone {bone.name!r} has no free bone id left: the format "
-                        "can only name 255 bones and this armature needs more"
-                    )
-                bone_id += 1
+            preferred = min(i, 254)
+            search = list(range(preferred, 255)) + list(range(preferred))
+            bone_id = next((c for c in search if c not in used and c not in taken), None)
+            if bone_id is None:
+                raise AlbamCheckFailure(
+                    f"Bone {bone.name!r} has no free bone id left: the format "
+                    "can only name 255 bones and this armature needs more"
+                )
         taken.add(bone_id)
         ids[bone.name] = bone_id
     return ids

--- a/albam/engines/cie/mesh.py
+++ b/albam/engines/cie/mesh.py
@@ -899,8 +899,13 @@ def _weight_key(bl_mesh_ob, vertex, group_ids):
     return tuple(bone_ids), tuple(percents), len(influences)
 
 
-def _collect_geometry(bl_mesh_objs):
+def _collect_geometry(bl_mesh_objs, armature):
     """Everything per-corner the format needs, in the order it stores it.
+
+    `armature` is the one the bone table is written from (see export_bin),
+    which is what every mesh is baked relative to and what names its vertex
+    groups' bones - a mesh parented under it without an Armature modifier of
+    its own is part of the same model and has to land in the same space.
 
     The format is non-indexed: positions, normals, UVs and weight indices are
     all one entry per face corner, consumed sequentially by each material's
@@ -920,13 +925,12 @@ def _collect_geometry(bl_mesh_objs):
     weight_table = []
     weight_lookup = {}
 
+    bone_ids = _bone_ids_by_name(list(armature.data.bones)) if armature else {}
+
     for bl_mesh_ob in bl_mesh_objs:
         bl_mesh = bl_mesh_ob.data
-        armature_modifier = bl_mesh_ob.modifiers.get("Armature")
-        armature = armature_modifier.object if armature_modifier else None
         group_ids = {}
         if armature:
-            bone_ids = _bone_ids_by_name(list(armature.data.bones))
             for group in bl_mesh_ob.vertex_groups:
                 if group.name in bone_ids:
                     group_ids[group.index] = bone_ids[group.name]
@@ -1255,7 +1259,7 @@ def export_bin(bl_obj):
         armature = bl_obj
 
     (groups, positions, normals, uvs,
-     weight_indices, weight_table) = _collect_geometry(bl_mesh_objs)
+     weight_indices, weight_table) = _collect_geometry(bl_mesh_objs, armature)
 
     num_vertices = len(positions)
     if num_vertices > MAX_VERTICES:

--- a/albam/engines/cie/mesh.py
+++ b/albam/engines/cie/mesh.py
@@ -700,45 +700,47 @@ def _classify_mesh_ob(bl_mesh_ob):
         return bin_type, armature
 
 
-def _bone_id(bl_bone, fallback):
-    """The .bin bone id a Blender bone stands for.
+def _claimed_id(bone_name):
+    """The .bin bone id a Blender bone name claims outright, or None.
 
     Import names each bone after its id (see _build_armature), so the name is
-    the id coming back. A bone the user added by hand won't be named that way;
-    it gets its position in the armature instead, which at least stays inside
-    the u1 the format allows.
+    the id coming back. A zero-padded spelling names the same id its
+    canonical form does, so "05" and "5" claim one id between them rather
+    than one each.
     """
-    name = bl_bone.name
-    if name.isdigit() and int(name) < 255:
-        return int(name)
-    return min(fallback, 254)
+    if bone_name.isdigit() and int(bone_name) < 255:
+        return int(bone_name)
+    return None
 
 
 def _bone_ids_by_name(all_bones):
-    """{bone name: id}, resolving every bone through _bone_id without two of
-    them landing on the same id.
+    """{bone name: id}, with no two bones landing on the same id.
 
-    A bone literally named after an id (say "5") claims it outright; a
-    hand-added bone falls back to its position in the armature, and that
-    position can be the very number an id-named bone elsewhere claims - a
-    hand-added bone at index 5 collides with one named "5" wherever it sits.
-    Digit names are therefore resolved first, reserving their ids, and a
-    colliding fallback is nudged to the next free one instead of silently
-    doubling up.
+    A bone named after an id claims it (see _claimed_id); a bone the user
+    added by hand falls back to its position in the armature, which at least
+    stays inside the u1 the format allows. That position can be the very
+    number an id-named bone elsewhere claims - a hand-added bone at index 5
+    collides with one named "5" wherever it sits. Claimed ids are therefore
+    reserved up front, and anything colliding with one is nudged to the next
+    free id instead of silently doubling up.
     """
-    reserved = {int(bone.name) for bone in all_bones
-                if bone.name.isdigit() and int(bone.name) < 255}
-    used = set(reserved)
+    used = {claimed for claimed in (_claimed_id(bone.name) for bone in all_bones)
+            if claimed is not None}
+    taken = set()
     ids = {}
     for i, bone in enumerate(all_bones):
-        if bone.name.isdigit() and int(bone.name) < 255:
-            ids[bone.name] = int(bone.name)
-            continue
-        candidate = min(i, 254)
-        while candidate in used and candidate < 254:
-            candidate += 1
-        used.add(candidate)
-        ids[bone.name] = candidate
+        bone_id = _claimed_id(bone.name)
+        if bone_id is None or bone_id in taken:
+            bone_id = min(i, 254)
+            while bone_id in used or bone_id in taken:
+                if bone_id == 254:
+                    raise AlbamCheckFailure(
+                        f"Bone {bone.name!r} has no free bone id left: the format "
+                        "can only name 255 bones and this armature needs more"
+                    )
+                bone_id += 1
+        taken.add(bone_id)
+        ids[bone.name] = bone_id
     return ids
 
 

--- a/albam/engines/cie/mesh.py
+++ b/albam/engines/cie/mesh.py
@@ -940,7 +940,9 @@ def _collect_geometry(bl_mesh_objs, armature):
     weight_table = []
     weight_lookup = {}
 
-    bone_ids = _bone_ids_by_name(list(armature.data.bones)) if armature else {}
+    all_bones = list(armature.data.bones) if armature else []
+    bone_ids = _bone_ids_by_name(all_bones)
+    bone_names = {bone.name for bone in all_bones}
 
     for bl_mesh_ob in bl_mesh_objs:
         bl_mesh = bl_mesh_ob.data
@@ -949,6 +951,17 @@ def _collect_geometry(bl_mesh_objs, armature):
             for group in bl_mesh_ob.vertex_groups:
                 if group.name in bone_ids:
                     group_ids[group.index] = bone_ids[group.name]
+                elif group.name in bone_names:
+                    raise AlbamCheckFailure(
+                        f"{bl_mesh_ob.name} is weighted to {group.name!r}, a bone the "
+                        f"format cannot name",
+                        details="A bone is named by a single byte, so an armature can "
+                                "only hand out 255 ids, and this one has more bones "
+                                "than that. Weights on a bone left without an id would "
+                                "otherwise fall onto the first bone instead.",
+                        solution="Remove bones the model does not need, so every bone "
+                                 "it is weighted to can be named",
+                    )
                 elif group.name.isdigit():
                     group_ids[group.index] = int(group.name)
 

--- a/albam/engines/cie/mesh.py
+++ b/albam/engines/cie/mesh.py
@@ -18,9 +18,10 @@ GLOBAL_SCALE = 0.001  # same raw unit as vertex positions
 GLOBAL_NORMAL_FIX_EXTENDED = 545460800000
 GLOBAL_NORMAL_FIX_REDUCED = 16384
 
-# Header layout. The format allows 0x40, 0x50 and 0x60 headers - the shorter
-# ones simply stop before the trailing offsets - and offset_bones doubles as
-# the header's own size.
+# Header layout. The format allows 0x40, 0x50 and 0x60 headers - a 0x40 one
+# stops before the four trailing offsets, a 0x50 one is exactly those four
+# present and a 0x60 one adds 16 bytes of padding nothing reads - and
+# offset_bones doubles as the header's own size.
 HEADER_SIZE = 0x60
 BONE_SIZE = 16
 WEIGHT_SIZE = 8
@@ -1432,8 +1433,9 @@ def _layout_and_write(dst_bin, num_vertices):
     Offsets are all explicit in the header, so the file's layout is ours to
     choose rather than something to reproduce; blocks go in the order shipped
     files use them, each aligned to 16. The header is a fixed 0x60 here - the
-    format allows 0x40 and 0x50 too, which simply stop before the four
-    trailing offsets, and writing the largest means never having to decide.
+    format allows 0x40, which stops before the four trailing offsets, and
+    0x50, which is exactly those four present - and writing the largest means
+    never having to decide.
     """
     header = dst_bin.header
     header.num_bones = len(dst_bin.bones)

--- a/albam/engines/cie/mesh.py
+++ b/albam/engines/cie/mesh.py
@@ -726,6 +726,12 @@ def _bone_ids_by_name(all_bones):
     id the format allows instead of silently doubling up - a model bound to
     the upper half of a shared rig leaves the ids below it free, so the
     search wraps rather than stopping at 254.
+
+    An armature can hold more bones than the format can name, since only some
+    of them are ever written (see _bones_to_write) - a rig carrying control
+    and IK bones nothing is weighted to, say. A bone left with no free id is
+    simply absent from the mapping; whether that matters is decided where the
+    table is written, not here.
     """
     used = {claimed for claimed in (_claimed_id(bone.name) for bone in all_bones)
             if claimed is not None}
@@ -738,10 +744,7 @@ def _bone_ids_by_name(all_bones):
             search = list(range(preferred, 255)) + list(range(preferred))
             bone_id = next((c for c in search if c not in used and c not in taken), None)
             if bone_id is None:
-                raise AlbamCheckFailure(
-                    f"Bone {bone.name!r} has no free bone id left: the format "
-                    "can only name 255 bones and this armature needs more"
-                )
+                continue
         taken.add(bone_id)
         ids[bone.name] = bone_id
     return ids
@@ -776,7 +779,8 @@ def _bones_to_write(bl_armature, ids, used_ids, own_ids=()):
     all_bones = list(bl_armature.data.bones)
     by_id = {}
     for bone in all_bones:
-        by_id.setdefault(ids[bone.name], bone)
+        if bone.name in ids:
+            by_id.setdefault(ids[bone.name], bone)
 
     kept = set()
     for bone_id in own_ids:
@@ -831,10 +835,20 @@ def _serialize_bones(dst_bin, bl_armature, used_ids=(), own_ids=(), own_parents=
     if not bones:
         # Nothing said which bones are used - a model with no weights at all.
         bones = all_bones
+    unnamed = [bone.name for bone in bones if bone.name not in ids]
+    if unnamed:
+        raise AlbamCheckFailure(
+            f"{bl_armature.name} needs to write more bones than the format can name",
+            details=f"A bone is named by a single byte, so an exported table holds at "
+                    f"most 255 of them, and {len(unnamed)} of the bones this model "
+                    f"writes have no id left: {', '.join(unnamed[:5])}",
+            solution="Remove bones the model does not need, or unweight the ones it "
+                     "does not use",
+        )
     kept = {bone.name for bone in bones}
 
     own_parents = own_parents or {}
-    by_id = {ids[bone.name]: bone for bone in all_bones}
+    by_id = {ids[bone.name]: bone for bone in all_bones if bone.name in ids}
 
     dst_bones = []
     for bone in sorted(bones, key=lambda b: ids[b.name]):

--- a/albam/engines/cie/mesh.py
+++ b/albam/engines/cie/mesh.py
@@ -714,6 +714,34 @@ def _bone_id(bl_bone, fallback):
     return min(fallback, 254)
 
 
+def _bone_ids_by_name(all_bones):
+    """{bone name: id}, resolving every bone through _bone_id without two of
+    them landing on the same id.
+
+    A bone literally named after an id (say "5") claims it outright; a
+    hand-added bone falls back to its position in the armature, and that
+    position can be the very number an id-named bone elsewhere claims - a
+    hand-added bone at index 5 collides with one named "5" wherever it sits.
+    Digit names are therefore resolved first, reserving their ids, and a
+    colliding fallback is nudged to the next free one instead of silently
+    doubling up.
+    """
+    reserved = {int(bone.name) for bone in all_bones
+                if bone.name.isdigit() and int(bone.name) < 255}
+    used = set(reserved)
+    ids = {}
+    for i, bone in enumerate(all_bones):
+        if bone.name.isdigit() and int(bone.name) < 255:
+            ids[bone.name] = int(bone.name)
+            continue
+        candidate = min(i, 254)
+        while candidate in used and candidate < 254:
+            candidate += 1
+        used.add(candidate)
+        ids[bone.name] = candidate
+    return ids
+
+
 def _bones_to_write(bl_armature, ids, used_ids, own_ids=()):
     """The armature's bones this model needs: the ones it was imported with,
     the ones its weights name, and the ones between those.
@@ -793,7 +821,7 @@ def _serialize_bones(dst_bin, bl_armature, used_ids=(), own_ids=(), own_parents=
     model hangs off part of a larger skeleton.
     """
     all_bones = list(bl_armature.data.bones)
-    ids = {bone.name: _bone_id(bone, i) for i, bone in enumerate(all_bones)}
+    ids = _bone_ids_by_name(all_bones)
     bones = _bones_to_write(bl_armature, ids, used_ids, own_ids)
     if not bones:
         # Nothing said which bones are used - a model with no weights at all.
@@ -894,8 +922,7 @@ def _collect_geometry(bl_mesh_objs):
         armature = armature_modifier.object if armature_modifier else None
         group_ids = {}
         if armature:
-            bone_ids = {bone.name: _bone_id(bone, i)
-                        for i, bone in enumerate(armature.data.bones)}
+            bone_ids = _bone_ids_by_name(list(armature.data.bones))
             for group in bl_mesh_ob.vertex_groups:
                 if group.name in bone_ids:
                     group_ids[group.index] = bone_ids[group.name]
@@ -906,11 +933,25 @@ def _collect_geometry(bl_mesh_objs):
         slots = bl_mesh_ob.material_slots
 
         # Object-level transforms are baked in: moving, rotating or scaling
-        # the object itself is an edit like any other, and import leaves
+        # the mesh itself is an edit like any other, and import leaves
         # everything at the origin so this is the identity for an unmodified
         # model. Normals go through the inverse transpose, which is what
         # keeps them perpendicular under a non-uniform scale.
+        #
+        # Relative to the armature, not the mesh's own matrix_world outright:
+        # the file has no field for where the armature sits in the scene -
+        # that is scenario placement, a separate concern from the model
+        # itself (see scenario._place) - so bones are already written in the
+        # armature's own local rest space, unaffected by it. A mesh normally
+        # parented to its armature with an identity local transform inherits
+        # the armature's matrix_world, so baking that in outright moved,
+        # rotated or scaled the exported vertices by whatever the armature
+        # object's own placement in the scene happened to be, while the bones
+        # they are meant to bind to stayed exactly where they started -
+        # skinning a moved mesh to an unmoved skeleton.
         matrix = bl_mesh_ob.matrix_world
+        if armature:
+            matrix = armature.matrix_world.inverted_safe() @ matrix
         normal_matrix = matrix.to_3x3().inverted_safe().transposed()
 
         # Weights depend only on the vertex, while corners are visited once

--- a/albam/engines/cie/scenario.py
+++ b/albam/engines/cie/scenario.py
@@ -201,6 +201,12 @@ def _entry_matrices(entry):
     scale and cannot be folded in, and as None when the whole placement is
     one object transform.
     """
+    # The rotation-vs-identity comparison below is exact rather than
+    # tolerant, which issue #271 lists as a latent defect worth checking.
+    # Tried and not reproduced: zero angles, angles that are whole multiples
+    # of 2*pi and very small angles all classify correctly through the change
+    # of basis. Getting it wrong would only ever cost an extra placement
+    # Empty, never wrong geometry, so the comparison is left as it is.
     to_blender = Matrix.Rotation(math.radians(90), 4, "X")
     rotation = Euler((entry.angles.x, entry.angles.y, entry.angles.z), "XYZ").to_matrix().to_4x4()
     scale = Matrix.Diagonal(Vector((entry.scale.x, entry.scale.y, entry.scale.z, 1.0)))

--- a/albam/engines/cie/structs/re4-uhd-bin.ksy
+++ b/albam/engines/cie/structs/re4-uhd-bin.ksy
@@ -94,10 +94,16 @@ types:
       # 0x20030818 where the adjacency and bone-pair blocks are present,
       # 0x20010801 where they are not, always in step with unk_01.
       - {id: version_flags, type: u4}
-      - {id: offset_bonepairs, type: u4} # bonepair_offset
-      - {id: offset_adjacents, type: u4} # adjacent_offset
-      - {id: offset_index_buffer, type: u4} # vertex_weight_index_offset
-      - {id: offset_index_buffer2, type: u4} # vertex_weight2_index_offset
+      # These four do not exist in a 0x40 header at all - offset_bones (see
+      # above) is what says so. The hand-maintained reader in
+      # re4_uhd_bin.py defaults each to 0 ("not present") on that branch,
+      # since every reader downstream of this struct - here and in fs.py -
+      # expects the field to exist and reads a nonzero value as "this
+      # optional block is present".
+      - {id: offset_bonepairs, type: u4, if: offset_bones > 0x40} # bonepair_offset
+      - {id: offset_adjacents, type: u4, if: offset_bones > 0x40} # adjacent_offset
+      - {id: offset_index_buffer, type: u4, if: offset_bones > 0x40} # vertex_weight_index_offset
+      - {id: offset_index_buffer2, type: u4, if: offset_bones > 0x40} # vertex_weight2_index_offset
     instances:
       size_:
         value: 96

--- a/albam/engines/cie/structs/re4-uhd-bin.ksy
+++ b/albam/engines/cie/structs/re4-uhd-bin.ksy
@@ -95,15 +95,18 @@ types:
       # 0x20010801 where they are not, always in step with unk_01.
       - {id: version_flags, type: u4}
       # These four do not exist in a 0x40 header at all - offset_bones (see
-      # above) is what says so. The hand-maintained reader in
-      # re4_uhd_bin.py defaults each to 0 ("not present") on that branch,
-      # since every reader downstream of this struct - here and in fs.py -
-      # expects the field to exist and reads a nonzero value as "this
-      # optional block is present".
-      - {id: offset_bonepairs, type: u4, if: offset_bones > 0x40} # bonepair_offset
-      - {id: offset_adjacents, type: u4, if: offset_bones > 0x40} # adjacent_offset
-      - {id: offset_index_buffer, type: u4, if: offset_bones > 0x40} # vertex_weight_index_offset
-      - {id: offset_index_buffer2, type: u4, if: offset_bones > 0x40} # vertex_weight2_index_offset
+      # above) is what says so - and every reader downstream of this struct,
+      # here and in fs.py, expects the field to exist and reads a nonzero
+      # value as "this optional block is present". An `if:` here would make
+      # the field absent rather than 0, so those readers would raise instead
+      # of skipping the block; ksy has no way to say "defaults to 0 when
+      # absent". They are therefore declared as the plain unconditional
+      # reads they are, and re4_uhd_bin.py's _read carries the short-header
+      # branch by hand - see the comment there before regenerating.
+      - {id: offset_bonepairs, type: u4} # bonepair_offset
+      - {id: offset_adjacents, type: u4} # adjacent_offset
+      - {id: offset_index_buffer, type: u4} # vertex_weight_index_offset
+      - {id: offset_index_buffer2, type: u4} # vertex_weight2_index_offset
     instances:
       size_:
         value: 96

--- a/albam/engines/cie/structs/re4-uhd-bin.ksy
+++ b/albam/engines/cie/structs/re4-uhd-bin.ksy
@@ -49,8 +49,11 @@ instances:
 types:
   uhd_bin_header:
     seq:
-      # Doubles as the header's own size: 0x40, 0x50 or 0x60. The shorter
-      # ones stop before the four trailing offsets. albam writes 0x60.
+      # Doubles as the header's own size: 0x40, 0x50 or 0x60. The fields
+      # down to version_flags are exactly 0x40 bytes and the four trailing
+      # offsets bring the header to exactly 0x50, so only a 0x40 header stops
+      # before those four; 0x60 is 0x50 plus 16 bytes of padding nothing
+      # reads, which is why size_ below is 96. albam writes 0x60.
       - {id: offset_bones, type: u4} # bone_offset
       - {id: unk_00, type: u4} # unknown_x04 //--zeros
       - {id: unk_01, type: u4} #unknown_x08 adress to blank area
@@ -95,7 +98,8 @@ types:
       # 0x20010801 where they are not, always in step with unk_01.
       - {id: version_flags, type: u4}
       # These four do not exist in a 0x40 header at all - offset_bones (see
-      # above) is what says so - and every reader downstream of this struct,
+      # above) is what says so, and a 0x50 header is exactly these four
+      # present - and every reader downstream of this struct,
       # here and in fs.py, expects the field to exist and reads a nonzero
       # value as "this optional block is present". An `if:` here would make
       # the field absent rather than 0, so those readers would raise instead

--- a/albam/engines/cie/structs/re4_uhd_bin.py
+++ b/albam/engines/cie/structs/re4_uhd_bin.py
@@ -1029,6 +1029,14 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
             # from a bogus absolute offset. None of a several-hundred-file
             # sample of the shipped game uses a header this short, but a
             # reader has no business assuming that always holds.
+            #
+            # This branch is a deliberate hand edit that a straight
+            # regeneration from re4-uhd-bin.ksy does not produce: ksy's `if:`
+            # makes an absent field raise on access rather than read as 0,
+            # which is what every guard downstream (bone_pairs, adjacent,
+            # indexes, indexes2, and fs.py) needs, so the .ksy declares these
+            # four unconditionally and this reader carries the defaulting.
+            # Reapply it if this file is ever regenerated (see issue #271).
             if self.offset_bones > 0x40:
                 self.offset_bonepairs = self._io.read_u4le()
                 self.offset_adjacents = self._io.read_u4le()

--- a/albam/engines/cie/structs/re4_uhd_bin.py
+++ b/albam/engines/cie/structs/re4_uhd_bin.py
@@ -1019,8 +1019,13 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
             self.num_vertex_normals = self._io.read_u2le()
             self.version_flags = self._io.read_u4le()
             # offset_bones doubles as the header's own size (0x40, 0x50 or
-            # 0x60 - see re4-uhd-bin.ksy): a 0x40 header stops right here,
-            # before these four trailing offsets exist in the file at all.
+            # 0x60 - see re4-uhd-bin.ksy). Everything above is exactly 0x40
+            # bytes, and these four trailing u4s bring it to exactly 0x50, so
+            # a 0x50 header does state all four and is read like a 0x60 one
+            # (0x60 is those same 0x50 bytes plus 16 of padding nothing
+            # reads, which is why size_ is 96 while _write__seq emits 80).
+            # Only a 0x40 header stops right here, before these four exist in
+            # the file at all.
             # Reading them unconditionally, as this generated file used to,
             # would consume the next 16 bytes of whatever actually follows
             # the header - bone data, for such a file - as if they were these

--- a/albam/engines/cie/structs/re4_uhd_bin.py
+++ b/albam/engines/cie/structs/re4_uhd_bin.py
@@ -1018,10 +1018,27 @@ class Re4UhdBin(ReadWriteKaitaiStruct):
             self.num_vertices = self._io.read_u2le()
             self.num_vertex_normals = self._io.read_u2le()
             self.version_flags = self._io.read_u4le()
-            self.offset_bonepairs = self._io.read_u4le()
-            self.offset_adjacents = self._io.read_u4le()
-            self.offset_index_buffer = self._io.read_u4le()
-            self.offset_index_buffer2 = self._io.read_u4le()
+            # offset_bones doubles as the header's own size (0x40, 0x50 or
+            # 0x60 - see re4-uhd-bin.ksy): a 0x40 header stops right here,
+            # before these four trailing offsets exist in the file at all.
+            # Reading them unconditionally, as this generated file used to,
+            # would consume the next 16 bytes of whatever actually follows
+            # the header - bone data, for such a file - as if they were these
+            # fields, and a nonzero misread offset_bonepairs/offset_adjacents
+            # would then send albam.bone_pairs/.adjacent off to parse garbage
+            # from a bogus absolute offset. None of a several-hundred-file
+            # sample of the shipped game uses a header this short, but a
+            # reader has no business assuming that always holds.
+            if self.offset_bones > 0x40:
+                self.offset_bonepairs = self._io.read_u4le()
+                self.offset_adjacents = self._io.read_u4le()
+                self.offset_index_buffer = self._io.read_u4le()
+                self.offset_index_buffer2 = self._io.read_u4le()
+            else:
+                self.offset_bonepairs = 0
+                self.offset_adjacents = 0
+                self.offset_index_buffer = 0
+                self.offset_index_buffer2 = 0
             self._dirty = False
 
 

--- a/docs/modding-a-character.md
+++ b/docs/modding-a-character.md
@@ -126,15 +126,19 @@ override for when you want a specific one.
 Anything you do to the mesh is what gets written:
 
 - **Vertex edits** - move, scale, sculpt, add or remove geometry.
-- **Object transforms** - moving, rotating or scaling the object itself is baked
-  in on export, so you do not need to apply transforms first.
+- **Object transforms** - moving, rotating or scaling the mesh itself is baked
+  in on export, so you do not need to apply transforms first. What is baked is
+  the mesh's placement *relative to its armature*, so moving the armature
+  object carries the whole model with it in Blender and changes nothing in the
+  exported file - where a model sits in the world is the room's data, not the
+  model's.
 - **Materials** - swapping the image in a texture node changes which texture the
   model uses, because the exporter reads the binding back rather than a stored
   value. Note what this is and is not: it re-points the material at a texture
   **already in the archive's texture pack**. Bringing a new image into the game
   is not supported - see below.
 
-Two things to keep in mind:
+Three things to keep in mind:
 
 - **Keep the vertex groups.** They are the skinning, named after bone ids. A
   vertex in no group gets pinned to the first bone.
@@ -143,6 +147,12 @@ Two things to keep in mind:
   strip but never across a UV seam or a shading split, so a mesh needs somewhere
   between one and three per triangle. Exceeding it is reported, not silently
   truncated. Only one model in the whole game is near it.
+- **There is a bone limit as well.** A bone is named by a single byte, so a
+  model can write at most 255 of them. Only the bones the model actually needs
+  count - the ones it was imported with, plus the ones its weights name - so
+  control and IK bones nothing is weighted to are free, however many of them a
+  rig carries. Going past the limit is reported too, rather than exported with
+  bones silently sharing an id.
 
 ## 5. Export the model
 

--- a/tests/cie/datasets/archive_update_hashes.json
+++ b/tests/cie/datasets/archive_update_hashes.json
@@ -1,0 +1,17 @@
+[
+  {
+    "app_id": "re4uhd",
+    "archive_path_hash": "6e6baa5d3a23db73",
+    "payload_extension": ".udas"
+  },
+  {
+    "app_id": "re4uhd",
+    "archive_path_hash": "ec06d9e1d6db3fa6",
+    "payload_extension": ".tpl"
+  },
+  {
+    "app_id": "re4uhd",
+    "archive_path_hash": "6365b5b2145d343c",
+    "payload_extension": ".dat"
+  }
+]

--- a/tests/cie/test_archive_update.py
+++ b/tests/cie/test_archive_update.py
@@ -1,0 +1,244 @@
+"""update_lfs and _rebuild_udas: the archive writer's own coverage gaps.
+
+_rebuild_udas was previously only ever exercised by substituting an entry for
+itself (test_lfs_fs.test_repacking_an_archive_unchanged_preserves_every_entry),
+which never resizes the DAT block and so never took the descriptor-shifting
+path - the whole reason a rebuild has to touch the block table at all - nor
+exercised update_lfs itself: neither its extension dispatch (.udas rebuild vs.
+single-file-archive replacement vs. "not supported") nor archive_writer_registry
+calling it, which is what bpy.ops.albam.pack actually drives.
+"""
+import json
+import os
+
+import pytest
+
+from tests.cie.lfs_paths import resolve_archive_hashes
+
+DATASETS_DIR = os.path.join(os.path.dirname(__file__), "datasets")
+DATASET_PATH = os.path.join(DATASETS_DIR, "archive_update_hashes.json")
+with open(DATASET_PATH) as f:
+    ARCHIVE_UPDATE_DATASET = json.load(f)
+
+BLOCK_TYPE_DAT = 0
+
+
+class _FakeExportedFile:
+    """A stand-in for the VirtualFile update_lfs actually receives.
+
+    update_lfs only ever reads `display_name` and calls `get_bytes()` on what
+    it is handed, so a plain object serves - a real VirtualFile is a bpy
+    PropertyGroup, meant to live as an item of a registered VFS collection,
+    not to be built standalone for a unit test.
+    """
+
+    def __init__(self, display_name, data):
+        self.display_name = display_name
+        self._data = data
+
+    def get_bytes(self):
+        return self._data
+
+
+def pytest_generate_tests(metafunc):
+    if ("local_app_id" in metafunc.fixturenames and
+            "local_archive_path_hash" in metafunc.fixturenames):
+        argnames = ("local_app_id", "local_archive_path_hash")
+        argvalues = [(d["app_id"], d["archive_path_hash"]) for d in ARCHIVE_UPDATE_DATASET]
+        ids = [f"{d['app_id']}-{d['payload_extension'].lstrip('.')}-{d['archive_path_hash']}"
+               for d in ARCHIVE_UPDATE_DATASET]
+        metafunc.parametrize(argnames, argvalues, ids=ids, scope="session")
+
+
+def test_dataset_hashes_are_in_catalog():
+    """No plaintext game asset path is ever committed - see
+    tests/cie/test_lfs_fs.py, same check. CI-safe."""
+    for entry in ARCHIVE_UPDATE_DATASET:
+        catalog_path = os.path.join(DATASETS_DIR, f"{entry['app_id']}_catalog.json")
+        with open(catalog_path) as f:
+            catalog = {e["path_hash"]: e for e in json.load(f)}
+        assert entry["archive_path_hash"] in catalog, (
+            f"{entry['archive_path_hash']!r} is not in {catalog_path!r}"
+        )
+
+
+@pytest.fixture(scope="session")
+def local_payload_extension(local_archive_path_hash):
+    return next(d["payload_extension"] for d in ARCHIVE_UPDATE_DATASET
+                if d["archive_path_hash"] == local_archive_path_hash)
+
+
+@pytest.fixture(scope="session")
+def archive_path(game_root, local_archive_path_hash):
+    return resolve_archive_hashes(game_root, {local_archive_path_hash})[local_archive_path_hash]
+
+
+def test_rebuild_udas_shifts_blocks_after_a_resized_entry(
+        archive_path, local_payload_extension, tmp_path):
+    """The path test_repacking_an_archive_unchanged_preserves_every_entry
+    cannot reach: substituting an entry for itself never changes the DAT
+    block's size, so shift is always 0 there and comparing every block
+    descriptor to the original - which that test does - is only a
+    meaningful check in that one case. Resizing an entry here forces shift
+    != 0, so a descriptor after the DAT block actually has to move.
+    """
+    if local_payload_extension != ".udas":
+        pytest.skip("only .udas archives are rebuilt by _rebuild_udas")
+
+    from albam.engines.cie.archive import _read_payload, _rebuild_udas
+    from albam.engines.cie.fs import LfsFS, read_udas_block_table
+
+    fs = LfsFS(archive_path)
+    try:
+        paths = list(fs.walk.files())
+        target = paths[0].lstrip("/")
+        before = {p.lstrip("/"): fs.readbytes(p) for p in paths}
+    finally:
+        fs.close()
+    original_entry_bytes = before[target]
+
+    payload, _extension = _read_payload(archive_path)
+    original_blocks = read_udas_block_table(payload, "<")
+    assert len(original_blocks) > 1, (
+        "this archive should hold a block after the DAT one to exercise the shift"
+    )
+    dat_type, dat_size, data_offset = original_blocks[0]
+    assert dat_type == BLOCK_TYPE_DAT
+
+    # Bigger than the original by enough that it survives 16-byte entry
+    # alignment and still changes the DAT block's overall size.
+    resized_bytes = original_entry_bytes + b"\xAA" * 64
+    rebuilt_payload = _rebuild_udas(payload, {target: resized_bytes})
+
+    rebuilt_blocks = read_udas_block_table(rebuilt_payload, "<")
+    assert len(rebuilt_blocks) == len(original_blocks)
+    new_dat_type, new_dat_size, new_data_offset = rebuilt_blocks[0]
+    assert new_dat_type == BLOCK_TYPE_DAT
+    assert new_data_offset == data_offset, "the DAT block itself does not move"
+    shift = new_dat_size - dat_size
+    assert shift != 0, "the resize should have changed the DAT block's size"
+
+    for (orig_type, _orig_size, orig_offset), (new_type, new_size, new_offset) in zip(
+            original_blocks[1:], rebuilt_blocks[1:]):
+        assert new_type == orig_type
+        assert new_size == _orig_size, "only the DAT block's own size should change"
+        expected_offset = orig_offset + shift if orig_offset > data_offset else orig_offset
+        assert new_offset == expected_offset, (
+            f"block {orig_type:#x} should have moved by {shift}, from {orig_offset} "
+            f"to {expected_offset}, not {new_offset}"
+        )
+
+    # And the rebuilt archive still mounts and reads back correctly: the
+    # resized entry comes back as what it was resized to, everything else
+    # exactly as it shipped.
+    from albam.engines.cie.lfs_decompress import xcompress_compress_re4hd
+
+    archive_bytes = xcompress_compress_re4hd(rebuilt_payload)
+    out_path = tmp_path / os.path.basename(archive_path)
+    out_path.write_bytes(archive_bytes)
+    rebuilt_fs = LfsFS(str(out_path))
+    try:
+        after = {p.lstrip("/"): rebuilt_fs.readbytes(p) for p in rebuilt_fs.walk.files()}
+    finally:
+        rebuilt_fs.close()
+
+    assert after[target] == resized_bytes
+    unchanged = {k: v for k, v in before.items() if k != target}
+    assert {k: after[k] for k in unchanged} == unchanged
+
+
+def test_update_lfs_rebuilds_a_udas_archive(archive_path, local_payload_extension, tmp_path):
+    """update_lfs's own extension dispatch, on the branch that matters most:
+    a .udas archive with one entry replaced comes back as a whole .lfs the
+    game can load, with the replacement in place and everything else intact.
+    """
+    if local_payload_extension != ".udas":
+        pytest.skip("only .udas archives take this branch of update_lfs")
+
+    from albam.engines.cie.archive import update_lfs
+    from albam.engines.cie.fs import LfsFS
+
+    fs = LfsFS(archive_path)
+    try:
+        paths = list(fs.walk.files())
+        target_path = paths[0]
+        before = {p.lstrip("/"): fs.readbytes(p) for p in paths}
+    finally:
+        fs.close()
+
+    replacement = before[target_path.lstrip("/")] + b"\xAA" * 16
+    vfile = _FakeExportedFile(target_path.lstrip("/"), replacement)
+
+    archive_bytes = update_lfs(archive_path, [vfile])
+
+    out_path = tmp_path / os.path.basename(archive_path)
+    out_path.write_bytes(archive_bytes)
+    rebuilt_fs = LfsFS(str(out_path))
+    try:
+        after = {p.lstrip("/"): rebuilt_fs.readbytes(p) for p in rebuilt_fs.walk.files()}
+    finally:
+        rebuilt_fs.close()
+
+    assert after[target_path.lstrip("/")] == replacement
+    unchanged = {k: v for k, v in before.items() if k != target_path.lstrip("/")}
+    assert {k: after[k] for k in unchanged} == unchanged
+
+
+def test_update_lfs_replaces_a_single_file_archive_wholesale(
+        archive_path, local_payload_extension, tmp_path):
+    """A single-file .lfs (no container inside it) is replaced outright: the
+    whole payload becomes the one exported file, not something rebuilt
+    around a file table it never had.
+    """
+    if local_payload_extension in (".udas", ".dat", ".pack", ".evd"):
+        pytest.skip("only a single-file archive takes this branch of update_lfs")
+
+    from albam.engines.cie.archive import update_lfs
+    from albam.engines.cie.fs import LfsFS
+
+    fs = LfsFS(archive_path)
+    try:
+        paths = list(fs.walk.files())
+        assert len(paths) == 1, "this dataset entry should be a single-file archive"
+        display_name = paths[0].lstrip("/")
+    finally:
+        fs.close()
+
+    replacement = b"\xBB" * 128
+    vfile = _FakeExportedFile(display_name, replacement)
+
+    archive_bytes = update_lfs(archive_path, [vfile])
+
+    out_path = tmp_path / os.path.basename(archive_path)
+    out_path.write_bytes(archive_bytes)
+    rebuilt_fs = LfsFS(str(out_path))
+    try:
+        paths = list(rebuilt_fs.walk.files())
+        assert paths == [f"/{display_name}"]
+        assert rebuilt_fs.readbytes(paths[0]) == replacement
+    finally:
+        rebuilt_fs.close()
+
+
+def test_update_lfs_refuses_a_container_it_cannot_rebuild(
+        archive_path, local_payload_extension):
+    """.dat/.pack/.evd containers have no rebuild support (only .udas does),
+    so update_lfs says so plainly rather than silently doing nothing or
+    corrupting the archive.
+    """
+    if local_payload_extension != ".dat":
+        pytest.skip("only the .dat entry in this dataset exercises this branch")
+
+    from albam.engines.cie.archive import update_lfs
+    from albam.engines.cie.fs import LfsFS
+
+    fs = LfsFS(archive_path)
+    try:
+        display_name = next(iter(fs.walk.files())).lstrip("/")
+    finally:
+        fs.close()
+
+    vfile = _FakeExportedFile(display_name, b"\xCC" * 16)
+
+    with pytest.raises(NotImplementedError, match="dat"):
+        update_lfs(archive_path, [vfile])

--- a/tests/cie/test_bin_export_fidelity.py
+++ b/tests/cie/test_bin_export_fidelity.py
@@ -350,3 +350,79 @@ def test_every_model_in_an_archive_keeps_its_texture_slots(
             f"{vfile.display_name} exported different texture slots than it came with")
         checked += 1
     assert checked == len(models)
+
+
+def _positions(bin_bytes):
+    from albam.engines.cie.structs.re4_uhd_bin import Re4UhdBin
+
+    parsed = Re4UhdBin.from_bytes(bin_bytes)
+    parsed._read()
+    return [(v.x, v.y, v.z) for v in parsed.vertex_positions]
+
+
+def test_moving_the_armature_does_not_desync_the_mesh_from_its_bones(
+        game_root, local_app_id, local_archive_path_hash, _clean_scene):
+    """Repositioning the armature object - the thing import actually returns
+    and links into the scene for a skinned model - must not move the
+    exported vertex positions away from the bone table.
+
+    Before this was fixed, export baked the mesh's matrix_world outright: for
+    a mesh parented to its armature with an identity local transform (the
+    ordinary case), that matrix_world is inherited from the armature, so
+    moving, rotating or scaling the armature object moved the exported
+    vertices while the bone table - always written in the armature's own
+    local rest space, never premultiplied by its object transform - stayed
+    exactly where it started. The file still parsed and still imported back
+    looking fine (a second import bakes the same, now-doubled, transform into
+    both), which is exactly why the reimport-based checks in
+    test_bin_serialization.py could not have caught this.
+    """
+    import math
+
+    from mathutils import Euler, Matrix, Vector
+
+    from albam.engines.cie.mesh import AUTO_TPL
+    from albam.registry import blender_registry
+
+    archive_path = resolve_archive_hashes(
+        game_root, {local_archive_path_hash})[local_archive_path_hash]
+
+    vfs = bpy.context.scene.albam.vfs
+    bpy.context.scene.albam.apps.app_selected = local_app_id
+    root = vfs.add_real_file(local_app_id, archive_path)
+    models = _mesh_models(vfs, root)
+    assert models, "this archive should hold a mesh .bin"
+
+    import_function = blender_registry.import_registry[(local_app_id, "bin")]
+    bpy.context.scene.albam.import_options_bin.tpl_file_id = AUTO_TPL
+
+    skinned = None
+    for vfile in models:
+        vfs.file_list_selected_index = vfs.file_list.find(vfile.name)
+        original_bytes = vfile.get_bytes()
+        bl_object = import_function(vfile, bpy.context)
+        if bl_object.type == "ARMATURE":
+            skinned = (vfile, original_bytes, bl_object)
+            break
+    if skinned is None:
+        pytest.skip("no model in this archive imported as an armature")
+
+    vfile, original_bytes, armature_ob = skinned
+    unmoved_bytes = _export(armature_ob, vfile, original_bytes, local_app_id)
+
+    armature_ob.matrix_world = (
+        Matrix.Translation(Vector((1.5, -2.0, 0.75))) @
+        Euler((0.3, 0.1, 0.6), "XYZ").to_matrix().to_4x4()
+    )
+    bpy.context.view_layer.update()
+    moved_bytes = _export(armature_ob, vfile, original_bytes, local_app_id)
+
+    unmoved_positions = _positions(unmoved_bytes)
+    moved_positions = _positions(moved_bytes)
+    assert moved_positions, "this model should have vertex positions to compare"
+    max_delta = max(
+        math.dist(a, b) for a, b in zip(unmoved_positions, moved_positions))
+    assert max_delta < 1.0, (
+        f"moving the armature object should not change the exported model at all "
+        f"(largest vertex delta: {max_delta})"
+    )

--- a/tests/cie/test_bin_export_fidelity.py
+++ b/tests/cie/test_bin_export_fidelity.py
@@ -420,6 +420,10 @@ def test_moving_the_armature_does_not_desync_the_mesh_from_its_bones(
     unmoved_positions = _positions(unmoved_bytes)
     moved_positions = _positions(moved_bytes)
     assert moved_positions, "this model should have vertex positions to compare"
+    assert len(moved_positions) == len(unmoved_positions), (
+        f"moving the armature object changed the exported corner count "
+        f"({len(unmoved_positions)} -> {len(moved_positions)})"
+    )
     max_delta = max(
         math.dist(a, b) for a, b in zip(unmoved_positions, moved_positions))
     assert max_delta < 1.0, (

--- a/tests/cie/test_bin_serialization.py
+++ b/tests/cie/test_bin_serialization.py
@@ -104,9 +104,10 @@ def _decoded_triangles(bin_bytes):
     bytes through the same per-corner arrays and strip-to-triangle logic
     import uses (see albam.engines.cie.mesh), not through Blender.
 
-    Position and UV are kept exact enough to catch a scale, axis or UV
-    regression: rounded only to absorb float32 round-tripping, not to hide
-    one. The normal is kept alongside each corner rather than folded into the
+    Position and UV are kept exact, and compared later on a grid fine enough
+    to catch a scale, axis or UV regression but coarse enough to absorb
+    float32 round-tripping (see _unmatched_surfaces). The normal is kept
+    alongside each corner rather than folded into the
     same comparison key: Blender recomputes a loop's split normal from the
     surrounding topology on every mesh edit, and reproduces it only to
     within about a tenth even for a model that came back with the same
@@ -132,21 +133,75 @@ def _decoded_triangles(bin_bytes):
     uvs = [(uv.u, 1.0 - uv.v) for uv in parsed.texcoords] if parsed.texcoords else None
 
     def corner(i):
-        position = tuple(round(v, 3) for v in positions[i])
-        uv = tuple(round(v, 4) for v in uvs[i]) if uvs else None
+        uv = tuple(uvs[i]) if uvs else None
         normal = tuple(round(v, 1) for v in normals[i]) if normals else None
-        return (position, uv), normal
+        return (tuple(positions[i]), uv), normal
 
     triangles = []
     for triangle in faces:
-        triangles.append(tuple(sorted(corner(i) for i in triangle)))
+        corners = [corner(i) for i in triangle]
+        triangles.append(tuple(sorted(corners, key=lambda c: _corner_key(c[0], 0.0))))
     return triangles
+
+
+# One raw unit at GLOBAL_SCALE, and the UV precision the file itself stores.
+POSITION_STEP = 0.001
+UV_STEP = 0.0001
+
+
+def _corner_key(shape, offset):
+    """A corner's (position, UV) snapped to a grid, as integer cell indices.
+
+    `offset` shifts the grid by that fraction of a cell, which is what makes
+    a coordinate sitting exactly on a cell boundary comparable at all: see
+    _unmatched_surfaces.
+    """
+    position, uv = shape
+    key = [round(v / POSITION_STEP + offset) for v in position]
+    if uv is not None:
+        key.extend(round(v / UV_STEP + offset) for v in uv)
+    return tuple(key)
 
 
 def _surfaces(triangles):
     """A triangle's shape alone (position + UV per corner), dropping its
     normal - the strict part of the geometry comparison."""
     return [tuple(shape for shape, _normal in triangle) for triangle in triangles]
+
+
+def _unmatched_surfaces(original_surfaces, exported_surfaces):
+    """The original triangles no exported triangle describes, matched one
+    for one.
+
+    Comparison is on a grid rather than on raw floats because a coordinate
+    makes a float32 -> double -> float32 round trip on the way through
+    Blender and comes back a few ulps off. A coordinate landing exactly on a
+    cell boundary - an exact half raw unit, which axis-aligned or
+    tool-quantized geometry produces readily - would then snap one way in the
+    shipped file and the other in the re-export, so whatever the first pass
+    leaves over is matched again on a grid shifted by half a cell, where
+    those same coordinates sit in the middle of a cell instead.
+    """
+    from collections import defaultdict
+
+    remaining_original = list(original_surfaces)
+    remaining_exported = list(exported_surfaces)
+    for offset in (0.0, 0.5):
+        if not remaining_original:
+            break
+        pool = defaultdict(list)
+        for surface in remaining_exported:
+            pool[tuple(_corner_key(shape, offset) for shape in surface)].append(surface)
+        unmatched = []
+        for surface in remaining_original:
+            bucket = pool.get(tuple(_corner_key(shape, offset) for shape in surface))
+            if bucket:
+                bucket.pop()
+            else:
+                unmatched.append(surface)
+        remaining_original = unmatched
+        remaining_exported = [s for bucket in pool.values() for s in bucket]
+    return remaining_original
 
 
 def _normal_agreement(original_triangles, exported_triangles):
@@ -160,9 +215,12 @@ def _normal_agreement(original_triangles, exported_triangles):
     """
     from collections import Counter
 
-    original_count = Counter(original_triangles)
-    exported_count = Counter(exported_triangles)
-    matched = sum(min(original_count[key], exported_count[key]) for key in original_count)
+    def key(triangle):
+        return tuple((_corner_key(shape, 0.0), normal) for shape, normal in triangle)
+
+    original_count = Counter(key(t) for t in original_triangles)
+    exported_count = Counter(key(t) for t in exported_triangles)
+    matched = sum(min(original_count[k], exported_count[k]) for k in original_count)
     return matched / len(original_triangles)
 
 
@@ -283,8 +341,14 @@ def test_bin_round_trip_matches_the_original_geometry(
     # Strict: position and UV, decoded straight off the bytes on both sides.
     # This is what would catch a scale, axis or UV regression - the surface a
     # re-exported model describes has to be exactly the one it shipped with.
-    assert sorted(_surfaces(exported_triangles)) == sorted(_surfaces(original_triangles)), (
-        "the re-exported geometry does not describe the same surface as the shipped file"
+    assert len(exported_triangles) == len(original_triangles), (
+        "the re-export does not describe as many triangles as the shipped file"
+    )
+    unmatched = _unmatched_surfaces(
+        _surfaces(original_triangles), _surfaces(exported_triangles))
+    assert not unmatched, (
+        f"{len(unmatched)} of {len(original_triangles)} shipped triangles are not "
+        f"described by the re-export, e.g. {unmatched[0]}"
     )
 
     # Loose: normals agree for the large majority of triangles rather than

--- a/tests/cie/test_bin_serialization.py
+++ b/tests/cie/test_bin_serialization.py
@@ -76,7 +76,15 @@ def _is_mesh_bin(data):
 
 
 def _model_state(bl_object):
-    """What has to survive a round trip."""
+    """What has to survive a round trip.
+
+    Vertex count is deliberately not part of this: it is only ever compared
+    between two re-imports (see the module docstring), where a strip restart
+    legitimately adds corners without changing the surface. Whether the
+    geometry itself - positions, normals, UVs - actually matches the shipped
+    file is test_bin_round_trip_matches_the_original_geometry's job, which
+    compares against the original bytes instead.
+    """
     meshes = [o for o in bl_object.children_recursive if o.type == "MESH"]
     if bl_object.type == "MESH":
         meshes.append(bl_object)
@@ -87,8 +95,75 @@ def _model_state(bl_object):
                          for o in meshes for polygon in o.data.polygons),
         "materials": len(materials),
         "bones": len(armatures[0].data.bones) if armatures else 0,
-        "vertices": sum(len(o.data.vertices) for o in meshes),
     }
+
+
+def _decoded_triangles(bin_bytes):
+    """Every triangle `bin_bytes` describes, as a multiset of
+    ((position, uv), normal) corners - decoded straight off the file's own
+    bytes through the same per-corner arrays and strip-to-triangle logic
+    import uses (see albam.engines.cie.mesh), not through Blender.
+
+    Position and UV are kept exact enough to catch a scale, axis or UV
+    regression: rounded only to absorb float32 round-tripping, not to hide
+    one. The normal is kept alongside each corner rather than folded into the
+    same comparison key: Blender recomputes a loop's split normal from the
+    surrounding topology on every mesh edit, and reproduces it only to
+    within about a tenth even for a model that came back with the same
+    surface - see test_bin_round_trip_matches_the_original_geometry, which
+    checks normals on their own with a looser, majority-agreement tolerance
+    instead of demanding every one match exactly.
+
+    Order-independent and winding-independent (each triangle's three corners
+    are sorted before comparison) because a no-edit re-export is free to walk
+    materials and strips in a different corner order and still describe the
+    same surface - triangle count is what has to match exactly, not corner
+    order or count (see the module docstring).
+    """
+    from albam.engines.cie.mesh import _build_faces, _decode_normal, _yz_flip
+    from albam.engines.cie.structs.re4_uhd_bin import Re4UhdBin
+
+    parsed = Re4UhdBin.from_bytes(bin_bytes)
+    parsed._read()
+    faces, _mat_face_ranges = _build_faces(parsed)
+
+    positions = [_yz_flip(v.x, v.y, v.z) for v in parsed.vertex_positions]
+    normals = [_decode_normal(n) for n in parsed.normals] if parsed.normals else None
+    uvs = [(uv.u, 1.0 - uv.v) for uv in parsed.texcoords] if parsed.texcoords else None
+
+    def corner(i):
+        position = tuple(round(v, 3) for v in positions[i])
+        uv = tuple(round(v, 4) for v in uvs[i]) if uvs else None
+        normal = tuple(round(v, 1) for v in normals[i]) if normals else None
+        return (position, uv), normal
+
+    triangles = []
+    for triangle in faces:
+        triangles.append(tuple(sorted(corner(i) for i in triangle)))
+    return triangles
+
+
+def _surfaces(triangles):
+    """A triangle's shape alone (position + UV per corner), dropping its
+    normal - the strict part of the geometry comparison."""
+    return [tuple(shape for shape, _normal in triangle) for triangle in triangles]
+
+
+def _normal_agreement(original_triangles, exported_triangles):
+    """The fraction of `original_triangles` whose exact triangle (surface and
+    rounded normal both) reappears in `exported_triangles`.
+
+    Every triangle here is already known to reappear by surface alone (see
+    the caller); this measures how many also carry the same normal, which -
+    unlike the surface - Blender does not reproduce exactly on every triangle
+    even for a model with no real regression (see _decoded_triangles).
+    """
+    from collections import Counter
+
+    original_count = Counter(original_triangles)
+    exported_count = Counter(exported_triangles)
+    matched = sum(min(original_count[key], exported_count[key]) for key in original_count)
+    return matched / len(original_triangles)
 
 
 def _texture_slots(bin_bytes):
@@ -157,6 +232,68 @@ def test_bin_round_trips_through_export(game_root, local_app_id,
     assert after["triangles"] == before["triangles"]
     assert after["materials"] == before["materials"]
     assert after["bones"] == before["bones"]
+
+
+def test_bin_round_trip_matches_the_original_geometry(
+        game_root, local_app_id, local_archive_path_hash, _clean_scene):
+    """A no-edit re-export describes the same surface the shipped file did.
+
+    Every other geometry check in this module goes through a second import
+    of albam's own output, which cannot catch a bug that is consistent with
+    itself - a wrong scale, a flipped axis or a broken normal decoding would
+    still come back looking right, since the same (wrong) math reads it back
+    that wrote it. This instead decodes both files' raw per-corner arrays
+    independently (see _decoded_triangles) and compares them directly, which
+    is the only check here that touches the bytes the game actually shipped.
+    """
+    from albam.engines.cie.mesh import AUTO_TPL
+    from albam.registry import blender_registry
+
+    archive_path = resolve_archive_hashes(
+        game_root, {local_archive_path_hash})[local_archive_path_hash]
+
+    vfs = bpy.context.scene.albam.vfs
+    bpy.context.scene.albam.apps.app_selected = local_app_id
+    root = vfs.add_real_file(local_app_id, archive_path)
+
+    models = [vf for vf in vfs.file_list
+              if vf.tree_node.root_id == root.name and not vf.is_root and
+              vf.display_name.lower().endswith(".bin") and _is_mesh_bin(vf.get_bytes())]
+    assert models, "this archive should hold a mesh .bin"
+    vfile = models[0]
+
+    import_function = blender_registry.import_registry[(local_app_id, "bin")]
+    export_function = blender_registry.export_registry[(local_app_id, "bin")]
+
+    vfs.file_list_selected_index = vfs.file_list.find(vfile.name)
+    bpy.context.scene.albam.import_options_bin.tpl_file_id = AUTO_TPL
+    original_bytes = vfile.get_bytes()
+    bl_object = import_function(vfile, bpy.context)
+
+    bl_object.albam_asset.app_id = local_app_id
+    bl_object.albam_asset.extension = "bin"
+    bl_object.albam_asset.relative_path = vfile.display_name
+    bl_object.albam_asset.original_bytes = original_bytes
+    exported_bytes = export_function(bl_object)[0].data_bytes
+
+    original_triangles = _decoded_triangles(original_bytes)
+    exported_triangles = _decoded_triangles(exported_bytes)
+    assert original_triangles, "this model should hold at least one triangle"
+
+    # Strict: position and UV, decoded straight off the bytes on both sides.
+    # This is what would catch a scale, axis or UV regression - the surface a
+    # re-exported model describes has to be exactly the one it shipped with.
+    assert sorted(_surfaces(exported_triangles)) == sorted(_surfaces(original_triangles)), (
+        "the re-exported geometry does not describe the same surface as the shipped file"
+    )
+
+    # Loose: normals agree for the large majority of triangles rather than
+    # all of them - see _decoded_triangles for why an exact-match normal
+    # check would fail even a faithful re-export.
+    agreement = _normal_agreement(original_triangles, exported_triangles)
+    assert agreement > 0.9, (
+        f"only {agreement:.0%} of triangles kept the normals they shipped with"
+    )
 
 
 def test_importing_several_models_from_one_archive(game_root, local_app_id,

--- a/tests/cie/test_bin_serialization.py
+++ b/tests/cie/test_bin_serialization.py
@@ -130,13 +130,19 @@ def _decoded_triangles(bin_bytes):
     faces, _mat_face_ranges = _build_faces(parsed)
 
     positions = [_yz_flip(v.x, v.y, v.z) for v in parsed.vertex_positions]
-    normals = [_decode_normal(n) for n in parsed.normals] if parsed.normals else None
+    # A mesh .bin states one normal per face corner. Tolerating a file that
+    # states none would make the normal comparison pass without ever having
+    # compared anything, which is precisely the regression it exists to catch.
+    assert len(parsed.normals or ()) == len(parsed.vertex_positions), (
+        f"this file states {len(parsed.normals or ())} normals against "
+        f"{len(parsed.vertex_positions)} face corners"
+    )
+    normals = [_decode_normal(n) for n in parsed.normals]
     uvs = [(uv.u, 1.0 - uv.v) for uv in parsed.texcoords] if parsed.texcoords else None
 
     def corner(i):
         uv = tuple(uvs[i]) if uvs else ()
-        normal = tuple(normals[i]) if normals else ()
-        return (tuple(positions[i]), uv), normal
+        return (tuple(positions[i]), uv), tuple(normals[i])
 
     return [tuple(corner(i) for i in triangle) for triangle in faces]
 

--- a/tests/cie/test_bin_serialization.py
+++ b/tests/cie/test_bin_serialization.py
@@ -104,21 +104,20 @@ def _decoded_triangles(bin_bytes):
     bytes through the same per-corner arrays and strip-to-triangle logic
     import uses (see albam.engines.cie.mesh), not through Blender.
 
-    Position and UV are kept exact, and compared later on a grid fine enough
-    to catch a scale, axis or UV regression but coarse enough to absorb
-    float32 round-tripping (see _unmatched_surfaces). The normal is kept
-    alongside each corner rather than folded into the
-    same comparison key: Blender recomputes a loop's split normal from the
-    surrounding topology on every mesh edit, and reproduces it only to
-    within about a tenth even for a model that came back with the same
-    surface - see test_bin_round_trip_matches_the_original_geometry, which
-    checks normals on their own with a looser, majority-agreement tolerance
-    instead of demanding every one match exactly.
+    Every value is kept exactly as the file states it; what absorbs the
+    float32 round trip is the tolerance the triangles are matched within
+    (see _match_triangles), not any rounding done here. The normal is kept
+    alongside each corner rather than folded into the surface it belongs to:
+    Blender recomputes a loop's split normal from the surrounding topology on
+    every mesh edit, and reproduces it only to within about a tenth even for
+    a model that came back with the same surface - see
+    test_bin_round_trip_matches_the_original_geometry, which checks normals
+    on their own with a looser, majority-agreement tolerance instead of
+    demanding every one match.
 
     Corners are kept in the order the file gives them; the comparison itself
-    is order-independent and winding-independent (a triangle is matched by
-    the sorted multiset of its corner keys, see _unmatched_surfaces) because
-    a no-edit re-export is free to walk materials and strips in a different
+    is order-independent and winding-independent (see _shape) because a
+    no-edit re-export is free to walk materials and strips in a different
     corner order and still describe the same surface - triangle count is what
     has to match exactly, not corner order or count (see the module
     docstring).
@@ -135,98 +134,103 @@ def _decoded_triangles(bin_bytes):
     uvs = [(uv.u, 1.0 - uv.v) for uv in parsed.texcoords] if parsed.texcoords else None
 
     def corner(i):
-        uv = tuple(uvs[i]) if uvs else None
-        normal = tuple(round(v, 1) for v in normals[i]) if normals else None
+        uv = tuple(uvs[i]) if uvs else ()
+        normal = tuple(normals[i]) if normals else ()
         return (tuple(positions[i]), uv), normal
 
     return [tuple(corner(i) for i in triangle) for triangle in faces]
 
 
-# One raw unit at GLOBAL_SCALE, and the UV precision the file itself stores.
-POSITION_STEP = 0.001
-UV_STEP = 0.0001
+# A coordinate makes a float32 -> double -> float32 round trip on the way
+# through Blender and comes back a few ulps off, so nothing here is compared
+# for equality. These are the absolute tolerances a corner is matched
+# within - one raw unit of whatever the file itself stores, which is orders
+# of magnitude tighter than any scale, axis or UV regression and wide enough
+# that no value sits on a boundary where the round trip decides the answer.
+POSITION_TOLERANCE = 0.001
+UV_TOLERANCE = 0.0001
+NORMAL_TOLERANCE = 0.15
 
 
-def _corner_key(shape, offset):
-    """A corner's (position, UV) snapped to a grid, as integer cell indices.
+def _shape(triangle):
+    """A triangle's surface: its corner positions and UVs, sorted.
 
-    `offset` shifts the grid by that fraction of a cell, which is what makes
-    a coordinate sitting exactly on a cell boundary comparable at all: see
-    _unmatched_surfaces.
+    Sorted so that which corner the file listed first never decides a match -
+    a re-export is free to state the same triangle from a different corner or
+    in the opposite winding.
     """
-    position, uv = shape
-    key = [round(v / POSITION_STEP + offset) for v in position]
-    if uv is not None:
-        key.extend(round(v / UV_STEP + offset) for v in uv)
-    return tuple(key)
+    return tuple(sorted(position + uv for position, uv in
+                        (corner for corner, _normal in triangle)))
 
 
-def _surfaces(triangles):
-    """A triangle's shape alone (position + UV per corner), dropping its
-    normal - the strict part of the geometry comparison."""
-    return [tuple(shape for shape, _normal in triangle) for triangle in triangles]
+def _same_surface(one, other):
+    """Whether two surfaces (see _shape) are the same one within tolerance."""
+    if len(one) != len(other):
+        return False
+    for corner, other_corner in zip(one, other):
+        if len(corner) != len(other_corner):
+            return False
+        for i, (value, other_value) in enumerate(zip(corner, other_corner)):
+            tolerance = POSITION_TOLERANCE if i < 3 else UV_TOLERANCE
+            if abs(value - other_value) > tolerance:
+                return False
+    return True
 
 
-def _unmatched_surfaces(original_surfaces, exported_surfaces):
-    """The original triangles no exported triangle describes, matched one
-    for one.
+def _match_triangles(original_triangles, exported_triangles):
+    """Pair each original triangle with the exported triangle describing the
+    same surface, as (pairs, originals nothing matched).
 
-    A triangle is keyed by the sorted multiset of its corner keys, so which
-    corner the file happened to list first never decides a match.
-
-    Comparison is on a grid rather than on raw floats because a coordinate
-    makes a float32 -> double -> float32 round trip on the way through
-    Blender and comes back a few ulps off. A coordinate landing exactly on a
-    cell boundary - an exact half raw unit, which axis-aligned or
-    tool-quantized geometry produces readily - would then snap one way in the
-    shipped file and the other in the re-export, so whatever the first pass
-    leaves over is matched again on a grid shifted by half a cell, where
-    those same coordinates sit in the middle of a cell instead.
+    Both sides are sorted by surface and walked together, so a pair costs a
+    sort rather than a scan. Nothing is snapped to a grid on the way: a
+    quantized coordinate landing on a cell boundary - an exact half raw unit,
+    which axis-aligned or tool-quantized geometry produces readily - is
+    exactly the value an exact-key comparison cannot survive, since the round
+    trip alone decides which side of the boundary it lands on.
     """
-    from collections import defaultdict
+    original = sorted((_shape(t), t) for t in original_triangles)
+    exported = sorted((_shape(t), t) for t in exported_triangles)
 
-    remaining_original = list(original_surfaces)
-    remaining_exported = list(exported_surfaces)
-    for offset in (0.0, 0.5):
-        if not remaining_original:
-            break
-        def key(surface):
-            return tuple(sorted(_corner_key(shape, offset) for shape in surface))
-
-        pool = defaultdict(list)
-        for surface in remaining_exported:
-            pool[key(surface)].append(surface)
-        unmatched = []
-        for surface in remaining_original:
-            bucket = pool.get(key(surface))
-            if bucket:
-                bucket.pop()
-            else:
-                unmatched.append(surface)
-        remaining_original = unmatched
-        remaining_exported = [s for bucket in pool.values() for s in bucket]
-    return remaining_original
+    pairs = []
+    unmatched = []
+    i = j = 0
+    while i < len(original) and j < len(exported):
+        if _same_surface(original[i][0], exported[j][0]):
+            pairs.append((original[i][1], exported[j][1]))
+            i += 1
+            j += 1
+        elif original[i][0] < exported[j][0]:
+            unmatched.append(original[i][1])
+            i += 1
+        else:
+            j += 1
+    unmatched.extend(triangle for _surface, triangle in original[i:])
+    return pairs, unmatched
 
 
-def _normal_agreement(original_triangles, exported_triangles):
-    """The fraction of `original_triangles` whose exact triangle (surface and
-    rounded normal both) reappears in `exported_triangles`.
+def _normal_agreement(pairs):
+    """The fraction of matched triangles (see _match_triangles) that also
+    carry the normals they shipped with.
 
-    Every triangle here is already known to reappear by surface alone (see
-    the caller); this measures how many also carry the same normal, which -
-    unlike the surface - Blender does not reproduce exactly on every triangle
-    even for a model with no real regression (see _decoded_triangles).
+    Every triangle here already describes the surface it shipped with; this
+    measures how many also kept its normals, which - unlike the surface -
+    Blender does not reproduce on every triangle even for a model with no
+    real regression (see _decoded_triangles).
     """
-    from collections import Counter
+    if not pairs:
+        return 0.0
 
-    def key(triangle):
-        return tuple(sorted((_corner_key(shape, 0.0), normal)
-                            for shape, normal in triangle))
+    def normals(triangle):
+        return [normal for _corner, normal in sorted(triangle, key=lambda c: c[0])]
 
-    original_count = Counter(key(t) for t in original_triangles)
-    exported_count = Counter(key(t) for t in exported_triangles)
-    matched = sum(min(original_count[k], exported_count[k]) for k in original_count)
-    return matched / len(original_triangles)
+    agreed = 0
+    for original, exported in pairs:
+        if all(abs(a - b) <= NORMAL_TOLERANCE
+               for original_normal, exported_normal in zip(normals(original),
+                                                           normals(exported))
+               for a, b in zip(original_normal, exported_normal)):
+            agreed += 1
+    return agreed / len(pairs)
 
 
 def _texture_slots(bin_bytes):
@@ -349,17 +353,16 @@ def test_bin_round_trip_matches_the_original_geometry(
     assert len(exported_triangles) == len(original_triangles), (
         "the re-export does not describe as many triangles as the shipped file"
     )
-    unmatched = _unmatched_surfaces(
-        _surfaces(original_triangles), _surfaces(exported_triangles))
+    pairs, unmatched = _match_triangles(original_triangles, exported_triangles)
     assert not unmatched, (
         f"{len(unmatched)} of {len(original_triangles)} shipped triangles are not "
-        f"described by the re-export, e.g. {unmatched[0]}"
+        f"described by the re-export, e.g. {_shape(unmatched[0])}"
     )
 
     # Loose: normals agree for the large majority of triangles rather than
     # all of them - see _decoded_triangles for why an exact-match normal
     # check would fail even a faithful re-export.
-    agreement = _normal_agreement(original_triangles, exported_triangles)
+    agreement = _normal_agreement(pairs)
     assert agreement > 0.9, (
         f"only {agreement:.0%} of triangles kept the normals they shipped with"
     )

--- a/tests/cie/test_bin_serialization.py
+++ b/tests/cie/test_bin_serialization.py
@@ -115,11 +115,13 @@ def _decoded_triangles(bin_bytes):
     checks normals on their own with a looser, majority-agreement tolerance
     instead of demanding every one match exactly.
 
-    Order-independent and winding-independent (each triangle's three corners
-    are sorted before comparison) because a no-edit re-export is free to walk
-    materials and strips in a different corner order and still describe the
-    same surface - triangle count is what has to match exactly, not corner
-    order or count (see the module docstring).
+    Corners are kept in the order the file gives them; the comparison itself
+    is order-independent and winding-independent (a triangle is matched by
+    the sorted multiset of its corner keys, see _unmatched_surfaces) because
+    a no-edit re-export is free to walk materials and strips in a different
+    corner order and still describe the same surface - triangle count is what
+    has to match exactly, not corner order or count (see the module
+    docstring).
     """
     from albam.engines.cie.mesh import _build_faces, _decode_normal, _yz_flip
     from albam.engines.cie.structs.re4_uhd_bin import Re4UhdBin
@@ -137,11 +139,7 @@ def _decoded_triangles(bin_bytes):
         normal = tuple(round(v, 1) for v in normals[i]) if normals else None
         return (tuple(positions[i]), uv), normal
 
-    triangles = []
-    for triangle in faces:
-        corners = [corner(i) for i in triangle]
-        triangles.append(tuple(sorted(corners, key=lambda c: _corner_key(c[0], 0.0))))
-    return triangles
+    return [tuple(corner(i) for i in triangle) for triangle in faces]
 
 
 # One raw unit at GLOBAL_SCALE, and the UV precision the file itself stores.
@@ -173,6 +171,9 @@ def _unmatched_surfaces(original_surfaces, exported_surfaces):
     """The original triangles no exported triangle describes, matched one
     for one.
 
+    A triangle is keyed by the sorted multiset of its corner keys, so which
+    corner the file happened to list first never decides a match.
+
     Comparison is on a grid rather than on raw floats because a coordinate
     makes a float32 -> double -> float32 round trip on the way through
     Blender and comes back a few ulps off. A coordinate landing exactly on a
@@ -189,12 +190,15 @@ def _unmatched_surfaces(original_surfaces, exported_surfaces):
     for offset in (0.0, 0.5):
         if not remaining_original:
             break
+        def key(surface):
+            return tuple(sorted(_corner_key(shape, offset) for shape in surface))
+
         pool = defaultdict(list)
         for surface in remaining_exported:
-            pool[tuple(_corner_key(shape, offset) for shape in surface)].append(surface)
+            pool[key(surface)].append(surface)
         unmatched = []
         for surface in remaining_original:
-            bucket = pool.get(tuple(_corner_key(shape, offset) for shape in surface))
+            bucket = pool.get(key(surface))
             if bucket:
                 bucket.pop()
             else:
@@ -216,7 +220,8 @@ def _normal_agreement(original_triangles, exported_triangles):
     from collections import Counter
 
     def key(triangle):
-        return tuple((_corner_key(shape, 0.0), normal) for shape, normal in triangle)
+        return tuple(sorted((_corner_key(shape, 0.0), normal)
+                            for shape, normal in triangle))
 
     original_count = Counter(key(t) for t in original_triangles)
     exported_count = Counter(key(t) for t in exported_triangles)

--- a/tests/cie/test_bone_ids.py
+++ b/tests/cie/test_bone_ids.py
@@ -1,11 +1,13 @@
-"""_bone_ids_by_name: the export id a Blender bone gets written under.
+"""_bone_ids_by_name: the export id a Blender bone gets written under, and
+which bones that id space has to cover.
 
 CI-safe: no game data or scene state, just the pure id-assignment logic (see
 albam/engines/cie/mesh.py).
 """
 import pytest
 
-from albam.engines.cie.mesh import _bone_ids_by_name
+from albam.engines.cie.mesh import (_bone_ids_by_name, _bones_to_write,
+                                    _serialize_bones)
 from albam.exceptions import AlbamCheckFailure
 
 
@@ -58,13 +60,19 @@ def test_a_zero_padded_name_does_not_claim_an_id_a_second_time():
     assert ids["5"] == 5
 
 
-def test_an_armature_with_no_free_id_left_errors_instead_of_doubling_up():
+def test_a_bone_with_no_free_id_left_gets_none_rather_than_a_duplicate():
     """Nudging a fallback used to stop at 254 and hand it out anyway, which
-    is the very duplicate this function exists to prevent."""
+    is the very duplicate this function exists to prevent. A bone past the
+    255 the format can name is left out of the mapping instead - it only
+    matters if the model actually writes it (see _serialize_bones).
+    """
     bones = [_FakeBone(str(i)) for i in range(255)] + [_FakeBone("extra")]
 
-    with pytest.raises(AlbamCheckFailure):
-        _bone_ids_by_name(bones)
+    ids = _bone_ids_by_name(bones)
+
+    assert len(set(ids.values())) == len(ids), f"id collision in {ids}"
+    assert "extra" not in ids
+    assert len(ids) == 255
 
 
 def test_a_model_bound_to_the_upper_half_of_a_rig_still_gets_an_id():
@@ -78,3 +86,51 @@ def test_a_model_bound_to_the_upper_half_of_a_rig_still_gets_an_id():
 
     assert len(set(ids.values())) == len(ids), f"id collision in {ids}"
     assert ids["helper"] < 60
+
+
+class _FakeArmature:
+    def __init__(self, bones):
+        self.name = "Armature"
+        self.data = type("_Data", (), {"bones": bones})()
+
+
+class _FakeBoneWithParent(_FakeBone):
+    def __init__(self, name, parent=None):
+        super().__init__(name)
+        self.parent = parent
+
+    @property
+    def parent_recursive(self):
+        return [self.parent] + self.parent.parent_recursive if self.parent else []
+
+
+def test_bones_nothing_writes_do_not_have_to_fit_in_the_format_s_id_space():
+    """A rig can carry far more bones than a .bin can name - control and IK
+    bones nothing is weighted to, say - and only the ones the model writes
+    ever reach the file (see _bones_to_write). Assigning ids over the whole
+    armature made such a rig refuse to export over bones no table would have
+    held.
+    """
+    weighted = _FakeBoneWithParent("7")
+    bones = [weighted] + [_FakeBoneWithParent(f"control_{i}") for i in range(300)]
+    armature = _FakeArmature(bones)
+
+    ids = _bone_ids_by_name(bones)
+    written = _bones_to_write(armature, ids, used_ids=(7,))
+
+    assert [bone.name for bone in written] == ["7"]
+    assert all(bone.name in ids for bone in written)
+
+
+def test_writing_a_bone_the_format_cannot_name_fails_with_a_clear_error():
+    """The id space only has to cover what reaches the file, but a model that
+    does write more bones than the format can name has to say so rather than
+    write a table with bones missing.
+    """
+    bones = [_FakeBoneWithParent(f"bone_{i}") for i in range(300)]
+
+    with pytest.raises(AlbamCheckFailure) as raised:
+        _serialize_bones(None, _FakeArmature(bones))
+
+    assert raised.value.details
+    assert raised.value.solution

--- a/tests/cie/test_bone_ids.py
+++ b/tests/cie/test_bone_ids.py
@@ -65,3 +65,16 @@ def test_an_armature_with_no_free_id_left_errors_instead_of_doubling_up():
 
     with pytest.raises(AlbamCheckFailure):
         _bone_ids_by_name(bones)
+
+
+def test_a_model_bound_to_the_upper_half_of_a_rig_still_gets_an_id():
+    """An armature can hold only the upper part of a shared rig (see
+    _bones_to_write), leaving every id below it free. Nudging upward alone
+    ran out at 254 and errored while those lower ids were still available.
+    """
+    bones = [_FakeBone(str(i)) for i in range(60, 255)] + [_FakeBone("helper")]
+
+    ids = _bone_ids_by_name(bones)
+
+    assert len(set(ids.values())) == len(ids), f"id collision in {ids}"
+    assert ids["helper"] < 60

--- a/tests/cie/test_bone_ids.py
+++ b/tests/cie/test_bone_ids.py
@@ -1,0 +1,43 @@
+"""_bone_ids_by_name: the export id a Blender bone gets written under.
+
+CI-safe: no game data or scene state, just the pure id-assignment logic (see
+albam/engines/cie/mesh.py).
+"""
+from albam.engines.cie.mesh import _bone_ids_by_name
+
+
+class _FakeBone:
+    def __init__(self, name):
+        self.name = name
+
+
+def test_ids_follow_name_or_armature_position():
+    bones = [_FakeBone(n) for n in ("root", "spine", "head")]
+    assert _bone_ids_by_name(bones) == {"root": 0, "spine": 1, "head": 2}
+
+
+def test_a_digit_name_claims_its_own_id_outright():
+    bones = [_FakeBone("root"), _FakeBone("5"), _FakeBone("head")]
+    ids = _bone_ids_by_name(bones)
+    assert ids["5"] == 5
+
+
+def test_a_fallback_id_colliding_with_a_digit_name_is_not_dropped():
+    """A hand-added bone whose armature position matches a digit-named bone
+    elsewhere used to collide with it silently: both bones would map to the
+    same id, and whichever _bones_to_write met first hid the other one
+    entirely from the exported table.
+    """
+    bones = [_FakeBone("5"), _FakeBone("a"), _FakeBone("b"),
+             _FakeBone("c"), _FakeBone("d"), _FakeBone("e")]
+    ids = _bone_ids_by_name(bones)
+
+    assert len(set(ids.values())) == len(ids), f"id collision in {ids}"
+    assert ids["5"] == 5
+    assert ids["e"] != 5
+
+
+def test_every_id_stays_within_the_format_s_u1_ceiling():
+    bones = [_FakeBone(str(i)) for i in range(200, 260)]
+    ids = _bone_ids_by_name(bones)
+    assert all(0 <= bone_id <= 254 for bone_id in ids.values())

--- a/tests/cie/test_bone_ids.py
+++ b/tests/cie/test_bone_ids.py
@@ -7,7 +7,7 @@ albam/engines/cie/mesh.py).
 import pytest
 
 from albam.engines.cie.mesh import (_bone_ids_by_name, _bones_to_write,
-                                    _serialize_bones)
+                                    _collect_geometry, _serialize_bones)
 from albam.exceptions import AlbamCheckFailure
 
 
@@ -132,5 +132,37 @@ def test_writing_a_bone_the_format_cannot_name_fails_with_a_clear_error():
     with pytest.raises(AlbamCheckFailure) as raised:
         _serialize_bones(None, _FakeArmature(bones))
 
+    assert raised.value.details
+    assert raised.value.solution
+
+
+class _FakeVertexGroup:
+    def __init__(self, index, name):
+        self.index = index
+        self.name = name
+
+
+class _FakeMeshObject:
+    def __init__(self, name, vertex_groups):
+        self.name = name
+        self.data = None
+        self.vertex_groups = vertex_groups
+
+
+def test_weighting_a_mesh_to_a_bone_the_format_cannot_name_fails_loudly():
+    """A rig larger than the id space is fine as long as the bones past it
+    carry no weights (see the test above). One that does carry them cannot
+    be written: dropping the vertex group would pin those vertices to the
+    first bone instead, which exports cleanly and deforms wrongly.
+    """
+    bones = [_FakeBoneWithParent(f"bone_{i}") for i in range(300)]
+    unnamed = next(bone.name for bone in bones
+                   if bone.name not in _bone_ids_by_name(bones))
+    mesh_ob = _FakeMeshObject("body", [_FakeVertexGroup(0, unnamed)])
+
+    with pytest.raises(AlbamCheckFailure) as raised:
+        _collect_geometry([mesh_ob], _FakeArmature(bones))
+
+    assert unnamed in raised.value.message
     assert raised.value.details
     assert raised.value.solution

--- a/tests/cie/test_bone_ids.py
+++ b/tests/cie/test_bone_ids.py
@@ -3,7 +3,10 @@
 CI-safe: no game data or scene state, just the pure id-assignment logic (see
 albam/engines/cie/mesh.py).
 """
+import pytest
+
 from albam.engines.cie.mesh import _bone_ids_by_name
+from albam.exceptions import AlbamCheckFailure
 
 
 class _FakeBone:
@@ -41,3 +44,24 @@ def test_every_id_stays_within_the_format_s_u1_ceiling():
     bones = [_FakeBone(str(i)) for i in range(200, 260)]
     ids = _bone_ids_by_name(bones)
     assert all(0 <= bone_id <= 254 for bone_id in ids.values())
+
+
+def test_a_zero_padded_name_does_not_claim_an_id_a_second_time():
+    """"05" and "5" spell the same id, so letting both claim it dropped one
+    of the two bones from the exported table while its weights re-mapped
+    onto the survivor.
+    """
+    bones = [_FakeBone("5"), _FakeBone("05"), _FakeBone("head")]
+    ids = _bone_ids_by_name(bones)
+
+    assert len(set(ids.values())) == len(ids), f"id collision in {ids}"
+    assert ids["5"] == 5
+
+
+def test_an_armature_with_no_free_id_left_errors_instead_of_doubling_up():
+    """Nudging a fallback used to stop at 254 and hand it out anyway, which
+    is the very duplicate this function exists to prevent."""
+    bones = [_FakeBone(str(i)) for i in range(255)] + [_FakeBone("extra")]
+
+    with pytest.raises(AlbamCheckFailure):
+        _bone_ids_by_name(bones)

--- a/tests/cie/test_face_corner_limit.py
+++ b/tests/cie/test_face_corner_limit.py
@@ -1,0 +1,59 @@
+"""export_bin's face-corner ceiling: a clear, loud error rather than a
+silently truncated file.
+
+The format states both position and normal counts in a u2 (see
+albam.engines.cie.mesh.MAX_VERTICES and structs/re4-uhd-bin.ksy), and the
+format is non-indexed - one entry per face corner, not per Blender vertex -
+so a mesh with enough triangles and no shared corners can exceed it. One
+model in the game needs 79,959 corners against the 65,535 the format can
+state (see the module docstring on GitHub issue #271); the next largest is
+at 70% of the limit. That gap is real, but a model actually hitting it errors
+here rather than writing a corrupt file, which is what this test pins down -
+closing this as a wontfix rather than engineering around a single model
+still needs that error to stay loud.
+
+CI-safe: builds the oversized mesh directly, no game data needed.
+"""
+import bpy
+import pytest
+
+from albam.engines.cie.mesh import MAX_VERTICES, export_bin
+from albam.exceptions import AlbamCheckFailure
+
+
+def _disjoint_triangles_mesh(name, triangle_count):
+    """A mesh of `triangle_count` triangles sharing no vertex, UV or normal
+    with any other - so every corner the exporter walks is its own, and the
+    corner count is exactly 3 * triangle_count (see mesh._collect_geometry's
+    per-material corner deduplication, which this gives nothing to merge)."""
+    vertices = []
+    faces = []
+    for i in range(triangle_count):
+        base = len(vertices)
+        vertices.extend([(i, 0.0, 0.0), (i, 1.0, 0.0), (i, 0.0, 1.0)])
+        faces.append((base, base + 1, base + 2))
+
+    mesh = bpy.data.meshes.new(name)
+    mesh.from_pydata(vertices, [], faces)
+    mesh.update()
+    return mesh
+
+
+@pytest.fixture
+def _oversized_mesh_object():
+    # One more triangle than fits: 3 corners each, none shareable.
+    triangle_count = MAX_VERTICES // 3 + 1
+    mesh = _disjoint_triangles_mesh("albam-test-oversized", triangle_count)
+    bl_object = bpy.data.objects.new("albam-test-oversized", mesh)
+    bpy.context.collection.objects.link(bl_object)
+    bl_object.albam_asset.app_id = "re4uhd"
+    yield bl_object
+    bpy.data.objects.remove(bl_object, do_unlink=True)
+    bpy.data.meshes.remove(mesh)
+
+
+def test_export_bin_refuses_more_face_corners_than_the_format_can_state(
+        _oversized_mesh_object):
+    with pytest.raises(AlbamCheckFailure, match="too much geometry") as excinfo:
+        export_bin(_oversized_mesh_object)
+    assert str(MAX_VERTICES) in excinfo.value.details

--- a/tests/cie/test_pack_operator.py
+++ b/tests/cie/test_pack_operator.py
@@ -1,0 +1,139 @@
+"""bpy.ops.albam.pack, driven end to end for RE4UHD.
+
+Never exercised by the suite before: ALBAM_OT_Pack's own _execute is marked
+`# pragma: no cover` (see albam/blender_ui/export_panel.py), which is where a
+defect was found by review rather than by any test. A script exists that
+drives the same chain against a whole archive (tests/tools/cie_build_mod.py),
+but it needs a real game install and is not part of CI.
+"""
+import json
+import os
+
+import bpy
+import pytest
+
+from albam.lib import fs_registry
+from tests.conftest import close_new_fs_roots, remove_new_vfs_roots, vfs_root_names
+from tests.cie.lfs_paths import resolve_archive_hashes
+from tests.cie.test_bin_serialization import _is_mesh_bin
+
+DATASETS_DIR = os.path.join(os.path.dirname(__file__), "datasets")
+DATASET_PATH = os.path.join(DATASETS_DIR, "bin_serialization_hashes.json")
+with open(DATASET_PATH) as f:
+    PACK_DATASET = json.load(f)
+
+
+def pytest_generate_tests(metafunc):
+    if ("local_app_id" in metafunc.fixturenames and
+            "local_archive_path_hash" in metafunc.fixturenames):
+        argnames = ("local_app_id", "local_archive_path_hash")
+        argvalues = [(d["app_id"], d["archive_path_hash"]) for d in PACK_DATASET]
+        ids = [f"{d['app_id']}-{d['archive_path_hash']}" for d in PACK_DATASET]
+        metafunc.parametrize(argnames, argvalues, ids=ids, scope="session")
+
+
+@pytest.fixture
+def _clean_scene():
+    before = fs_registry.keys()
+    before_roots = vfs_root_names()
+    # Not every test in this session cleans up after itself here: some drive
+    # bpy.ops.albam.import_vfile() directly and leave stale entries in
+    # "exportable" behind (see test_bin_serialization.py). Starting from a
+    # clean list is what lets this test assert on its own import by count
+    # rather than by some fragile "last added" bookkeeping.
+    bpy.context.scene.albam.exportable.file_list.clear()
+    yield
+    bpy.ops.object.select_all(action="SELECT")
+    bpy.ops.object.delete(use_global=True)
+    remove_new_vfs_roots(before_roots)
+    bpy.context.scene.albam.exported.file_list.clear()
+    bpy.context.scene.albam.exportable.file_list.clear()
+    close_new_fs_roots(before)
+
+
+def _exported_root_names():
+    return {vf.name for vf in bpy.context.scene.albam.exported.file_list if vf.is_root}
+
+
+def test_pack_operator_repacks_a_udas_archive(game_root, local_app_id,
+                                              local_archive_path_hash, _clean_scene, tmp_path):
+    """The whole chain bpy.ops.albam.pack drives: import a model through the
+    real import operator (so it lands in the "exportable" list the way a user
+    driving the UI would produce it), export it, then repack the archive it
+    came from - and the resulting file mounts with the exported bytes in
+    place of the original entry.
+    """
+    from albam.engines.cie.mesh import AUTO_TPL
+
+    archive_path = resolve_archive_hashes(
+        game_root, {local_archive_path_hash})[local_archive_path_hash]
+
+    vfs = bpy.context.scene.albam.vfs
+    bpy.context.scene.albam.apps.app_selected = local_app_id
+    root = vfs.add_real_file(local_app_id, archive_path)
+
+    models = [vf for vf in vfs.file_list
+              if vf.tree_node.root_id == root.name and not vf.is_root and
+              vf.display_name.lower().endswith(".bin") and _is_mesh_bin(vf.get_bytes())]
+    assert models, "this archive should hold a mesh .bin"
+    vfile = models[0]
+
+    bpy.context.scene.albam.import_options_bin.tpl_file_id = AUTO_TPL
+    vfs.file_list_selected_index = vfs.file_list.find(vfile.name)
+    assert bpy.ops.albam.import_vfile() == {"FINISHED"}
+
+    exportable = bpy.context.scene.albam.exportable
+    assert len(exportable.file_list) == 1, "the import should have made one object exportable"
+    exportable.file_list_selected_index = 0
+
+    exported_roots_before = _exported_root_names()
+    assert bpy.ops.albam.export() == {"FINISHED"}
+    new_root_name = next(iter(_exported_root_names() - exported_roots_before))
+
+    exported = bpy.context.scene.albam.exported
+    exported_vfile = exported.select_vfile(local_app_id, vfile.display_name)
+    assert exported_vfile, "the exported file should be findable in the export VFS"
+    exported_bytes = exported_vfile.get_bytes()
+    # ALBAM_OT_Pack.poll needs the export *root* selected, not the file
+    # select_vfile just left selected.
+    exported.file_list_selected_index = exported.file_list.find(new_root_name)
+
+    # ALBAM_OT_Pack.poll requires the *archive* root selected on the import
+    # side, not the .bin file that was picked to start the import above.
+    vfs.file_list_selected_index = vfs.file_list.find(root.name)
+    assert bpy.ops.albam.pack.poll(), (
+        "pack should be available: an archive is selected on the import side "
+        "and a root is selected on the export side"
+    )
+
+    # Same basename as the source archive: LfsFS numbers a container's
+    # entries after the mounted file's own stem (see albam.engines.cie.fs),
+    # so a differently-named output would compare against differently-named
+    # entries below for no reason connected to the rebuild itself.
+    out_path = tmp_path / os.path.basename(archive_path)
+    result = bpy.ops.albam.pack(filepath=str(out_path))
+    assert result == {"FINISHED"}
+    assert out_path.exists() and out_path.stat().st_size > 0
+
+    from albam.engines.cie.fs import LfsFS
+
+    original = LfsFS(archive_path)
+    try:
+        before = {p.lstrip("/"): original.readbytes(p) for p in original.walk.files()}
+    finally:
+        original.close()
+
+    repacked = LfsFS(str(out_path))
+    try:
+        after = {p.lstrip("/"): repacked.readbytes(p) for p in repacked.walk.files()}
+    finally:
+        repacked.close()
+
+    assert after.keys() == before.keys(), "repacking should not add or drop entries"
+    assert after[vfile.display_name] == exported_bytes, (
+        "the repacked archive should hold the freshly exported bytes for this entry"
+    )
+    unchanged = {k: v for k, v in before.items() if k != vfile.display_name}
+    assert {k: after[k] for k in unchanged} == unchanged, (
+        "every other entry should have survived the rebuild untouched"
+    )

--- a/tests/cie/test_short_bin_header.py
+++ b/tests/cie/test_short_bin_header.py
@@ -1,15 +1,18 @@
-"""A 0x40 (short) .bin header: albam.engines.cie.structs.re4_uhd_bin.py.
+"""Short .bin headers: albam.engines.cie.structs.re4_uhd_bin.py.
 
 The format allows a header of 0x40, 0x50 or 0x60 bytes - offset_bones (the
-header's first field) doubles as its own size, and the shorter variants stop
-before the four trailing offset fields exist in the file at all (see
-re4-uhd-bin.ksy). Reading them unconditionally, as this hand-maintained
-generated file used to, consumed the next 16 bytes of whatever actually
-follows a short header - here, bone data - as if they were those fields.
+header's first field) doubles as its own size. The fields down to
+version_flags are exactly 0x40 bytes and the four trailing offsets bring the
+header to exactly 0x50, so only a 0x40 header stops before those four exist
+in the file at all; a 0x50 header states all four, and a 0x60 one is a 0x50
+header plus 16 bytes of padding nothing reads (see re4-uhd-bin.ksy). Reading
+the four unconditionally, as this hand-maintained generated file used to,
+consumed the next 16 bytes of whatever actually follows a 0x40 header - here,
+bone data - as if they were those fields.
 
 No file in a several-hundred-file sample of the shipped game (see
 tests/cie/test_lfs_fs.py's dataset scale, and GitHub issue #271) uses a
-header this short, so this is a synthetic file rather than a real one - a
+header this short, so these are synthetic files rather than real ones - a
 reader still has no business assuming a format it did not design always
 ships the longest variant.
 """
@@ -18,17 +21,24 @@ import struct
 from albam.engines.cie.structs.re4_uhd_bin import Re4UhdBin
 
 SHORT_HEADER_SIZE = 0x40
+MEDIUM_HEADER_SIZE = 0x50
 
 
-def _short_header_bin(bone_id=42, bone_parent=0xFF, bone_xyz=(1.0, 2.0, 3.0)):
-    """A minimal, otherwise-empty mesh .bin whose header stops at 0x40,
-    followed immediately by one bone - exactly where offset_bones says it
-    should be.
+def _bin_with_one_bone(bone_id=42, bone_parent=0xFF, bone_xyz=(1.0, 2.0, 3.0),
+                       trailing_offsets=None):
+    """A minimal, otherwise-empty mesh .bin followed immediately by one bone -
+    exactly where offset_bones says it should be.
+
+    `trailing_offsets` are the four the header ends with: None builds the
+    0x40 header that stops before them, a 4-tuple the 0x50 header that
+    states them.
     """
-    end = SHORT_HEADER_SIZE + 16  # header + one bone, nothing else in this file
+    header_size = (SHORT_HEADER_SIZE if trailing_offsets is None
+                   else MEDIUM_HEADER_SIZE)
+    end = header_size + 16  # header + one bone, nothing else in this file
     header = struct.pack(
         "<IIIIIIBBHIIIBBHIIIHHI",
-        SHORT_HEADER_SIZE,  # offset_bones (doubles as header size)
+        header_size,        # offset_bones (doubles as header size)
         0,                  # unk_00
         0,                  # unk_01
         0,                  # offset_vertex_colors
@@ -51,12 +61,15 @@ def _short_header_bin(bone_id=42, bone_parent=0xFF, bone_xyz=(1.0, 2.0, 3.0)):
         0,                  # version_flags
     )
     assert len(header) == SHORT_HEADER_SIZE
+    if trailing_offsets is not None:
+        header += struct.pack("<IIII", *trailing_offsets)
+    assert len(header) == header_size
     bone = struct.pack("<BBHfff", bone_id, bone_parent, 0, *bone_xyz)
     return header + bone
 
 
 def test_a_short_header_s_trailing_offsets_default_to_absent():
-    parsed = Re4UhdBin.from_bytes(_short_header_bin())
+    parsed = Re4UhdBin.from_bytes(_bin_with_one_bone())
     parsed._read()
 
     assert parsed.header.offset_bones == SHORT_HEADER_SIZE
@@ -64,14 +77,17 @@ def test_a_short_header_s_trailing_offsets_default_to_absent():
     assert parsed.header.offset_adjacents == 0
     assert parsed.header.offset_index_buffer == 0
     assert parsed.header.offset_index_buffer2 == 0
-    # None of these optional blocks should even be attempted: each is only
-    # read `if offset_X > 0` (see re4-uhd-bin.ksy).
-    assert parsed.header.offset_bonepairs == 0 and not hasattr(parsed, "_m_bone_pairs")
-    assert parsed.header.offset_adjacents == 0 and not hasattr(parsed, "_m_adjacent")
+    # Each optional block is only read `if offset_X > 0` (see
+    # re4-uhd-bin.ksy), so asking for one comes back with nothing rather than
+    # parsing whatever those bytes happen to be.
+    assert parsed.bone_pairs is None
+    assert parsed.adjacent is None
+    assert parsed.indexes is None
+    assert parsed.indexes2 is None
 
 
 def test_a_short_header_s_bone_data_is_read_correctly_not_as_trailing_offsets():
-    bin_bytes = _short_header_bin(bone_id=42, bone_parent=0xFF, bone_xyz=(1.0, 2.0, 3.0))
+    bin_bytes = _bin_with_one_bone(bone_id=42, bone_parent=0xFF, bone_xyz=(1.0, 2.0, 3.0))
     parsed = Re4UhdBin.from_bytes(bin_bytes)
     parsed._read()
 
@@ -80,3 +96,26 @@ def test_a_short_header_s_bone_data_is_read_correctly_not_as_trailing_offsets():
     assert bone.bone_id == 42
     assert bone.parent == 0xFF
     assert (bone.x, bone.y, bone.z) == (1.0, 2.0, 3.0)
+
+
+def test_a_0x50_header_states_its_trailing_offsets_and_its_bone_follows_them():
+    """A 0x50 header is exactly the four trailing offsets present, so it must
+    keep being read like a 0x60 one: defaulting them to 0 here would drop the
+    bone-pair, adjacency and weight-index blocks such a file does state.
+    """
+    trailing = (0x1000, 0x2000, 0x3000, 0x4000)
+    parsed = Re4UhdBin.from_bytes(
+        _bin_with_one_bone(bone_id=7, bone_parent=3, bone_xyz=(4.0, 5.0, 6.0),
+                           trailing_offsets=trailing))
+    parsed._read()
+
+    assert parsed.header.offset_bones == MEDIUM_HEADER_SIZE
+    assert (parsed.header.offset_bonepairs, parsed.header.offset_adjacents,
+            parsed.header.offset_index_buffer,
+            parsed.header.offset_index_buffer2) == trailing
+
+    assert len(parsed.bones) == 1
+    bone = parsed.bones[0]
+    assert bone.bone_id == 7
+    assert bone.parent == 3
+    assert (bone.x, bone.y, bone.z) == (4.0, 5.0, 6.0)

--- a/tests/cie/test_short_bin_header.py
+++ b/tests/cie/test_short_bin_header.py
@@ -1,0 +1,82 @@
+"""A 0x40 (short) .bin header: albam.engines.cie.structs.re4_uhd_bin.py.
+
+The format allows a header of 0x40, 0x50 or 0x60 bytes - offset_bones (the
+header's first field) doubles as its own size, and the shorter variants stop
+before the four trailing offset fields exist in the file at all (see
+re4-uhd-bin.ksy). Reading them unconditionally, as this hand-maintained
+generated file used to, consumed the next 16 bytes of whatever actually
+follows a short header - here, bone data - as if they were those fields.
+
+No file in a several-hundred-file sample of the shipped game (see
+tests/cie/test_lfs_fs.py's dataset scale, and GitHub issue #271) uses a
+header this short, so this is a synthetic file rather than a real one - a
+reader still has no business assuming a format it did not design always
+ships the longest variant.
+"""
+import struct
+
+from albam.engines.cie.structs.re4_uhd_bin import Re4UhdBin
+
+SHORT_HEADER_SIZE = 0x40
+
+
+def _short_header_bin(bone_id=42, bone_parent=0xFF, bone_xyz=(1.0, 2.0, 3.0)):
+    """A minimal, otherwise-empty mesh .bin whose header stops at 0x40,
+    followed immediately by one bone - exactly where offset_bones says it
+    should be.
+    """
+    end = SHORT_HEADER_SIZE + 16  # header + one bone, nothing else in this file
+    header = struct.pack(
+        "<IIIIIIBBHIIIBBHIIIHHI",
+        SHORT_HEADER_SIZE,  # offset_bones (doubles as header size)
+        0,                  # unk_00
+        0,                  # unk_01
+        0,                  # offset_vertex_colors
+        0,                  # offset_vertex_texcoord
+        0,                  # offset_weights
+        0,                  # num_weights
+        1,                  # num_bones
+        0,                  # num_materials
+        end,                # offset_materials (unread: num_materials == 0)
+        0x80000000,         # flags (mesh)
+        0,                  # num_tpl
+        0,                  # vertex_scale
+        0,                  # unk_02
+        0,                  # num_weights2
+        0,                  # offset_morphs
+        end,                # offset_vertex_position (unread: num_vertices == 0)
+        end,                # offset_vertex_normals
+        0,                  # num_vertices
+        0,                  # num_vertex_normals
+        0,                  # version_flags
+    )
+    assert len(header) == SHORT_HEADER_SIZE
+    bone = struct.pack("<BBHfff", bone_id, bone_parent, 0, *bone_xyz)
+    return header + bone
+
+
+def test_a_short_header_s_trailing_offsets_default_to_absent():
+    parsed = Re4UhdBin.from_bytes(_short_header_bin())
+    parsed._read()
+
+    assert parsed.header.offset_bones == SHORT_HEADER_SIZE
+    assert parsed.header.offset_bonepairs == 0
+    assert parsed.header.offset_adjacents == 0
+    assert parsed.header.offset_index_buffer == 0
+    assert parsed.header.offset_index_buffer2 == 0
+    # None of these optional blocks should even be attempted: each is only
+    # read `if offset_X > 0` (see re4-uhd-bin.ksy).
+    assert parsed.header.offset_bonepairs == 0 and not hasattr(parsed, "_m_bone_pairs")
+    assert parsed.header.offset_adjacents == 0 and not hasattr(parsed, "_m_adjacent")
+
+
+def test_a_short_header_s_bone_data_is_read_correctly_not_as_trailing_offsets():
+    bin_bytes = _short_header_bin(bone_id=42, bone_parent=0xFF, bone_xyz=(1.0, 2.0, 3.0))
+    parsed = Re4UhdBin.from_bytes(bin_bytes)
+    parsed._read()
+
+    assert len(parsed.bones) == 1
+    bone = parsed.bones[0]
+    assert bone.bone_id == 42
+    assert bone.parent == 0xFF
+    assert (bone.x, bone.y, bone.z) == (1.0, 2.0, 3.0)


### PR DESCRIPTION
## Intent

Close the gaps in albam issue #271, "RE4UHD: test gaps and latent defects left after the initial merge" (https://github.com/Brachi/albam/issues/271).

The captains ask, in the substance of that issue (which the captain wrote). Collected from two reviews and left unfixed there deliberately. None is a live failure; each is either untested code or a defect no shipped file reaches today.

Untested paths:
- `_rebuild_udas` is only exercised at `shift == 0`: the test substitutes an entry for itself, so the descriptor-shifting path - the whole point of `update_lfs` - has no coverage, and one assertion in it is only correct for that case. `update_lfs` itself, its extension dispatch and its single-file-archive branch have no test at all.
- Geometry fidelity is only checked through albam re-importing its own output. Nothing compares exported vertex positions, normals or UVs against the bytes the original shipped with, which is the check that would catch a scale, axis or normal-encoding regression. `_model_state` even computes `"vertices"` and never asserts on it.
- `bpy.ops.albam.pack` has no test on either engine, and its `_execute` is marked `# pragma: no cover` - which is where a defect was found by review rather than by the suite. A script driving the whole chain exists but is not part of the suite.

Latent defects:
- Short `.bin` headers (0x40 and 0x50) would be misread: albam always reads the full 96 bytes, so bone data would be parsed as offsets. None found in a 245-file sample.
- Unverified review findings, none reproduced: the armature object transform is ignored on export while the mesh bakes `matrix_world`; `_bone_id`s fallback can collide with a digit-named bone; `_build_dat_block` does not pad its last entry to 16; `_place` compares a composed matrix to the identity with `==`.
- One model in the game needs 79,959 face corners against the 65,535 the format can state. It errors clearly rather than truncating and the next largest is at 70%, so this may be a wontfix.

One item is already struck through as fixed in #288: the `fs_registry.clear()` hazard in `tests/test_vfs_fs_backed.py`.

## What Changed

- **Parsing and export fixes in `albam/engines/cie`:** `re4_uhd_bin.py` now only reads the four trailing header offsets when `offset_bones > 0x40`, defaulting them to 0 for a 0x40 header instead of consuming bone data as offsets (with the `.ksy` left unconditional and both files documenting the hand edit); `_bone_id` is replaced by `_bone_ids_by_name`, which reserves digit-named ids up front and wraps the fallback search so no two bones share an id, raising `AlbamCheckFailure` when a bone that must be written — or a vertex group weighted to one — has no id left; `_collect_geometry` now takes the export's armature and bakes each mesh relative to `armature.matrix_world` so moving the armature object no longer desyncs vertices from the bone table.
- **New tests:** `test_archive_update.py` covers `_rebuild_udas` block shifting after a resized entry plus `update_lfs`'s udas, single-file and unsupported-container paths; `test_bone_ids.py`, `test_short_bin_header.py` and `test_face_corner_limit.py` pin the fixes and the `MAX_VERTICES` error above; `test_pack_operator.py` drives `bpy.ops.albam.pack` end to end, and the `# pragma: no cover` on `ALBAM_OT_Pack._execute` is removed.
- **Existing tests and docs:** `test_bin_serialization.py` gains a round trip comparing exported positions, normals and UVs against the original bytes rather than a re-import; `test_bin_export_fidelity.py` adds the moved-armature check; README and `docs/modding-a-character.md` document the hand-maintained parser branch, the armature-relative bake and the 255-bone limit, and `scenario.py` records that the identity comparison in `_entry_matrices` was checked and not reproduced.

## Risk Assessment

✅ Low: The change is overwhelmingly test additions plus narrow, intent-mandated source fixes whose new logic (bone-id assignment, the two >255-bone refusals, the armature-relative bake, and the short-header read branch) I traced by hand against concrete inputs without finding a wrong result or a spuriously reachable failure.

## Testing

`Stood the addon up the way an end user runs it (Blender's bpy module with albam registered) and drove eleven scenarios end to end against synthetic RE4UHD files: importing 0x40 and 0x50 short-header .bin files through the VFS import operator (bone data decoded correctly in both), exporting a model on a 301-bone rig whose excess bones carry no weights (succeeds, one bone written), weighting the mesh to a bone past the 255-id space (refused with the user-facing Albam error report naming 'deform_254' and giving details and a solution), moving the armature object (export byte-identical), the face-corner ceiling (clear "too much geometry" check failure), a hand-built .udas.lfs archive where a resized entry grows the DAT block by 256 bytes and the following block descriptor shifts by exactly that while its bytes survive, the single-file and unsupported-extension branches of update_lfs, the whole import -> edit -> export -> bpy.ops.albam.pack chain producing a repacked archive whose model entry carries the edit and whose sibling entry is untouched, and a geometry-fidelity comparison of an unedited re-export against the original file's own bytes (8/8 triangles matched, all per-corner normals within tolerance) with an injected 5% scale proving the comparison actually fails when geometry drifts. Two fixes were additionally confirmed against the base commit, where the short-header read returned garbage offsets and the armature move changed the exported bytes. Evidence is CLI transcripts rather than screenshots: this change has no rendered UI surface - the only user-visible surface is Blender's textual Albam error report, which is captured verbatim in the bone-id transcript. The scenarios that require shipped RE4 UHD archives (the parameterized fidelity, pack and archive-update tests) skip here for lack of R2 credentials or a game install and are reported untested.`

- Live validation: ✅ go - 11 of 12 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A user imports a .bin whose header is the short 0x40 variant; its bone is read as bone data, not as trailing offsets | ✅ pass | live | drive_short_header_import.log - import {&#39;FINISHED&#39;}, bone &#39;42&#39; at head_local (0.001, -0.003, 0.002), i.e. the 1/2/3 mm the file states; pre-fix the same bytes yielded offset_bonepairs=65322 (short_hea… |
| A user imports a .bin with a 0x50 header, which does state all four trailing offsets; it takes the read-all-four branch and its bone still parses | ✅ pass | live | drive_short_header_import.log - import {&#39;FINISHED&#39;}, bone &#39;7&#39; at (0.004, -0.006, 0.005); tests/cie/test_short_bin_header.py::test_a_0x50_header_states_its_trailing_offsets_and_its_bone_follows_them |
| A user adds 300 unweighted rig control bones to an imported model and exports it: the export succeeds and writes only the bone the model uses | ✅ pass | live | drive_bone_id_export.log - 301 bones in the armature, bpy.ops.albam.export() -&gt; FINISHED, bones written [7], 3 vertices |
| Adversarial: a user weights the mesh to a bone past the 255-id space; the export refuses loudly instead of silently pinning those vertices to bone 0 | ✅ pass | live | drive_bone_id_export.log - Albam error report: &#34;modelB.bin.000 is weighted to &#39;deform_254&#39;, a bone the format cannot name&#34;, with details and solution; no file written |
| A user moves the armature object in the scene and re-exports: the exported bytes are unchanged | ✅ pass | live | drive_bone_id_export.log - armature moved to (5.0, -3.0, 2.5), export identical: True; on base 25127af the same drive reports False (armature_move_before_fix.log) |
| Adversarial: a mesh with more face corners than the format&#39;s 16-bit count errors clearly rather than truncating | ✅ pass | live | `pytest tests/cie/test_face_corner_limit.py` - export_bin on a real 21846-triangle Blender mesh raises AlbamCheckFailure matching &#34;too much geometry&#34; and naming the 65535 limit (pytest_ci_safe.log) |
| A user replaces an archive entry with a bigger one: the DAT block grows and every block descriptor after it shifts, with the trailing block intact | ✅ pass | live | drive_pack_udas.log - block table (0,127,128),(1,80,255) -&gt; (0,383,128),(1,80,511); DAT grew 256, following block moved 256 and its bytes compare equal; re-opened archive holds the edited entry and th… |
| update_lfs dispatch: a single-file archive is replaced wholesale, and an archive albam cannot write refuses instead of emitting a broken container | ✅ pass | live | drive_pack_udas.log - single.bin repacked with the edited bytes; a .dat archive raises NotImplementedError naming the supported cases |
| A user opens an archive, imports a model, edits it, exports it and packs it back with bpy.ops.albam.pack; the repacked archive carries the edit and keeps every other entry | ✅ pass | live | drive_pack_udas.log - pack.poll() True, pack(filepath=...) {&#39;FINISHED&#39;}, 258-byte archive re-opened: model entry changed and re-parses with 3 vertices and bone 7, sibling entry byte-identical |
| A model exported unedited keeps the geometry the original file stated, checked against the original bytes rather than against a re-import | ✅ pass | live | drive_geometry_fidelity.log - 8/8 triangles matched against the original bytes by position and UV, 0 unmatched, per-corner normal agreement 1.00 |
| Adversarial: a scale regression injected into the exported positions must break the fidelity comparison | ✅ pass | live | drive_geometry_fidelity.log - a 5% scale leaves 8/8 triangles unmatched, so the check is not vacuous |
| The same fidelity, pack and archive-update scenarios against the shipped RE4 UHD archives the new tests are parameterized on | ⏸️ untested | no | Needs the real game data: either an RE4 UHD install passed as `--game-dir re4uhd::&lt;path&gt;`, or R2 credentials (R2_ACCOUNT_ID / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY / R2_BUCKET_NAME in a .env, see .e… |

<details>
<summary>Evidence: Import of synthetic 0x40 and 0x50 short-header .bin files</summary>

```text
Traceback (most recent call last):
Traceback (most recent call last):
Traceback (most recent call last):
Traceback (most recent call last):
== user imports a .bin whose header is the short 0x40 variant ==
Info: Import successful
[short40] header size 0x40 -> import {'FINISHED'}, object 'short40.bin.000'
[short40]   bone '42' head_local=(0.001, -0.003, 0.002)
== user imports a .bin whose header is the 0x50 variant (states 4 trailing offsets) ==
Info: Import successful
[medium50] header size 0x50 -> import {'FINISHED'}, object 'medium50.bin.000'
[medium50]   bone '7' head_local=(0.004, -0.006, 0.005)
OK
```
</details>
<details>
<summary>Evidence: Bone-id scenarios: 301-bone rig export, unnameable weighted bone refusal (with the user-facing error report), armature move</summary>

```text
=== Scenario A: 300 unweighted control bones on a rig, model still exports ===
Info: Import successful
armature 'modelA.bin_armature' now has 301 bones (format can name at most 255)
Info: Export successful
bpy.ops.albam.export() -> FINISHED, 352 bytes, bones written: [7], vertices: 3

=== Scenario C: moving the armature object leaves the export unchanged ===
Info: Export successful
armature moved to (5.0, -3.0, 2.5); export identical: True

=== Scenario B: weighting the mesh to a bone the format cannot name ===
Info: Import successful
301 bones in the rig; 255 fit the id space; user weights the mesh to 'deform_254', which does not

==================
Albam error report
==================

Blender version: 5.2.0
Albam version: 0.5.0
Operating System: Linux-7.2.3-arch1-2-x86_64-with-glibc2.44
Error: AlbamCheckFailure: modelB.bin.000 is weighted to 'deform_254', a bone the format cannot name
Traceback:
  File "******/.no-mistakes/worktrees/731f537710a6/01M2461RKYF7G7WZJP53YMNG4F/albam/blender_ui/export_panel.py", line 289, in execute
    self._execute(context, item)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "******/.no-mistakes/worktrees/731f537710a6/01M2461RKYF7G7WZJP53YMNG4F/albam/blender_ui/export_panel.py", line 303, in _execute
    vfiles = export_function(item.bl_object)
  File "******/.no-mistakes/worktrees/731f537710a6/01M2461RKYF7G7WZJP53YMNG4F/albam/engines/cie/mesh.py", line 1290, in export_bin
    weight_indices, weight_table) = _collect_geometry(bl_mesh_objs, armature)
                                    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "******/.no-mistakes/worktrees/731f537710a6/01M2461RKYF7G7WZJP53YMNG4F/albam/engines/cie/mesh.py", line 955, in _collect_geometry
    raise AlbamCheckFailure(
    ...<8 lines>...
    )

=================

Error: Python: Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M2461RKYF7G7WZJP53YMNG4F/albam/blender_ui/export_panel.py", line 291, in execute
    handle_operator_exception(self, "Export failed")
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M2461RKYF7G7WZJP53YMNG4F/albam/blender_ui/error_handling.py", line 70, in handle_operator_exception
    raise err
  File "~/.no-mistakes/worktrees/731f537710a6/01M2461RKYF7G7WZJP53YMNG4F/albam/blender_ui/export_panel.py", line 289, in execute
    self._execute(context, item)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M2461RKYF7G7WZJP53YMNG4F/albam/blender_ui/export_panel.py", line 303, in _execute
    vfiles = export_function(item.bl_object)
  File "~/.no-mistakes/worktrees/731f537710a6/01M2461RKYF7G7WZJP53YMNG4F/albam/engines/cie/mesh.py", line 1290, in export_bin
    wei... truncatedbpy.ops.albam.export() refused: RuntimeError
  message : modelB.bin.000 is weighted to 'deform_254', a bone the format cannot name
  details : A bone is named by a single byte, so an armature can only hand out 255 ids, and this one has more bones than that. Weights on a bone left without an id would otherwise fall onto the first bone instead.
  solution: Remove bones the model does not need, so every bone it is weighted to can be named

OK
```
</details>
<details>
<summary>Evidence: Synthetic .udas archive: update_lfs block shifting, dispatch branches, and the full bpy.ops.albam.pack chain</summary>

```text
Traceback (most recent call last):
Traceback (most recent call last):
Traceback (most recent call last):
built synthetic.udas.lfs: 184 bytes on disk, 335 decompressed
albam lists its entries as ['synthetic_000.bin', 'synthetic_001.txt']

=== a user replaces one entry with a bigger one: update_lfs ===
extension dispatch: .udas -> _rebuild_udas
block table before: [(0, 127, 128), (1, 80, 255)]
block table after : [(0, 383, 128), (1, 80, 511)]
DAT block grew by 256 bytes; block after it moved 256 bytes and is intact: True
re-opened: ['synthetic_updated_000.bin', 'synthetic_updated_001.txt']
  replaced entry is the edited bytes : True
  untouched entry came back as       : b'a second entry\n'

=== a single-file archive takes the replacement branch instead ===
['single.bin'] -> repacked, entry is the edited bytes: True

=== an archive albam cannot write refuses rather than emitting a broken one ===
NotImplementedError: writing a .dat archive isn't supported yet - only .udas containers and single-file archives

=== the whole chain through bpy.ops: import -> export -> pack ===
Info: Import successful
user selects 'synthetic_000.bin' in the archive and imports it: {'FINISHED'}
user adds a triangle to the model, skinned to bone 7
Info: Export successful
bpy.ops.albam.export(): {'FINISHED'}
bpy.ops.albam.pack.poll(): True
bpy.ops.albam.pack(filepath=...): {'FINISHED'}
wrote packed.udas.lfs: 258 bytes
packed archive holds ['packed_000.bin', 'packed_001.txt']
  the model entry changed          : True
  and re-parses with the edit in it: 3 vertices, bones [7]
  the untouched entry came back as : b'a second entry\n'

OK
```
</details>
<details>
<summary>Evidence: Geometry fidelity against the original file&#39;s own bytes, plus an injected scale regression</summary>

```text
Traceback (most recent call last):
Traceback (most recent call last):
Traceback (most recent call last):
Traceback (most recent call last):
Info: Import successful
Info: Export successful
a RE4UHD model of 8 triangles: 1168 bytes on disk

=== the user imports it and exports it again without editing anything ===
[re4uhd] weights: 24 verts, 1 vertex groups
Info: Import successful
Info: Export successful
re-exported: 1168 bytes
triangles in the original file : 8
triangles in the exported file : 8
matched against the ORIGINAL bytes by position and UV: 8, unmatched: 0
fraction of triangles that also kept their per-corner normals: 1.00

=== adversarial: a scale regression must NOT match ===
a 5% scale applied to the exported positions leaves 8/8 triangles unmatched (the check would fail, as it must)

OK
```
</details>
<details>
<summary>Evidence: Pre-fix reproduction: 0x40 header trailing offset read as 65322</summary>

```text
# Pre-fix (base 25127af) behaviour, same synthetic 0x40-header .bin

    def test_a_short_header_s_trailing_offsets_default_to_absent():
        parsed = Re4UhdBin.from_bytes(_bin_with_one_bone())
        parsed._read()
    
        assert parsed.header.offset_bones == SHORT_HEADER_SIZE
>       assert parsed.header.offset_bonepairs == 0
E       assert 65322 == 0
E        +  where 65322 = <albam.engines.cie.structs.re4_uhd_bin.Re4UhdBin.UhdBinHeader object at 0x7fe998f76120>.offset_bonepairs
E        +    where <albam.engines.cie.structs.re4_uhd_bin.Re4UhdBin.UhdBinHeader object at 0x7fe998f76120> = <albam.engines.cie.structs.re4_uhd_bin.Re4UhdBin object at 0x7fe998f75fd0>.header

tests/cie/test_short_bin_header.py:76: AssertionError
=========================== short test summary info ============================
FAILED tests/cie/test_short_bin_header.py::test_a_short_header_s_trailing_offsets_default_to_absent
1 failed, 2 passed in 0.03s
```
</details>
<details>
<summary>Evidence: Pre-fix reproduction: moving the armature changed the exported bytes</summary>

```text
# Pre-fix (base 25127af mesh.py): the same driven scenario, armature moved

=== Scenario C: moving the armature object leaves the export unchanged ===
Info: Export successful
armature moved to (5.0, -3.0, 2.5); export identical: False
```
</details>
<details>
<summary>Evidence: Targeted pytest run of the touched cie test modules</summary>

```text
...............ssssssssssssssssssssssssssssss.                           [100%]
=========================== short test summary info ============================
SKIPPED [3] tests/cie/test_archive_update.py:76: No --game-dir supplied for app_id='re4uhd'
SKIPPED [3] tests/cie/test_archive_update.py:150: No --game-dir supplied for app_id='re4uhd'
SKIPPED [3] tests/cie/test_archive_update.py:187: No --game-dir supplied for app_id='re4uhd'
SKIPPED [3] tests/cie/test_archive_update.py:223: No --game-dir supplied for app_id='re4uhd'
SKIPPED [3] tests/cie/test_pack_operator.py:58: No --game-dir supplied for app_id='re4uhd'
SKIPPED [3] tests/cie/test_bin_export_fidelity.py:121: No --game-dir supplied for app_id='re4uhd'
SKIPPED [3] tests/cie/test_bin_export_fidelity.py:171: No --game-dir supplied for app_id='re4uhd'
SKIPPED [3] tests/cie/test_bin_export_fidelity.py:245: No --game-dir supplied for app_id='re4uhd'
SKIPPED [3] tests/cie/test_bin_export_fidelity.py:314: No --game-dir supplied for app_id='re4uhd'
SKIPPED [3] tests/cie/test_bin_export_fidelity.py:363: No --game-dir supplied for app_id='re4uhd'
16 passed, 30 skipped in 0.94s
```
</details>
<details>
<summary>Evidence: Driver scripts used to stand the addon up and drive each scenario</summary>

```text
"""Drive the RE4UHD archive chain end to end on a synthetic .udas.lfs:
open the archive, import the model, edit it, export it and pack it back,
then re-open the packed archive and check what came back.

The shipped archives this normally runs against are not redistributable, so
the container here is built by hand to the same layout (see
albam.engines.cie.fs.read_udas_block_table): eight signature words, a DAT
block descriptor, a second block after it, a terminator.
"""
import os, struct, sys, tempfile
sys.path.insert(0, os.environ["ALBAM_REPO"])
import bpy
from albam import register
from albam.blender_ui.error_handling import RERAISE_ERRORS_ENV_VAR
os.environ[RERAISE_ERRORS_ENV_VAR] = "1"
register()

from albam.engines.cie.archive import _build_dat_block, _read_payload, update_lfs
from albam.engines.cie.fs import LfsFS, read_udas_block_table
from albam.engines.cie.lfs_decompress import xcompress_compress_re4hd
from tests.cie.test_short_bin_header import _bin_with_one_bone

TABLE_OFFSET = 0x20
DESCRIPTOR_SIZE = 32
TERMINATOR = 0xFFFFFFFF
TRAILING = b"SOUNDBLOCK" * 8

def build_udas(entries):
    dat = _build_dat_block(entries)
    data_offset = TABLE_OFFSET + 3 * DESCRIPTOR_SIZE
    out = bytearray(b"\xAB" * TABLE_OFFSET)          # signature words, carried as-is
    def descriptor(block_type, size, offset):
        # 32 bytes per descriptor: the four words read, then padding.
        return struct.pack("<4I", block_type, size, 0, offset).ljust(DESCRIPTOR_SIZE, b"\x00")

    out += descriptor(0, len(dat), data_offset)                     # DAT block
    out += descriptor(1, len(TRAILING), data_offset + len(dat))     # block after it
    out += descriptor(TERMINATOR, 0, 0)
    assert len(out) == data_offset
    out += dat + TRAILING
    return bytes(out)

model_bytes = _bin_with_one_bone(bone_id=7, bone_parent=0xFF, bone_xyz=(1.0, 2.0, 3.0))
payload = build_udas([("BIN", model_bytes), ("TXT", b"a second entry\n")])
tmp = tempfile.mkdtemp()
archive_path = os.path.join(tmp, "synthetic.udas.lfs")
open(archive_path, "wb").write(xcompress_compress_re4hd(payload))
print(f"built {os.path.basename(archive_path)}: {os.path.getsize(archive_path)} bytes on disk, "
      f"{len(payload)} decompressed")

fs = LfsFS(archive_path)
names = [p.lstrip("/") for p in fs.walk.files()]
fs.close()
print(f"albam lists its entries as {names}")

print()
print("=== a user replaces one entry with a bigger one: update_lfs ===")

class _Exported:
    def __init__(self, name, data):
        self.display_name, self._data = name, data

    def get_bytes(self):
        return self._data

before_payload, extension = _read_payload(archive_path)
before_blocks = read_udas_block_table(before_payload, "<")
bigger = model_bytes + b"\xAA" * 256
updated = update_lfs(archive_path, [_Exported(names[0], bigger)])
updated_path = os.path.join(tmp, "synthetic_updated.udas.lfs")
open(updated_path, "wb").write(updated)
after_payload, _ = _read_payload(updated_path)
after_blocks = read_udas_block_table(after_payload, "<")
print(f"extension dispatch: {extension} -> _rebuild_udas")
print(f"block table before: {before_blocks}")
print(f"block table after : {after_blocks}")
shift = after_blocks[0][1] - before_blocks[0][1]
print(f"DAT block grew by {shift} bytes; block after it moved "
      f"{after_blocks[1][2] - before_blocks[1][2]} bytes and is intact: "
      f"{after_payload[after_blocks[1][2]:after_blocks[1][2] + len(TRAILING)] == TRAILING}")

fs = LfsFS(updated_path)
back = {p.lstrip("/"): fs.readbytes(p) for p in fs.walk.files()}
fs.close()
back_names = sorted(back)
print(f"re-opened: {back_names}")
print(f"  replaced entry is the edited bytes : {back[back_names[0]] == bigger}")
print(f"  untouched entry came back as       : {back[back_names[1]]!r}")

print()
print("=== a single-file archive takes the replacement branch instead ===")
single_path = os.path.join(tmp, "single.bin.lfs")
open(single_path, "wb").write(xcompress_compress_re4hd(model_bytes))
fs = LfsFS(single_path)
single_names = [p.lstrip("/") for p in fs.walk.files()]
fs.close()
single_updated = update_lfs(single_path, [_Exported(single_names[0], bigger)])
open(os.path.join(tmp, "single_updated.bin.lfs"), "wb").write(single_updated)
fs = LfsFS(os.path.join(tmp, "single_updated.bin.lfs"))
single_back = fs.readbytes(next(iter(fs.walk.files())))
fs.close()
print(f"{single_names} -> repacked, entry is the edited bytes: {single_back == bigger}")

print()
print("=== an archive albam cannot write refuses rather than emitting a broken one ===")
dat_path = os.path.join(tmp, "unsupported.dat.lfs")
open(dat_path, "wb").write(xcompress_compress_re4hd(b"not a udas" * 32))
try:
    update_lfs(dat_path, [_Exported("whatever_000.bin", bigger)])
except NotImplementedError as err:
    print(f"NotImplementedError: {err}")
else:
    print("!! it wrote something")

print()
print("=== the whole chain through bpy.ops: import -> export -> pack ===")
bpy.context.scene.albam.apps.app_selected = "re4uhd"
vfs = bpy.context.scene.albam.vfs
root = vfs.add_fs_root("re4uhd", LfsFS(archive_path), display_name="synthetic.udas.lfs",
                       is_archive=True, absolute_path=archive_path)
vfile = next(vf for vf in vfs.file_list
             if not vf.is_root and vf.display_name.endswith(".bin"))
vfs.file_list_selected_index = vfs.file_list.find(vfile.name)
print(f"user selects {vfile.display_name!r} in the archive and imports it: "
      f"{bpy.ops.albam.import_vfile()}")
arm = next(o for o in bpy.data.objects if o.type == "ARMATURE")
mesh_ob = next(o for o in arm.children_recursive if o.type == "MESH")
mesh_ob.data.from_pydata([(0, 0, 0), (1, 0, 0), (0, 1, 0)], [], [(0, 1, 2)])
mesh_ob.data.update()
uv = mesh_ob.data.uv_layers.new(name="UVMap")
for loop in mesh_ob.data.loops:
    uv.data[loop.index].uv = (0.0, 0.0)
group = mesh_ob.vertex_groups.new(name="7")
group.add([0, 1, 2], 1.0, "REPLACE")
mesh_ob.data.materials.append(bpy.data.materials.new("albam-test-mat"))
print("user adds a triangle to the model, skinned to bone 7")

exportable = bpy.context.scene.albam.exportable
exportable.file_list_selected_index = next(
    i for i, it in enumerate(exportable.file_list)
    if it.bl_object and it.bl_object.name == arm.name)
print(f"bpy.ops.albam.export(): {bpy.ops.albam.export()}")
exported = bpy.context.scene.albam.exported
# pack needs the export *root* selected on the export side, and the archive
# root - not the .bin inside it - selected on the import side.
exported.file_list_selected_index = next(
    i for i, vf in enumerate(exported.file_list) if vf.is_root)
vfs.file_list_selected_index = vfs.file_list.find(root.name)
packed_path = os.path.join(tmp, "packed.udas.lfs")
print(f"bpy.ops.albam.pack.poll(): {bool(bpy.ops.albam.pack.poll())}")
print(f"bpy.ops.albam.pack(filepath=...): {bpy.ops.albam.pack(filepath=packed_path)}")
print(f"wrote {os.path.basename(packed_path)}: {os.path.getsize(packed_path)} bytes")

fs = LfsFS(packed_path)
packed = {p.lstrip("/"): fs.readbytes(p) for p in fs.walk.files()}
fs.close()
packed_names = sorted(packed)
packed_model = packed[packed_names[0]]
from albam.engines.cie.structs.re4_uhd_bin import Re4UhdBin
parsed = Re4UhdBin.from_bytes(packed_model)
parsed._read()
print(f"packed archive holds {sorted(packed)}")
print(f"  the model entry changed          : {packed_model != model_bytes}")
print(f"  and re-parses with the edit in it: {parsed.header.num_vertices} vertices, "
      f"bones {[b.bone_id for b in parsed.bones]}")
print(f"  the untouched entry came back as : {packed[packed_names[1]]!r}")
print()
print("OK")
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"1cfb9ce96129fa8d2f6ca953730382e234663af8","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed (8) ✅</summary>

- ⚠️ `albam/engines/cie/mesh.py:703` - `_bone_id` is now dead code: both of its call sites (`_serialize_bones` and `_collect_geometry`) were replaced by `_bone_ids_by_name`, and no other module imports it - it survives only as a mention in the new function&#39;s docstring. Remedy: delete `_bone_id` and reword the `_bone_ids_by_name` docstring, which currently claims to resolve bones &#34;through _bone_id&#34;. (Minor, same spot: `reserved` is only ever used to seed `used`, so `used = {int(b.name) for ...}` says the same thing in one pass.)
- ⚠️ `albam/engines/cie/mesh.py:729` - The new de-duplication still lets two bones land on the same id in two reachable ways. (1) Zero-padded digit names bypass the nudge entirely: an armature imported with bone &#34;5&#34; plus a hand-added bone named &#34;05&#34; both take the `isdigit()` branch and both get id 5, so `_bones_to_write`&#39;s `by_id.setdefault` keeps whichever comes first and the other bone is silently dropped from the exported table while its vertex-group weights re-map onto the survivor - exactly the silent drop this function was added to prevent. (2) The nudge loop `while candidate in used and candidate &lt; 254` stops at 254 and assigns it regardless, so once 254 is taken a further fallback bone duplicates it instead of erroring. Remedy for (1) is mechanical: only treat a name as claiming an id when it is canonical (`str(int(name)) == name`), letting &#34;05&#34; fall through to the fallback path; for (2), raise a clear AlbamCheckFailure when no free id remains rather than emitting a duplicate.
- ℹ️ `albam/engines/cie/structs/re4-uhd-bin.ksy:103` - The `.ksy` now declares the four trailing offsets with `if: offset_bones &gt; 0x40`, but kaitai&#39;s `if` makes an absent field raise on access, while the hand-edited generated reader defaults each to 0. Every downstream instance guard (`bone_pairs`/`adjacent`/`indexes`/`indexes2`, all `if: header.offset_x &gt; 0`) relies on the 0 default, so anyone who regenerates `re4_uhd_bin.py` from the `.ksy` - which the file&#39;s own header instructs (&#34;This is a generated file! Please edit source .ksy&#34;) - gets a parser that raises AttributeError on a 0x40-header file instead of skipping the optional blocks. The same divergence exists in `_write__seq`, which still writes all four unconditionally (currently unreachable: nothing re-serializes a parsed header). The comments document the split deliberately, so this is flagged for a decision rather than fixed: either express the default in the `.ksy` (e.g. rename the seq fields and add `instances` with `value:` expressions that fall back to 0) or state that this file is no longer regenerable from its `.ksy`.
- ℹ️ `albam/engines/cie/mesh.py:953` - Baking the mesh relative to `armature.matrix_world` matches Blender&#39;s own armature bind space, so the fix is the right one - but it also means moving, rotating or scaling the armature object now has no effect at all on the exported file, silently. A user who scales a rig to resize a model sees the deformed result change in the viewport (the armature modifier follows the object transform) and gets an unchanged .bin. The alternative durable fix - applying `armature.matrix_world` to the bone heads in `_serialize_bones` as well, so the edit survives in both - was not taken. Noting the trade-off, which the code comment already justifies (the format has no placement field); no action needed unless the silent discard is considered a regression for modders.
- ℹ️ `tests/cie/test_bin_serialization.py:133` - `_decoded_triangles` quantizes each coordinate with `round(v, 3)` (1 raw unit, since GLOBAL_SCALE is 0.001) and `round(v, 4)` for UVs, then `_surfaces` demands exact multiset equality. A shipped coordinate that lands on a quantization boundary - a position at an exact half raw unit, which axis-aligned or tool-quantized geometry produces readily - can round one way in the original and the other in the re-export after the float32 -&gt; double -&gt; float32 round trip, failing the test with a one-unit &#34;difference&#34; that is not a regression. Over tens of thousands of corners per model that is a real false-failure surface for a data-driven test. Remedy: pair triangles by a coarser key and compare the paired coordinates with an explicit tolerance (e.g. math.isclose) rather than relying on rounding alone to make equality work.

🔧 Fix applied.
4 issues (3 warnings, 1 info) still open:

- ⚠️ `albam/engines/cie/mesh.py:735` - The fallback nudge only scans upward from `min(i, 254)`, so it raises AlbamCheckFailure while free ids below the bone&#39;s index are still available, with an error message that is then factually wrong (&#34;the format can only name 255 bones and this armature needs more&#34;). Concrete case: an armature of 195 bones named &#34;60&#34;..&#34;254&#34; (a model bound to the upper part of a shared rig - see _bones_to_write, which exists precisely because an armature is larger than one model) plus one hand-added helper bone at index 195. `used` = {60..254}; the helper starts at 195, walks to 254, hits the `bone_id == 254` guard and raises - even though ids 0..59 are unclaimed and the armature has only 196 bones. Before this fix round the same armature exported fine. Remedy is mechanical and stays inside the new function: after the upward scan fails, scan the whole 0..254 range for a free id and raise only when none is left, so the error means what it says.
- ⚠️ `tests/cie/test_bin_serialization.py:143` - The half-cell second pass in `_unmatched_surfaces` cannot rescue the boundary case it was added for, because each triangle&#39;s corner order is still frozen at `_corner_key(c[0], 0.0)` in `_decoded_triangles` - the very key that is unstable at a cell boundary. Concrete: corners A=(0.0005, 0.010, 0.0), B=(0.0010, 0.005, 0.0), C=(0.0100, 0.0, 0.0). At offset 0 the original sorts A(0,10,0) &lt; B(1,5,0) &lt; C; after the float32-&gt;double-&gt;float32 round trip A becomes 0.00050000002, its key flips to (1,10,0), and the export sorts B &lt; A &lt; C. Pass 1 misses (different keys). Pass 2 at offset 0.5 gives every corner a matching key, but the two surface tuples are still ordered (A,B,C) vs (B,A,C), so they do not compare equal and the triangle is reported unmatched - a false failure of exactly the kind the fix round set out to remove. Remedy: build the match key inside `_unmatched_surfaces` as a *sorted* tuple of per-corner keys at the offset being used, instead of relying on a corner order canonicalized at offset 0.0.
- ⚠️ `albam/engines/cie/scenario.py:211` - Intent conformance: the issue&#39;s latent-defect list requires closing &#34;Unverified review findings, none reproduced: ... `_place` compares a composed matrix to the identity with `==`&#34;. Three of the four are handled by this change (armature transform baked relative to the armature, `_bone_id` collisions, and `_build_dat_block`&#39;s last-entry padding, which already carries an in-code justification at the base commit), but `_entry_matrices`&#39; `rotation == Matrix.Identity(4)` is untouched and gains no test. `rotation` is `to_blender @ euler @ to_blender.inverted()` where `to_blender` is built from cosf(pi/2) != 0, so for a zero-angle entry the product is only approximately identity; whether mathutils&#39; `==` uses an epsilon decides whether a non-uniformly-scaled, unrotated entry is placed as one object (as the docstring promises) or split into an empty plus a child. Geometry stays correct either way, which is why this needs the author&#39;s call rather than a fix here: either verify and drop the item, or replace the comparison with a tolerant check and pin it with a test.
- ℹ️ `tests/cie/test_bin_export_fidelity.py:423` - `zip(unmoved_positions, moved_positions)` silently truncates to the shorter list, so if moving the armature ever changed the exported corner *count* (normal clustering and per-material corner dedup both depend on the transformed values) the test would compare only the common prefix and could still pass. Add `assert len(moved_positions) == len(unmoved_positions)` before the max-delta comparison.

🔧 Fix applied.
3 issues (1 warning, 2 infos) still open:

- ⚠️ `tests/cie/test_bin_serialization.py:190` - The half-cell second pass moves the quantization boundary rather than removing it, so the false-failure class the round-1 finding asked to eliminate is still reachable. `_corner_key` computes `round(v/STEP + offset)`. At `offset=0.5` the rounding boundaries land where `v/STEP` is an *exact integer* - i.e. exact raw units, the most common quantized coordinate in this data - and Python&#39;s round-half-to-even makes the choice there depend on parity while the float32-&gt;double-&gt;float32 perturbation makes it depend on the sign of the error. Concrete: a triangle with corner A at 0.0005 (half raw unit, unstable at offset 0.0, so it survives pass 1 unmatched) and corner B at 0.003 whose re-export comes back as 0.0029999998. Pass 2: A matches, but B keys as round(3.5)=4 in the shipped file and round(3.4999998)=3 in the re-export, so the triangle is reported unmatched and the test fails on geometry that is in fact identical. Both `_corner_key`&#39;s `offset` parameter and the two-pass loop are machinery this run&#39;s fix rounds introduced, and they exceed what the original finding asked for (&#34;comparing with a small tolerance instead of exact quantized-multiset equality&#34;). Smallest honest remedy is to revert that machinery to the minimal fix: keep the order-independent per-triangle key (sorted multiset of corner keys, which is correct and required by round 2) but drop `offset` and the second pass, and match a corner by explicit tolerance - e.g. bucket on a coarse cell and accept a candidate whose coordinates are all within a small epsilon, or match the paired coordinates with math.isclose - so no coordinate value class sits on a boundary in every pass. Flagging rather than fixing because the remedy replaces prior-round machinery rather than repairing it.
- ℹ️ `albam/engines/cie/mesh.py:957` - The armature-transform desync fix is keyed on the mesh&#39;s own `Armature` modifier (`_collect_geometry` reads `bl_mesh_ob.modifiers.get(&#34;Armature&#34;)`), but the bone table is written from the armature `export_bin` resolves separately, which also falls back to `bl_obj` itself when `bl_obj.type == &#34;ARMATURE&#34;` (mesh.py:1257-1258). A mesh child that is parented to the armature but carries no `Armature` modifier - e.g. a part the user modelled in Blender and parented without &#34;With Automatic Weights&#34;, exported by selecting the armature root - therefore still gets `matrix_world` baked in outright, which includes the armature object&#39;s placement, while `_serialize_bones` writes bones in the armature&#39;s local rest space. That is the same desync the change set out to close, just on a sibling path; it is not a regression (before the change every mesh took it), so this is informational. Remedy is mechanical: resolve the armature once in `export_bin` and pass it to `_collect_geometry` so every mesh in the export is baked relative to the same armature the bone table is written from, instead of each mesh relying on its own modifier.
- ℹ️ `albam/engines/cie/mesh.py:737` - Which of two equivalent spellings wins an id is decided by armature order, not by the canonical form: for bones `[&#34;05&#34;, &#34;5&#34;]` the hand-added `&#34;05&#34;` claims id 5 and the imported `&#34;5&#34;` is bumped to 1. `_bones_to_write` then resolves `own_ids` through `by_id`, so id 5 - which the imported model recorded as its own bone - now resolves to the hand-added bone, and the original is dropped from the table unless something is weighted to it. The docstring also says the fallback takes &#34;the nearest free id&#34;, while `search = list(range(preferred, 255)) + list(range(preferred))` is upward-then-wrap, not nearest. Both are cosmetic against realistic usage (a user has to name a bone with a leading zero), so noting rather than prescribing; if it is worth closing, preferring the canonical spelling when two names normalize to the same id is the narrow fix.

🔧 Fix applied.
2 issues (1 warning, 1 info) still open:

- ⚠️ `tests/cie/test_bin_serialization.py:216` - The normal half of the new byte-level fidelity test can pass on an export that wrote no normals at all. `_decoded_triangles` sets each corner&#39;s normal to `()` when `parsed.normals` is empty (line 141: `[...] if parsed.normals else None`), and `_normal_agreement` compares with `for a, b in zip(original_normal, exported_normal)` inside an `all(...)`: with either side empty the zip yields nothing, `all([])` is True for every pair, agreement comes out 1.00 and `assert agreement &gt; 0.9` passes. Normals are deliberately not part of `_shape`/`_same_surface`, so no other assertion in this test notices either. Concrete: change `_layout_and_write` to leave `header.num_vertex_normals = 0` (or `offset_vertex_normals = 0`) - the .ksy reads `normals` with `repeat-expr: header.num_vertex_normals` and no guard, so `parsed.normals` comes back empty, every exported corner normal is `()`, and this test - the only one in the suite that compares against the bytes the game shipped, added specifically to catch a normal-encoding regression per issue #271 - still reports 100% agreement and passes. Fix is mechanical inside the existing helper: before measuring agreement, assert both sides decoded one normal per corner (e.g. `assert parsed.normals and len(parsed.normals) == len(parsed.vertex_positions)` in `_decoded_triangles`, or reject a pair whose two normal tuples differ in length in `_normal_agreement`).
- ℹ️ `albam/engines/cie/structs/re4_uhd_bin.py:1073` - Read and write of the header are now asymmetric: `_read` skips the four trailing offsets when `offset_bones &lt;= 0x40`, while `_write__seq` (line ~1073 onward) still writes all four unconditionally, and the .ksy&#39;s new `if: offset_bones &gt; 0x40` says they do not exist in such a file. A 0x40-header struct read and serialized back would therefore emit an 80-byte header and push 16 bytes over the bone data offset_bones points at. Not reachable in intended usage and not a regression: `export_bin` always builds a fresh header with `offset_bones = HEADER_SIZE` (0x60), and nothing in the codebase re-serializes a `.bin` parsed from a file (only `_layout_and_write` writes one). Recording it because it is the sibling path of the changed read logic; no action needed unless a read-modify-write path is ever added.

🔧 Fix applied.
2 issues (1 warning, 1 info) still open:

- ⚠️ `albam/engines/cie/structs/re4-uhd-bin.ksy:103` - The .ksy and the hand-edited generated reader now express *different* semantics for a 0x40 header, and the README documents regeneration as the normal workflow (&#39;kaitai-struct-compiler --target python -w --outdir . &lt;file&gt;.ksy&#39;, README.md:64; the file&#39;s own first line says &#39;This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild&#39;). re4_uhd_bin.py:1030-1041 sets offset_bonepairs/offset_adjacents/offset_index_buffer/offset_index_buffer2 to 0 on the short branch, but a Kaitai `if:` on a seq attribute emits only the positive branch - regenerating leaves those four attributes undefined. The .ksy&#39;s own instances then evaluate `header.offset_bonepairs &gt; 0` (re4-uhd-bin.ksy:26) and `header.offset_index_buffer &gt; 0` (line 33), and fs.py/mesh.py read the same fields, so the regenerated struct raises AttributeError on exactly the 0x40 file this change added support for - silently reverting the fix and turning a misread into a crash. The .ksy comment at lines 97-102 acknowledges the divergence rather than resolving it, which is why this is ask-user: the smallest honest remedy changes how the format is *declared* (e.g. read the four as `*_raw` under the `if:` and expose value-instances that fall back to 0, so generated and hand-maintained code agree), not just a repair of what the diff already does. Flagging rather than fixing because the author deliberately documented accepting the divergence.
- ℹ️ `tests/cie/test_bin_serialization.py:136` - `_decoded_triangles` is used for both sides of the comparison, so the new `assert len(parsed.normals or ()) == len(parsed.vertex_positions)` also runs against the bytes the game shipped. Import itself tolerates a normal-less .bin (`if bin.normals:` at mesh.py:139) and the header states num_vertices and num_vertex_normals as two independent u2s, so a shipped model whose counts differ imports fine but makes this test fail with an assertion rather than a diagnosis. The round-4 instruction allowed either &#39;fail loudly&#39; or &#39;explicitly asserted as expected/skipped with a clear reason&#39;, and this picked the former, so it conforms - noting it only because the narrower form (keep the hard assert for the *exported* side, where mesh.py:1442 guarantees the counts match, and `pytest.skip` with a reason when the *original* states no normals) would keep the vacuous-pass closed without adding a data-dependent failure mode. No action needed unless a dataset archive turns out to hold such a file.

🔧 Fix applied.
4 issues (1 warning, 3 infos) still open:

- ⚠️ `albam/engines/cie/structs/re4_uhd_bin.py:1040` - The intent lists &#34;Short `.bin` headers (0x40 and 0x50) would be misread&#34; as a latent defect to close, and the change guards only `if self.offset_bones &gt; 0x40`, which puts a 0x50 header on the read-all-four branch with no test. Counting the header&#39;s declared fields, offset_bones..version_flags is exactly 64 bytes (0x40) and the four trailing u4s bring it to exactly 80 (0x50); a 0x60 header is those same 80 bytes plus 16 unread pad bytes (which is why `size_` is 96 while `_write__seq` emits only 80). So a 0x50 header does contain all four trailing offsets and the guard is right - but every comment in the change and around it still asserts the opposite: tests/cie/test_short_bin_header.py:3-8 (&#34;the shorter variants stop before the four trailing offset fields exist in the file at all&#34;), albam/engines/cie/mesh.py:21-22, mesh.py:1435, and re4-uhd-bin.ksy:52. Taken at face value those comments say a 0x50 header is still misread by exactly the bug this change fixes, and a future maintainer reading them would either &#34;fix&#34; 0x50 by widening the guard to `&gt;= 0x50` (which would then default the four offsets to 0 for a header that really does state them, silently dropping the bone-pair, adjacency and weight-index blocks of such a file) or conclude the intent item was left half-done. Either the comments are wrong and should say that only a 0x40 header stops short - with the 0x50 case named as covered by the same branch - or 0x50 genuinely differs and needs its own handling and test. This is the author&#39;s call about a format claim I cannot verify from source, hence ask-user rather than a mechanical correction.
- ℹ️ `tests/cie/test_short_bin_header.py:69` - `assert parsed.header.offset_bonepairs == 0 and not hasattr(parsed, &#34;_m_bone_pairs&#34;)` proves nothing about the optional blocks being skipped. `_m_bone_pairs` is only ever set by the `bone_pairs` property, and nothing in the test touches it - `_read()` does not populate instances (`_fetch_instances` is called from the write path, re4_uhd_bin.py:56-58). The `hasattr` half is therefore True even with the bug present: before the fix, offset_bonepairs would hold garbage read out of the bone data, and this assertion would still pass because the property was never accessed. The first clause is also a verbatim repeat of the assertion three lines above. Mechanical fix: access the guarded instances instead - `assert parsed.bone_pairs is None` and `assert parsed.adjacent is None`, which is what the generated properties return when the offset is 0 (re4_uhd_bin.py:1189-1192) and which actually exercises the guard the test claims to check.
- ℹ️ `albam/engines/cie/archive.py:62` - The intent&#39;s latent-defect list includes &#34;`_build_dat_block` does not pad its last entry to 16&#34;. The commit message records the disposition (&#34;not reproduced: every real archive sampled rebuilds to a 16-byte-aligned block size&#34;), but unlike the sibling `_place` item - which got an in-source comment at scenario.py:204-209 recording what was tried and why it was left alone - nothing next to `_build_dat_block` says this was investigated, and `test_rebuild_udas_shifts_blocks_after_a_resized_entry` resizes `paths[0]`, so the last-entry case is not what it exercises. No action needed if the commit message and PR body are considered sufficient; noting it because the two &#34;not reproduced&#34; items in the same intent list were closed to different standards.
- ℹ️ `albam/engines/cie/mesh.py:962` - `matrix = armature.matrix_world.inverted_safe() @ matrix` is correct for the case the new test covers (a mesh parented to its own armature: moving the armature now leaves the export unchanged, since bones are written from `bone.head_local`). It also silently changes a second case nothing covers: a model reusing another&#39;s armature is parented to a fresh Empty, not to the armature (mesh.py:178-190), so its `matrix_world` does not follow the armature at all. Moving that shared armature object - which at rest deforms nothing, so the mesh does not visibly move - now displaces this model&#39;s exported vertices by the inverse of the armature&#39;s transform, where before it had no effect. That is arguably the right semantic (the file stores mesh coordinates in the bones&#39; own space, so an Empty left behind really is offset from its skeleton), which is why this is informational rather than a defect; recording it because it is the sibling path of the changed line and `test_moving_the_armature_does_not_desync_the_mesh_from_its_bones` only reaches the armature-parented one.

🔧 Fix applied.
2 issues (1 error, 1 warning) still open:

- 🚨 `albam/engines/cie/mesh.py:741` - `raise AlbamCheckFailure(f&#34;Bone {bone.name!r} has no free bone id left: ...&#34;)` passes a single positional argument, but `AlbamCheckFailure.__init__(self, message, details, solution)` (albam/exceptions.py:3-7) declares all three as required with no defaults. Every other raise in this module (mesh.py:103, 110, 1251, 1267) supplies `details=` and `solution=`. So the branch raises `TypeError: __init__() missing 2 required positional arguments: &#39;details&#39; and &#39;solution&#39;` instead of the intended check failure: `tests/cie/test_bone_ids.py::test_an_armature_with_no_free_id_left_errors_instead_of_doubling_up` (which does `pytest.raises(AlbamCheckFailure)` on a 256-bone armature) fails, and in Blender `ALBAM_OT_Export`&#39;s `handle_operator_exception` reports a generic failure rather than the bone-id message this line exists to give. Mechanical fix: add `details=` and `solution=` in the style of the neighbouring raises.
- ⚠️ `albam/engines/cie/mesh.py:717` - `_bone_ids_by_name` assigns an id to every bone of the armature and errors when the 255 the format allows run out - but `_bones_to_write` (mesh.py:750) then narrows the exported table to the bones the model was imported with plus the ones its weights name. A user who imports a ~100-bone RE4 rig and adds Rigify-style control/IK bones past a 255-bone total now has `export_bin` -&gt; `_collect_geometry` -&gt; `_bone_ids_by_name(list(armature.data.bones))` abort on an unweighted control bone, where before this change the old `min(fallback, 254)` clamp let those bones collide harmlessly and the export succeeded, because none of them was written. The exhaustion branch (and the wrap-around search that feeds it) is machinery a prior fix round added beyond what the intent&#39;s &#34;`_bone_id`s fallback can collide with a digit-named bone&#34; item requires; the smallest honest remedy is to scope id assignment to the bones the export actually writes, or to drop the exhaustion error and keep the collision fix alone. Because that is a design decision about when an export should refuse rather than a repair of what the code already does, it needs the author&#39;s call.

🔧 Fix applied.
2 issues (1 warning, 1 info) still open:

- ⚠️ `albam/engines/cie/mesh.py:949` - The exhaustion check now only fires for bones that reach the file (`mesh.py:838`), but the sibling read of the same mapping in `_collect_geometry` has no such check and fails silently. Concrete path: a 300-bone Rigify-style armature - exactly the case commit e197d2d exists to let export - has `_bone_ids_by_name` hand out all 255 ids to bones at index 0..254 and `continue` past every bone from index 255 on, so those names are absent from `bone_ids`. If one of those late bones is a deform bone the user weighted a mesh to, the loop at 949-953 finds `group.name not in bone_ids` and `not group.name.isdigit()`, so its vertex group never enters `group_ids`; `_weight_key` then sees no influence for those vertices and returns `(0,0,0),(100,0,0),1` - every such vertex pinned 100% to bone 0. `_serialize_bones` cannot catch it either, because `used_ids` comes from `_weighted_bone_ids(weight_table)`, which was already built from the mapping that lost the bone, so nothing lands in `unnamed` and the export finishes cleanly with a corrupt skinning. `test_bones_nothing_writes_do_not_have_to_fit_in_the_format_s_id_space` only covers unweighted excess bones, so this path has no coverage. The smallest honest remedy is to refuse when a vertex group names an armature bone that got no id (the same AlbamCheckFailure `_serialize_bones` already raises), which extends when an export refuses rather than correcting what the code computes - and it sits inside the exhaustion machinery the previous rounds added, so the author should confirm the boundary rather than have it widened automatically.
- ℹ️ `albam/blender_ui/export_panel.py:369` - `# pragma: no cover` is removed from `ALBAM_OT_Pack._execute`, but the only test driving it (`tests/cie/test_pack_operator.py`) is RE4UHD, so the MTFW-specific branch inside it - `origin_arc_path(root_fs(item_i), item_i.fs_path) or item_i.absolute_path` and the &#34;isn&#39;t backed by a packed file&#34; report at `export_panel.py:381` - is now counted as uncovered without being exercised. The intent&#39;s wording is &#34;`bpy.ops.albam.pack` has no test on either engine&#34;, while the issue itself is RE4UHD-scoped, so covering one engine is a defensible reading; noting it so the scope choice is deliberate rather than accidental. No action needed if RE4UHD-only was the intent.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 11 of 12 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A user imports a .bin whose header is the short 0x40 variant; its bone is read as bone data, not as trailing offsets | ✅ pass | live | drive_short_header_import.log - import {&#39;FINISHED&#39;}, bone &#39;42&#39; at head_local (0.001, -0.003, 0.002), i.e. the 1/2/3 mm the file states; pre-fix the same bytes yielded offset_bonepairs=65322 (short_hea… |
| A user imports a .bin with a 0x50 header, which does state all four trailing offsets; it takes the read-all-four branch and its bone still parses | ✅ pass | live | drive_short_header_import.log - import {&#39;FINISHED&#39;}, bone &#39;7&#39; at (0.004, -0.006, 0.005); tests/cie/test_short_bin_header.py::test_a_0x50_header_states_its_trailing_offsets_and_its_bone_follows_them |
| A user adds 300 unweighted rig control bones to an imported model and exports it: the export succeeds and writes only the bone the model uses | ✅ pass | live | drive_bone_id_export.log - 301 bones in the armature, bpy.ops.albam.export() -&gt; FINISHED, bones written [7], 3 vertices |
| Adversarial: a user weights the mesh to a bone past the 255-id space; the export refuses loudly instead of silently pinning those vertices to bone 0 | ✅ pass | live | drive_bone_id_export.log - Albam error report: &#34;modelB.bin.000 is weighted to &#39;deform_254&#39;, a bone the format cannot name&#34;, with details and solution; no file written |
| A user moves the armature object in the scene and re-exports: the exported bytes are unchanged | ✅ pass | live | drive_bone_id_export.log - armature moved to (5.0, -3.0, 2.5), export identical: True; on base 25127af the same drive reports False (armature_move_before_fix.log) |
| Adversarial: a mesh with more face corners than the format&#39;s 16-bit count errors clearly rather than truncating | ✅ pass | live | `pytest tests/cie/test_face_corner_limit.py` - export_bin on a real 21846-triangle Blender mesh raises AlbamCheckFailure matching &#34;too much geometry&#34; and naming the 65535 limit (pytest_ci_safe.log) |
| A user replaces an archive entry with a bigger one: the DAT block grows and every block descriptor after it shifts, with the trailing block intact | ✅ pass | live | drive_pack_udas.log - block table (0,127,128),(1,80,255) -&gt; (0,383,128),(1,80,511); DAT grew 256, following block moved 256 and its bytes compare equal; re-opened archive holds the edited entry and th… |
| update_lfs dispatch: a single-file archive is replaced wholesale, and an archive albam cannot write refuses instead of emitting a broken container | ✅ pass | live | drive_pack_udas.log - single.bin repacked with the edited bytes; a .dat archive raises NotImplementedError naming the supported cases |
| A user opens an archive, imports a model, edits it, exports it and packs it back with bpy.ops.albam.pack; the repacked archive carries the edit and keeps every other entry | ✅ pass | live | drive_pack_udas.log - pack.poll() True, pack(filepath=...) {&#39;FINISHED&#39;}, 258-byte archive re-opened: model entry changed and re-parses with 3 vertices and bone 7, sibling entry byte-identical |
| A model exported unedited keeps the geometry the original file stated, checked against the original bytes rather than against a re-import | ✅ pass | live | drive_geometry_fidelity.log - 8/8 triangles matched against the original bytes by position and UV, 0 unmatched, per-corner normal agreement 1.00 |
| Adversarial: a scale regression injected into the exported positions must break the fidelity comparison | ✅ pass | live | drive_geometry_fidelity.log - a 5% scale leaves 8/8 triangles unmatched, so the check is not vacuous |
| The same fidelity, pack and archive-update scenarios against the shipped RE4 UHD archives the new tests are parameterized on | ⏸️ untested | no | Needs the real game data: either an RE4 UHD install passed as `--game-dir re4uhd::&lt;path&gt;`, or R2 credentials (R2_ACCOUNT_ID / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY / R2_BUCKET_NAME in a .env, see .e… |

- <code>`pytest tests/cie/test_face_corner_limit.py tests/cie/test_bone_ids.py tests/cie/test_short_bin_header.py tests/cie/test_archive_update.py tests/cie/test_pack_operator.py tests/cie/test_bin_export_fidelity.py -q -rs` (16 passed, 30 skipped for missing game data)</code>
- <code>`drive_short_header_import.py` - bpy.ops.albam.import_vfile() on synthetic 0x40 and 0x50 header .bin files</code>
- <code>`drive_bone_id_export.py` - import -&gt; add 300 rig bones -&gt; bpy.ops.albam.export() for the unweighted-excess, unnameable-weighted-bone and moved-armature cases</code>
- <code>`drive_pack_udas.py` - synthetic .udas.lfs: update_lfs resize/shift, single-file branch, unsupported-extension refusal, and import -&gt; edit -&gt; export -&gt; bpy.ops.albam.pack -&gt; re-open</code>
- <code>`drive_geometry_fidelity.py` - unedited re-export decoded and matched against the original file&#39;s bytes, plus an injected 5% scale regression</code>
- <code>pre-fix reproduction: `git checkout 25127af -- albam/engines/cie/structs/re4_uhd_bin.py` then `pytest tests/cie/test_short_bin_header.py`; `git checkout 25127af -- albam/engines/cie/mesh.py` then re-drove the armature-move scenario</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/README.md:3` - docs/README.md (&#34;for how the code is organised, read the repo&#39;s `CLAUDE.md`&#34;) and the flake8 exclude comment in pyproject.toml (&#34;real game bytes never get committed, see CLAUDE.md&#34;) both send readers to a CLAUDE.md that is not in the tree and is not gitignored, so the code-organisation and test-data facts they defer to have no owner document a contributor can reach. Pre-existing and untouched by this change, so it is left alone here; the follow-up is either to commit that document or to move the two facts into an owner that exists (README.md for layout, CONTRIBUTING/README for the test-data rule) and drop the dangling pointers.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

