### PR TITLE
fix(mtfw): stop a buffer type 5 lmt track from aborting the whole animation import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   expanding either one listed both archives' contents
 - "Batch import folder" importing a second, same-named archive's identically
   placed files along with the selected folder's own
+- A `.lmt` track using buffer type 5 (quadratic_vector3) aborting the whole
+  animation import instead of just that track
 
 ### Changed
 

--- a/albam/engines/mtfw/animation/keyframes.py
+++ b/albam/engines/mtfw/animation/keyframes.py
@@ -1,8 +1,10 @@
 """The .lmt keyframe codec: a track's bytes to poses and back again.
 
 Every buffer type the format uses is decoded and encoded here, along with the
-quantization each one applies. Nothing in this module touches Blender beyond
-mathutils, which is what lets the codec tests drive it directly.
+quantization each one applies - except v51's buffer type 5 (quadratic_vector3),
+which decode_framedata() skips for want of a real sample to verify its record
+layout against. Nothing in this module touches Blender beyond mathutils, which
+is what lets the codec tests drive it directly.
 """
 import math
 from io import BytesIO

--- a/albam/engines/mtfw/animation/keyframes.py
+++ b/albam/engines/mtfw/animation/keyframes.py
@@ -131,6 +131,17 @@ class LMTKeyFrames:
         if kfcls is None:
             print("Unknown keyframe type:", key_type)
             return
+        if kfcls is Lmt.QuadraticVector3:
+            # size_ is a constant that only covers the fixed part of the
+            # record (see lmt.ksy); the tangent fields it can carry are
+            # unverified against any real file, so a record that has them
+            # would be misread rather than just yielding a wrong pose. No
+            # buffer_type 5 (v51) sample has turned up to check against -
+            # see https://github.com/Brachi/albam/issues/255 - so skip the
+            # track instead of guessing.
+            print(f"albam: buffer type {key_type} (quadratic_vector3) is not verified for "
+                  f"reading; skipping this track")
+            return
         keyframe = kfcls()  # hack to get the size before reading
         for start in range(0, len(data), keyframe.size_):
             chunk = data[start: start + keyframe.size_]

--- a/albam/engines/mtfw/structs/lmt.ksy
+++ b/albam/engines/mtfw/structs/lmt.ksy
@@ -195,7 +195,17 @@ types:
       - {id: nextframeintangent_z, type: f4, if: flags >> 32 > 0}
     instances:
       size_:
-        value: size
+        # A constant, like every other keyframe type here: keyframes.py
+        # builds an unread instance (`kfcls()`) to learn a type's size
+        # before reading, so this cannot alias `size`, a parsed field.
+        # 16 is the record's fixed part (size + flags + duration + x/y/z);
+        # unlike its siblings this type's on-disk records can run longer
+        # when tangents are present, which this constant does not account
+        # for - no real buffer_type-5 (v51) sample has turned up to verify
+        # the tangent fields against, so decode_framedata() refuses this
+        # type rather than read past a tangent-bearing record on a wrong
+        # offset. See https://github.com/Brachi/albam/issues/255.
+        value: 16
 
   vec3_frame12:
     seq:

--- a/albam/engines/mtfw/structs/lmt.py
+++ b/albam/engines/mtfw/structs/lmt.py
@@ -1345,7 +1345,7 @@ class Lmt(ReadWriteKaitaiStruct):
             if hasattr(self, '_m_size_'):
                 return self._m_size_
 
-            self._m_size_ = self.size
+            self._m_size_ = 16
             return getattr(self, '_m_size_', None)
 
         def _invalidate_size_(self):

--- a/tests/mtfw/test_lmt_keyframes.py
+++ b/tests/mtfw/test_lmt_keyframes.py
@@ -259,6 +259,35 @@ def test_a_rotation_that_misses_unit_norm_still_round_trips():
     assert drift < 0.05, f"rotation drifted {drift:.4f} deg"
 
 
+def test_quadratic_vector3_size_is_constant_before_reading():
+    """decode_framedata() builds an unread instance purely to learn its size.
+
+    QuadraticVector3.size_ used to alias `size`, a field that only exists
+    after `_read()` runs - so an unread instance raised AttributeError and
+    took the whole import down with it. See
+    https://github.com/Brachi/albam/issues/255.
+    """
+    from albam.engines.mtfw.structs.lmt import Lmt
+
+    assert Lmt.QuadraticVector3().size_ == 16
+
+
+def test_buffer_type_5_skips_its_track_instead_of_aborting_the_import():
+    """No real buffer_type 5 (v51) sample exists to verify the tangent-flag
+    reading against, so decode_framedata() refuses the type rather than
+    risk misdecoding a record that carries tangents - leaving the track's
+    pose empty, which animation_import.py already treats as "skip".
+    """
+    from albam.engines.mtfw.animation import LMTKeyFrames
+
+    decoder = LMTKeyFrames()
+    decoder.version = 51
+    decoder.track_type = "location"
+    decoder.decode_framedata(51, 5, b"\x00" * 32)
+
+    assert decoder.decoded_frames == []
+
+
 def test_an_unknown_track_type_raises_something_catchable():
     """The diagnostic has to reach the caller as an exception.
 


### PR DESCRIPTION
## Intent

Fix albam issue #255, "Buffer type 5 (quadratic_vector3) cannot be read: size_ aliases a parsed field and the tangent flags are shifts, not bit tests" (https://github.com/Brachi/albam/issues/255). The captain wrote it; its substance:

Two problems in quadratic_vector3 (albam/engines/mtfw/structs/lmt.ksy), both unreachable with stock re5 data, which only uses buffer types 2, 4, 6 and 9.

1. size_ aliases a parsed field, so instantiating the type raises. keyframes.py builds an empty instance to learn a type's size before reading (keyframe = kfcls() then keyframe.size_). Every other keyframe type returns a constant there. QuadraticVector3 defines size_ as value: size, where size is a parsed u1, so on an unread instance Lmt.QuadraticVector3().size_ raises AttributeError. A track with buffer_type == 5 therefore aborts the whole import rather than skipping the track.

2. The tangent conditions are shifts where bit tests were meant: if: flags >> 1 > 0, >> 2, >> 4, >> 8, >> 16, >> 32. flags >> 1 > 0 is true for any flags >= 2, not "bit 1 is set", so the first three read together whenever any high bit is set. flags is a u1, so the last three can never be read at all. The record layout is wrong whenever tangents are present. These look like they should be flags & 2, flags & 4, flags & 8, flags & 16, flags & 32, flags & 64.

The captain's note: "Fixing this needs a file that actually uses type 5 to check against, which is why it is an issue rather than a patch. Regenerate with kaitai-struct-compiler --target python --read-write after editing." Found during the review of #180; not introduced by it.

## What Changed

- `QuadraticVector3.size_` no longer aliases `size`, a parsed field: it is now the constant `16` (the record's fixed part) in both `lmt.ksy` and the generated `lmt.py`, so the unread instance `decode_framedata()` builds to learn a type's size no longer raises `AttributeError`.
- `LMTKeyFrames.decode_framedata()` now recognizes `Lmt.QuadraticVector3` explicitly, prints a diagnostic and returns, skipping just that track instead of taking the import down. The tangent fields remain unverified against any real buffer-type-5 sample, so the type is refused rather than read on a possibly wrong offset; the module docstring and the `size_` instance carry that reasoning and the issue link.
- Added two tests — `size_` is a constant on an unread instance, and a buffer-type-5 track leaves `decoded_frames` empty — plus a CHANGELOG entry under Fixed.

## Risk Assessment

✅ Low: A tightly scoped crash fix on a code path stock data never reaches: the size_ constant matches the generated struct, the skip leaves the track's raw data intact for export, and the only open question is whether permanently refusing buffer type 5 is the intended resolution instead of fixing the tangent bit tests.

## Testing

Stood the addon up headless with the pip bpy build and a real Resident Evil 5 install, then imported a real .mod plus a real .lmt whose one translation track had its buffer_type byte switched to 5 — the exact situation issue #255 describes and which no stock file provides. At the base commit that import dies with "AttributeError: 'QuadraticVector3' object has no attribute 'size'" and leaves a partial 60-fcurve action; at the target commit the same operators return FINISHED, print the skip notice for that single track, and produce 231 fcurves, with the character rendering correctly posed. The unmodified file imports identically before and after (234 fcurves), exporting the type-5 animation back out preserves buffer_type 5 and the track bytes verbatim, a real RE6 v67 type-5 track still decodes 401 frames so the refusal is v51-only, and a scan of 2088 re5 .lmt files found no type-5 track, so stock imports are untouched. The existing real-data lmt import and reimport-roundtrip tests pass against the local game dir, and recompiling the edited .ksy with kaitai-struct-compiler 0.11 --read-write reproduces the committed lmt.py byte-for-byte. Visual evidence is the two Cycles renders of the imported pose; the change has no other rendered UI surface.

- Live validation: ✅ go - 7 of 7 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A user imports an re5 .lmt containing a buffer type 5 track: the import finishes and only that track is skipped | ✅ pass | live | `DRIVER_EXPORT=1 python drive_lmt5.py &#34;&lt;RE5 install&gt;&#34; &lt;out&gt;` — bpy.ops.albam.import_vfile() returned FINISHED, printed the skip notice, action carries 231 fcurves; see import_buffer_type_5_before_afte… |
| Regression reproduced: the same file on the base commit aborts the whole import | ✅ pass | live | Same driver with PYTHONPATH=&lt;base-commit copy&gt; — operator raised RuntimeError wrapping &#34;AttributeError: &#39;QuadraticVector3&#39; object has no attribute &#39;size&#39;&#34;, action left with 60 fcurves (import_buffer_t… |
| A stock, unmodified re5 .lmt still imports exactly as before (no regression) | ✅ pass | live | `python drive_lmt5.py ... --unpatched` on base and target: both FINISHED with 234 fcurves/keyframes (before_unpatched.json vs after_unpatched.json); `pytest tests/mtfw/test_lmt_import.py tests/mtfw/te… |
| Adversarial: exporting an animation imported from a type-5 file keeps that track&#39;s bytes intact | ✅ pass | live | bpy.ops.albam.export() returned FINISHED; reparsing the exported bytes shows buffer_type still 5 and the track data byte-identical to the input (after_patched_export.json) |
| Adversarial: the refusal is v51-only — a real v67 buffer type 5 track (Quatized8Vec3) still decodes | ✅ pass | live | `python v67_type5.py &#34;&lt;RE6 install&gt;&#34; re6` — a real RE6 v67 track decoded 401 frames (v67_and_stock_corpus_scan.txt) |
| Adversarial: no stock re5 file trips the new guard | ✅ pass | live | `python v67_type5.py &#34;&lt;RE5 install&gt;&#34; re5` — 2088 re5 .lmt files scanned, no buffer_type 5 track found |
| The edited lmt.ksy regenerates exactly the committed lmt.py with --read-write, as the issue instructs | ✅ pass | live | `kaitai-struct-compiler 0.11 --target python --read-write` on lmt.ksy, diff against albam/engines/mtfw/structs/lmt.py — identical; `pytest tests/test_generated_structs.py` 5 passed with the compiler p… |

<details>
<summary>Evidence: Before/after transcript: importing an re5 .lmt with a buffer type 5 track</summary>

<code>=== BEFORE (base 25127af) ===&#10;[driver] track switched to buffer type 5: {&#34;block&#34;: 0, &#34;track&#34;: 15, &#34;bone_index&#34;: 255, &#34;usage&#34;: 4, &#34;original_buffer_type&#34;: 2, &#34;len_data&#34;: 12}&#10;Error: AttributeError: &#39;QuadraticVector3&#39; object has no attribute &#39;size&#39;&#10;[driver] import FAILED: RuntimeError: Error: Import failed: AttributeError: ...&#10;[driver] actions: 1 fcurves: 60 keyframes: 60&#10;&#10;=== AFTER (cc5edc0) ===&#10;albam: buffer type 5 (quadratic_vector3) is not verified for reading; skipping this track&#10;[driver] import operator returned [&#39;FINISHED&#39;]&#10;[driver] actions: 1 fcurves: 231 keyframes: 231&#10;[driver] export: [&#39;FINISHED&#39;] buffer_type kept: 5 track bytes preserved: True</code>

```text
=== BEFORE (base 25127af): importing an re5 .lmt whose track 15 is buffer type 5 ===
[driver] imported .mod -> armature 'a shipped .mod file', 130 bones
[driver] track switched to buffer type 5: {"block": 0, "track": 15, "bone_index": 255, "usage": 4, "original_buffer_type": 2, "len_data": 12}
Error: AttributeError: 'QuadraticVector3' object has no attribute 'size'
Error: Import failed: AttributeError: 'QuadraticVector3' object has no attribute 'size'
[driver] import FAILED: RuntimeError: Error: Import failed: AttributeError: 'QuadraticVector3' object has no attribute 'size'
[driver] actions: 1 fcurves: 60 keyframes: 60
[driver] wrote before_patched.json

=== AFTER (cc5edc0): same file, same operators ===
[driver] imported .mod -> armature 'a shipped .mod file', 130 bones
[driver] track switched to buffer type 5: {"block": 0, "track": 15, "bone_index": 255, "usage": 4, "original_buffer_type": 2, "len_data": 12}
albam: buffer type 5 (quadratic_vector3) is not verified for reading; skipping this track
[driver] import operator returned ['FINISHED']
[driver] actions: 1 fcurves: 231 keyframes: 231
[driver] wrote after_patched_export.json
[driver] export: ['FINISHED'] buffer_type kept: 5 track bytes preserved: True
```
</details>

<details>
<summary>Evidence: v67 type-5 decode and re5 corpus scan</summary>

<code>[scan] re6 lmt v67 buffer_type 5 track (bone 251, 20 bytes) decoded 401 frames after 2 files&#10;[scan] first frame: &lt;Vector (0.0097, 0.0097, 0.0003)&gt;&#10;[scan] no buffer_type 5 track found in 2088 re5 lmt files</code>

```text
$ python v67_type5.py "<RE6 install>" re6
[scan] re6 lmt v67 buffer_type 5 track (bone 251, 20 bytes) decoded 401 frames after 2 files
[scan] first frame: <Vector (0.0097, 0.0097, 0.0003)>

$ python v67_type5.py "<RE5 install>" re5
[scan] no buffer_type 5 track found in 2088 re5 lmt files
```
</details>
<details>
<summary>Evidence: Import/export driver script used for the live drives</summary>

```text
"""Drive the real Blender addon: import an re5 .mod, then a .lmt whose one
track has been switched to buffer type 5 (quadratic_vector3), through the
same operators the UI uses.

usage: python drive_lmt5.py <game_dir> <out_dir> [--unpatched]
"""
import json
import math
import os
import struct
import sys

GAME_DIR = sys.argv[1]
OUT_DIR = sys.argv[2]
PATCH = "--unpatched" not in sys.argv
REPO = os.environ["ALBAM_REPO"]
sys.path.insert(0, REPO)

import bpy  # noqa: E402

from albam import register  # noqa: E402
from albam.engines.mtfw.arc_fs import MTFW_FS  # noqa: E402
from tests.mtfw.scripts.catalog_paths import resolve_hashes  # noqa: E402

MOD_HASH = "5d45d4682b062d49"
LMT_HASH = "5c3eb9bca5af514e"
TRACK_SIZE = 32
report = {"patched": PATCH}

register()

game_fs = MTFW_FS(GAME_DIR)
resolved = resolve_hashes(game_fs, {MOD_HASH, LMT_HASH})
mod_path = resolved[MOD_HASH]
lmt_path = resolved[LMT_HASH]
mod_arc = game_fs._owning_arc_fs(mod_path)

bpy.context.scene.albam.apps.app_selected = "re5"
vfs = bpy.context.scene.albam.vfs

# --- the .mod first, for an armature the .lmt can land on
vfs.add_fs_root("re5", mod_arc, display_name="single-arc-mod")
assert vfs.select_vfile("re5", mod_path.lstrip("/"))
assert bpy.ops.albam.import_vfile() == {"FINISHED"}
latest = len(bpy.context.scene.albam.exportable.file_list) - 1
armature = bpy.context.scene.albam.exportable.file_list[latest].bl_object
assert armature and armature.type == "ARMATURE"
bpy.context.scene.albam.import_options_lmt.armature = armature
print(f"[driver] imported .mod -> armature {armature.name!r}, "
      f"{len(armature.data.bones)} bones")

# --- the .lmt bytes, with one track switched to buffer type 5
with game_fs.open(lmt_path, "rb") as f:
    raw = bytearray(f.read())

version, num_blocks = struct.unpack_from("<HH", raw, 4)
report["lmt_version"] = version
block_offsets = struct.unpack_from(f"<{num_blocks}I", raw, 8)
patched_track = None
for block_index, block_offset in enumerate(block_offsets):
    if not block_offset:
        continue
    ofs_frame, num_tracks = struct.unpack_from("<II", raw, block_offset)
    for track_index in range(num_tracks):
        base = ofs_frame + track_index * TRACK_SIZE
        buffer_type, usage, _joint, bone_index = struct.unpack_from("<BBBB", raw, base)
        len_data, = struct.unpack_from("<I", raw, base + 8)
        if usage in (1, 2, 4, 5) and len_data:
            patched_track = {
                "block": block_index, "track": track_index, "bone_index": bone_index,
                "usage": usage, "original_buffer_type": buffer_type, "len_data": len_data,
            }
            if PATCH:
                raw[base] = 5
            break
    if patched_track:
        break
assert patched_track, "no candidate track found"
report["track_switched_to_buffer_type_5"] = patched_track
print("[driver] track switched to buffer type 5:", json.dumps(patched_track))

loose_root = os.path.join(OUT_DIR, "loose_game")
os.makedirs(loose_root, exist_ok=True)
lmt_name = os.path.basename(lmt_path)
with open(os.path.join(loose_root, lmt_name), "wb") as f:
    f.write(bytes(raw))

# --- import it the way "Add files" on a game folder does
loose_fs = MTFW_FS(loose_root)
vfs.add_fs_root("re5", loose_fs, display_name="loose-lmt")
assert vfs.select_vfile("re5", lmt_name), "the loose .lmt is not in the file list"
try:
    result = bpy.ops.albam.import_vfile()
    report["operator_result"] = sorted(result)
except Exception as err:  # what the user sees as a failed import
    report["operator_result"] = "EXCEPTION"
    report["error"] = f"{type(err).__name__}: {err}"
    print("[driver] import FAILED:", report["error"])
else:
    print("[driver] import operator returned", report["operator_result"])

actions = [a for a in bpy.data.actions if a.name.startswith(f"{armature.name}.")]
report["actions_created"] = len(actions)
total_fcurves = 0
total_keys = 0
for action in actions:
    for slot in getattr(action, "layers", []) or []:
        pass
    try:
        from tests.mtfw.conftest import action_fcurves
        fcurves = action_fcurves(action)
    except Exception:
        fcurves = list(action.fcurves)
    total_fcurves += len(fcurves)
    total_keys += sum(len(fc.keyframe_points) for fc in fcurves)
report["fcurves"] = total_fcurves
report["keyframes"] = total_keys
print("[driver] actions:", len(actions), "fcurves:", total_fcurves, "keyframes:", total_keys)

with open(os.path.join(OUT_DIR, report_name := os.environ.get("REPORT_NAME", "report.json")), "w") as f:
    json.dump(report, f, indent=2)
print("[driver] wrote", report_name)

# --- export the animation straight back out: the skipped track's bytes are
# kept verbatim, so a user who imports a type-5 file can still export it.
if os.environ.get("DRIVER_EXPORT"):
    from albam.lib.kaitai_utils import parse
    from albam.engines.mtfw.structs.lmt import Lmt

    latest_lmt = len(bpy.context.scene.albam.exportable.file_list) - 1
    entry = bpy.context.scene.albam.exportable.file_list[latest_lmt]
    bpy.context.scene.albam.exportable.file_list_selected_index = latest_lmt
    export_result = bpy.ops.albam.export()
    report["export_result"] = sorted(export_result)
    rel = entry.bl_object.albam_asset.relative_path
    vfile = bpy.context.scene.albam.exported.select_vfile("re5", rel)
    exported = vfile.get_bytes()
    parsed = parse(Lmt, exported, "re5")
    tracks = parsed.block_offsets[0].block_header.tracks
    t = tracks[report["track_switched_to_buffer_type_5"]["track"]]
    report["exported_buffer_type_of_that_track"] = t.buffer_type
    report["exported_track_data_matches_input"] = (
        bytes(t.data) == bytes(raw[t.ofs_data:t.ofs_data + t.len_data]))
    print("[driver] export:", report["export_result"],
          "buffer_type kept:", t.buffer_type,
          "track bytes preserved:", report["exported_track_data_matches_input"])
    with open(os.path.join(OUT_DIR, report_name), "w") as f:
        json.dump(report, f, indent=2)

# --- render the character with the imported action applied, so the imported
# animation is visible rather than only counted
if os.environ.get("DRIVER_RENDER"):
    import mathutils

    action = [a for a in bpy.data.actions if a.name.startswith(f"{armature.name}.")][0]
    armature.animation_data_create()
    armature.animation_data.action = action
    if hasattr(armature.animation_data, "action_slot") and action.slots:
        armature.animation_data.action_slot = action.slots[0]
    bpy.context.scene.frame_set(int(action.frame_range[0]))
    bpy.context.view_layer.update()

    meshes = [o for o in bpy.data.objects if o.type == "MESH" and o.parent == armature]
    coords = []
    dg = bpy.context.evaluated_depsgraph_get()
    for ob in meshes:
        ev = ob.evaluated_get(dg)
        for v in ev.data.vertices:
            coords.append(ob.matrix_world @ v.co)
    lo = mathutils.Vector((min(c[i] for c in coords) for i in range(3)))
    hi = mathutils.Vector((max(c[i] for c in coords) for i in range(3)))
    center = (lo + hi) / 2
    size = max(hi - lo)

    cam_data = bpy.data.cameras.new("evidence_cam")
    cam = bpy.data.objects.new("evidence_cam", cam_data)
    bpy.context.scene.collection.objects.link(cam)
    cam.location = center + mathutils.Vector((0, -size * 2.2, size * 0.35))
    direction = center - cam.location
    cam.rotation_euler = direction.to_track_quat('-Z', 'Y').to_euler()
    bpy.context.scene.camera = cam

    light_data = bpy.data.lights.new("evidence_light", type="SUN")
    light_data.energy = 4
    light = bpy.data.objects.new("evidence_light", light_data)
    bpy.context.scene.collection.objects.link(light)
    light.location = center + mathutils.Vector((size, -size, size * 2))
    light.rotation_euler = (math.radians(50), 0, math.radians(30))

    scene = bpy.context.scene
    scene.render.engine = "CYCLES"
    scene.cycles.device = "CPU"
    scene.cycles.samples = 24
    scene.render.resolution_x = 700
    scene.render.resolution_y = 700
    scene.render.film_transparent = False
    scene.render.filepath = os.path.join(
        OUT_DIR, os.environ["DRIVER_RENDER"])
    bpy.ops.render.render(write_still=True)
    print("[driver] rendered", scene.render.filepath, "frame",
          scene.frame_current, "action", action.name)
```
</details>
<details>
<summary>Evidence: Per-run JSON reports (before/after, patched/unpatched, export)</summary>

```text
{
  "patched": true,
  "lmt_version": 51,
  "track_switched_to_buffer_type_5": {
    "block": 0,
    "track": 15,
    "bone_index": 255,
    "usage": 4,
    "original_buffer_type": 2,
    "len_data": 12
  },
  "operator_result": [
    "FINISHED"
  ],
  "actions_created": 1,
  "fcurves": 231,
  "keyframes": 231,
  "export_result": [
    "FINISHED"
  ],
  "exported_buffer_type_of_that_track": 5,
  "exported_track_data_matches_input": true
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"5f1d7a340f69e4f920ee4fe2808bc61b7b849e50","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 2 issues (1 warning, 1 info)</summary>

- ⚠️ `albam/engines/mtfw/structs/lmt.ksy:190` - Intent problem 2 is not addressed: the intent states &#34;The tangent conditions are shifts where bit tests were meant: if: flags &gt;&gt; 1 &gt; 0, &gt;&gt; 2, &gt;&gt; 4... These look like they should be flags &amp; 2, flags &amp; 4, flags &amp; 8, flags &amp; 16, flags &amp; 32, flags &amp; 64.&#34; lmt.ksy:190-195 (and the generated lmt.py _read/_write/_check) still carry the shift forms unchanged. Instead the change contains the issue by refusing buffer type 5 outright in decode_framedata (keyframes.py:134-143), which makes QuadraticVector3 unreachable for reading in every version (v67 maps type 5 to Quatized8Vec3), so the wrong conditions are now dead rather than corrected. The captain&#39;s note (&#34;Fixing this needs a file that actually uses type 5 to check against&#34;) plausibly authorizes this deferral, but choosing permanent refusal over the bit-test fix is a deliberate product decision that the intent&#39;s own wording points the other way on - confirm the containment is what you want, or apply the `flags &amp; N` tests and keep reading the type.
- ℹ️ `albam/engines/mtfw/structs/lmt.ksy:207` - size_ == 16 is now unreachable in practice: decode_framedata returns before the `kfcls()` size probe for this type, and no other caller reads it (encode_framedata can&#39;t select type 5 in v51 - _check_buffer_type allows only {1,2,9}/{3,4,6,7}). Noting the latent trap for whoever lifts the guard: 16 is only the fixed part, so a tangent-bearing record would be strided wrong, whereas the record&#39;s own parsed `size` byte is the real per-record length. The comment already says this; no action needed now.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 7 of 7 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A user imports an re5 .lmt containing a buffer type 5 track: the import finishes and only that track is skipped | ✅ pass | live | `DRIVER_EXPORT=1 python drive_lmt5.py &#34;&lt;RE5 install&gt;&#34; &lt;out&gt;` — bpy.ops.albam.import_vfile() returned FINISHED, printed the skip notice, action carries 231 fcurves; see import_buffer_type_5_before_afte… |
| Regression reproduced: the same file on the base commit aborts the whole import | ✅ pass | live | Same driver with PYTHONPATH=&lt;base-commit copy&gt; — operator raised RuntimeError wrapping &#34;AttributeError: &#39;QuadraticVector3&#39; object has no attribute &#39;size&#39;&#34;, action left with 60 fcurves (import_buffer_t… |
| A stock, unmodified re5 .lmt still imports exactly as before (no regression) | ✅ pass | live | `python drive_lmt5.py ... --unpatched` on base and target: both FINISHED with 234 fcurves/keyframes (before_unpatched.json vs after_unpatched.json); `pytest tests/mtfw/test_lmt_import.py tests/mtfw/te… |
| Adversarial: exporting an animation imported from a type-5 file keeps that track&#39;s bytes intact | ✅ pass | live | bpy.ops.albam.export() returned FINISHED; reparsing the exported bytes shows buffer_type still 5 and the track data byte-identical to the input (after_patched_export.json) |
| Adversarial: the refusal is v51-only — a real v67 buffer type 5 track (Quatized8Vec3) still decodes | ✅ pass | live | `python v67_type5.py &#34;&lt;RE6 install&gt;&#34; re6` — a real RE6 v67 track decoded 401 frames (v67_and_stock_corpus_scan.txt) |
| Adversarial: no stock re5 file trips the new guard | ✅ pass | live | `python v67_type5.py &#34;&lt;RE5 install&gt;&#34; re5` — 2088 re5 .lmt files scanned, no buffer_type 5 track found |
| The edited lmt.ksy regenerates exactly the committed lmt.py with --read-write, as the issue instructs | ✅ pass | live | `kaitai-struct-compiler 0.11 --target python --read-write` on lmt.ksy, diff against albam/engines/mtfw/structs/lmt.py — identical; `pytest tests/test_generated_structs.py` 5 passed with the compiler p… |

- <code>`python drive_lmt5.py &#34;&lt;RE5 install&gt;&#34; &lt;out&gt;` — imports a real re5 .mod then a real .lmt whose track 15 buffer_type byte was switched to 5, through bpy.ops.albam.import_vfile(), run against both the base commit&#39;s sources and the target commit&#39;s</code>
- <code>`python drive_lmt5.py ... --unpatched` — same drive with the unmodified .lmt, on base and target, as a no-regression control</code>
- <code>`DRIVER_EXPORT=1 python drive_lmt5.py ...` — bpy.ops.albam.export() on the imported type-5 animation, reparsing the exported bytes to confirm buffer_type 5 and byte-identical track data</code>
- <code>`DRIVER_RENDER=... python drive_lmt5.py ...` — Cycles render of the character with the imported action applied (type-5 file and stock file)</code>
- <code>`python v67_type5.py &#34;&lt;RE6 install&gt;&#34; re6` and `... &#34;&lt;RE5 install&gt;&#34; re5` — corpus scan decoding a real v67 buffer_type 5 track and confirming no v51 type-5 track exists in 2088 re5 .lmt files</code>
- `pytest tests/mtfw/test_lmt_import.py tests/mtfw/test_lmt_reimport_roundtrip.py --game-dir=re5::<RE5 install>`
- `pytest tests/mtfw/test_lmt_keyframes.py tests/test_generated_structs.py`
- <code>`kaitai-struct-compiler 0.11 --target python --read-write` on albam/engines/mtfw/structs/lmt.ksy, diffed against the committed albam/engines/mtfw/structs/lmt.py</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `albam/engines/mtfw/structs/lmt.py:1348` - README.md documents lmt.py as generated from lmt.ksy via kaitai-struct-compiler, but the compiler is not available in this environment, so I could not verify by regeneration that lmt.py matches the edited lmt.ksy. The single changed line (`self._m_size_ = 16`) is exactly what `value: 16` compiles to and the added .ksy comments emit nothing, so drift is very unlikely; recording it only because the check itself could not be run here.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

