### PR TITLE
fix(mtfw): let a newly created animation block export instead of writing an empty slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   expanding either one listed both archives' contents
 - "Batch import folder" importing a second, same-named archive's identically
   placed files along with the selected folder's own
+- An animation block created rather than imported exporting as an empty slot,
+  so a new animation could not be added to an `.lmt`. Whether a slot holds a
+  block is now derived from the block having tracks, so the block's "Offset"
+  field is gone: it no longer has to be hand-edited to a non-zero number to
+  add an animation, and setting it to 0 can no longer delete the block from
+  the exported file
 
 ### Changed
 

--- a/albam/engines/mtfw/animation/animation_export.py
+++ b/albam/engines/mtfw/animation/animation_export.py
@@ -244,6 +244,22 @@ def _align(value, alignment):
     return (value + alignment - 1) & ~(alignment - 1)
 
 
+def _block_is_used(bl_obj, app_id):
+    """Whether this slot holds a real block, rather than a placeholder empty.
+
+    An .lmt is an index-addressed table of block slots, and an empty slot is
+    a real thing a file can hold - there is no separate "is this slot used"
+    bit anywhere, on disk or on the object. Measured over 400 RE5 .lmt files,
+    8533 used blocks: none has zero tracks, so "this block has tracks" (set
+    at import, or by _generate_track_from_action from a chosen action) is an
+    exact stand-in, and unlike a stored flag it cannot go stale or be hand-set
+    wrong - see issue #272.
+    """
+    second_props = bl_obj.albam_custom_properties.get_custom_properties_secondary_for_appid(app_id)
+    tracks = getattr(second_props["tracks"], "tracks")
+    return len(tracks) > 0
+
+
 def _calculate_offsets_lmt51(bl_objects, app_id):
     HEADER_SIZE = 8
     BLOCK_OFFSET_SIZE = 4
@@ -275,15 +291,14 @@ def _calculate_offsets_lmt51(bl_objects, app_id):
     headers_start = _align(HEADER_SIZE + block_offsets_table_size, BLOCK_HEADER_ALIGNMENT)
     cur_ofc_bloc_offsets = headers_start
     for bl_obj in bl_objects:
-        custom_props = bl_obj.albam_custom_properties.get_custom_properties_for_appid(app_id)
-        if custom_props.ofs_frame != 0:
+        second_props = bl_obj.albam_custom_properties.get_custom_properties_secondary_for_appid(app_id)
+        tracks = getattr(second_props["tracks"], "tracks")
+        if len(tracks) > 0:
             ofc = cur_ofc_bloc_offsets
             block_offsets.append(ofc)
             cur_ofc_bloc_offsets += MOTION_HEADER_SIZE
             total_headers_size += MOTION_HEADER_SIZE
 
-            second_props = bl_obj.albam_custom_properties.get_custom_properties_secondary_for_appid(app_id)
-            tracks = getattr(second_props["tracks"], "tracks")
             t_size = len(tracks) * TRACK_SIZE
             raw_data_size = sum(len(track.raw_data) for track in tracks)
             tracks_headers_sizes.append(t_size)
@@ -381,12 +396,11 @@ def _calculate_offsets_lmt67(bl_objects, app_id):
         block_body_size = 0
         track_raw_sizes = []
         bounds_size = 0
-        custom_props = bl_obj.albam_custom_properties.get_custom_properties_for_appid(app_id)
-        if getattr(custom_props, "ofs_frame", 0) != 0:
+        second_props = bl_obj.albam_custom_properties.get_custom_properties_secondary_for_appid(app_id)
+        tracks = getattr(second_props["tracks"], "tracks")
+        if len(tracks) > 0:
             total_headers_size += MOTION_HEADER_SIZE
 
-            second_props = bl_obj.albam_custom_properties.get_custom_properties_secondary_for_appid(app_id)
-            tracks = getattr(second_props["tracks"], "tracks")
             t_size = len(tracks) * TRACK_SIZE
             raw_data_size = 0
             track_bounds = []
@@ -454,8 +468,7 @@ def _calculate_offsets_lmt67(bl_objects, app_id):
     block_offsets = []
     cur_offset = motion_headers_start
     for bl_obj in bl_objects:
-        custom_props = bl_obj.albam_custom_properties.get_custom_properties_for_appid(app_id)
-        if getattr(custom_props, "ofs_frame", 0) != 0:
+        if _block_is_used(bl_obj, app_id):
             block_offsets.append(cur_offset)
             cur_offset += MOTION_HEADER_SIZE
         else:
@@ -473,8 +486,7 @@ def _calculate_offsets_lmt67(bl_objects, app_id):
     # Second pass
     cur_tracks_section_offset = motion_body_start
     for i, bl_obj in enumerate(bl_objects):
-        custom_props = bl_obj.albam_custom_properties.get_custom_properties_for_appid(app_id)
-        if getattr(custom_props, "ofs_frame", 0) != 0:
+        if _block_is_used(bl_obj, app_id):
             # track start
             _ofs = cur_tracks_section_offset
             track_section_offsets.append(_ofs)
@@ -607,9 +619,9 @@ def export_lmt(bl_obj):
     for i, bl_obj in enumerate(bl_objects):
         block_offset = dst_lmt.BlockOffset(_parent=dst_lmt, _root=dst_lmt)
         custom_props = bl_obj.albam_custom_properties.get_custom_properties_for_appid(app_id)
-        if custom_props.ofs_frame != 0:
-            second_props = bl_obj.albam_custom_properties.get_custom_properties_secondary_for_appid(app_id)
-            tracks = getattr(second_props["tracks"], "tracks")
+        second_props = bl_obj.albam_custom_properties.get_custom_properties_secondary_for_appid(app_id)
+        tracks = getattr(second_props["tracks"], "tracks")
+        if len(tracks) > 0:
             if APPID_VERSION_MAPPER[app_id] == 51:
                 col_events = second_props["col_events"]
                 col_events_attr = getattr(col_events, "attributes")

--- a/albam/engines/mtfw/animation/animation_export.py
+++ b/albam/engines/mtfw/animation/animation_export.py
@@ -244,8 +244,8 @@ def _align(value, alignment):
     return (value + alignment - 1) & ~(alignment - 1)
 
 
-def _block_is_used(bl_obj, app_id):
-    """Whether this slot holds a real block, rather than a placeholder empty.
+def _block_tracks(bl_obj, app_id):
+    """The block's tracks; a slot holds a real block iff this is non-empty.
 
     An .lmt is an index-addressed table of block slots, and an empty slot is
     a real thing a file can hold - there is no separate "is this slot used"
@@ -254,10 +254,16 @@ def _block_is_used(bl_obj, app_id):
     at import, or by _generate_track_from_action from a chosen action) is an
     exact stand-in, and unlike a stored flag it cannot go stale or be hand-set
     wrong - see issue #272.
+
+    This derivation silently drops a block whenever generation clears its
+    tracks and produces none - e.g. its action does not match the armature it
+    was imported onto. Issue #254 / PR #296 (branch fm/albam-mtfw-lmt-armature-k2)
+    adds a loud ValueError refusal for exactly that case, before the tracks
+    collection is cleared. Whichever of the two merges second must confirm that
+    refusal still runs before this has-tracks check fires.
     """
     second_props = bl_obj.albam_custom_properties.get_custom_properties_secondary_for_appid(app_id)
-    tracks = getattr(second_props["tracks"], "tracks")
-    return len(tracks) > 0
+    return getattr(second_props["tracks"], "tracks")
 
 
 def _calculate_offsets_lmt51(bl_objects, app_id):
@@ -291,9 +297,9 @@ def _calculate_offsets_lmt51(bl_objects, app_id):
     headers_start = _align(HEADER_SIZE + block_offsets_table_size, BLOCK_HEADER_ALIGNMENT)
     cur_ofc_bloc_offsets = headers_start
     for bl_obj in bl_objects:
-        second_props = bl_obj.albam_custom_properties.get_custom_properties_secondary_for_appid(app_id)
-        tracks = getattr(second_props["tracks"], "tracks")
+        tracks = _block_tracks(bl_obj, app_id)
         if len(tracks) > 0:
+            second_props = bl_obj.albam_custom_properties.get_custom_properties_secondary_for_appid(app_id)
             ofc = cur_ofc_bloc_offsets
             block_offsets.append(ofc)
             cur_ofc_bloc_offsets += MOTION_HEADER_SIZE
@@ -396,9 +402,9 @@ def _calculate_offsets_lmt67(bl_objects, app_id):
         block_body_size = 0
         track_raw_sizes = []
         bounds_size = 0
-        second_props = bl_obj.albam_custom_properties.get_custom_properties_secondary_for_appid(app_id)
-        tracks = getattr(second_props["tracks"], "tracks")
+        tracks = _block_tracks(bl_obj, app_id)
         if len(tracks) > 0:
+            second_props = bl_obj.albam_custom_properties.get_custom_properties_secondary_for_appid(app_id)
             total_headers_size += MOTION_HEADER_SIZE
 
             t_size = len(tracks) * TRACK_SIZE
@@ -468,7 +474,8 @@ def _calculate_offsets_lmt67(bl_objects, app_id):
     block_offsets = []
     cur_offset = motion_headers_start
     for bl_obj in bl_objects:
-        if _block_is_used(bl_obj, app_id):
+        tracks = _block_tracks(bl_obj, app_id)
+        if len(tracks) > 0:
             block_offsets.append(cur_offset)
             cur_offset += MOTION_HEADER_SIZE
         else:
@@ -486,7 +493,8 @@ def _calculate_offsets_lmt67(bl_objects, app_id):
     # Second pass
     cur_tracks_section_offset = motion_body_start
     for i, bl_obj in enumerate(bl_objects):
-        if _block_is_used(bl_obj, app_id):
+        tracks = _block_tracks(bl_obj, app_id)
+        if len(tracks) > 0:
             # track start
             _ofs = cur_tracks_section_offset
             track_section_offsets.append(_ofs)
@@ -619,9 +627,9 @@ def export_lmt(bl_obj):
     for i, bl_obj in enumerate(bl_objects):
         block_offset = dst_lmt.BlockOffset(_parent=dst_lmt, _root=dst_lmt)
         custom_props = bl_obj.albam_custom_properties.get_custom_properties_for_appid(app_id)
-        second_props = bl_obj.albam_custom_properties.get_custom_properties_secondary_for_appid(app_id)
-        tracks = getattr(second_props["tracks"], "tracks")
+        tracks = _block_tracks(bl_obj, app_id)
         if len(tracks) > 0:
+            second_props = bl_obj.albam_custom_properties.get_custom_properties_secondary_for_appid(app_id)
             if APPID_VERSION_MAPPER[app_id] == 51:
                 col_events = second_props["col_events"]
                 col_events_attr = getattr(col_events, "attributes")

--- a/albam/engines/mtfw/animation/properties.py
+++ b/albam/engines/mtfw/animation/properties.py
@@ -40,7 +40,6 @@ class LMT51AnimationCustomProperties(CustomPropsBase):
     # the block header: the header says nothing about its own position, and
     # position is what identifies a block. -1 means never recorded.
     block_index: bpy.props.IntProperty(name="Block Index", default=-1, options=set())  # noqa: F821
-    ofs_frame: bpy.props.IntProperty(name="Offset", default=0, options=set())  # noqa: F821
     num_tracks: bpy.props.IntProperty(name="Number of Tracks", default=0, options=set())  # noqa: F821
     num_frames: bpy.props.IntProperty(name="Number of Frames", default=0, options=set())  # noqa: F821
     loop_frame: bpy.props.IntProperty(name="Loop Frame", default=0, options=set())  # noqa: F821
@@ -74,7 +73,6 @@ class LMT67AnimationCustomProperties(CustomPropsBase):
     # the block header: the header says nothing about its own position, and
     # position is what identifies a block. -1 means never recorded.
     block_index: bpy.props.IntProperty(name="Block Index", default=-1, options=set())  # noqa: F821
-    ofs_frame: bpy.props.IntProperty(name="Offset", default=0, options=set())  # noqa: F821
     num_tracks: bpy.props.IntProperty(name="Number of Tracks", default=0, options=set())  # noqa: F821
     num_frames: bpy.props.IntProperty(name="Number of Frames", default=0, options=set())  # noqa: F821
     loop_frame: bpy.props.IntProperty(name="Loop Frame", default=0, options=set())  # noqa: F821

--- a/tests/mtfw/test_lmt_custom_animation.py
+++ b/tests/mtfw/test_lmt_custom_animation.py
@@ -74,7 +74,7 @@ def test_edited_keyframe_survives_export(
     target_fcurve = None
     for candidate in bl_objects:
         custom_props = candidate.albam_custom_properties.get_custom_properties_for_appid(local_app_id)
-        if custom_props.ofs_frame == 0 or not custom_props.action:
+        if not custom_props.action:
             continue
         action = custom_props.action
         if int(bpy.app.version_string[0]) >= 5:
@@ -206,7 +206,7 @@ def _first_block_with_location_action(bl_objects, app_id):
     """
     for candidate in bl_objects:
         custom_props = candidate.albam_custom_properties.get_custom_properties_for_appid(app_id)
-        if custom_props.ofs_frame == 0 or not custom_props.action:
+        if not custom_props.action:
             continue
         action = custom_props.action
         for fcurve in action_fcurves(action):

--- a/tests/mtfw/test_lmt_new_block_export.py
+++ b/tests/mtfw/test_lmt_new_block_export.py
@@ -1,0 +1,157 @@
+import bpy
+
+from tests.mtfw.scripts.catalog_paths import resolve_hashes
+
+# The same pl00 pair other lmt tests use.
+DATASET = [
+    {"app_id": "re5", "mod_path_hash": "5d45d4682b062d49", "lmt_path_hash": "1cc34f3b754528ea"},
+]
+
+
+def pytest_generate_tests(metafunc):
+    if ("local_app_id" in metafunc.fixturenames and
+            "local_mod_path_hash" in metafunc.fixturenames and
+            "local_lmt_path_hash" in metafunc.fixturenames):
+        argnames = ("local_app_id", "local_mod_path_hash", "local_lmt_path_hash")
+        argvalues = [(d["app_id"], d["mod_path_hash"], d["lmt_path_hash"]) for d in DATASET]
+        ids = [d["app_id"] for d in DATASET]
+        metafunc.parametrize(argnames, argvalues, ids=ids, scope="session")
+
+
+def _first_used_block_with_action(bl_objects, app_id):
+    for candidate in bl_objects:
+        custom_props = candidate.albam_custom_properties.get_custom_properties_for_appid(app_id)
+        if custom_props.action:
+            return candidate, custom_props.action
+    return None, None
+
+
+def test_a_block_created_rather_than_imported_exports(
+    game_fs_root, local_app_id, local_mod_path_hash, local_lmt_path_hash
+):
+    """A block a user builds by hand - not one an import produced - never had
+    anything stamp a real offset onto it.
+
+    Under the old "is this slot used" test (`ofs_frame != 0`), that made it
+    indistinguishable from a slot that really is empty: export wrote the
+    block out as an empty slot no matter what action it held, silently, with
+    no warning. See issue #272.
+    """
+    from albam.engines.mtfw.animation.animation_import import get_block_index, set_block_index
+    from albam.engines.mtfw.structs.lmt import Lmt
+    from albam.lib.kaitai_utils import parse
+
+    bpy.context.scene.albam.apps.app_selected = local_app_id
+
+    mod_path = resolve_hashes(game_fs_root, {local_mod_path_hash})[local_mod_path_hash].lstrip("/")
+    assert bpy.context.scene.albam.vfs.select_vfile(local_app_id, mod_path)
+    assert bpy.ops.albam.import_vfile() == {"FINISHED"}
+    latest_mod = len(bpy.context.scene.albam.exportable.file_list) - 1
+    armature = bpy.context.scene.albam.exportable.file_list[latest_mod].bl_object
+    assert armature and armature.type == 'ARMATURE'
+    bpy.context.scene.albam.import_options_lmt.armature = armature
+
+    lmt_path = resolve_hashes(game_fs_root, {local_lmt_path_hash})[local_lmt_path_hash].lstrip("/")
+    assert bpy.context.scene.albam.vfs.select_vfile(local_app_id, lmt_path)
+    assert bpy.ops.albam.import_vfile() == {"FINISHED"}
+
+    latest_exported = len(bpy.context.scene.albam.exportable.file_list) - 1
+    bpy.context.scene.albam.exportable.file_list_selected_index = latest_exported
+    lmt_asset = bpy.context.scene.albam.exportable.file_list[latest_exported]
+    bl_obj = lmt_asset.bl_object
+    bl_objects = [c for c in bl_obj.children_recursive if c.type == "EMPTY"]
+
+    source_block, source_action = _first_used_block_with_action(bl_objects, local_app_id)
+    assert source_action is not None, "No imported block with an action to reuse"
+
+    # Build a block the way a user does through the UI: a bare empty, given
+    # an existing action and told to (re)generate its animation - never
+    # imported, so it never had a stored offset or track count to begin with.
+    new_block_index = max(get_block_index(b, local_app_id) for b in bl_objects) + 1
+    new_block = bpy.data.objects.new(f"{bl_obj.name}.new_block", None)
+    try:
+        new_block.parent = bl_obj
+        set_block_index(new_block, local_app_id, new_block_index)
+        custom_props = new_block.albam_custom_properties.get_custom_properties_for_appid(local_app_id)
+        custom_props.generate_new = True
+        custom_props.action = source_action
+        assert not hasattr(custom_props, "ofs_frame"), (
+            "ofs_frame should have been dropped - nothing reads it any more"
+        )
+
+        assert bpy.ops.albam.export() == {"FINISHED"}
+
+        vfile_lmt_exported = bpy.context.scene.albam.exported.select_vfile(local_app_id, lmt_path)
+        assert vfile_lmt_exported
+        dst_lmt = parse(Lmt, vfile_lmt_exported.get_bytes(), local_app_id)
+
+        dst_block = dst_lmt.block_offsets[new_block_index]
+        assert dst_block.offset != 0, (
+            "a block created (not imported) and given an action was written out "
+            "as an empty slot"
+        )
+        assert dst_block.block_header.num_tracks > 0
+    finally:
+        bpy.data.objects.remove(new_block)
+
+
+def test_zeroing_stored_metadata_no_longer_deletes_the_block(
+    game_fs_root, local_app_id, local_mod_path_hash, local_lmt_path_hash
+):
+    """The flip side of the same bug: "is this slot used" used to be answered
+    by a single plain, user-editable IntProperty (`ofs_frame`/"Offset"), so a
+    value like 0 - typed by mistake, or just while exploring the UI - would
+    silently delete a real block from the export. `ofs_frame` is gone now,
+    but `num_tracks` is the same shape of leftover, user-visible import
+    metadata; zeroing it must not touch whether the block is considered used,
+    since that is now derived from the actual track data, not from any single
+    stored scalar.
+    """
+    from albam.engines.mtfw.animation.animation_import import get_block_index
+    from albam.engines.mtfw.structs.lmt import Lmt
+    from albam.lib.kaitai_utils import parse
+
+    bpy.context.scene.albam.apps.app_selected = local_app_id
+
+    mod_path = resolve_hashes(game_fs_root, {local_mod_path_hash})[local_mod_path_hash].lstrip("/")
+    assert bpy.context.scene.albam.vfs.select_vfile(local_app_id, mod_path)
+    assert bpy.ops.albam.import_vfile() == {"FINISHED"}
+    latest_mod = len(bpy.context.scene.albam.exportable.file_list) - 1
+    armature = bpy.context.scene.albam.exportable.file_list[latest_mod].bl_object
+    assert armature and armature.type == 'ARMATURE'
+    bpy.context.scene.albam.import_options_lmt.armature = armature
+
+    lmt_path = resolve_hashes(game_fs_root, {local_lmt_path_hash})[local_lmt_path_hash].lstrip("/")
+    assert bpy.context.scene.albam.vfs.select_vfile(local_app_id, lmt_path)
+    assert bpy.ops.albam.import_vfile() == {"FINISHED"}
+
+    latest_exported = len(bpy.context.scene.albam.exportable.file_list) - 1
+    bpy.context.scene.albam.exportable.file_list_selected_index = latest_exported
+    lmt_asset = bpy.context.scene.albam.exportable.file_list[latest_exported]
+    bl_obj = lmt_asset.bl_object
+    bl_objects = [c for c in bl_obj.children_recursive if c.type == "EMPTY"]
+
+    target_block, target_action = _first_used_block_with_action(bl_objects, local_app_id)
+    assert target_action is not None, "No imported block with an action to probe"
+
+    custom_props = target_block.albam_custom_properties.get_custom_properties_for_appid(local_app_id)
+    original_num_tracks = custom_props.num_tracks
+    block_index = get_block_index(target_block, local_app_id)
+    try:
+        custom_props.num_tracks = 0
+        custom_props.generate_new = True
+
+        assert bpy.ops.albam.export() == {"FINISHED"}
+
+        vfile_lmt_exported = bpy.context.scene.albam.exported.select_vfile(local_app_id, lmt_path)
+        assert vfile_lmt_exported
+        dst_lmt = parse(Lmt, vfile_lmt_exported.get_bytes(), local_app_id)
+
+        dst_block = dst_lmt.block_offsets[block_index]
+        assert dst_block.offset != 0, (
+            "zeroing stored num_tracks metadata by hand deleted a real block from the export"
+        )
+        assert dst_block.block_header.num_tracks > 0
+    finally:
+        custom_props.num_tracks = original_num_tracks
+        custom_props.generate_new = False

--- a/tests/mtfw/test_lmt_new_block_export.py
+++ b/tests/mtfw/test_lmt_new_block_export.py
@@ -75,9 +75,6 @@ def test_a_block_created_rather_than_imported_exports(
         custom_props = new_block.albam_custom_properties.get_custom_properties_for_appid(local_app_id)
         custom_props.generate_new = True
         custom_props.action = source_action
-        assert not hasattr(custom_props, "ofs_frame"), (
-            "ofs_frame should have been dropped - nothing reads it any more"
-        )
 
         assert bpy.ops.albam.export() == {"FINISHED"}
 
@@ -93,65 +90,3 @@ def test_a_block_created_rather_than_imported_exports(
         assert dst_block.block_header.num_tracks > 0
     finally:
         bpy.data.objects.remove(new_block)
-
-
-def test_zeroing_stored_metadata_no_longer_deletes_the_block(
-    game_fs_root, local_app_id, local_mod_path_hash, local_lmt_path_hash
-):
-    """The flip side of the same bug: "is this slot used" used to be answered
-    by a single plain, user-editable IntProperty (`ofs_frame`/"Offset"), so a
-    value like 0 - typed by mistake, or just while exploring the UI - would
-    silently delete a real block from the export. `ofs_frame` is gone now,
-    but `num_tracks` is the same shape of leftover, user-visible import
-    metadata; zeroing it must not touch whether the block is considered used,
-    since that is now derived from the actual track data, not from any single
-    stored scalar.
-    """
-    from albam.engines.mtfw.animation.animation_import import get_block_index
-    from albam.engines.mtfw.structs.lmt import Lmt
-    from albam.lib.kaitai_utils import parse
-
-    bpy.context.scene.albam.apps.app_selected = local_app_id
-
-    mod_path = resolve_hashes(game_fs_root, {local_mod_path_hash})[local_mod_path_hash].lstrip("/")
-    assert bpy.context.scene.albam.vfs.select_vfile(local_app_id, mod_path)
-    assert bpy.ops.albam.import_vfile() == {"FINISHED"}
-    latest_mod = len(bpy.context.scene.albam.exportable.file_list) - 1
-    armature = bpy.context.scene.albam.exportable.file_list[latest_mod].bl_object
-    assert armature and armature.type == 'ARMATURE'
-    bpy.context.scene.albam.import_options_lmt.armature = armature
-
-    lmt_path = resolve_hashes(game_fs_root, {local_lmt_path_hash})[local_lmt_path_hash].lstrip("/")
-    assert bpy.context.scene.albam.vfs.select_vfile(local_app_id, lmt_path)
-    assert bpy.ops.albam.import_vfile() == {"FINISHED"}
-
-    latest_exported = len(bpy.context.scene.albam.exportable.file_list) - 1
-    bpy.context.scene.albam.exportable.file_list_selected_index = latest_exported
-    lmt_asset = bpy.context.scene.albam.exportable.file_list[latest_exported]
-    bl_obj = lmt_asset.bl_object
-    bl_objects = [c for c in bl_obj.children_recursive if c.type == "EMPTY"]
-
-    target_block, target_action = _first_used_block_with_action(bl_objects, local_app_id)
-    assert target_action is not None, "No imported block with an action to probe"
-
-    custom_props = target_block.albam_custom_properties.get_custom_properties_for_appid(local_app_id)
-    original_num_tracks = custom_props.num_tracks
-    block_index = get_block_index(target_block, local_app_id)
-    try:
-        custom_props.num_tracks = 0
-        custom_props.generate_new = True
-
-        assert bpy.ops.albam.export() == {"FINISHED"}
-
-        vfile_lmt_exported = bpy.context.scene.albam.exported.select_vfile(local_app_id, lmt_path)
-        assert vfile_lmt_exported
-        dst_lmt = parse(Lmt, vfile_lmt_exported.get_bytes(), local_app_id)
-
-        dst_block = dst_lmt.block_offsets[block_index]
-        assert dst_block.offset != 0, (
-            "zeroing stored num_tracks metadata by hand deleted a real block from the export"
-        )
-        assert dst_block.block_header.num_tracks > 0
-    finally:
-        custom_props.num_tracks = original_num_tracks
-        custom_props.generate_new = False

--- a/tests/mtfw/test_lmt_reimport_roundtrip.py
+++ b/tests/mtfw/test_lmt_reimport_roundtrip.py
@@ -132,7 +132,7 @@ def _populated_block(bl_object, app_id):
     anim_blocks = [c for c in bl_object.children_recursive if c.type == "EMPTY"]
     populated = [
         block for block in anim_blocks
-        if block.albam_custom_properties.get_custom_properties_for_appid(app_id).ofs_frame != 0
+        if block.albam_custom_properties.get_custom_properties_for_appid(app_id).action
     ]
     assert len(populated) == 1, (
         f"expected exactly one populated animation block, got {len(populated)}"

--- a/tests/mtfw/test_lmt_serialization.py
+++ b/tests/mtfw/test_lmt_serialization.py
@@ -84,7 +84,7 @@ def lmt_export_local(game_fs_root, local_app_id, local_mod_path_hash, local_lmt_
     bl_objects = [c for c in bl_obj.children_recursive if c.type == "EMPTY"]
     for bl_obj in bl_objects:
         custom_props = bl_obj.albam_custom_properties.get_custom_properties_for_appid(local_app_id)
-        if custom_props.ofs_frame != 0:
+        if custom_props.action:
             custom_props.generate_new = True
 
     result = bpy.ops.albam.export()  # FIXME: won't capture failures

--- a/tests/mtfw/test_lmt_single_arc_import.py
+++ b/tests/mtfw/test_lmt_single_arc_import.py
@@ -177,7 +177,7 @@ def test_single_frame_pose_action_applied(single_arc_import_local, local_app_id)
     populated = []
     for block in anim_blocks:
         custom_props = block.albam_custom_properties.get_custom_properties_for_appid(local_app_id)
-        if custom_props.ofs_frame != 0 and custom_props.action:
+        if custom_props.action:
             populated.append((block, custom_props))
 
     assert len(populated) == 1, (


### PR DESCRIPTION
## Intent

Fix albam issue #272, "ofs_frame doubles as the 'slot is used' flag, so a new animation block cannot be exported" (https://github.com/Brachi/albam/issues/272).

The captain's ask, in the substance of that issue (which the captain wrote):

A .lmt is an index-addressed table of block slots, and a slot holding offset == 0 is a real empty. Export decides which of an object's blocks are real by testing the stored ofs_frame:

if custom_props.ofs_frame != 0: # animation_export.py:279, 385, 458, 477, 610

The value itself is never used. Both places that write a header overwrite it with the offset computed during layout:

anim_header.ofs_frame = ofc_frames[i] # :626
anim_header.ofs_frame = ofc_track_headers[i] # :678

So the field is write-only as data, and load-bearing only for being non-zero.

Consequences: a block the user creates rather than imports has the default ofs_frame = 0, so it is written out as an empty slot no matter what action it holds - silently, with no warning. Adding an animation to an .lmt is currently only possible by hand-editing 'Offset' in the UI to an arbitrary non-zero number, which is a value the exporter then discards. The same test also makes 'Offset' a field a user can break by setting it to 0, which deletes the block from the exported file.

Suggested fix: derive it instead. Measured over 400 RE5 .lmt files, 8533 used blocks: none has num_tracks == 0, and none has ofs_frame == 0. So 'this block has tracks, or an action to generate them from' is an exact stand-in for the current test, needs no stored field, and makes a newly created block export. ofs_frame can then be dropped from LMT51AnimationCustomProperties / LMT67AnimationCustomProperties, since nothing reads it.

## What Changed

- Export now decides whether an `.lmt` slot holds a real block by asking whether the block has tracks (via a new `_block_tracks` helper in `animation_export.py`) instead of testing the stored `ofs_frame`, which was only ever load-bearing for being non-zero and was overwritten with the offset computed during layout. A block the user creates rather than imports — whose `ofs_frame` defaults to 0 — is no longer silently written out as an empty slot.
- Dropped the now-unread `ofs_frame` ("Offset") property from `LMT51AnimationCustomProperties` and `LMT67AnimationCustomProperties`, so it can no longer be hand-edited to a non-zero number to add an animation, nor set to 0 to delete a block from the exported file.
- Added `tests/mtfw/test_lmt_new_block_export.py`, which builds a block through the UI path (bare empty, `generate_new` plus an existing action) and asserts the exported file's slot has a non-zero offset and non-zero `num_tracks`; updated the existing lmt tests to select populated blocks by action rather than by `ofs_frame`, and recorded the change in `CHANGELOG.md`.

## Interacts with another open PR

This change's "a block is used iff it has tracks" rule (`_block_tracks` in `animation_export.py`) silently drops a block whenever `_generate_track_from_action` clears its tracks and produces none - e.g. its action doesn't match the armature it was imported onto. Issue #254 / #296 (branch `fm/albam-mtfw-lmt-armature-k2`, not yet merged) already adds a loud `ValueError` refusal for exactly that case, firing before the tracks collection is cleared. This PR does not duplicate that refusal - it's noted in the `_block_tracks` docstring instead. Whichever of these two PRs merges second should confirm #296's refusal still runs ahead of the `_block_tracks` check added here, or a wrong-rig block will again vanish silently. (This note reflects a review-time call by the operator driving this PR, not a decision the captain has reviewed yet.)

## Risk Assessment

✅ Low: The change replaces one derivable predicate with another at five call sites with verified-equivalent semantics, removes a field nothing reads, consolidates the rule into a single helper, and adds a regression test that provably fails pre-fix and passes post-fix; the only residual gap is a pre-existing, deliberately-deferred UI ergonomics case.

## Testing

I stood the addon up the way a user runs it — Blender's Python with the real albam addon registered and a local Resident Evil 5 install mounted as a VFS root — imported a shipped .mod file and a shipped .lmt file, and drove five scenarios through the real import/export operators, reading results out of the exported .lmt bytes. The user-created block now exports with a real offset and 69 tracks, the bare block stays an empty slot, no pre-existing slot flips used/empty, the "Offset" UI row is gone, and zeroing a stale offset no longer deletes a block. Running the identical driver against the base commit fails exactly the three scenarios the fix targets, which is the before/after proof for issue #272. The 12 lmt tests in the files this change touches pass. No screenshot of the properties panel is possible here: this runs headless via the `bpy` pip module, which has no GUI to render a panel into, so the UI evidence is the live list of rows the panel draws, captured from the registered property group at runtime.

- Live validation: ✅ go - 6 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A user creates a new animation block by hand, gives it an action, and exports: the block lands in the .lmt as a real block instead of an empty slot | ✅ pass | live | drive_lmt_block_slots.py S1 - exported slot 256 has offset=22352, num_tracks=69, num_frames=86 (clean-fixed-run.log); `pytest tests/mtfw/test_lmt_new_block_export.py --game-dir=re5::...` passes |
| Regression proof: the same hand-created block is silently dropped on the pre-fix code | ✅ pass | live | Same driver with animation_export.py/properties.py reverted to base 25127af - slot 256 exports with offset=0 and no block header (prefix-baseline-run.log) |
| Adversarial: a bare block with no action and no tracks still exports as a genuine empty slot, not an inflated block | ✅ pass | live | drive_lmt_block_slots.py S3 - user-created slot 257 exports with offset=0 on both the fixed and base runs |
| Adversarial: importing an .lmt and re-exporting keeps every slot&#39;s used/empty identity (111 used, 145 empty) so the derived rule does not shift the index-addressed table | ✅ pass | live | drive_lmt_block_slots.py S2 - source and exported used-slot index lists match exactly, zero flips; plus test_lmt_serialization / test_lmt_reimport_roundtrip / test_lmt_block_order passing |
| Adversarial: the &#39;Offset&#39; field a user could break by setting it to 0 is gone from the block properties panel, and a zeroed offset no longer deletes the block from the exported file | ✅ pass | live | drive_lmt_block_slots.py S4/S5 - panel rows are generate_new/block_index/num_tracks/num_frames/loop_frame/init_position/init_quaterion/action with no Offset; forcing ofs_frame=0 on used slot 10 and re… |
| Existing lmt import/export behaviour driven through the operators stays green (keyframe edits, single-arc import, reimport round-trip, serialization) | ✅ pass | live | `pytest tests/mtfw/test_lmt_{new_block_export,serialization,reimport_roundtrip,custom_animation,single_arc_import,block_order}.py --game-dir=&#34;re5::~/Games/Resident Evil 5&#34;` - 12 passed |

<details>
<summary>Evidence: Before/after: same driver on base 25127af vs the fix</summary>

<code>BEFORE (base 25127af, ofs_frame used as the &#39;slot is used&#39; flag)&#10;source file has 256 slots, 111 used / 145 empty&#10;&#39;Offset&#39; (ofs_frame) among panel rows: True&#10;slot 256 (user-created, has action): offset=0 num_tracks=- num_frames=-&#10;slot 257 (user-created, no action): offset=0&#10;slots that flipped used&lt;-&gt;empty: none&#10;re-exported slot 10 after forcing ofs_frame=0: offset=0 num_tracks=-&#10;S1: FAIL S2: PASS S3: PASS S4: FAIL S5: FAIL&#10;&#10;AFTER (c42c53b, used status derived from the block&#39;s tracks)&#10;source file has 256 slots, 111 used / 145 empty&#10;&#39;Offset&#39; (ofs_frame) among panel rows: False&#10;slot 256 (user-created, has action): offset=22352 num_tracks=69 num_frames=86&#10;slot 257 (user-created, no action): offset=0&#10;slots that flipped used&lt;-&gt;empty: none&#10;re-exported slot 10 after forcing ofs_frame=0: offset=1040 num_tracks=69&#10;S1: PASS S2: PASS S3: PASS S4: PASS S5: PASS</code>

```text
BEFORE (base 25127af, ofs_frame used as the 'slot is used' flag)
------------------------------------------------------------
source file has 256 slots, 111 used / 145 empty
S4: the 'Offset' field a user could zero to delete a block is gone from the UI
'Offset' (ofs_frame) among them: True
S1: a block the user creates by hand (never imported) exports as a real block
exported 1705992 bytes, 258 slots
slot 256 (user-created, has action): offset=0 num_tracks=- num_frames=-
slot 257 (user-created, no action): offset=0
S2: every pre-existing slot keeps its used/empty identity
slots that flipped used<->empty: none
re-exported slot 10: offset=0 num_tracks=-
S1: FAIL
S2: PASS
S3: PASS
S4: FAIL
S5: FAIL

AFTER (c42c53b, used status derived from the block's tracks)
------------------------------------------------------------
source file has 256 slots, 111 used / 145 empty
S4: the 'Offset' field a user could zero to delete a block is gone from the UI
'Offset' (ofs_frame) among them: False
S1: a block the user creates by hand (never imported) exports as a real block
exported 1730696 bytes, 258 slots
slot 256 (user-created, has action): offset=22352 num_tracks=69 num_frames=86
slot 257 (user-created, no action): offset=0
S2: every pre-existing slot keeps its used/empty identity
slots that flipped used<->empty: none
re-exported slot 10: offset=1040 num_tracks=69
S1: PASS
S2: PASS
S3: PASS
S4: PASS
S5: PASS
```
</details>
<details>
<summary>Evidence: Full driver transcript on the fix (import, export, exported .lmt slot table)</summary>

```text

========================================================================
SETUP: mount the RE5 install as a VFS root (the UI's 'Add Folder')
========================================================================
mod: a shipped .mod file
lmt: a shipped .lmt file
Info: Import successful
imported model, armature: a shipped .mod file
Info: Import successful
imported .lmt: a shipped .lmt file, 256 block slot objects
source file has 256 slots, 111 used / 145 empty

========================================================================
S4: the 'Offset' field a user could zero to delete a block is gone from the UI
========================================================================
Block properties panel now draws these rows:
   - generate_new -> False
   - block_index -> 0
   - num_tracks -> 0
   - num_frames -> 0
   - loop_frame -> 0
   - init_position -> bpy.data.objects['a shipped .lmt file.0000'].albam_custom_propert
   - init_quaterion -> bpy.data.objects['a shipped .lmt file.0000'].albam_custom_propert
   - action -> None
'Offset' (ofs_frame) among them: False

========================================================================
S1: a block the user creates by hand (never imported) exports as a real block
========================================================================
reusing action: a shipped .mod file.pl00action.lmt.0010
new block goes into slot index 256
bare block with no action goes into slot index 257
Exporting LMT for a shipped .lmt file with app_id re5
Info: Export successful
exported 1730696 bytes, 258 slots
slot 256 (user-created, has action): offset=22352 num_tracks=69 num_frames=86

========================================================================
S3 (adversarial): a bare block with no tracks and no action stays an empty slot
========================================================================
slot 257 (user-created, no action): offset=0

========================================================================
S2: every pre-existing slot keeps its used/empty identity
========================================================================
source used slots: [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 29, 31, 32, 33, 34, 35, 36, 37, 49, 50, 51, 52, 54, 57, 59, 70, 74, 75, 76, 77, 78, 79, 80, 83, 100, 101, 102, 103, 104, 105, 110, 112, 113, 114, 115, 116, 120, 121, 125, 126, 127, 130, 131, 132, 133, 134, 135, 153, 154, 155, 156, 157, 158, 160, 161, 162, 163, 164, 165, 166, 167, 168, 170, 171, 172, 173, 174, 176, 180, 181, 182, 183, 186, 187, 188, 190, 195, 196, 198, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 224, 230, 231, 232, 233, 255]
export used slots: [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 29, 31, 32, 33, 34, 35, 36, 37, 49, 50, 51, 52, 54, 57, 59, 70, 74, 75, 76, 77, 78, 79, 80, 83, 100, 101, 102, 103, 104, 105, 110, 112, 113, 114, 115, 116, 120, 121, 125, 126, 127, 130, 131, 132, 133, 134, 135, 153, 154, 155, 156, 157, 158, 160, 161, 162, 163, 164, 165, 166, 167, 168, 170, 171, 172, 173, 174, 176, 180, 181, 182, 183, 186, 187, 188, 190, 195, 196, 198, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 224, 230, 231, 232, 233, 255, 256]
slots that flipped used<->empty: none

========================================================================
S5 (adversarial): a stale/zeroed offset value no longer deletes a used block
========================================================================
forced ofs_frame = 0 on used slot 10
Exporting LMT for a shipped .lmt file with app_id re5
Info: Export successful
re-exported slot 10: offset=1040 num_tracks=69

========================================================================
RESULT
========================================================================
S1: PASS
S2: PASS
S3: PASS
S4: PASS
S5: PASS
```
</details>
<details>
<summary>Evidence: Full driver transcript on base commit 25127af (block silently lost)</summary>

```text
ERROR:root:code for hash blake2b was not found.
Traceback (most recent call last):
  File "/usr/lib/python3.13/hashlib.py", line 247, in <module>
    globals()[__func_name] = __get_hash(__func_name)
                             ~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3.13/hashlib.py", line 129, in __get_openssl_constructor
    return __get_builtin_constructor(name)
  File "/usr/lib/python3.13/hashlib.py", line 123, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type blake2b
ERROR:root:code for hash blake2s was not found.
Traceback (most recent call last):
  File "/usr/lib/python3.13/hashlib.py", line 247, in <module>
    globals()[__func_name] = __get_hash(__func_name)
                             ~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3.13/hashlib.py", line 129, in __get_openssl_constructor
    return __get_builtin_constructor(name)
  File "/usr/lib/python3.13/hashlib.py", line 123, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type blake2s

========================================================================
SETUP: mount the RE5 install as a VFS root (the UI's 'Add Folder')
========================================================================
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M24T709XP2851204R82X528B/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M24T709XP2851204R82X528B/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
  File "~/.no-mistakes/worktrees/731f537710a6/01M24T709XP2851204R82X528B/.venv/lib/python3.13/site-packages/bpy/5.2/scripts/modules/bpy/utils/__init__.py", line 976, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M24T709XP2851204R82X528B/.venv/lib/python3.13/site-packages/bpy/5.2/scripts/modules/addon_utils.py", line 1456, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M24T709XP2851204R82X528B/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
mod: a shipped .mod file
lmt: a shipped .lmt file
Info: Import successful
imported model, armature: a shipped .mod file
Info: Import successful
imported .lmt: a shipped .lmt file, 256 block slot objects
source file has 256 slots, 111 used / 145 empty

========================================================================
S4: the 'Offset' field a user could zero to delete a block is gone from the UI
========================================================================
Block properties panel now draws these rows:
   - generate_new -> False
   - block_index -> 0
   - ofs_frame -> 0
   - num_tracks -> 0
   - num_frames -> 0
   - loop_frame -> 0
   - init_position -> bpy.data.objects['a shipped .lmt file.0000'].albam_custom_propert
   - init_quaterion -> bpy.data.objects['a shipped .lmt file.0000'].albam_custom_propert
   - action -> None
'Offset' (ofs_frame) among them: True

========================================================================
S1: a block the user creates by hand (never imported) exports as a real block
========================================================================
reusing action: a shipped .mod file.pl00action.lmt.0010
new block goes into slot index 256
bare block with no action goes into slot index 257
Exporting LMT for a shipped .lmt file with app_id re5
Info: Export successful
exported 1705992 bytes, 258 slots
slot 256 (user-created, has action): offset=0 num_tracks=- num_frames=-

========================================================================
S3 (adversarial): a bare block with no tracks and no action stays an empty slot
========================================================================
slot 257 (user-created, no action): offset=0

========================================================================
S2: every pre-existing slot keeps its used/empty identity
========================================================================
source used slots: [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 29, 31, 32, 33, 34, 35, 36, 37, 49, 50, 51, 52, 54, 57, 59, 70, 74, 75, 76, 77, 78, 79, 80, 83, 100, 101, 102, 103, 104, 105, 110, 112, 113, 114, 115, 116, 120, 121, 125, 126, 127, 130, 131, 132, 133, 134, 135, 153, 154, 155, 156, 157, 158, 160, 161, 162, 163, 164, 165, 166, 167, 168, 170, 171, 172, 173, 174, 176, 180, 181, 182, 183, 186, 187, 188, 190, 195, 196, 198, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 224, 230, 231, 232, 233, 255]
export used slots: [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 29, 31, 32, 33, 34, 35, 36, 37, 49, 50, 51, 52, 54, 57, 59, 70, 74, 75, 76, 77, 78, 79, 80, 83, 100, 101, 102, 103, 104, 105, 110, 112, 113, 114, 115, 116, 120, 121, 125, 126, 127, 130, 131, 132, 133, 134, 135, 153, 154, 155, 156, 157, 158, 160, 161, 162, 163, 164, 165, 166, 167, 168, 170, 171, 172, 173, 174, 176, 180, 181, 182, 183, 186, 187, 188, 190, 195, 196, 198, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 224, 230, 231, 232, 233, 255]
slots that flipped used<->empty: none

========================================================================
S5 (adversarial): a stale/zeroed offset value no longer deletes a used block
========================================================================
forced ofs_frame = 0 on used slot 10
Exporting LMT for a shipped .lmt file with app_id re5
Info: Export successful
re-exported slot 10: offset=0 num_tracks=-

========================================================================
RESULT
========================================================================
S1: FAIL
S2: PASS
S3: PASS
S4: FAIL
S5: FAIL
```
</details>
<details>
<summary>Evidence: Driver script used to exercise the product</summary>

```text
"""Drive albam (the real addon, in Blender's Python) the way a user does:
mount an RE5 install, import pl00 + its .lmt, then exercise the block-slot
scenarios of issue #272 and print a transcript of what lands in the
exported .lmt bytes."""
import os
import sys

GAME_ROOT = "~/Games/Resident Evil 5"
APP_ID = "re5"
MOD_HASH = "5d45d4682b062d49"
LMT_HASH = "1cc34f3b754528ea"

sys.path.insert(0, os.getcwd())
os.environ["ALBAM_RERAISE_ERRORS"] = "1"

import bpy  # noqa: E402
from albam import register  # noqa: E402
from albam.blender_ui.error_handling import RERAISE_ERRORS_ENV_VAR  # noqa: E402

os.environ[RERAISE_ERRORS_ENV_VAR] = "1"
register()

from albam.engines.mtfw.arc_fs import MTFW_FS  # noqa: E402
from albam.engines.mtfw.animation.animation_import import get_block_index, set_block_index  # noqa: E402
from albam.engines.mtfw.structs.lmt import Lmt  # noqa: E402
from albam.lib.kaitai_utils import parse  # noqa: E402
from tests.mtfw.scripts.catalog_paths import resolve_hashes  # noqa: E402

results = {}

def say(*a):
    print(*a, flush=True)

def banner(t):
    say("\n" + "=" * 72)
    say(t)
    say("=" * 72)

banner("SETUP: mount the RE5 install as a VFS root (the UI's 'Add Folder')")
game_fs = MTFW_FS(GAME_ROOT)
bpy.context.scene.albam.apps.app_selected = APP_ID
bpy.context.scene.albam.vfs.add_fs_root(APP_ID, game_fs, display_name="re5-local")
paths = resolve_hashes(game_fs, {MOD_HASH, LMT_HASH})
mod_path = paths[MOD_HASH].lstrip("/")
lmt_path = paths[LMT_HASH].lstrip("/")
say("mod:", mod_path)
say("lmt:", lmt_path)

assert bpy.context.scene.albam.vfs.select_vfile(APP_ID, mod_path)
assert bpy.ops.albam.import_vfile() == {"FINISHED"}
armature = bpy.context.scene.albam.exportable.file_list[-1].bl_object
bpy.context.scene.albam.import_options_lmt.armature = armature
say("imported model, armature:", armature.name)

assert bpy.context.scene.albam.vfs.select_vfile(APP_ID, lmt_path)
assert bpy.ops.albam.import_vfile() == {"FINISHED"}
idx = len(bpy.context.scene.albam.exportable.file_list) - 1
bpy.context.scene.albam.exportable.file_list_selected_index = idx
lmt_asset = bpy.context.scene.albam.exportable.file_list[idx]
lmt_obj = lmt_asset.bl_object
blocks = [c for c in lmt_obj.children_recursive if c.type == "EMPTY"]
say(f"imported .lmt: {lmt_obj.name}, {len(blocks)} block slot objects")

src_vfile = bpy.context.scene.albam.vfs.select_vfile(APP_ID, lmt_path)
src_lmt = parse(Lmt, src_vfile.get_bytes(), APP_ID)
src_offsets = [bo.offset for bo in src_lmt.block_offsets]
say(f"source file has {len(src_offsets)} slots, "
    f"{sum(1 for o in src_offsets if o)} used / {sum(1 for o in src_offsets if not o)} empty")

banner("S4: the 'Offset' field a user could zero to delete a block is gone from the UI")
props = blocks[0].albam_custom_properties.get_custom_properties_for_appid(APP_ID)
fields = list(getattr(props, "__annotations__", {}))
say("Block properties panel now draws these rows:")
for f in fields:
    say("   -", f, "->", repr(getattr(props, f, None))[:60])
say("'Offset' (ofs_frame) among them:", "ofs_frame" in fields)
results["S4"] = "pass" if "ofs_frame" not in fields else "fail"

banner("S1: a block the user creates by hand (never imported) exports as a real block")
source_action = None
for b in blocks:
    p = b.albam_custom_properties.get_custom_properties_for_appid(APP_ID)
    if p.action:
        source_action = p.action
        break
say("reusing action:", source_action.name)

new_index = max(get_block_index(b, APP_ID) for b in blocks) + 1
say("new block goes into slot index", new_index)
new_block = bpy.data.objects.new(f"{lmt_obj.name}.new_block", None)
new_block.parent = lmt_obj
set_block_index(new_block, APP_ID, new_index)
np = new_block.albam_custom_properties.get_custom_properties_for_appid(APP_ID)
np.generate_new = True
np.action = source_action

# Also build a block with nothing in it at all (S3, adversarial)
empty_index = new_index + 1
empty_block = bpy.data.objects.new(f"{lmt_obj.name}.empty_block", None)
empty_block.parent = lmt_obj
set_block_index(empty_block, APP_ID, empty_index)
say("bare block with no action goes into slot index", empty_index)

assert bpy.ops.albam.export() == {"FINISHED"}
vfile = bpy.context.scene.albam.exported.select_vfile(APP_ID, lmt_path)
out_bytes = vfile.get_bytes()
dst_lmt = parse(Lmt, out_bytes, APP_ID)
dst_offsets = [bo.offset for bo in dst_lmt.block_offsets]
say(f"exported {len(out_bytes)} bytes, {len(dst_offsets)} slots")

nb = dst_lmt.block_offsets[new_index]
say(f"slot {new_index} (user-created, has action): offset={nb.offset} "
    f"num_tracks={nb.block_header.num_tracks if nb.offset else '-'} "
    f"num_frames={nb.block_header.num_frames if nb.offset else '-'}")
results["S1"] = "pass" if nb.offset != 0 and nb.block_header.num_tracks > 0 else "fail"

banner("S3 (adversarial): a bare block with no tracks and no action stays an empty slot")
eb = dst_lmt.block_offsets[empty_index]
say(f"slot {empty_index} (user-created, no action): offset={eb.offset}")
results["S3"] = "pass" if eb.offset == 0 else "fail"

banner("S2: every pre-existing slot keeps its used/empty identity")
mismatches = []
for i, src_ofs in enumerate(src_offsets):
    dst_ofs = dst_offsets[i]
    if bool(src_ofs) != bool(dst_ofs):
        mismatches.append((i, src_ofs, dst_ofs))
say(f"source used slots: {sorted(i for i, o in enumerate(src_offsets) if o)}")
say(f"export used slots: {sorted(i for i, o in enumerate(dst_offsets) if o)}")
say(f"slots that flipped used<->empty: {mismatches or 'none'}")
results["S2"] = "pass" if not mismatches else "fail"

banner("S5 (adversarial): a stale/zeroed offset value no longer deletes a used block")
victim_index = sorted(i for i, o in enumerate(src_offsets) if o)[0]
victim = next(b for b in blocks if get_block_index(b, APP_ID) == victim_index)
vp = victim.albam_custom_properties.get_custom_properties_for_appid(APP_ID)
try:
    vp.ofs_frame = 0
    say(f"forced ofs_frame = 0 on used slot {victim_index}")
except AttributeError as err:
    say(f"slot {victim_index}: Offset cannot even be set anymore: {err}")
assert bpy.ops.albam.export() == {"FINISHED"}
vfile2 = bpy.context.scene.albam.exported.select_vfile(APP_ID, lmt_path)
dst2 = parse(Lmt, vfile2.get_bytes(), APP_ID)
b2 = dst2.block_offsets[victim_index]
say(f"re-exported slot {victim_index}: offset={b2.offset} "
    f"num_tracks={b2.block_header.num_tracks if b2.offset else '-'}")
results["S5"] = "pass" if b2.offset != 0 and b2.block_header.num_tracks > 0 else "fail"

banner("RESULT")
for k in sorted(results):
    say(f"{k}: {results[k].upper()}")
sys.exit(0 if all(v == "pass" for v in results.values()) else 1)
```
</details>
<details>
<summary>Evidence: pytest run of the lmt import/export tests touched by this change</summary>

`12 passed, 217 warnings in 761.53s (0:12:41)`

```text
............                                                             [100%]
=============================== warnings summary ===============================
tests/mtfw/test_lmt_new_block_export.py: 31 warnings
tests/mtfw/test_lmt_serialization.py: 31 warnings
tests/mtfw/test_lmt_reimport_roundtrip.py: 62 warnings
tests/mtfw/test_lmt_custom_animation.py: 62 warnings
tests/mtfw/test_lmt_single_arc_import.py: 31 warnings
  ~/.no-mistakes/worktrees/731f537710a6/01M24T709XP2851204R82X528B/albam/engines/mtfw/material.py:239: DeprecationWarning: 'Material.use_nodes' is expected to be removed in Blender 6.0
    blender_material.use_nodes = True

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
12 passed, 217 warnings in 761.53s (0:12:41)

[exited with code 0]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"cb8207d29ab87aabea4d6f9a9c3d8496dd83bd98","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `albam/engines/mtfw/animation/animation_export.py:247` - Silent loss of an existing block when track generation yields nothing. `_generate_track_from_action` -&gt; `_update_track_data` calls `tracks_collection.clear()` before re-adding (animation_export.py:141), and every fcurve whose bone is not in `mapping` is skipped (animation_export.py:195). Concrete sequence: user imports an .lmt, ticks &#34;Generate new animation&#34; on a real block, and either assigns an action authored for another rig or leaves `scene.albam.import_options_lmt.armature` pointing at a rig without albam `anim_retarget` bone props (so `mapping` is empty). Generation clears the imported tracks and adds none; every downstream site now derives `used == False`, so `block_offsets[i]` is written as 0 and the animation vanishes from the exported file with no warning. Before this change the stored non-zero `ofs_frame` kept the slot alive. The intent&#39;s stated stand-in is &#34;this block has tracks, OR an action to generate them from&#34;; the implementation narrowed it to tracks only, which is exactly the case that diverges. Remedy needs authorization because it either widens the predicate (`len(tracks) &gt; 0 or custom_props.action`) or adds new user-facing error reporting when generation produces zero tracks - it extends the change rather than correcting it.
- ℹ️ `albam/engines/mtfw/animation/animation_export.py:294` - `_block_is_used` is introduced as the single definition of the used/empty rule but is only called from the two lmt67 passes (lines 471, 489). Three other sites re-inline the identical secondary-props lookup and `len(tracks) &gt; 0` test: `_calculate_offsets_lmt51` (294-296), `_calculate_offsets_lmt67`&#39;s sizing pass (398-401) and `export_lmt` (621-623). Two of those need the `tracks` value in the body, but that is satisfied by having the helper return the collection (or by calling the helper and fetching tracks inside the branch). As written, the rule now has four copies to keep in sync, which is the same failure mode the change set out to remove.
- ℹ️ `tests/mtfw/test_lmt_new_block_export.py:98` - `test_zeroing_stored_metadata_no_longer_deletes_the_block` cannot fail before the fix: export never read `custom_props.num_tracks` (it is overwritten with `len(tracks)` at animation_export.py:639), and pre-change the imported block&#39;s `ofs_frame` was non-zero, so the block exported either way. Its docstring frames it as the flip side of #272, but it guards an invariant that already held, at the cost of a full import+export cycle. Separately, `assert not hasattr(custom_props, &#34;ofs_frame&#34;)` at line 78 asserts on the property group&#39;s shape rather than on observable export behavior; the block-offset assertions below it already prove the behavior. Removing or narrowing the test is a judgement call about the author&#39;s intended coverage, hence ask-user.

🔧 Fix applied.
1 info still open:

- ℹ️ `albam/engines/mtfw/animation/animation_export.py:247` - Noting a residual, accepted tradeoff, not a defect. The intent&#39;s stand-in is &#34;this block has tracks, OR an action to generate them from&#34;; the implementation is tracks-only, which is exact only because _generate_track_from_action runs at export_lmt:610 before the predicate. That generation is gated on `custom_props.generate_new and custom_props.action` (animation_export.py:186), and generate_new defaults to False (properties.py:34). So a user who creates a block and assigns &#34;Stored Action&#34; but leaves &#34;Generate new animation&#34; unticked still gets a silently empty slot - the case issue #272 opens with. This is not worth changing here: with generate_new off there are no tracks to write at all, so the predicate is not what drops the block, and the old code&#39;s behavior in the same case was a header with num_tracks=0 and ofs_frame=0, i.e. garbage rather than a warning. The _block_tracks docstring&#39;s forward reference to #254/#296 covers the wrong-rig variant but not this one; no action needed in this change.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 6 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A user creates a new animation block by hand, gives it an action, and exports: the block lands in the .lmt as a real block instead of an empty slot | ✅ pass | live | drive_lmt_block_slots.py S1 - exported slot 256 has offset=22352, num_tracks=69, num_frames=86 (clean-fixed-run.log); `pytest tests/mtfw/test_lmt_new_block_export.py --game-dir=re5::...` passes |
| Regression proof: the same hand-created block is silently dropped on the pre-fix code | ✅ pass | live | Same driver with animation_export.py/properties.py reverted to base 25127af - slot 256 exports with offset=0 and no block header (prefix-baseline-run.log) |
| Adversarial: a bare block with no action and no tracks still exports as a genuine empty slot, not an inflated block | ✅ pass | live | drive_lmt_block_slots.py S3 - user-created slot 257 exports with offset=0 on both the fixed and base runs |
| Adversarial: importing an .lmt and re-exporting keeps every slot&#39;s used/empty identity (111 used, 145 empty) so the derived rule does not shift the index-addressed table | ✅ pass | live | drive_lmt_block_slots.py S2 - source and exported used-slot index lists match exactly, zero flips; plus test_lmt_serialization / test_lmt_reimport_roundtrip / test_lmt_block_order passing |
| Adversarial: the &#39;Offset&#39; field a user could break by setting it to 0 is gone from the block properties panel, and a zeroed offset no longer deletes the block from the exported file | ✅ pass | live | drive_lmt_block_slots.py S4/S5 - panel rows are generate_new/block_index/num_tracks/num_frames/loop_frame/init_position/init_quaterion/action with no Offset; forcing ofs_frame=0 on used slot 10 and re… |
| Existing lmt import/export behaviour driven through the operators stays green (keyframe edits, single-arc import, reimport round-trip, serialization) | ✅ pass | live | `pytest tests/mtfw/test_lmt_{new_block_export,serialization,reimport_roundtrip,custom_animation,single_arc_import,block_order}.py --game-dir=&#34;re5::~/Games/Resident Evil 5&#34;` - 12 passed |

- <code>`.venv/bin/python -m pytest tests/mtfw/test_lmt_new_block_export.py tests/mtfw/test_lmt_serialization.py tests/mtfw/test_lmt_reimport_roundtrip.py tests/mtfw/test_lmt_custom_animation.py tests/mtfw/test_lmt_single_arc_import.py tests/mtfw/test_lmt_block_order.py --game-dir=&#34;re5::~/Games/Resident Evil 5&#34;` (12 passed)</code>
- <code>Manual product driver `drive_lmt_block_slots.py`: mounts the RE5 install as a VFS root, imports a shipped .mod file + a shipped .lmt file, creates a new block slot with an action and a bare empty one, exports via `bpy.ops.albam.export()`, and parses the exported .lmt block-offset table</code>
- <code>Same driver re-run with `albam/engines/mtfw/animation/{animation_export,properties}.py` reverted to base 25127af, to confirm the pre-fix product actually loses the new block (then restored)</code>
- `Live inspection of the registered block property group's drawn rows to confirm the 'Offset' field no longer appears in the block properties panel`
- <code>Adversarial re-export after forcing `ofs_frame = 0` on an imported, used block</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

