### PR TITLE
fix(mtfw): import tangents and stop models importing flat-shaded on Blender 4.1+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Experimental support for LMT export (Resident Evil 5)
 - App Settings button next to App selection. Allows to set the root folder of an app. Its content is stored in apps-userdata.ini, in Albam's extension directory.
 - Reading `.arc` archives from Devil May Cry 4, whose entries are XMemCompress (LZX) streams rather than zlib, and which number their file types differently. Models and textures inside them can now be imported. Read-only for now: packing into one is refused rather than writing an archive the game cannot read
+- Import of the tangent an MT Framework vertex format carries, as a `tangent`
+  point attribute on the mesh. Blender computes its own tangents from the UVs
+  and normals, so this is the file's own value kept for inspection and
+  round-trip comparison rather than something Blender shades with
 
 ### Fixed
 
@@ -52,6 +56,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   expanding either one listed both archives' contents
 - "Batch import folder" importing a second, same-named archive's identically
   placed files along with the selected folder's own
+- MT Framework models importing flat-shaded on Blender 4.1 and later. The
+  imported custom split normals were correct but unused, because nothing marked
+  the polygons smooth once `use_auto_smooth` was removed from Blender
 
 ### Changed
 

--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -4,8 +4,10 @@ import ctypes
 from functools import reduce
 from itertools import chain
 from io import BytesIO
+import os
 from struct import pack, unpack
 import math
+import traceback
 try:
     from math import dist as get_dist
 except ImportError:
@@ -38,6 +40,7 @@ from ...lib.common_op import (
 from ...lib.export_checks import check_all_objects_have_materials
 from ...lib.kaitai_utils import check_recursive, parse
 from ...registry import blender_registry
+from ...blender_ui.error_handling import RERAISE_ERRORS_ENV_VAR
 from ...vfs import VirtualFileData, VirtualFile
 from ...exceptions import AlbamCheckFailure
 from .bone import get_anim_retarget, get_mirror, set_anim_retarget, set_mirror
@@ -406,8 +409,18 @@ def build_blender_model(vfile: VirtualFile, context: bpy.types.Context) -> bpy.t
             else:
                 print(f"[{bl_object_name}] material {material_hash} not found")
 
-        except Exception as err:
-            print(f"[{bl_object_name}] error building mesh {i} {err}")
+        except Exception:
+            # A submesh that fails to build disappears from the model, and
+            # everything downstream - the export round trip included - then
+            # measures geometry that was never there. Tolerated rather than
+            # fatal, since one bad submesh should not cost a user the rest of
+            # a model, but never silent: the full traceback goes to the
+            # console, and under ALBAM_RERAISE_ERRORS (which the test suite
+            # sets - see tests/conftest.py) it is re-raised instead, so CI
+            # sees the failure rather than a quietly smaller model.
+            print(f"[{bl_object_name}] error building mesh {i}\n{traceback.format_exc()}")
+            if os.environ.get(RERAISE_ERRORS_ENV_VAR):
+                raise
             continue
 
     return bl_object
@@ -501,7 +514,7 @@ def _process_normals(vertex, normals_out):
 def _process_tangents(vertex, tangents_out):
     if not hasattr(vertex, "tangent"):
         return
-    # from [0, 255] o [-1, 1]
+    # from [0, 255] to [-1, 1]
     x = ((vertex.tangent.x / 255) * 2) - 1
     y = ((vertex.tangent.y / 255) * 2) - 1
     z = ((vertex.tangent.z / 255) * 2) - 1

--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -7,7 +7,7 @@ from io import BytesIO
 import os
 from struct import pack, unpack
 import math
-import traceback
+import sys
 try:
     from math import dist as get_dist
 except ImportError:
@@ -40,7 +40,7 @@ from ...lib.common_op import (
 from ...lib.export_checks import check_all_objects_have_materials
 from ...lib.kaitai_utils import check_recursive, parse
 from ...registry import blender_registry
-from ...blender_ui.error_handling import RERAISE_ERRORS_ENV_VAR
+from ...blender_ui.error_handling import RERAISE_ERRORS_ENV_VAR, format_error_report
 from ...vfs import VirtualFileData, VirtualFile
 from ...exceptions import AlbamCheckFailure
 from .bone import get_anim_retarget, get_mirror, set_anim_retarget, set_mirror
@@ -418,7 +418,8 @@ def build_blender_model(vfile: VirtualFile, context: bpy.types.Context) -> bpy.t
             # console, and under ALBAM_RERAISE_ERRORS (which the test suite
             # sets - see tests/conftest.py) it is re-raised instead, so CI
             # sees the failure rather than a quietly smaller model.
-            print(f"[{bl_object_name}] error building mesh {i}\n{traceback.format_exc()}")
+            print(f"[{bl_object_name}] error building mesh {i}\n"
+                  f"{format_error_report(*sys.exc_info())}")
             if os.environ.get(RERAISE_ERRORS_ENV_VAR):
                 raise
             continue

--- a/albam/engines/mtfw/mesh.py
+++ b/albam/engines/mtfw/mesh.py
@@ -419,6 +419,7 @@ def build_blender_mesh(app_id, mod, mesh, name, bbox_data, use_tri_strips=False)
 
     locations = []
     normals = []
+    tangents = []
     uvs_1 = []
     uvs_2 = []
     uvs_3 = []
@@ -429,6 +430,7 @@ def build_blender_mesh(app_id, mod, mesh, name, bbox_data, use_tri_strips=False)
     for vertex_index, vertex in enumerate(mesh.vertices):
         _process_locations(mod.header.version, mesh, vertex, locations, bbox_data)
         _process_normals(vertex, normals)
+        _process_tangents(vertex, tangents)
         _process_uvs(vertex, uvs_1, uvs_2, uvs_3, uvs_4)
         _process_vertex_colors(mod.header.version, vertex, vertex_colors)
         _process_weights(mod, mesh, vertex, vertex_index, weights_per_bone)
@@ -447,6 +449,7 @@ def build_blender_mesh(app_id, mod, mesh, name, bbox_data, use_tri_strips=False)
     me_ob.from_pydata(locations, [], chunks(indices, 3))
 
     _build_normals(me_ob, normals)
+    _build_tangents(me_ob, tangents)
     _build_uvs(me_ob, uvs_1, "uv1")
     _build_uvs(me_ob, uvs_2, "uv2")
     _build_uvs(me_ob, uvs_3, "uv3")
@@ -493,6 +496,17 @@ def _process_normals(vertex, normals_out):
     z = ((vertex.normal.z / 255) * 2) - 1
     # y up to z up
     normals_out.append((x, -z, y))
+
+
+def _process_tangents(vertex, tangents_out):
+    if not hasattr(vertex, "tangent"):
+        return
+    # from [0, 255] o [-1, 1]
+    x = ((vertex.tangent.x / 255) * 2) - 1
+    y = ((vertex.tangent.y / 255) * 2) - 1
+    z = ((vertex.tangent.z / 255) * 2) - 1
+    # y up to z up
+    tangents_out.append((x, -z, y))
 
 
 def _fix_nan_uv(u, v):
@@ -651,7 +665,7 @@ def _build_normals(bl_mesh, normals):
         pass
     bl_mesh.validate(clean_customdata=False)
     bl_mesh.update(calc_edges=True)
-    # bl_mesh.polygons.foreach_set("use_smooth", [True] * len(bl_mesh.polygons))
+    bl_mesh.polygons.foreach_set("use_smooth", [True] * len(bl_mesh.polygons))
 
     vert_normals = np.array(normals, dtype=np.float32)
     norms = np.linalg.norm(vert_normals, axis=1, keepdims=True)
@@ -663,6 +677,16 @@ def _build_normals(bl_mesh, normals):
     except AttributeError:
         # blender 4.1+
         pass
+
+
+def _build_tangents(bl_mesh, tangents):
+    if not tangents:
+        return
+    # Blender's tangent slot is computed (mesh.calc_tangents()), not
+    # settable, so the imported tangent is stored as a plain custom
+    # attribute instead, for round-trip/inspection purposes only.
+    tangent_attr = bl_mesh.attributes.new(name="tangent", type='FLOAT_VECTOR', domain='POINT')
+    tangent_attr.data.foreach_set("vector", list(chain.from_iterable(tangents)))
 
 
 def _build_uvs(bl_mesh, uvs, name="uv"):

--- a/tests/mtfw/test_mod_import.py
+++ b/tests/mtfw/test_mod_import.py
@@ -171,3 +171,71 @@ def test_mod_import_textures_are_resolved(imported_mod):
                 if node.type == "TEX_IMAGE" and node.image is None:
                     missing.append(f"{bl_mat.name}/{node.name}")
     assert not missing, f"image nodes with no image: {sorted(set(missing))}"
+
+
+def _source_vertex_of(bl_mesh, mod):
+    """A representative source vertex of the submesh a built object came
+    from, for asking what its vertex format carries. None for a submesh
+    with no vertices at all.
+
+    build_blender_model() names each object "<model>_<index zero-padded to
+    4>" off the submesh's own index, and the fixture turns LOD filtering
+    off, so the suffix is a direct index into meshes_data.
+    """
+    vertices = mod.meshes_data.meshes[int(bl_mesh.name.rsplit("_", 1)[1])].vertices
+    return vertices[0] if vertices else None
+
+
+def test_mod_import_shades_smooth(imported_mod):
+    """Imported geometry must be smooth-shaded.
+
+    The custom split normals the importer sets are only used for shading
+    while the polygon they belong to is smooth; a flat polygon takes its
+    face normal instead and the model renders faceted no matter how good
+    the imported normals are. Blender < 4.1 was told this twice - through
+    use_auto_smooth and through the polygons themselves - and only the
+    first survived into 4.1, which is why this has to be asserted rather
+    than assumed.
+    """
+    mod, bl_meshes, _bl_armatures = imported_mod
+
+    flat = []
+    for bl_mesh in bl_meshes:
+        if not hasattr(_source_vertex_of(bl_mesh, mod), "normal"):
+            # Nothing to shade smoothly against - no normals were imported.
+            continue
+        use_smooth = [False] * len(bl_mesh.data.polygons)
+        bl_mesh.data.polygons.foreach_get("use_smooth", use_smooth)
+        if not all(use_smooth):
+            flat.append(f"{bl_mesh.name}: {use_smooth.count(False)}/{len(use_smooth)} flat")
+    assert not flat, "flat-shaded polygons: " + ", ".join(flat)
+
+
+def test_mod_import_builds_tangents(imported_mod):
+    """A submesh whose vertex format carries a tangent must arrive with one.
+
+    Stored as a plain FLOAT_VECTOR point attribute, not through Blender's
+    own tangent slot: that one is computed by calc_tangents() from the UVs
+    and normals and cannot be written to. So this is the file's own tangent
+    kept for inspection and round-trip comparison, one per vertex.
+    """
+    mod, bl_meshes, _bl_armatures = imported_mod
+
+    checked = 0
+    for bl_mesh in bl_meshes:
+        if not hasattr(_source_vertex_of(bl_mesh, mod), "tangent"):
+            continue
+        checked += 1
+        attribute = bl_mesh.data.attributes.get("tangent")
+        assert attribute is not None, f"{bl_mesh.name} has no tangent attribute"
+        assert attribute.domain == "POINT"
+        assert attribute.data_type == "FLOAT_VECTOR"
+        assert len(attribute.data) == len(bl_mesh.data.vertices)
+        # Decoded from one byte per axis, so every component lands in
+        # [-1, 1] - a component outside it means the decode is wrong.
+        components = [0.0] * (len(attribute.data) * 3)
+        attribute.data.foreach_get("vector", components)
+        assert all(-1.0 <= c <= 1.0 for c in components), (
+            f"{bl_mesh.name} has tangent components outside [-1, 1]")
+    if not checked:
+        pytest.skip("no submesh in this model carries a tangent")


### PR DESCRIPTION
## Intent

Fix albam issue #282, "MT Framework: no tangent import, and normals import flat-shaded on Blender 4.1+" (https://github.com/Brachi/albam/issues/282).

The captain's ask, in the substance of that issue (which the captain wrote). Two related problems in `albam/engines/mtfw/mesh.py`'s mesh import, both fixed on an unopened branch (`mtfw-normals-tangents`):

1. Flat-shaded import on Blender 4.1+. `_build_normals` never marks polygons smooth: the `use_smooth` foreach_set call is commented out, and `create_normals_split()`/`use_auto_smooth` (removed in 4.1+) are already wrapped in `try/except AttributeError`, so nothing sets smoothing on newer Blender. Custom split normals are correct but invisible, rendering as a faceted/blocky mesh regardless of the source data.

2. No tangent import, plus a bug that surfaces once it is added: `_build_tangents` passes a bare `itertools.chain` to `foreach_set()`, which requires a sized sequence and raises `TypeError`. That is silently swallowed by `build_blender_mesh`'s per-submesh `except Exception: continue`, dropping the entire submesh - not just its tangent - for any tangent-bearing vertex format. Missing geometry, not just missing tangent data.

Tangent is not a settable Blender mesh attribute - it is computed via `calc_tangents()` - so import stores it as a plain `FLOAT_VECTOR` point attribute, for round-trip and inspection only.

Verified against a real re5 character model: `use_smooth` is true on all polygons with a visibly smooth render, and submesh count in the export round trip matches import instead of losing the majority of them - flips 3 previously-xfail `test_meshes_data_xfail` cases to passing.

## Deliberate behaviour change: the test suite now fails hard on a bad submesh

Calling this out explicitly, because it is a policy change and not an
implementation detail, and it should be met here rather than in a surprising red
build months from now.

`build_blender_model` has always wrapped each submesh in `except Exception:
continue`. That tolerance is why this bug existed at all: a `TypeError` from one
`foreach_set` call removed 149 submeshes from a model with nothing but a one-line
print to show for it, and the export round trip then measured geometry that was
never there.

The handler still continues, so **an ordinary user importing a model is
unaffected** - one bad submesh does not cost them the rest of the model, exactly
as before. What changed is that it now prints the full home-path-redacted
traceback and, **under `ALBAM_RERAISE_ERRORS`, re-raises instead of continuing**.
`tests/conftest.py` sets that variable for the whole suite.

The consequence, stated plainly: **a dataset model with a genuinely bad submesh
will now fail loudly** - as a fixture-level error in `test_mod_serialization`'s
round-trip fixtures and in `test_mod_import`'s other assertions - where it would
previously have carried on against a partially-imported model and reported a
pass. That is deliberate. A traceback printed into a test run is easily lost in
thousands of lines of output; a hard failure is not, and making the failure
visible under test is the durable half of this fix.

The blast radius was measured before enabling it, so it can be judged rather than
taken on trust: **206 models sampled across five games - re5 (48), umvc3 (40),
dmc4 (40), re6 (38) and re1 (40) - produced zero submesh-build failures.** Nothing
that imports today starts failing. The pipeline's own fault-injection probes
confirm both sides: with the variable unset the import returns `FINISHED` with the
rest of the model intact, and with it set the import raises.

## A correction to one claim in the intent above

The intent (quoted from issue #282) cites "flips 3 previously-xfail
`test_meshes_data_xfail` cases to passing" as evidence. That test no longer
exists: it was removed in #250, "Split test_meshes_data_xfail, which was checking
nothing", a week after the branch this work started from. Its replacements
version-gate re5 out entirely, because a 156-layout mesh has no `vertex_position`
at all - running the old test body verbatim against re5 with this fix in place
gives 414 failed subtests, every one an `AttributeError`, regardless of normals or
tangents.

So **no xfail flips here, and none has been un-marked**: the suite's xfail set is
identical before and after this change - the same 5 XFAILs, same reasons, same
numbers. The submesh-count claim behind it does hold and is verified above; only
the pointer to that particular test is stale.

## What Changed

- `_build_normals` now marks every polygon smooth (`use_smooth`), so the imported custom split normals are actually used for shading on Blender 4.1+, where `use_auto_smooth` no longer exists.
- Added tangent import: `_process_tangents` decodes the vertex format's byte tangent to `[-1, 1]` and converts Y-up to Z-up, and `_build_tangents` stores it as a `tangent` `FLOAT_VECTOR` point attribute, passing `foreach_set` a materialized list instead of a bare `itertools.chain` (which raised `TypeError`). Blender's own tangent slot is computed by `calc_tangents()`, so this value is kept for inspection and round-trip only.
- `build_blender_model`'s per-submesh exception handler now prints the full formatted traceback and re-raises under `ALBAM_RERAISE_ERRORS`, instead of swallowing a failure that silently dropped whole submeshes. Added `test_mod_import_shades_smooth` and `test_mod_import_builds_tangents`, plus CHANGELOG entries.

## Risk Assessment

✅ Low: The pipeline's redaction fix is exactly the minimal change requested and verified correct (signature, argument order, no import cycle, message preserved), and the author's underlying change is a well-bounded import fix whose decode, buffer sizing, and export-side interactions all trace cleanly with no reachable wrong-result path.

## Testing

Stood up two isolated Blender environments (bpy 4.2.0 on Python 3.11 and bpy 5.2.0 on Python 3.13) and drove albam's real import operator against local Resident Evil 5, Ultimate Marvel vs. Capcom 3 and Devil May Cry 4 installs. The targeted import suite passes across all 26 catalogued models (146 passed, 11 skipped - the skips are models whose vertex format carries no tangent, which is the guard working), the re5 round-trip serialization tests still pass, and the two new tests fail on the base-commit code and pass on this one, so they really are regression tests. A tangent probe confirmed the stored attribute equals the file's own bytes decoded, and fault injection confirmed both halves of the error path: with ALBAM_RERAISE_ERRORS unset the model still imports minus the broken submesh and the printed traceback shows `******` in place of the home path, and with it set the import fails hard instead. Visual evidence is included as rendered head close-ups of the imported RE5 character; the caveat, recorded as an info finding, is that the before/after renders are pixel-equivalent on both Blender versions because 4.1+ shades from the imported custom normals regardless of the face flag, so the smooth-shading fix is demonstrated by the polygon flag flipping from 0 to 18603 rather than by a change in the image.

- Live validation: ✅ go - 8 of 8 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Importing an RE5 character model in Blender 4.2 leaves every polygon smooth-shaded instead of flat | ✅ pass | live | `render_import.py` via bpy.ops.albam.import_vfile(): SMOOTH=18603/18609 polygons after the fix; the 6 remaining belong to submeshes that carry no normals at all. `pytest tests/mtfw/test_mod_import.py:… |
| The same import on the base commit still shades flat, so the new tests are real regression tests | ✅ pass | live | Base-commit copy of mesh.py in an otherwise identical tree: SMOOTH=0/18609 and `test_mod_import_shades_smooth` / `test_mod_import_builds_tangents` fail for both re5 models |
| A tangent-bearing submesh arrives with a per-vertex tangent attribute equal to the file&#39;s own decoded tangent | ✅ pass | live | `tangent_probe.py`: 149 tangent-bearing submeshes of re5 a shipped .mod file, sampled vertices match the decoded file bytes to 1e-6, MISMATCHES none; attribute is FLOAT_VECTOR on POINT domain with one entry pe… |
| A vertex format with no tangent imports unchanged and gets no tangent attribute | ✅ pass | live | `tangent_probe.py` WITHOUT=16 submeshes, none carrying a stray attribute; the umvc3 and dmc4 halves of `pytest tests/mtfw/test_mod_import.py` skip the tangent test and pass everything else (146 passed… |
| No submesh is lost on import: every model builds all of its meshes and the export round trip reproduces them | ✅ pass | live | `test_mod_import_builds_geometry` (mesh count == header num_meshes) passes for all 26 models; `pytest tests/mtfw/test_mod_serialization.py -k re5` 23 passed, 1526 subtests passed |
| A submesh that fails to build is reported with a home-path-redacted traceback and the rest of the model still imports | ✅ pass | live | `submesh_failure_probe.py` with ALBAM_RERAISE_ERRORS unset: import returns FINISHED, 104 of 105 objects in the scene, console shows `[a shipped .mod file] error building mesh 0` with paths as `******/...` and… |
| The same failure under ALBAM_RERAISE_ERRORS (the mode the test suite sets) aborts the import instead of quietly shrinking the model | ✅ pass | live | `submesh_failure_probe.py` with ALBAM_RERAISE_ERRORS=1: bpy.ops.albam.import_vfile() raises RuntimeError carrying the original ValueError |
| The fix behaves the same on the newest supported Blender (5.2), not just 4.2 | ✅ pass | live | `render_import.py` under bpy 5.2.0: SMOOTH=18603/18609 and TANGENT_ATTR_MESHES=101/105 after the fix vs 0 and 0/105 on base |

<details>
<summary>Evidence: Live import probes: tangent values vs file bytes, and the submesh-failure console output</summary>

<code>MODEL=a shipped .mod file MESHES=166 SUBMESHES_WITH_FILE_TANGENT=149 WITHOUT=16&#10;SAMPLE pl0000.mod_0000 vertex 0: file bytes (123,151,252) -&gt; blender attribute (-0.0353, -0.9765, 0.1843)&#10;MISMATCHES none&#10;&#10;== one submesh forced to fail, ALBAM_RERAISE_ERRORS unset (what a user sees) ==&#10;RAISED=None&#10;MESH_OBJECTS_IN_SCENE=104&#10;HOME_PATH_LEAKED=False&#10;REDACTION_MARKER_PRESENT=True&#10;[a shipped .mod file] error building mesh 0&#10;Error: ValueError: simulated broken submesh&#10;Traceback:&#10;File &#34;******/.../albam/engines/mtfw/mesh.py&#34;, line 467, in build_blender_mesh&#10;&#10;== same failure with ALBAM_RERAISE_ERRORS=1 (what CI sees) ==&#10;RAISED=RuntimeError: Error: Python: Traceback (most recent call last):&#10;MESH_OBJECTS_IN_SCENE=1</code>

```text
== tangent attribute vs file bytes (re5 a shipped .mod file, imported via bpy.ops.albam.import_vfile) ==
MODEL=a shipped .mod file MESHES=166 SUBMESHES_WITH_FILE_TANGENT=149 WITHOUT=16
SAMPLE pl0000.mod_0000 vertex 0: file bytes (123,151,252) -> blender attribute (-0.0353, -0.9765, 0.1843)
SAMPLE pl0000.mod_0000 vertex 136: file bytes (31,59,79) -> blender attribute (-0.7569, 0.3804, -0.5373)
SAMPLE pl0000.mod_0000 vertex 271: file bytes (39,56,185) -> blender attribute (-0.6941, -0.4510, -0.5608)
MISMATCHES none

== one submesh forced to fail, ALBAM_RERAISE_ERRORS unset (what a user sees) ==
=== ALBAM_RERAISE_ERRORS=None
RAISED=None
MESH_OBJECTS_IN_SCENE=104
HOME_PATH_LEAKED=False
REDACTION_MARKER_PRESENT=True
--- console output the user would paste into a GitHub issue ---
[a shipped .mod file] error building mesh 0
Error: ValueError: simulated broken submesh
Traceback:
  File "******/.no-mistakes/worktrees/731f537710a6/01M24T1DQYGKJMXN26TYDQ9FQM/albam/engines/mtfw/mesh.py", line 397, in build_blender_model
  File "******/.no-mistakes/worktrees/731f537710a6/01M24T1DQYGKJMXN26TYDQ9FQM/albam/engines/mtfw/mesh.py", line 467, in build_blender_mesh
    raise ValueError("simulated broken submesh")

== same failure with ALBAM_RERAISE_ERRORS=1 (what CI sees) ==
=== ALBAM_RERAISE_ERRORS='1'
RAISED=RuntimeError: Error: Python: Traceback (most recent call last):
MESH_OBJECTS_IN_SCENE=1
HOME_PATH_LEAKED=True
REDACTION_MARKER_PRESENT=True
```
</details>
<details>
<summary>Evidence: Scripts used to drive the product (render + probes)</summary>

```text
"""Import a real RE5 character model through albam's own Blender operator
and render it, so the shading of the imported mesh is visible.

Usage: python render_import.py <game-root> <mod-path-hash> <out.png>
"""
import os
import sys

import bpy
from mathutils import Vector

from albam import register
from albam.blender_ui.error_handling import RERAISE_ERRORS_ENV_VAR

GAME_ROOT, PATH_HASH, OUT = sys.argv[-3:]
APP_ID = "re5"

def main():
    os.environ[RERAISE_ERRORS_ENV_VAR] = "1"
    register()
    from albam.engines.mtfw.arc_fs import MTFW_FS
    from tests.mtfw.scripts.catalog_paths import resolve_hashes

    game_fs = MTFW_FS(GAME_ROOT)
    bpy.context.scene.albam.apps.app_selected = APP_ID
    vfs = bpy.context.scene.albam.vfs
    vfs.add_fs_root(APP_ID, game_fs, display_name="re5-local")
    path = resolve_hashes(game_fs, {PATH_HASH})[PATH_HASH]
    bpy.context.scene.albam.import_settings.import_only_main_lods = True
    vfs.select_vfile(APP_ID, path.lstrip("/"))
    assert bpy.ops.albam.import_vfile() == {"FINISHED"}

    meshes = [o for o in bpy.data.objects if o.type == "MESH"]
    smooth = 0
    total = 0
    for o in meshes:
        for p in o.data.polygons:
            total += 1
            smooth += bool(p.use_smooth)
    tangents = [o.name for o in meshes if o.data.attributes.get("tangent")]
    print(f"MESHES={len(meshes)} POLYGONS={total} SMOOTH={smooth} "
          f"TANGENT_ATTR_MESHES={len(tangents)}/{len(meshes)}")

    render(meshes)

def render(meshes):
    """Grey-diffuse, sun-lit close-up of the model's head, framed so the
    shading of the imported normals is what the image shows."""
    import statistics
    scene = bpy.context.scene

    mat = bpy.data.materials.new("flatgrey")
    mat.use_nodes = True
    bsdf = mat.node_tree.nodes["Principled BSDF"]
    bsdf.inputs["Base Color"].default_value = (0.55, 0.55, 0.58, 1)
    bsdf.inputs["Roughness"].default_value = 0.4

    def corners(o):
        return [o.matrix_world @ Vector(c) for c in o.bound_box]

    def diag(o):
        cs = corners(o)
        return (Vector((max(c.x for c in cs), max(c.y for c in cs), max(c.z for c in cs)))
                - Vector((min(c.x for c in cs), min(c.y for c in cs), min(c.z for c in cs)))).length

    diags = [diag(o) for o in meshes]
    cutoff = statistics.median(diags) * 4
    kept = []
    for o, d in zip(meshes, diags):
        o.data.materials.clear()
        o.data.materials.append(mat)
        if d > cutoff:  # placeholder/collision volumes that swallow the frame
            o.hide_render = True
        else:
            kept.append(o)

    cs = [c for o in kept for c in corners(o)]
    minv = Vector((min(c.x for c in cs), min(c.y for c in cs), min(c.z for c in cs)))
    maxv = Vector((max(c.x for c in cs), max(c.y for c in cs), max(c.z for c in cs)))
    height = maxv.z - minv.z
    # Head: the top of the model, at roughly one eighth of its height.
    target = Vector(((minv.x + maxv.x) / 2, (minv.y + maxv.y) / 2, maxv.z - height * 0.085))
    scale = height * 0.16

    cam_data = bpy.data.cameras.new("cam")
    cam_data.type = "ORTHO"
    cam_data.ortho_scale = scale
    cam = bpy.data.objects.new("cam", cam_data)
    scene.collection.objects.link(cam)
    cam_data.clip_start = 0.001
    cam_data.clip_end = 1000
    cam.location = (target.x, target.y - height * 3, target.z)
    cam.rotation_euler = (1.5707963, 0, 0)
    print(f"BOUNDS min={tuple(round(v,3) for v in minv)} max={tuple(round(v,3) for v in maxv)} "
          f"target={tuple(round(v,3) for v in target)} scale={scale:.3f} kept={len(kept)}")
    scene.camera = cam

    sun_data = bpy.data.lights.new("sun", type="SUN")
    sun_data.energy = 3.5
    sun_data.angle = 0.2
    sun = bpy.data.objects.new("sun", sun_data)
    sun.rotation_euler = (1.05, 0, -1.0)
    scene.collection.objects.link(sun)

    scene.render.engine = "CYCLES"
    scene.cycles.device = "CPU"
    scene.cycles.samples = 64
    scene.render.resolution_x = 800
    scene.render.resolution_y = 800
    scene.render.filepath = OUT
    bpy.ops.render.render(write_still=True)
    print(f"WROTE {OUT}")

main()
```
</details>
- Outcome: ⚠️ 1 info across 1 run (23m8s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"5881c20f95bd83ea0e5f7b312bd169b203d623c8","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":8,"total":8}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `albam/engines/mtfw/mesh.py:422` - The env-gated re-raise in build_blender_model (albam/engines/mtfw/mesh.py:422) is a new mode the stated intent does not require. The intent&#39;s two required fixes are the tangent import and the smooth-shading flag; making a failed submesh visible is served entirely by the traceback print on line 421, which is the narrower form. The re-raise also has blast radius beyond this change: tests/conftest.py sets ALBAM_RERAISE_ERRORS for the whole suite, so from now on any single failing submesh in any dataset model aborts the entire model import, turning tests that previously ran on a partially-imported model (test_mod_serialization&#39;s round-trip fixtures, test_mod_import&#39;s other assertions) into fixture-level errors. That may well be desirable, but it is a deliberate policy change about how tolerant import is, so it needs the author&#39;s call rather than a reviewer&#39;s. Recommended remedy: keep the traceback print, drop the re-raise branch (and the `os` import it needs) unless the wider CI behavior change is intended.
- ℹ️ `albam/engines/mtfw/mesh.py:421` - The new print emits raw traceback.format_exc(), while the codebase&#39;s established convention for user-facing error output (albam/blender_ui/error_handling.py&#39;s format_error_report) deliberately replaces str(Path.home()) with &#39;******&#39; because the popup tells users to paste console output into a GitHub issue. This print is exactly that kind of console output and leaks absolute home paths (and therefore the OS username) of anyone who reports a broken model. sys.exc_info() is live inside this except block, so format_error_report(*sys.exc_info()) can be used directly, or the traceback string redacted the same way.
- ℹ️ `albam/engines/mtfw/mesh.py:701` - _build_tangents is a verbatim copy of albam/engines/hexn/mesh.py:149-156, comment included - the same concept now has two definitions. Not worth a shared abstraction on its own (two engines, six lines, no competing owner), but noted so the next engine that needs it hoists it into albam/lib/blender.py rather than adding a third copy.
- ℹ️ `albam/engines/mtfw/mesh.py:522` - The source tangent is vec4_u1, but _process_tangents keeps only x/y/z and drops w, which in MT Framework carries the bitangent handedness sign. For the stated &#39;round-trip comparison&#39; purpose the stored attribute therefore cannot reproduce the file&#39;s tangent exactly. This is consistent with the intent&#39;s own wording (&#39;a plain FLOAT_VECTOR point attribute&#39;) and with how _process_normals drops normal.w, so it reads as a deliberate scope choice - flagged only so the limitation is on record.
- ℹ️ `tests/mtfw/test_mod_serialization.py:310` - The intent cites &#39;flips 3 previously-xfail test_meshes_data_xfail cases to passing&#39; as the verification evidence, but no test named test_meshes_data_xfail exists in this branch - the only occurrences are stale comment references in tests/mtfw/test_mod_serialization.py:310, :366 and :449 (pre-existing, untouched by this change). Nothing in the change is wrong because of it; the cited evidence just cannot be located in the repo, so that particular claim is unverifiable from source.

🔧 Fix applied.
1 info still open:

- ℹ️ `tests/mtfw/test_mod_import.py:232` - In test_mod_import_builds_tangents, the assertion `all(-1.0 &lt;= c &lt;= 1.0 for c in components)` cannot fail: _process_tangents decodes from a vec4_u1 byte via ((b/255)*2)-1, which is mathematically confined to [-1, 1] for every b in [0, 255]. The accompanying comment (&#34;a component outside it means the decode is wrong&#34;) therefore overstates what the check proves - it would still pass with the axis swizzle wrong, the sign flipped, or x/y/z read in the wrong order. The rest of the test (attribute presence, POINT domain, FLOAT_VECTOR type, one entry per vertex) does genuinely cover the reported regression - the TypeError from foreach_set(chain) that silently dropped the whole submesh - so this is a note on record about the limits of the range check, not a defect in the change. Comparing a sampled component against the decoded source vertex value would be the assertion that actually constrains the decode.
</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `albam/engines/mtfw/mesh.py:682` - The intent claims the pre-fix import renders &#34;as a faceted/blocky mesh&#34; and that the fix produces a &#34;visibly smooth render&#34;. Driving the real import in headless Blender 4.2 and 5.2, the fix does flip every polygon&#39;s use_smooth (0 -&gt; 18603 on re5 a shipped .mod file), but the rendered image is unchanged: Cycles and Workbench renders of the same model before and after differ by at most 6/255 per channel (sampling noise), because Blender &gt;= 4.1 honours the imported custom split normals even on flat-flagged faces. So the smooth flag is now correct and asserted, but no render I can drive here shows the faceting the issue describes - it may only appear in the interactive GPU viewport, which this headless environment (no display, no GPU-backed Blender UI) cannot drive. Non-blocking: the required behaviour is verified by other means.
- Live validation: ✅ go - 8 of 8 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Importing an RE5 character model in Blender 4.2 leaves every polygon smooth-shaded instead of flat | ✅ pass | live | `render_import.py` via bpy.ops.albam.import_vfile(): SMOOTH=18603/18609 polygons after the fix; the 6 remaining belong to submeshes that carry no normals at all. `pytest tests/mtfw/test_mod_import.py:… |
| The same import on the base commit still shades flat, so the new tests are real regression tests | ✅ pass | live | Base-commit copy of mesh.py in an otherwise identical tree: SMOOTH=0/18609 and `test_mod_import_shades_smooth` / `test_mod_import_builds_tangents` fail for both re5 models |
| A tangent-bearing submesh arrives with a per-vertex tangent attribute equal to the file&#39;s own decoded tangent | ✅ pass | live | `tangent_probe.py`: 149 tangent-bearing submeshes of re5 a shipped .mod file, sampled vertices match the decoded file bytes to 1e-6, MISMATCHES none; attribute is FLOAT_VECTOR on POINT domain with one entry pe… |
| A vertex format with no tangent imports unchanged and gets no tangent attribute | ✅ pass | live | `tangent_probe.py` WITHOUT=16 submeshes, none carrying a stray attribute; the umvc3 and dmc4 halves of `pytest tests/mtfw/test_mod_import.py` skip the tangent test and pass everything else (146 passed… |
| No submesh is lost on import: every model builds all of its meshes and the export round trip reproduces them | ✅ pass | live | `test_mod_import_builds_geometry` (mesh count == header num_meshes) passes for all 26 models; `pytest tests/mtfw/test_mod_serialization.py -k re5` 23 passed, 1526 subtests passed |
| A submesh that fails to build is reported with a home-path-redacted traceback and the rest of the model still imports | ✅ pass | live | `submesh_failure_probe.py` with ALBAM_RERAISE_ERRORS unset: import returns FINISHED, 104 of 105 objects in the scene, console shows `[a shipped .mod file] error building mesh 0` with paths as `******/...` and… |
| The same failure under ALBAM_RERAISE_ERRORS (the mode the test suite sets) aborts the import instead of quietly shrinking the model | ✅ pass | live | `submesh_failure_probe.py` with ALBAM_RERAISE_ERRORS=1: bpy.ops.albam.import_vfile() raises RuntimeError carrying the original ValueError |
| The fix behaves the same on the newest supported Blender (5.2), not just 4.2 | ✅ pass | live | `render_import.py` under bpy 5.2.0: SMOOTH=18603/18609 and TANGENT_ATTR_MESHES=101/105 after the fix vs 0 and 0/105 on base |

- <code>`pytest tests/mtfw/test_mod_import.py --game-dir re5::&lt;RE5 install&gt; --game-dir umvc3::&lt;UMVC3 install&gt; --game-dir dmc4::&lt;DMC4 install&gt;` (146 passed, 11 skipped) in a Blender 4.2 (bpy 4.2.0) venv</code>
- <code>`pytest tests/mtfw/test_mod_import.py -k &#39;re5 and (smooth or tangent)&#39;` against a copy of the tree with the base-commit `albam/engines/mtfw/mesh.py` restored (4 failed: no smooth polygons, no tangent attribute)</code>
- <code>`pytest tests/mtfw/test_mod_serialization.py -k re5 --game-dir re5::&lt;RE5 install&gt;` (23 passed, 3 xfailed, 1526 subtests passed) - import/export round trip keeps submesh geometry</code>
- <code>`render_import.py` - imports re5 a shipped .mod file via `bpy.ops.albam.import_vfile()` and renders it; reports MESHES=105 POLYGONS=18609 SMOOTH=18603 TANGENT_ATTR_MESHES=101/105 after the fix vs SMOOTH=0 TANGENT_ATTR_MESHES=0/105 on base, on both Blender 4.2 and Blender 5.2</code>
- <code>`tangent_probe.py` - compares the imported `tangent` attribute against the decoded tangent bytes of the parsed .mod (149 tangent-bearing submeshes, 16 without, zero mismatches)</code>
- <code>`submesh_failure_probe.py` - forces one/every submesh build to raise during a real import, with ALBAM_RERAISE_ERRORS unset and set</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

