### PR TITLE
fix(hexn): mount the id_magic 5 .ssg variant instead of rejecting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,12 +52,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   expanding either one listed both archives' contents
 - "Batch import folder" importing a second, same-named archive's identically
   placed files along with the selected folder's own
-- Resident Evil: Operation Raccoon City weapon archives (135 of ~2100 on a
+- Resident Evil: Operation Raccoon City weapon archives (130 of ~2100 on a
   full install) being rejected outright and their contents silently missing
   from the file browser. They use a second `.ssg` layout that locates each
-  entry by its own stored offset instead of packing them end to end
+  entry by its own stored offset instead of packing them end to end. Five
+  more archives share that layout but hold cutscene/mocap streams rather
+  than model data, and are still refused on purpose
 - Adding a game folder no longer skips archives it cannot read in silence -
-  the ones left out, and why, are now reported
+  the ones left out, and why, are now reported, so those five cutscene
+  archives are listed as skipped instead of just going missing
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   expanding either one listed both archives' contents
 - "Batch import folder" importing a second, same-named archive's identically
   placed files along with the selected folder's own
+- Resident Evil: Operation Raccoon City weapon archives (135 of ~2100 on a
+  full install) being rejected outright and their contents silently missing
+  from the file browser. They use a second `.ssg` layout that locates each
+  entry by its own stored offset instead of packing them end to end
+- Adding a game folder no longer skips archives it cannot read in silence -
+  the ones left out, and why, are now reported
 
 ### Changed
 

--- a/albam/engines/hexn/fs.py
+++ b/albam/engines/hexn/fs.py
@@ -194,8 +194,12 @@ class SsgFS(FS):
             # file_info.size until the first read and the real size after
             # would make getinfo() answer differently depending on whether
             # anything had been read yet.
-            self._sizes[path] = archive_size if is_skeleton else file_info.size
-            self._offsets[path] = file_info.ofs_in_buffer_chunks if is_v5 else offset
+            # A .dds is filed as a TPKH/TPKD pair sharing one entry name
+            # (see SSG_V5_CONTENT_TYPES): the stub never wins the path off
+            # the real texture, whichever order the two are stored in.
+            if not (path in self._sizes and _content_type(file_info) == b"TPKH"):
+                self._sizes[path] = archive_size if is_skeleton else file_info.size
+                self._offsets[path] = file_info.ofs_in_buffer_chunks if is_v5 else offset
 
             parts = path.strip("/").split("/")
             for i in range(len(parts)):
@@ -223,7 +227,7 @@ class SsgFS(FS):
         """Refuse an id_magic 5 archive this reader has no evidence it can
         serve correctly, before any of it is exposed as files.
 
-        Both conditions below hold for every id_magic 5 archive on a full
+        Every condition below holds for every id_magic 5 archive on a full
         install (135 of them, 881 entries), and each one failing would mean
         `file_info.ofs_in_buffer_chunks` no longer points where this class
         reads from:
@@ -236,6 +240,9 @@ class SsgFS(FS):
         * every entry's `file_type` is one of SSG_V5_CONTENT_TYPES, which is
           what tells the model-data family apart from the cutscene/mocap one
           sharing this id_magic - see that constant.
+        * no entry runs past the end of `buffer_chunks`. Slicing one that
+          does yields short bytes with nothing raised, i.e. the wrong
+          content served silently.
 
         Raises rather than mounting what it can: `HexnFS` collects the
         failure per-archive and surfaces it (see HexnFS.skipped_archives()),
@@ -255,6 +262,14 @@ class SsgFS(FS):
                 f"id_magic 5 archive holds content types this reader doesn't model "
                 f"({tags}) - not mounted rather than served on the model-data layout's "
                 f"assumptions"
+            )
+        overrun = max(
+            (fi.ofs_in_buffer_chunks + fi.size for fi in ssg.files_info), default=0)
+        if overrun > ssg.size_chunks_buffer:
+            raise CreateFailed(
+                f"id_magic 5 archive has an entry running past the end of its buffer "
+                f"({overrun} > size_chunks_buffer={ssg.size_chunks_buffer}), which no "
+                f"known one does - its file_info offsets would slice short bytes"
             )
 
     def _open_and_parse(self, struct_cls):

--- a/albam/engines/hexn/fs.py
+++ b/albam/engines/hexn/fs.py
@@ -73,12 +73,16 @@ ANIM_CLIP_EXTENSION = ".animclip"
 # the "DDS " magic, TPKD the real texture under the same name.
 #
 # Mounting one makes its files readable, which is not the same as
-# importable: their 108 .edgemodel entries are all format version 15, and
-# structs/edgemodel.ksy models 17/18 (the only versions the current
-# archives hold). Version 15 is a pre-existing gap, not one mounting these
-# opens - 129 more of them are already reachable as loose files on disk,
-# and parsing any of the 189 runs off the end of the file today. Their
-# .matb/.dds/.hkx entries do read normally.
+# importable: the 108 .edgemodel entries these archives hold are all
+# format version 15, and structs/edgemodel.ksy models 17/18 (the only
+# versions the current archives hold). Version 15 is a pre-existing gap,
+# not one mounting these opens: only 60 of the 108 win their path in a
+# full mount, the other 48 staying behind a current archive's version-17/18
+# copy (id_magic 5 mounts below current content - see _ssg_priority), and
+# 129 more version-15 files already resolve to loose files on disk. All
+# 189 version-15 paths a full mount resolves - those 60 plus those 129 -
+# run off the end of the file when parsed today. Their .matb/.dds/.hkx
+# entries do read normally.
 #
 # An allowlist rather than a denylist because the offsets an id_magic 5
 # archive is read by are only as trustworthy as the census that established

--- a/albam/engines/hexn/fs.py
+++ b/albam/engines/hexn/fs.py
@@ -3,16 +3,23 @@ PyFilesystem2 adapter for Hexane Engine (RE:ORC) .ssg archives.
 
 An .ssg bundles every file's bytes into one contiguous "solid" compressed
 stream (see structs/ssg.ksy): fixed-size file-info entries record each
-file's name and *uncompressed* size, but not its own compressed range - only
-the whole `buffer_chunks` blob (itself split into independently
+file's name and *uncompressed* size, but not its own compressed range -
+only the whole `buffer_chunks` blob (itself split into independently
 zlib-compressed chunks) decompresses to a stream that files are sliced out
-of sequentially, each padded up to `size_padding`. That solid layout means -
-unlike ArcFS/PakFS, where openbin() seeks straight to one entry's own
-compressed range - resolving any single file's bytes means decompressing
-the *whole* archive's `buffer_chunks` together. `SsgFS` defers that to the
-first file actually requested from a given archive rather than doing it in
-__init__ (see `_ensure_decompressed()`) - a real game install has ~2000
-.ssg, and a typical session only ever touches a handful of them.
+of. That solid layout means - unlike ArcFS/PakFS, where openbin() seeks
+straight to one entry's own compressed range - resolving any single file's
+bytes means decompressing the *whole* archive's `buffer_chunks` together.
+`SsgFS` defers that to the first file actually requested from a given
+archive rather than doing it in __init__ (see `_ensure_decompressed()`) - a
+real game install has ~2000 .ssg, and a typical session only ever touches a
+handful of them.
+
+Where in that stream a given entry lands depends on the archive's
+`id_magic`: 6 slices them out sequentially, each padded up to
+`size_padding`, while 5 gives every entry its own `ofs_in_buffer_chunks`
+and is read by that instead (structs/ssg.ksy documents both layouts;
+SSG_V5_CONTENT_TYPES below covers which id_magic 5 archives are mounted at
+all).
 
 `SsgFS` exposes a single .ssg as a read-only PyFilesystem2 filesystem;
 `HexnFS` overlays every .ssg under a game root - plus loose files - into one
@@ -27,11 +34,12 @@ little-endian format already registered here (archive.py), so there's no
 second registry slot to hang a separate `AnimsFS` off of. `_parse_header()`
 tries the regular little-endian `HexaneSsg` first (matches every real
 non-anims .ssg) and only falls back to the big-endian `HexaneAnims` if
-that raises (the two magics don't overlap - the same 4 bytes read as
-`contents: [0x06, 0x00, 0x00, 0x00]` little-endian vs. a big-endian u4
-can't both validate). Each clip entry is exposed as its own virtual leaf
-file, named `<file_info.name>.animclip` - a synthetic extension (no real
-file on disk ever has one) so the import registry can key an
+that raises (a big-endian archive can't be mistaken for a little-endian
+one - `HexaneSsg` accepts an `id_magic` of only 5 or 6, and a big-endian
+archive's own 5 or 6 reads back little-endian as 0x05000000/0x06000000).
+Each clip entry is exposed as its own virtual leaf file, named
+`<file_info.name>.animclip` - a synthetic extension (no real file on disk
+ever has one) so the import registry can key an
 `albam.engines.hexn.animation` import function off of it, the same way
 every other importable leaf here is dispatched by extension.
 """
@@ -55,9 +63,44 @@ from ...lib.s3 import S3LooseFS, build_s3_client, s3_opener
 
 ANIM_CLIP_EXTENSION = ".animclip"
 
+# file_info.file_type is a fourcc stored as a little-endian word, so the
+# readable tag is its big-endian view - see structs/ssg.ksy.
+#
+# The content types an id_magic 5 archive is read as. A full install's 130
+# such archives (all under dlc/pack1/Weapons/) carry exactly these five and
+# nothing else: MODL (.edgemodel), MATB (.matb), HAVK (.hkx), and the
+# TPKH/TPKD pair a .dds is filed as - TPKH being a 4-byte stub holding just
+# the "DDS " magic, TPKD the real texture under the same name.
+#
+# Mounting one makes its files readable, which is not the same as
+# importable: their 108 .edgemodel entries are all format version 15, and
+# structs/edgemodel.ksy models 17/18 (the only versions the current
+# archives hold). Version 15 is a pre-existing gap, not one mounting these
+# opens - 129 more of them are already reachable as loose files on disk,
+# and parsing any of the 189 runs off the end of the file today. Their
+# .matb/.dds/.hkx entries do read normally.
+#
+# An allowlist rather than a denylist because the offsets an id_magic 5
+# archive is read by are only as trustworthy as the census that established
+# them (see structs/ssg.ksy): a content type never seen in one gets refused
+# and reported instead of mounted on the assumption it behaves like these.
+# What it refuses today is the other id_magic 5 family - 5 archives under
+# NIS/ holding cutscene/mocap streams (STMH, MCPH, SANM, SCAM, LAYO), which
+# no part of albam parses and whose entry names repeat within one archive
+# (31 entries under 7 names in one), so mounting them would file several
+# entries' bytes under one path and serve whichever won.
+SSG_V5_CONTENT_TYPES = frozenset({b"MODL", b"MATB", b"HAVK", b"TPKH", b"TPKD"})
+
 
 def _local_opener(path):
     return open(path, "rb")
+
+
+def _content_type(file_info):
+    """`file_info.file_type` as its readable fourcc - the field is a signed
+    word holding a fourcc stored little-endian, so the tag is its
+    big-endian view (0x4d4f444c -> b"MODL"). See SSG_V5_CONTENT_TYPES."""
+    return (file_info.file_type & 0xFFFFFFFF).to_bytes(4, "big")
 
 
 class SsgFS(FS):
@@ -129,6 +172,16 @@ class SsgFS(FS):
         # file_info.size/offset here yields bytes that don't even start at
         # skel.ksy's own magic).
         is_be_container = self._struct_cls is HexaneAnims
+        # This archive's own layout version, exposed for _ssg_priority() -
+        # None for the big-endian container, whose id_magic is 5 or 6 too
+        # but means nothing comparable (see structs/anims.ksy).
+        self.id_magic = None if is_be_container else ssg.id_magic
+        # An id_magic 5 archive stores each entry's own offset rather than
+        # laying them out end to end, so the sequential walk below never
+        # applies to it - see _check_v5_supported() and structs/ssg.ksy.
+        is_v5 = self.id_magic == 5
+        if is_v5:
+            self._check_v5_supported(ssg)
         for file_info in ssg.files_info:
             name = file_info.name.replace("\\", "/").lstrip("/")
             is_anim_clip = is_be_container and file_info.file_type == 5
@@ -142,7 +195,7 @@ class SsgFS(FS):
             # would make getinfo() answer differently depending on whether
             # anything had been read yet.
             self._sizes[path] = archive_size if is_skeleton else file_info.size
-            self._offsets[path] = offset
+            self._offsets[path] = file_info.ofs_in_buffer_chunks if is_v5 else offset
 
             parts = path.strip("/").split("/")
             for i in range(len(parts)):
@@ -151,17 +204,58 @@ class SsgFS(FS):
                 if i < len(parts) - 1:
                     self._known_dirs.add(parent.rstrip("/") + "/" + parts[i])
 
-            # Both formats sharing the big-endian container pack their
-            # entries with no padding at all, unlike the regular
-            # little-endian format's size_padding-driven gaps (see
-            # structs/anims.ksy). id_magic 5 archives are unpadded too -
-            # they carry size_padding == 0.
-            padding = (0 if is_be_container or not ssg.size_padding
-                       else -file_info.size % ssg.size_padding)
-            offset += file_info.size + padding
+            if not is_v5:
+                # Both formats sharing the big-endian container pack their
+                # entries with no padding at all, unlike the regular
+                # little-endian format's size_padding-driven gaps (see
+                # structs/anims.ksy). An id_magic 5 archive looks unpadded
+                # by the same test - it carries size_padding == 0 - while
+                # really padding to 16, which is why it is read by its own
+                # stored offsets instead of by this walk.
+                padding = (0 if is_be_container or not ssg.size_padding
+                           else -file_info.size % ssg.size_padding)
+                offset += file_info.size + padding
 
         self._data = None  # populated lazily - see _ensure_decompressed()
         self._decompress_lock = threading.Lock()
+
+    def _check_v5_supported(self, ssg):
+        """Refuse an id_magic 5 archive this reader has no evidence it can
+        serve correctly, before any of it is exposed as files.
+
+        Both conditions below hold for every id_magic 5 archive on a full
+        install (135 of them, 881 entries), and each one failing would mean
+        `file_info.ofs_in_buffer_chunks` no longer points where this class
+        reads from:
+
+        * `size_chunks_info` == 0, i.e. `buffer_chunks` is stored
+          uncompressed. That offset is a position in the *stored* buffer;
+          for a chunk-compressed archive it is a zlib chunk boundary rather
+          than a position in the decompressed stream (see structs/ssg.ksy),
+          so it would slice the wrong bytes out.
+        * every entry's `file_type` is one of SSG_V5_CONTENT_TYPES, which is
+          what tells the model-data family apart from the cutscene/mocap one
+          sharing this id_magic - see that constant.
+
+        Raises rather than mounting what it can: `HexnFS` collects the
+        failure per-archive and surfaces it (see HexnFS.skipped_archives()),
+        so an archive left out says so instead of just going missing.
+        """
+        if ssg.size_chunks_info:
+            raise CreateFailed(
+                f"id_magic 5 archive is chunk-compressed "
+                f"(size_chunks_info={ssg.size_chunks_info}), which no known one is - its "
+                f"file_info offsets index the stored buffer, not the decompressed stream"
+            )
+        unsupported = sorted(
+            {_content_type(fi) for fi in ssg.files_info} - SSG_V5_CONTENT_TYPES)
+        if unsupported:
+            tags = ", ".join(t.decode("ascii", "replace") for t in unsupported)
+            raise CreateFailed(
+                f"id_magic 5 archive holds content types this reader doesn't model "
+                f"({tags}) - not mounted rather than served on the model-data layout's "
+                f"assumptions"
+            )
 
     def _open_and_parse(self, struct_cls):
         """Open the archive and read everything up to (not including)
@@ -366,27 +460,40 @@ def _is_info_only_ssg(ssg_path):
     return basename == "modelinfos.ssg" or basename.endswith(".minfo.ssg")
 
 
-def _ssg_priority(ssg_path):
+def _ssg_priority(ssg_path, ssg_fs):
     """MultiFS priority for one discovered .ssg (see HexnFS.__init__).
 
-    All real content archives share the default priority (0), resolved by
-    MultiFS's own reverse-add-order tie-break - fine on its own, except an
-    info-only archive (see _is_info_only_ssg() above) sorts alphabetically
-    after some real content archives too, so with everything at the same
-    priority it can silently shadow them: a lookup for a shared path
-    returns the tiny info stub instead of the real mesh. Confirmed on a
-    real install: without this priority ordering, across the 4
-    ModelInfos.ssg archives alone, 103 of 171 virtual paths they share
-    with a real content archive would resolve to the wrong stub (the 36
-    per-level .minfo.ssg archives add more of the same, unquantified).
+    Current-content archives share the default priority (0), resolved by
+    MultiFS's own reverse-add-order tie-break - fine on its own, except
+    two kinds of archive re-use the very same virtual paths and would
+    otherwise shadow the real thing depending on nothing but where they
+    sorted:
 
-    Giving info-only archives a strictly lower priority means one only
-    ever resolves a path no other (real-priority) archive already claims -
-    real content always wins on a shared path, while any path that turns
-    out to exist *only* inside an info-only archive still resolves
-    instead of disappearing outright.
+    * an info-only archive (see _is_info_only_ssg() above), whose entry at
+      a shared path is a tiny "IM6S" metadata stub rather than the mesh.
+      Confirmed on a real install: without this ordering, across the 4
+      ModelInfos.ssg archives alone, 103 of 171 virtual paths they share
+      with a real content archive would resolve to the wrong stub (the 36
+      per-level .minfo.ssg archives add more of the same, unquantified).
+    * an id_magic 5 archive, which holds a superseded revision of what it
+      shares with the current archives - the 130 on a real install are all
+      per-weapon copies under dlc/pack1/Weapons/, and where one shares a
+      path with the shipped aggregate dlc/pack1/Weapons/weapons.ssg, its
+      .edgemodel is format version 15 against that one's 17/18. Left at
+      the same priority they win 141 of the 469 virtual paths they claim,
+      29 of those .edgemodel paths that resolve to a version-18 mesh
+      today - a straight downgrade of what is already there.
+
+    Ordering them strictly below current content means one only ever
+    resolves a path no higher-priority archive already claims, so nothing
+    that resolves today changes and a path that exists *only* in one still
+    resolves instead of disappearing. id_magic 5 outranks info-only in
+    turn: both can claim the same path, and a superseded-but-real mesh
+    beats a metadata stub.
     """
     if _is_info_only_ssg(ssg_path):
+        return -2
+    if ssg_fs.id_magic == 5:
         return -1
     return 0
 
@@ -439,7 +546,7 @@ class HexnFS(MultiFS):
             except Exception as e:
                 self.failed_ssgs.append((ssg_path, e))
                 continue
-            self.add_fs(ssg_path, ssg_fs, priority=_ssg_priority(ssg_path))
+            self.add_fs(ssg_path, ssg_fs, priority=_ssg_priority(ssg_path, ssg_fs))
 
         # added last -> highest default priority -> wins over packed archives
         self.add_fs("<loose>", OSFS(game_root))
@@ -496,12 +603,40 @@ class HexnFS(MultiFS):
             except Exception as e:
                 self.failed_ssgs.append((ssg_key, e))
                 continue
-            self.add_fs(ssg_key, ssg_fs, priority=_ssg_priority(ssg_key))
+            self.add_fs(ssg_key, ssg_fs, priority=_ssg_priority(ssg_key, ssg_fs))
 
         if include_loose:
             # added last -> highest default priority -> wins over packed archives
             self.add_fs("<loose>", S3LooseFS(client, bucket, prefix))
         return self
+
+    def skipped_archives(self):
+        """(path relative to the game root, reason) for every .ssg found
+        under it that could not be mounted - the readable form of
+        `failed_ssgs`.
+
+        Construction deliberately keeps going past an archive it can't
+        read, so one unreadable .ssg out of ~2000 doesn't cost the user
+        every other one. Nothing said so, though: the failures were
+        collected here and never read by anything, leaving a silently
+        incomplete tree - files simply absent, with no hint they were ever
+        there. albam.vfs surfaces this list when a root is added (see
+        skipped_source_warnings() there); the same shape works for any FS
+        that overlays many sources.
+        """
+        return [
+            (self._display_path(path), str(exc) or type(exc).__name__)
+            for path, exc in self.failed_ssgs
+        ]
+
+    def _display_path(self, ssg_path):
+        """`ssg_path` as origin_of() would report it - relative to the game
+        root locally, to `prefix` for a from_s3() instance."""
+        if self._s3_prefix is not None:
+            if self._s3_prefix and ssg_path.startswith(self._s3_prefix + "/"):
+                return ssg_path[len(self._s3_prefix) + 1:]
+            return ssg_path
+        return os.path.relpath(ssg_path, self.game_root).replace(os.sep, "/")
 
     def _owning_ssg_fs(self, path):
         self.check()
@@ -521,12 +656,7 @@ class HexnFS(MultiFS):
         owner_fs = self._owning_ssg_fs(path)
         if owner_fs is None:
             return None
-        ssg_path = owner_fs.ssg_path
-        if self._s3_prefix is not None:
-            if self._s3_prefix and ssg_path.startswith(self._s3_prefix + "/"):
-                return ssg_path[len(self._s3_prefix) + 1:]
-            return ssg_path
-        return os.path.relpath(ssg_path, self.game_root).replace(os.sep, "/")
+        return self._display_path(owner_fs.ssg_path)
 
     # listdir()/scandir(): MultiFS's own versions (see fs.multifs.MultiFS)
     # aggregate every overlaid sub-filesystem's listing for `path` and only

--- a/albam/engines/hexn/structs/hexane_ssg.py
+++ b/albam/engines/hexn/structs/hexane_ssg.py
@@ -9,6 +9,36 @@ if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 11):
     raise Exception("Incompatible Kaitai Struct Python API: 0.11 or later is required, but you have %s" % (kaitaistruct.__version__))
 
 class HexaneSsg(ReadWriteKaitaiStruct):
+    """Two little-endian layouts share this header and file table, told apart by
+    `id_magic`, and they differ only in how an entry's bytes are found inside
+    `buffer_chunks`:
+    
+    * 6 packs every entry end to end in file-table order, each padded up to
+      `size_padding`. `file_info.ofs_in_buffer_chunks` is not usable for that
+      walk when the archive is chunk-compressed - see its own doc.
+    * 5 leaves `size_padding` 0 and is never chunk-compressed
+      (`size_chunks_info` is 0 in all 135 on a full install), so
+      `file_info.ofs_in_buffer_chunks` addresses the stored buffer and the
+      data itself alike, and is what locates an entry. Walking these end to
+      end the way 6 is walked lands on another entry's bytes rather than
+      failing - the offsets are real gaps, not padding this header describes.
+    
+    Verified on all 135 id_magic 5 archives of a full install (881 entries):
+    read at `ofs_in_buffer_chunks`, every entry whose `file_type` names a
+    format with a magic of its own starts on that magic exactly - "FM6S"
+    (108/108 MODL), "MAT\\x07" (148/148 MATB), "DDS " (244/244 TPKD and
+    244/244 TPKH), Havok's 57 e0 e0 57 (71/71 HAVK) - with no entry running
+    past the end of the buffer and no two entries overlapping.
+    
+    `file_type` is a fourcc stored as a little-endian word, so the readable
+    tag is its big-endian view. Two content families carry id_magic 5, and
+    no archive mixes them: 130 weapon archives holding MODL/MATB/TPKD/TPKH/
+    HAVK, and 5 under NIS/ holding cutscene/mocap streams (STMH/MCPH/SANM/
+    SCAM/LAYO) instead - see albam.engines.hexn.fs, which mounts the former
+    and refuses the latter. A TPKH entry is a 4-byte stub holding just the
+    "DDS " magic; the real texture is the TPKD entry filed under the same
+    name, which is the later of the two in every archive of either magic.
+    """
     def __init__(self, _io=None, _parent=None, _root=None):
         super(HexaneSsg, self).__init__(_io)
         self._parent = _parent
@@ -17,9 +47,9 @@ class HexaneSsg(ReadWriteKaitaiStruct):
         self.buffer_chunks__enabled = True
 
     def _read(self):
-        self.id_magic = self._io.read_bytes(4)
-        if not self.id_magic == b"\x06\x00\x00\x00":
-            raise kaitaistruct.ValidationNotEqualError(b"\x06\x00\x00\x00", self.id_magic, self._io, u"/seq/0")
+        self.id_magic = self._io.read_u4le()
+        if not  ((self.id_magic == 5) or (self.id_magic == 6)) :
+            raise kaitaistruct.ValidationNotAnyOfError(self.id_magic, self._io, u"/seq/0")
         self.reserved_01 = self._io.read_u4le()
         self.size_files_info = self._io.read_u4le()
         self.size_file_names = self._io.read_u4le()
@@ -61,7 +91,7 @@ class HexaneSsg(ReadWriteKaitaiStruct):
     def _write__seq(self, io=None):
         super(HexaneSsg, self)._write__seq(io)
         self._should_write_buffer_chunks = self.buffer_chunks__enabled
-        self._io.write_bytes(self.id_magic)
+        self._io.write_u4le(self.id_magic)
         self._io.write_u4le(self.reserved_01)
         self._io.write_u4le(self.size_files_info)
         self._io.write_u4le(self.size_file_names)
@@ -81,10 +111,8 @@ class HexaneSsg(ReadWriteKaitaiStruct):
 
 
     def _check(self):
-        if len(self.id_magic) != 4:
-            raise kaitaistruct.ConsistencyError(u"id_magic", 4, len(self.id_magic))
-        if not self.id_magic == b"\x06\x00\x00\x00":
-            raise kaitaistruct.ValidationNotEqualError(b"\x06\x00\x00\x00", self.id_magic, None, u"/seq/0")
+        if not  ((self.id_magic == 5) or (self.id_magic == 6)) :
+            raise kaitaistruct.ValidationNotAnyOfError(self.id_magic, None, u"/seq/0")
         if len(self.files_info) != self.size_files_info // 32:
             raise kaitaistruct.ConsistencyError(u"files_info", self.size_files_info // 32, len(self.files_info))
         for i in range(len(self.files_info)):
@@ -121,7 +149,7 @@ class HexaneSsg(ReadWriteKaitaiStruct):
             self.name_offset_rel = self._io.read_u4le()
             self.size = self._io.read_u4le()
             self.reserved_01 = self._io.read_u4le()
-            self.reserved_02 = self._io.read_u4le()
+            self.ofs_in_buffer_chunks = self._io.read_u4le()
             self.file_type = self._io.read_s4le()
             self.unk_01 = self._io.read_u4le()
             self.unk_02 = self._io.read_u4le()
@@ -143,7 +171,7 @@ class HexaneSsg(ReadWriteKaitaiStruct):
             self._io.write_u4le(self.name_offset_rel)
             self._io.write_u4le(self.size)
             self._io.write_u4le(self.reserved_01)
-            self._io.write_u4le(self.reserved_02)
+            self._io.write_u4le(self.ofs_in_buffer_chunks)
             self._io.write_s4le(self.file_type)
             self._io.write_u4le(self.unk_01)
             self._io.write_u4le(self.unk_02)

--- a/albam/engines/hexn/structs/ssg.ksy
+++ b/albam/engines/hexn/structs/ssg.ksy
@@ -6,20 +6,43 @@ meta:
   license: CC0-1.0
   ks-version: '0.11'
 
+doc: |
+  Two little-endian layouts share this header and file table, told apart by
+  `id_magic`, and they differ only in how an entry's bytes are found inside
+  `buffer_chunks`:
+
+  * 6 packs every entry end to end in file-table order, each padded up to
+    `size_padding`. `file_info.ofs_in_buffer_chunks` is not usable for that
+    walk when the archive is chunk-compressed - see its own doc.
+  * 5 leaves `size_padding` 0 and is never chunk-compressed
+    (`size_chunks_info` is 0 in all 135 on a full install), so
+    `file_info.ofs_in_buffer_chunks` addresses the stored buffer and the
+    data itself alike, and is what locates an entry. Walking these end to
+    end the way 6 is walked lands on another entry's bytes rather than
+    failing - the offsets are real gaps, not padding this header describes.
+
+  Verified on all 135 id_magic 5 archives of a full install (881 entries):
+  read at `ofs_in_buffer_chunks`, every entry whose `file_type` names a
+  format with a magic of its own starts on that magic exactly - "FM6S"
+  (108/108 MODL), "MAT\\x07" (148/148 MATB), "DDS " (244/244 TPKD and
+  244/244 TPKH), Havok's 57 e0 e0 57 (71/71 HAVK) - with no entry running
+  past the end of the buffer and no two entries overlapping.
+
+  `file_type` is a fourcc stored as a little-endian word, so the readable
+  tag is its big-endian view. Two content families carry id_magic 5, and
+  no archive mixes them: 130 weapon archives holding MODL/MATB/TPKD/TPKH/
+  HAVK, and 5 under NIS/ holding cutscene/mocap streams (STMH/MCPH/SANM/
+  SCAM/LAYO) instead - see albam.engines.hexn.fs, which mounts the former
+  and refuses the latter. A TPKH entry is a 4-byte stub holding just the
+  "DDS " magic; the real texture is the TPKD entry filed under the same
+  name, which is the later of the two in every archive of either magic.
+
 seq:
   - id: id_magic
-    contents: [0x06, 0x00, 0x00, 0x00]
-    doc: >
-      Only 6 is this layout. A second little-endian variant carries 5, and
-      is deliberately not accepted here: its header and file table parse
-      cleanly with these same fields (sizes add up to the file size, names
-      decode), but its entries are not laid out end to end in
-      buffer_chunks the way `size` alone implies - a file's real bytes are
-      elsewhere in the buffer, and some entries are 4-byte stubs whose
-      file_type differs from the full entry's by a single bit. Real
-      content is in there (a weapon archive holds its "FM6S" mesh several
-      hundred KB into the buffer), so this is worth modeling, but reading
-      it as this layout returns the wrong bytes rather than failing.
+    type: u4
+    valid:
+      any-of: [5, 6]
+    doc: Layout version - see meta.doc for what the two differ in.
   - {id: reserved_01, type: u4}
   - {id: size_files_info, type: u4}
   - {id: size_file_names, type: u4}
@@ -43,7 +66,19 @@ types:
       - {id: name_offset_rel, type: u4}
       - {id: size, type: u4}
       - {id: reserved_01, type: u4}
-      - {id: reserved_02, type: u4}
+      - id: ofs_in_buffer_chunks
+        type: u4
+        doc: >
+          Byte offset of this entry's data within `buffer_chunks` *as
+          stored*, i.e. before decompression. An uncompressed archive
+          (`size_chunks_info` == 0) stores the buffer verbatim, so this is
+          equally the entry's offset in the data - that is what an
+          id_magic 5 archive, always uncompressed, is read by. A
+          compressed one instead puts the start of the zlib chunk holding
+          the entry here, always exactly on a chunk boundary (confirmed
+          against the cumulative `chunk_sizes` of a compressed id_magic 6
+          archive), so it does not locate the entry in the decompressed
+          stream and the end-to-end walk is what does.
       - {id: file_type, type: s4}
       - {id: unk_01, type: u4}
       - {id: unk_02, type: u4}

--- a/albam/vfs.py
+++ b/albam/vfs.py
@@ -382,6 +382,48 @@ class VirtualFileSystemBase:
         return vfile
 
 
+# How many individually-named skipped archives one root's warning lists
+# before collapsing the rest into a count - see skipped_source_warnings().
+# A handful is enough to act on; a badly broken install could otherwise
+# push hundreds of lines into Blender's info log.
+MAX_SKIPPED_SOURCES_REPORTED = 5
+
+
+def skipped_source_warnings(root_vf):
+    """Warning lines for the archives an FS-backed root mounted *around*,
+    ready to be handed to `Operator.report({'WARNING'}, ...)`.
+
+    An FS overlaying a whole install deliberately keeps going when one of
+    the hundreds of archives under the game root won't parse, so a single
+    bad one doesn't cost the user every other one. Nothing said which ones,
+    though: the skipped list was collected and never read, so the user got
+    a silently incomplete tree - files simply missing, with no hint they
+    had ever been there.
+
+    Duck-typed on a `skipped_archives()` method returning (source, reason)
+    pairs, so nothing here needs to know which engine's FS it was handed.
+    `HexnFS` has one; a root whose FS doesn't (a single archive, an export
+    root, and `MTFW_FS` with its own equally-unread `failed_arcs` until it
+    grows one) warns about nothing.
+    """
+    if root_vf is None or not root_vf.fs_key:
+        return []
+    skipped_archives = getattr(fs_registry.get(root_vf.fs_key), "skipped_archives", None)
+    if skipped_archives is None:
+        return []
+    skipped = list(skipped_archives())
+    if not skipped:
+        return []
+
+    lines = [f"{root_vf.display_name}: {len(skipped)} archive(s) skipped, not mounted"]
+    for source, reason in skipped[:MAX_SKIPPED_SOURCES_REPORTED]:
+        lines.append(f"skipped {source}: {reason}")
+    remaining = len(skipped) - MAX_SKIPPED_SOURCES_REPORTED
+    if remaining > 0:
+        lines.append(f"...and {remaining} more skipped")
+    return lines
+
+
 def _fs_root_loader(vf):
     """The registered fs_root_loader able to rebuild root `vf`'s FS: keyed by
     the root's own extension for an archive root ("Add Files"), falling back
@@ -490,17 +532,23 @@ class ALBAM_OT_VirtualFileSystemAddFiles(bpy.types.Operator):
         return {"RUNNING_MODAL"}
 
     def execute(self, context):  # pragma: no cover
-        self._execute(context, self.directory, self.files)
+        for warning in self._execute(context, self.directory, self.files):
+            self.report({'WARNING'}, warning)
         context.scene.albam.vfs.file_list.update()
         return {"FINISHED"}
 
     @staticmethod
     def _execute(context, directory, files):
+        """Returns the warning lines execute() reports - see
+        skipped_source_warnings()."""
         app_id = context.scene.albam.apps.app_selected
         vfs = context.scene.albam.vfs
+        warnings = []
         for f in files:
             absolute_path = os.path.join(directory, f.name)
-            vfs.add_real_file(app_id, absolute_path)
+            root_vf = vfs.add_real_file(app_id, absolute_path)
+            warnings.extend(skipped_source_warnings(root_vf))
+        return warnings
 
 
 @blender_registry.register_blender_type
@@ -517,14 +565,17 @@ class ALBAM_OT_VirtualFileSystemAddFolder(bpy.types.Operator):
 
     def execute(self, context):  # pragma: no cover
         self.report({'INFO'}, f"Selected directory: {self.directory}")
-        self._execute(context, self.directory, self.files)
+        for warning in self._execute(context, self.directory, self.files):
+            self.report({'WARNING'}, warning)
         return {"FINISHED"}
 
     @staticmethod
     def _execute(context, directory, files):
+        """Returns the warning lines execute() reports - see
+        skipped_source_warnings()."""
         app_id = context.scene.albam.apps.app_selected
         vfs = context.scene.albam.vfs
-        vfs.add_real_file(app_id, directory)
+        return skipped_source_warnings(vfs.add_real_file(app_id, directory))
 
 
 class ALBAM_OT_VirtualFileSystemSaveFileBase:

--- a/tests/hexn/test_ssg_fs.py
+++ b/tests/hexn/test_ssg_fs.py
@@ -371,6 +371,7 @@ def test_ssg_v5_refuses_an_entry_running_past_the_end_of_the_buffer(tmp_path):
         SsgFS(str(ssg_path))
     assert "past the end" in str(excinfo.value)
 
+
 def test_ssg_v5_refuses_content_types_it_does_not_model(tmp_path):
     """The cutscene/mocap archives sharing id_magic 5 parse just as cleanly
     as the weapon ones, so nothing about the header tells them apart -

--- a/tests/hexn/test_ssg_fs.py
+++ b/tests/hexn/test_ssg_fs.py
@@ -332,6 +332,45 @@ def test_ssg_v5_reads_every_entry_from_its_own_offset(tmp_path):
     assert ssg_fs.readbytes("/weapons/textures/gun_d.dds") == V5_ENTRIES[3][1]
 
 
+def test_ssg_v5_dds_resolves_to_tpkd_whatever_order_the_pair_is_stored_in(tmp_path):
+    """A .dds is filed as a TPKH stub and the real TPKD texture under one
+    entry name. Which of the two wins that path has to be decided by
+    content type, not by which happens to come last: with the stub stored
+    later, reading the .dds by store order would hand back its 4-byte
+    "DDS " magic and report a size of 4, with nothing raised.
+    """
+    stub, real = V5_ENTRIES[2], V5_ENTRIES[3]
+    entries = [V5_ENTRIES[0], V5_ENTRIES[1], real, stub]
+    ssg_path = tmp_path / "weapon.ssg"
+    ssg_path.write_bytes(_build_ssg_v5_bytes(entries))
+
+    ssg_fs = SsgFS(str(ssg_path))
+    assert ssg_fs.readbytes("/weapons/textures/gun_d.dds") == real[1]
+    info = ssg_fs.getinfo("/weapons/textures/gun_d.dds", namespaces=["details"])
+    assert info.size == len(real[1])
+
+
+def test_ssg_v5_refuses_an_entry_running_past_the_end_of_the_buffer(tmp_path):
+    """An entry whose stored offset plus size overruns buffer_chunks slices
+    short rather than raising, so openbin() would hand back truncated
+    bytes. Refused up front instead - no real archive stores one.
+    """
+    from fs.errors import CreateFailed
+
+    ssg_bytes = bytearray(_build_ssg_v5_bytes(V5_ENTRIES))
+    # Push the last entry's ofs_in_buffer_chunks past the buffer's end.
+    # Header is 8 words, each file_info 8 words, ofs_in_buffer_chunks the
+    # 5th of them - see _build_ssg_v5_bytes.
+    ofs_field = 32 + (len(V5_ENTRIES) - 1) * 32 + 16
+    size_buffer = struct.unpack_from("<I", ssg_bytes, 16)[0]
+    struct.pack_into("<I", ssg_bytes, ofs_field, size_buffer)
+    ssg_path = tmp_path / "overrun.ssg"
+    ssg_path.write_bytes(bytes(ssg_bytes))
+
+    with pytest.raises(CreateFailed) as excinfo:
+        SsgFS(str(ssg_path))
+    assert "past the end" in str(excinfo.value)
+
 def test_ssg_v5_refuses_content_types_it_does_not_model(tmp_path):
     """The cutscene/mocap archives sharing id_magic 5 parse just as cleanly
     as the weapon ones, so nothing about the header tells them apart -

--- a/tests/hexn/test_ssg_fs.py
+++ b/tests/hexn/test_ssg_fs.py
@@ -93,10 +93,100 @@ def _build_ssg_bytes(entries, size_padding=SIZE_PADDING, chunk_size=None, raw=Fa
         compressed_chunks)
 
 
+# An id_magic 5 archive is laid out differently enough to need its own
+# builder - see _build_ssg_v5_bytes.
+V5_ALIGNMENT = 16
+
+
+def _build_ssg_v5_bytes(entries, chunk_size=None):
+    """Builds an id_magic 5 archive (see structs/ssg.ksy): every entry
+    located by its own `file_info.ofs_in_buffer_chunks` rather than by
+    walking sizes, `size_padding` 0 and no chunk table, exactly as every
+    real one is.
+
+    `entries` are (name, content, file_type) tuples, `file_type` a 4-byte
+    fourcc as it reads (b"MODL"), stored little-endian the way the format
+    does. Entries are laid out 16-byte aligned, like the real ones, so the
+    gaps that a sizes-only walk would swallow are genuinely there - a
+    fixture whose entries happened to pack end to end would pass under
+    either reading and prove nothing.
+
+    `chunk_size` builds the chunk-compressed variant instead - not a
+    layout any real id_magic 5 archive uses, and one SsgFS refuses (see
+    SsgFS._check_v5_supported).
+    """
+    buffer_ = bytearray()
+    file_infos = []  # (name, size, offset, file_type)
+    for name, content, file_type in entries:
+        offset = len(buffer_)
+        buffer_.extend(content)
+        buffer_.extend(b"\x00" * (-len(content) % V5_ALIGNMENT))
+        file_infos.append((name, len(content), offset, file_type))
+
+    if chunk_size:
+        chunk_sizes = []
+        chunks = bytearray()
+        for start in range(0, len(buffer_), chunk_size):
+            compressed = zlib.compress(bytes(buffer_[start:start + chunk_size]))
+            chunk_sizes.append(len(compressed))
+            chunks.extend(compressed)
+    else:
+        chunk_sizes = []
+        chunks = bytes(buffer_)
+
+    file_names = bytearray()
+    files_info_bytes = bytearray()
+    for name, size, offset, file_type in file_infos:
+        files_info_bytes.extend(struct.pack(
+            "<IIIIIiII",
+            0,                                          # ident
+            len(file_names),                            # name_offset_rel
+            size,
+            1,                                          # reserved_01
+            offset,                                     # ofs_in_buffer_chunks
+            int.from_bytes(file_type, "big"),           # file_type
+            0,                                          # unk_01
+            0,                                          # unk_02
+        ))
+        file_names.extend(name.encode("ascii") + b"\x00")
+
+    header = struct.pack(
+        "<IIIIIIII",
+        5,                                  # id_magic
+        0,                                  # reserved_01
+        len(files_info_bytes),              # size_files_info
+        len(file_names),                    # size_file_names
+        len(chunks),                        # size_chunks_buffer
+        0,                                  # reserverd_01
+        len(chunk_sizes) * 4,               # size_chunks_info
+        0,                                  # size_padding, always 0 here
+    )
+    chunk_sizes_bytes = b"".join(struct.pack("<I", s) for s in chunk_sizes)
+    return (header + bytes(files_info_bytes) + chunk_sizes_bytes +
+            bytes(file_names) + bytes(chunks))
+
+
 ENTRIES = [
     ("test/foo.matb", b"HELLO-MATERIAL-DATA"),
     ("test/bar.tex", b"WORLD"),
     ("baz.edgemodel", b"SOME-MESH-BYTES-" + os.urandom(64)),
+]
+
+# Sized so no entry is a multiple of V5_ALIGNMENT, i.e. every one of them
+# sits past where a sizes-only walk would look for it.
+V5_ENTRIES = [
+    ("weapons/models/gun.edgemodel", b"FM6S" + b"M" * 33, b"MODL"),
+    ("weapons/surfaces/gun.matb", b"MAT\x07" + b"A" * 21, b"MATB"),
+    ("weapons/textures/gun_d.dds", b"DDS ", b"TPKH"),
+    ("weapons/textures/gun_d.dds", b"DDS |" + b"T" * 60, b"TPKD"),
+]
+
+# The other family carrying id_magic 5: cutscene/mocap streams, which
+# SsgFS refuses rather than mounts - see SSG_V5_CONTENT_TYPES.
+V5_MOCAP_ENTRIES = [
+    ("StreamHeader", b"\x01\x00\x00\x00" + b"S" * 20, b"STMH"),
+    ("MocapHeader", b"\x07\x00\x00\x00" + b"M" * 60, b"MCPH"),
+    ("Tyrant", b"C" * 100, b"SANM"),
 ]
 
 
@@ -209,3 +299,105 @@ def test_hexn_fs_origin_of_packed_and_loose(tmp_path):
     assert game_fs.origin_of("/models/a.edgemodel") == "sub/a.ssg"
     assert game_fs.origin_of("/readme.txt") is None
     assert game_fs.origin_of("/nope/does/not/exist.foo") is None
+
+
+def test_ssg_v5_reads_every_entry_from_its_own_offset(tmp_path):
+    """An id_magic 5 archive's entries are not packed end to end the way an
+    id_magic 6 archive's are, so the sizes-only walk that reads one of
+    those returns another entry's bytes here rather than failing - which is
+    why they get read by file_info.ofs_in_buffer_chunks instead. Asserts
+    both halves: the right bytes come back, and the walk really would have
+    been wrong (a fixture that happened to pack end to end would pass under
+    either reading).
+    """
+    ssg_bytes = _build_ssg_v5_bytes(V5_ENTRIES)
+    ssg_path = tmp_path / "weapon.ssg"
+    ssg_path.write_bytes(ssg_bytes)
+
+    # What the sizes-only walk would have read for the last entry, taken
+    # straight out of the stored (uncompressed) buffer, which this builder
+    # leaves at the very end of the archive - the fixture is only
+    # meaningful if the two readings really do disagree.
+    size_buffer = sum(len(c) + (-len(c) % V5_ALIGNMENT) for _n, c, _t in V5_ENTRIES)
+    buffer_ = ssg_bytes[len(ssg_bytes) - size_buffer:]
+    walked = sum(len(c) for _n, c, _t in V5_ENTRIES[:-1])
+    last_content = V5_ENTRIES[-1][1]
+    assert buffer_[walked:walked + len(last_content)] != last_content
+
+    ssg_fs = SsgFS(str(ssg_path))
+    # The .dds is filed twice, as a TPKH stub and the real TPKD texture -
+    # the later entry is the real one, exactly as in a real archive.
+    assert ssg_fs.readbytes("/weapons/models/gun.edgemodel") == V5_ENTRIES[0][1]
+    assert ssg_fs.readbytes("/weapons/surfaces/gun.matb") == V5_ENTRIES[1][1]
+    assert ssg_fs.readbytes("/weapons/textures/gun_d.dds") == V5_ENTRIES[3][1]
+
+
+def test_ssg_v5_refuses_content_types_it_does_not_model(tmp_path):
+    """The cutscene/mocap archives sharing id_magic 5 parse just as cleanly
+    as the weapon ones, so nothing about the header tells them apart -
+    file_type does. Refusing beats mounting them: nothing here parses those
+    streams, and their entry names repeat within one archive, so several
+    entries would end up filed under one path.
+    """
+    from fs.errors import CreateFailed
+
+    ssg_path = tmp_path / "cutscene.ssg"
+    ssg_path.write_bytes(_build_ssg_v5_bytes(V5_MOCAP_ENTRIES))
+
+    with pytest.raises(CreateFailed) as excinfo:
+        SsgFS(str(ssg_path))
+    assert "MCPH" in str(excinfo.value) and "SANM" in str(excinfo.value)
+    assert "STMH" in str(excinfo.value)
+
+
+def test_ssg_v5_refuses_a_chunk_compressed_archive(tmp_path):
+    """ofs_in_buffer_chunks is a position in the *stored* buffer, so it only
+    doubles as a position in the data while the archive is uncompressed -
+    which every real id_magic 5 archive is. A compressed one would slice
+    the wrong bytes out silently, so it is refused instead.
+    """
+    from fs.errors import CreateFailed
+
+    ssg_path = tmp_path / "compressed.ssg"
+    ssg_path.write_bytes(_build_ssg_v5_bytes(V5_ENTRIES, chunk_size=32))
+
+    with pytest.raises(CreateFailed) as excinfo:
+        SsgFS(str(ssg_path))
+    assert "compressed" in str(excinfo.value)
+
+
+def test_hexn_fs_surfaces_skipped_archives(tmp_path):
+    """A .ssg that can't be mounted is skipped so the other ~2000 still
+    are - but it has to say so, or its files just silently aren't there.
+    """
+    (tmp_path / "weapon.ssg").write_bytes(_build_ssg_v5_bytes(V5_ENTRIES))
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "cutscene.ssg").write_bytes(_build_ssg_v5_bytes(V5_MOCAP_ENTRIES))
+
+    game_fs = HexnFS(str(tmp_path))
+    assert game_fs.readbytes("/weapons/models/gun.edgemodel") == V5_ENTRIES[0][1]
+
+    skipped = game_fs.skipped_archives()
+    assert len(skipped) == 1
+    source, reason = skipped[0]
+    assert source == "sub/cutscene.ssg"
+    assert "MCPH" in reason
+
+
+def test_hexn_fs_v5_archive_does_not_shadow_current_content(tmp_path):
+    """The id_magic 5 archives on a real install hold a superseded revision
+    of paths the current archives also carry (their .edgemodel is format
+    version 15 against the shipped 17/18), so one must never win a shared
+    path - while a path only it has still has to resolve.
+    """
+    (tmp_path / "aaa_weapon.ssg").write_bytes(_build_ssg_v5_bytes(
+        [("weapons/models/gun.edgemodel", b"FM6S" + b"O" * 33, b"MODL"),
+         ("weapons/models/only_here.edgemodel", b"FM6S" + b"U" * 21, b"MODL")]))
+    (tmp_path / "zzz_current.ssg").write_bytes(
+        _build_ssg_bytes([("weapons/models/gun.edgemodel", b"FM6S-CURRENT")]))
+
+    game_fs = HexnFS(str(tmp_path))
+    assert not game_fs.failed_ssgs
+    assert game_fs.readbytes("/weapons/models/gun.edgemodel") == b"FM6S-CURRENT"
+    assert game_fs.origin_of("/weapons/models/gun.edgemodel") == "zzz_current.ssg"
+    assert game_fs.readbytes("/weapons/models/only_here.edgemodel") == b"FM6S" + b"U" * 21

--- a/tests/hexn/test_vfs_add_files.py
+++ b/tests/hexn/test_vfs_add_files.py
@@ -11,7 +11,7 @@ _build_ssg_bytes, no real game data needed (see that file's own docstring).
 import bpy
 import pytest
 
-from .test_ssg_fs import _build_ssg_bytes
+from .test_ssg_fs import V5_ENTRIES, V5_MOCAP_ENTRIES, _build_ssg_bytes, _build_ssg_v5_bytes
 
 
 @pytest.fixture
@@ -46,3 +46,43 @@ def test_add_files_two_ssgs_with_the_same_name_read_their_own_bytes(tmp_path, ad
 
     assert vfs.get_vfile("reorc", "dup_addfiles/models/dup.edgemodel").get_bytes() == b"MESH-BYTES"
     assert vfs.get_vfile("reorc", "dup_addfiles/skel/dup").get_bytes() == b"SKEL-BYTES"
+
+
+def test_add_folder_reports_archives_it_skipped(tmp_path, added_roots):
+    """Mounting a game folder keeps going past a .ssg it can't read, so one
+    bad archive doesn't cost the user the other ~2000 - but the operator
+    has to say which ones, or those files are just missing from the tree
+    with nothing to explain it.
+    """
+    from albam.vfs import ALBAM_OT_VirtualFileSystemAddFolder
+
+    (tmp_path / "weapon.ssg").write_bytes(_build_ssg_v5_bytes(V5_ENTRIES))
+    (tmp_path / "cutscene.ssg").write_bytes(_build_ssg_v5_bytes(V5_MOCAP_ENTRIES))
+
+    app_selected = bpy.context.scene.albam.apps.app_selected
+    bpy.context.scene.albam.apps.app_selected = "reorc"
+    try:
+        warnings = ALBAM_OT_VirtualFileSystemAddFolder._execute(
+            bpy.context, str(tmp_path), [])
+    finally:
+        bpy.context.scene.albam.apps.app_selected = app_selected
+
+    assert warnings
+    assert "1 archive(s) skipped" in warnings[0]
+    assert any("cutscene.ssg" in line for line in warnings[1:])
+
+
+def test_add_folder_reports_nothing_when_every_archive_mounts(tmp_path, added_roots):
+    from albam.vfs import ALBAM_OT_VirtualFileSystemAddFolder
+
+    (tmp_path / "weapon.ssg").write_bytes(_build_ssg_v5_bytes(V5_ENTRIES))
+
+    app_selected = bpy.context.scene.albam.apps.app_selected
+    bpy.context.scene.albam.apps.app_selected = "reorc"
+    try:
+        warnings = ALBAM_OT_VirtualFileSystemAddFolder._execute(
+            bpy.context, str(tmp_path), [])
+    finally:
+        bpy.context.scene.albam.apps.app_selected = app_selected
+
+    assert warnings == []


### PR DESCRIPTION
## Intent

Work albam issue #247, "RE:ORC: model the id_magic 5 .ssg variant, so its archives mount"
(https://github.com/Brachi/albam/issues/247). The captain wrote it; its substance:

`ssg.ksy` only accepts `id_magic == 6`. A second little-endian variant carries 5, and on a real
install that is 145 of ~2100 archives - every one rejected outright. `SsgFS.__init__` raises,
`HexnFS.__init__` swallows the failure into `failed_ssgs`, and nothing surfaces that list, so their
contents are simply invisible in the file browser. Among them are ~125 real weapon `.edgemodel`
files.

Accepting the magic is NOT sufficient, and the captain recorded why before anyone tries:
- the header and file table parse cleanly with the same fields - sizes add up to the file size,
names decode as clean ASCII paths, on all 135 little-endian magic-5 archives checked;
- but the entries are NOT laid out end to end in `buffer_chunks` the way `size` alone implies.
Reading them as the magic-6 layout returns another entry's bytes rather than failing. In one
weapon archive the real `FM6S` mesh sits several hundred KB into the buffer while the walk
expects it near the start.

Two further observations from the captain:
- some entries are 4-byte stubs whose `file_type` differs from a full entry's by a single bit
(e.g. `0x54455848` vs `0x54455844`) - plausibly "this entry lives elsewhere" markers;
- `size_padding` is 0 in all of them, so whatever eventually reads them must not divide by it
(already guarded).

A likely place for the real offsets is one of `file_info`'s unattributed fields (`reserved_01`,
`reserved_02`, `unk_01`, `unk_02`).

The magic check deliberately still rejects these, and says why in `ssg.ksy` - failing loudly beats
serving the wrong bytes. There is also a second family with the same magic holding cutscene/mocap
streams (`StreamHeader`, `MocapHeader` entries, fourcc-like `file_type` values) rather than model
data.

## What Changed

- `ssg.ksy`/`hexane_ssg.py` now accept an `id_magic` of 5 or 6, and `file_info.reserved_02` is named `ofs_in_buffer_chunks` — the per-entry offset into the stored buffer. `SsgFS` reads magic-5 entries by that offset instead of the magic-6 end-to-end `size_padding` walk, and resolves the TPKH/TPKD name collision so the 4-byte stub never wins the path off the real texture.
- `SsgFS._check_v5_supported()` refuses a magic-5 archive before exposing any files when it is chunk-compressed, when an entry runs past the end of `buffer_chunks`, or when it carries a `file_type` outside the allowlisted `SSG_V5_CONTENT_TYPES` (MODL/MATB/HAVK/TPKH/TPKD) — which is what keeps the cutscene/mocap family under `NIS/` out. `_ssg_priority()` gains a tier so magic-5 archives mount below current content but above info-only stubs, leaving every path that resolves today unchanged.
- `HexnFS.skipped_archives()` exposes the previously write-only `failed_ssgs` list, and `albam/vfs.py` adds `skipped_source_warnings()` so "Add Files"/"Add Folder" report unmounted archives and why (capped at 5 named, rest collapsed to a count) rather than silently serving an incomplete tree. Tests cover the magic-5 offset reads, each refusal condition, priority ordering, and the new warnings.

## Risk Assessment

✅ Low: The change is well-bounded to a new, previously-unmountable archive variant, is gated behind an explicit allowlist plus compression and buffer-bounds checks that fail loudly rather than serving wrong bytes, mounts strictly below current content so nothing that resolves today changes, and the fix round's two additions are minimal, correctly ordered, and covered by tests that genuinely fail without them.

## Testing

I stood the addon up the way a user runs it (albam registered inside Blender 5.2's Python) and drove the "Add Folder" and "Add Files" operators against a synthetic RE:ORC install built from the format's own byte layout, since no real game data is available here. Every scenario passed: magic-5 weapon content mounts and reads from its per-entry offsets, a magic-5-only weapon mesh is reachable where nothing was before, the TPKH/TPKD pair resolves to the real texture regardless of store order, a magic-5 archive never shadows current magic-6 content on a shared path, and the cutscene/chunk-compressed/offset-overrun archives are refused with the exact warning lines the user now sees in Blender's info log. I also confirmed magic-6 archives and loose files are unaffected. No screenshot is included because the surface exercised is Blender's operator/info-log and file-browser data, and the pip `bpy` module is headless — it has no window or UI to capture; the operator report lines and the rendered file tree are captured as CLI transcripts instead. The ksy-to-generated-parser consistency check stayed skipped locally (kaitai-struct-compiler is not installed and installing system packages is out of bounds); CI covers it.

- Live validation: ✅ go - 9 of 10 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Adding a game folder mounts an id_magic 5 weapon archive and its files appear in the file browser | ✅ pass | live | add-folder-reorc-transcript.txt — after bpy.ops.albam.add_folder, the tree lists dlc/pack1/Weapons/{models,surfaces,textures,collision} entries that come from the magic-5 a shipped .ssg file |
| A weapon file only the id_magic 5 archive carries opens and returns its own bytes, read from its stored offset | ✅ pass | live | add-folder-reorc-transcript.txt — a shipped .edgemodel file reads b&#39;FM6S\x0fM9-PISTOL-MESH...&#39; with origin a shipped .ssg file; entries are 16-byte aligned so a sizes-only walk would land on other bytes |
| A .dds filed as a TPKH stub plus a TPKD texture opens as the real texture even when the stub is stored last (adversarial) | ✅ pass | live | add-folder-reorc-transcript.txt — a shipped .dds file returns the 126-byte TPKD payload with getinfo size 126, not the 4-byte &#39;DDS &#39; stub, with the stub stored after the texture |
| An id_magic 5 archive never shadows the current magic-6 archive on a shared path | ✅ pass | live | add-folder-reorc-transcript.txt — the shared a shipped .edgemodel file path resolves to b&#39;FM6S\x12CURRENT-v18-MESH&#39; with origin a shipped .ssg file |
| A cutscene/mocap id_magic 5 archive is refused and reported as skipped instead of silently missing (adversarial) | ✅ pass | live | add-folder-reorc-transcript.txt — Warning lines name a shipped .ssg file with the MCPH/SANM/STMH reason; its stream entries are absent from the tree while every other archive still mounted |
| A magic-5 archive whose header lies about an entry offset (runs past the buffer) is refused rather than serving truncated bytes (adversarial) | ✅ pass | live | add-folder-reorc-transcript.txt — a shipped .ssg file reported skipped (&#39;104 &gt; size_chunks_buffer=80&#39;); a shipped .edgemodel file is not present in the FS |
| A chunk-compressed magic-5 archive is refused rather than slicing the compressed buffer (adversarial) | ✅ pass | live | add-folder-reorc-transcript.txt — a shipped .ssg file reported skipped (size_chunks_info=8); a shipped .edgemodel file is not present in the FS |
| Existing magic-6 archives and loose files keep working after the change | ✅ pass | live | add-folder-reorc-transcript.txt — weapons.ssg entries (knife.edgemodel, a shipped .edgemodel file) and the loose readme.txt all read correctly; `pytest tests/hexn tests/test_vfs_fs_backed.py` green |
| Add Files on a single magic-5 weapon archive mounts it; on a cutscene archive the user gets a loud error naming the reason | ✅ pass | live | add-files-single-archive-transcript.txt — a shipped .ssg file returns {&#39;FINISHED&#39;} with its tree and readable .dds; nis_tyrant.ssg surfaces an operator error carrying the CreateFailed message and leaves the prev… |
| ssg.ksy and the checked-in generated parser stay in sync | ⏸️ untested | no | kaitai-struct-compiler is not installed on this host and installing system packages is outside the allowed boundary; provide the compiler on PATH (or rely on CI, which runs this check) to drive it. |

<details>
<summary>Evidence: Add Folder transcript: skipped-archive warnings, file browser tree, and file reads</summary>

```text
ERROR:root:code for hash blake2b was not found.
Traceback (most recent call last):
  File "/usr/lib/python3.13/hashlib.py", line 247, in <module>
    globals()[__func_name] = __get_hash(__func_name)
                             ~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3.13/hashlib.py", line 129, in __get_openssl_constructor
    return __get_builtin_constructor(name)
  File "/usr/lib/python3.13/hashlib.py", line 123, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type blake2b
ERROR:root:code for hash blake2s was not found.
Traceback (most recent call last):
  File "/usr/lib/python3.13/hashlib.py", line 247, in <module>
    globals()[__func_name] = __get_hash(__func_name)
                             ~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3.13/hashlib.py", line 129, in __get_openssl_constructor
    return __get_builtin_constructor(name)
  File "/usr/lib/python3.13/hashlib.py", line 123, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type blake2s
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
  File "<temp path>", line 976, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "<temp path>", line 1456, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
00:00.561  bpy.rna          | ERROR Python script error in ALBAM_OT_add_files.execute
=== game folder the user selects ===
  readme.txt  (10 bytes)
  a shipped .ssg file  (445 bytes)
  a shipped .ssg file  (125 bytes)
  a shipped .ssg file  (231 bytes)
  a shipped .ssg file  (670 bytes)
  a shipped .ssg file  (382 bytes)
  a shipped .ssg file  (223 bytes)

=== user clicks 'Add Folder' and picks that folder ===
operator result: {'FINISHED'}
--- operator reports shown to the user (Blender info log) ---
  Info: Selected directory: <temp path>
  Warning: reorc_install: 3 archive(s) skipped, not mounted
  Warning: skipped a shipped .ssg file: id_magic 5 archive holds content types this reader doesn't model (MCPH, SANM, STMH) - not mounted rather than served on the model-data layout's assumptions
  Warning: skipped a shipped .ssg file: id_magic 5 archive is chunk-compressed (size_chunks_info=8), which no known one is - its file_info offsets index the stored buffer, not the decompressed stream
  Warning: skipped a shipped .ssg file: id_magic 5 archive has an entry running past the end of its buffer (104 > size_chunks_buffer=80), which no known one does - its file_info offsets would slice short bytes

=== the file browser tree under the new root ===
  [root] reorc_install
    dir  NIS
    file a shipped .ssg file
    dir  broken
    file a shipped .ssg file
    file a shipped .ssg file
    dir  dlc
    dir  dlc/pack1
    dir  dlc/pack1/Weapons
    file a shipped .ssg file
    dir  dlc/pack1/Weapons/collision
    file dlc/pack1/Weapons/collision/ak47.hkx
    file a shipped .ssg file
    dir  dlc/pack1/Weapons/models
    file a shipped .edgemodel file
    file a shipped .edgemodel file
    file a shipped .edgemodel file
    dir  dlc/pack1/Weapons/surfaces
    file dlc/pack1/Weapons/surfaces/ak47.matb
    dir  dlc/pack1/Weapons/textures
    file a shipped .dds file
    file a shipped .dds file
    file a shipped .ssg file
    file readme.txt

=== user opens files from the browser ===
  [PASS] shared path resolves to the CURRENT magic-6 mesh, not the v5 revision
        path=a shipped .edgemodel file
        origin=a shipped .ssg file  size=21  bytes=b'FM6S\x12CURRENT-v18-MESH'
  [PASS] v5-only .matb reads its own bytes
        path=dlc/pack1/Weapons/surfaces/ak47.matb
        origin=a shipped .ssg file  size=34  bytes=b'MAT\x07weapon-materialweapo'...
  [PASS] v5-only .hkx reads its own bytes
        path=dlc/pack1/Weapons/collision/ak47.hkx
        origin=a shipped .ssg file  size=29  bytes=b'W\xe0\xe0Whavokhavokhavokhavok'...
  [PASS] TPKH stub stored later still loses the path to the real TPKD texture
        path=a shipped .dds file
        origin=a shipped .ssg file  size=126  bytes=b'DDS |\xab\xab\xab\xab\xab\xab\xab\xab\xab\xab\xab\xab\xab\xab\xab\xab\xab\xab\xab'...
  [PASS] a weapon mesh only the id_magic 5 archive has, read from its own stored offset
        path=a shipped .edgemodel file
        origin=a shipped .ssg file  size=47  bytes=b'FM6S\x0fM9-PISTOL-MESHM9-PI'...
  [PASS] loose file still readable
        path=readme.txt
        origin=None  size=10  bytes=b'loose file'

=== user instead uses 'Add Files' on one cutscene archive ===
Traceback (most recent call last):
  File "<temp path>", line 141, in <module>
    res2 = bpy.ops.albam.add_files(
        'EXEC_DEFAULT', directory=os.path.join(GAME, "NIS"),
        files=[{"name": "nis_tyrant.ssg"}])
RuntimeError: Error: Python: Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/vfs.py", line 535, in execute
    for warning in self._execute(context, self.directory, self.files):
                   ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/vfs.py", line 549, in _execute
    root_vf = vfs.add_real_file(app_id, absolute_path)
  File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/vfs.py", line 222, in add_real_file
    app_id, fs_loader(absolute_path), display_name=path.name,
            ~~~~~~~~~^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/engines/hexn/archive.py", line 7, in ssg_fs_root_loader
    return SsgFS(absolute_path)
  File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/engines/hexn/fs.py", line 184, in __init__
    self._check_v5_supported(ssg)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/engines/hexn/fs.py", line 261, in _check_v5_supported
    raise CreateFailed(
    ...<3 lines>...
    )
fs.errors.CreateFailed: id_magic 5 archive holds content types this reader doesn't model (MCPH, SANM, STMH) - not mounted rather than served on the model-data layout's assumptions
Location: <temp path>:141
```
</details>
<details>
<summary>Evidence: Add Files transcript: single magic-5 weapon archive mounts, cutscene archive errors loudly</summary>

```text
ERROR:root:code for hash blake2b was not found.
Traceback (most recent call last):
  File "/usr/lib/python3.13/hashlib.py", line 247, in <module>
    globals()[__func_name] = __get_hash(__func_name)
                             ~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3.13/hashlib.py", line 129, in __get_openssl_constructor
    return __get_builtin_constructor(name)
  File "/usr/lib/python3.13/hashlib.py", line 123, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type blake2b
ERROR:root:code for hash blake2s was not found.
Traceback (most recent call last):
  File "/usr/lib/python3.13/hashlib.py", line 247, in <module>
    globals()[__func_name] = __get_hash(__func_name)
                             ~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3.13/hashlib.py", line 129, in __get_openssl_constructor
    return __get_builtin_constructor(name)
  File "/usr/lib/python3.13/hashlib.py", line 123, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type blake2s
Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/blender_ui/import_panel.py", line 16, in get_app_dir_from_config
    current_app_userdata = AppsUserDataConfigManager().get_app_section(current_app)
                           ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/data_loading.py", line 19, in __new__
    ALBAM_EXTENSION_PATH = bpy.utils.extension_path_user(__package__, create=True)
  File "<temp path>", line 976, in extension_path_user
    repo_module, pkg_idname = _extension_module_name_decompose(package)
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "<temp path>", line 1456, in _extension_module_name_decompose
    raise ValueError("The \"package\" does not name an extension")
ValueError: The "package" does not name an extension
File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/blender_ui/import_panel.py", line 14, in get_app_dir_from_config
00:00.580  bpy.rna          | ERROR Python script error in ALBAM_OT_add_files.execute

=== user clicks 'Add Files' and picks a shipped .ssg file ===
operator result: {'FINISHED'}
  file browser now shows:
    [root] a shipped .ssg file  ()
           weapons  (weapons)
           models  (weapons/models)
           gun.edgemodel  (a shipped .edgemodel file)
           surfaces  (weapons/surfaces)
           gun.matb  (weapons/surfaces/gun.matb)
           textures  (weapons/textures)
           gun_d.dds  (a shipped .dds file)
  opening the .dds from the mounted archive -> b'DDS |TTTTTTTTTTT' (65 bytes)

=== user clicks 'Add Files' and picks nis_tyrant.ssg ===
operator result: exception: RuntimeError: Error: Python: Traceback (most recent call last):
  File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/vfs.py", line 535, in execute
    for warning in self._execute(context, self.directory, self.files):
                   ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/vfs.py", line 549, in _execute
    root_vf = vfs.add_real_file(app_id, absolute_path)
  File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/vfs.py", line 222, in add_real_file
    app_id, fs_loader(absolute_path), display_name=path.name,
            ~~~~~~~~~^^^^^^^^^^^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/engines/hexn/archive.py", line 7, in ssg_fs_root_loader
    return SsgFS(absolute_path)
  File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/engines/hexn/fs.py", line 184, in __init__
    self._check_v5_supported(ssg)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/engines/hexn/fs.py", line 261, in _check_v5_supported
    raise CreateFailed(
    ...<3 lines>...
    )
fs.errors.CreateFailed: id_magic 5 archive holds content types this reader doesn't model (MCPH, SANM, STMH) - not mounted rather than served on the model-data layout's assumptions
Location: <temp path>:18

  Traceback (most recent call last):
    File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/vfs.py", line 535, in execute
      for warning in self._execute(context, self.directory, self.files):
                     ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/vfs.py", line 549, in _execute
      root_vf = vfs.add_real_file(app_id, absolute_path)
    File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/vfs.py", line 222, in add_real_file
      app_id, fs_loader(absolute_path), display_name=path.name,
              ~~~~~~~~~^^^^^^^^^^^^^^^
    File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/engines/hexn/archive.py", line 7, in ssg_fs_root_loader
      return SsgFS(absolute_path)
    File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/engines/hexn/fs.py", line 184, in __init__
      self._check_v5_supported(ssg)
      ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
    File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/engines/hexn/fs.py", line 261, in _check_v5_supported
      raise CreateFailed(
      ...<3 lines>...
      )
  fs.errors.CreateFailed: id_magic 5 archive holds content types this reader doesn't model (MCPH, SANM, STMH) - not mounted rather than served on the model-data layout's assumptions
  Error: Python: Traceback (most recent call last):
    File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/vfs.py", line 535, in execute
      for warning in self._execute(context, self.directory, self.files):
                     ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/vfs.py", line 549, in _execute
      root_vf = vfs.add_real_file(app_id, absolute_path)
    File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/vfs.py", line 222, in add_real_file
      app_id, fs_loader(absolute_path), display_name=path.name,
              ~~~~~~~~~^^^^^^^^^^^^^^^
    File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/engines/hexn/archive.py", line 7, in ssg_fs_root_loader
      return SsgFS(absolute_path)
    File "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY/albam/engines/hexn/fs.py", line... truncated
  file browser now shows:
    [root] a shipped .ssg file  ()
           weapons  (weapons)
           models  (weapons/models)
           gun.edgemodel  (a shipped .edgemodel file)
           surfaces  (weapons/surfaces)
           gun.matb  (weapons/surfaces/gun.matb)
           textures  (weapons/textures)
           gun_d.dds  (a shipped .dds file)
```
</details>
<details>
<summary>Evidence: Driver script (Add Folder scenarios)</summary>

```text
"""Drive the real albam addon (Blender bpy) as an end user would: add a
RE:ORC game folder, look at the resulting file browser tree, and read files
out of it. Prints a transcript used as evidence."""
import os, sys, io, contextlib

WORKTREE = "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY"
sys.path.insert(0, WORKTREE)

import bpy
from albam import register
from albam.blender_ui.error_handling import RERAISE_ERRORS_ENV_VAR
os.environ[RERAISE_ERRORS_ENV_VAR] = "1"
register()

sys.path.insert(0, os.path.join(WORKTREE, "tests"))
from tests.hexn.test_ssg_fs import _build_ssg_bytes, _build_ssg_v5_bytes  # noqa

GAME = "<temp path>"
import shutil, struct
shutil.rmtree(GAME, ignore_errors=True)
for sub in ("dlc/pack1/Weapons", "NIS", "broken"):
    os.makedirs(os.path.join(GAME, sub), exist_ok=True)

MESH_V5 = b"FM6S" + b"\x0f" + b"WEAPON-MESH-v15-" * 3
MATB_V5 = b"MAT\x07" + b"weapon-material" * 2
DDS_STUB = b"DDS "
DDS_REAL = b"DDS |" + b"\xab" * 121
HKX_V5 = b"\x57\xe0\xe0\x57" + b"havok" * 5

# A weapon archive: TPKH stub stored AFTER the real TPKD texture, the order
# the reader must not depend on.
weapon = [
    ("a shipped .edgemodel file", MESH_V5, b"MODL"),
    ("dlc/pack1/Weapons/surfaces/ak47.matb", MATB_V5, b"MATB"),
    ("a shipped .dds file", DDS_REAL, b"TPKD"),
    ("a shipped .dds file", DDS_STUB, b"TPKH"),
    ("dlc/pack1/Weapons/collision/ak47.hkx", HKX_V5, b"HAVK"),
]
open(os.path.join(GAME, "a shipped .ssg file"), "wb").write(_build_ssg_v5_bytes(weapon))

# A second weapon archive whose mesh path no current archive carries.
M9 = b"FM6S" + b"\x0f" + b"M9-PISTOL-MESH" * 3
open(os.path.join(GAME, "a shipped .ssg file"), "wb").write(_build_ssg_v5_bytes([
    ("a shipped .dds file", DDS_STUB, b"TPKH"),
    ("a shipped .edgemodel file", M9, b"MODL"),
    ("a shipped .dds file", b"DDS |" + b"\xcd" * 60, b"TPKD"),
]))

# The shipped, current aggregate archive (id_magic 6) sharing the mesh path.
open(os.path.join(GAME, "a shipped .ssg file"), "wb").write(_build_ssg_bytes([
    ("a shipped .edgemodel file", b"FM6S" + b"\x12" + b"CURRENT-v18-MESH"),
    ("a shipped .edgemodel file", b"FM6S" + b"\x12" + b"KNIFE"),
]))

# The other id_magic 5 family: cutscene/mocap streams, refused on purpose.
open(os.path.join(GAME, "a shipped .ssg file"), "wb").write(_build_ssg_v5_bytes([
    ("StreamHeader", b"\x01\x00\x00\x00" + b"S" * 40, b"STMH"),
    ("MocapHeader", b"\x07\x00\x00\x00" + b"M" * 40, b"MCPH"),
    ("StreamHeader", b"\x02\x00\x00\x00" + b"S" * 40, b"STMH"),
    ("Tyrant", b"C" * 90, b"SANM"),
]))

# Adversarial: a magic-5 archive whose header lies - one entry's stored
# offset runs past the end of the buffer.
raw = bytearray(_build_ssg_v5_bytes([
    ("a shipped .edgemodel file", b"FM6S" + b"L" * 40, b"MODL"),
    ("broken/surfaces/liar.matb", b"MAT\x07" + b"L" * 20, b"MATB"),
]))
ofs_field = 32 + 1 * 32 + 16
size_buffer = struct.unpack_from("<I", raw, 16)[0]
struct.pack_into("<I", raw, ofs_field, size_buffer)
open(os.path.join(GAME, "a shipped .ssg file"), "wb").write(bytes(raw))

# Adversarial: a magic-5 archive that is chunk-compressed, so its offsets
# would index the compressed buffer.
open(os.path.join(GAME, "a shipped .ssg file"), "wb").write(
    _build_ssg_v5_bytes([("a shipped .edgemodel file", b"FM6S" + b"Z" * 60, b"MODL")], chunk_size=32))

# A loose file, as a real install has.
open(os.path.join(GAME, "readme.txt"), "wb").write(b"loose file")

print("=== game folder the user selects ===")
for root, _d, files in sorted(os.walk(GAME)):
    for f in sorted(files):
        p = os.path.join(root, f)
        print(f"  {os.path.relpath(p, GAME)}  ({os.path.getsize(p)} bytes)")

bpy.context.scene.albam.apps.app_selected = "reorc"

print("\n=== user clicks 'Add Folder' and picks that folder ===")
buf = io.StringIO()
with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
    res = bpy.ops.albam.add_folder('EXEC_DEFAULT', directory=GAME)
print("operator result:", res)
print("--- operator reports shown to the user (Blender info log) ---")
for line in buf.getvalue().splitlines():
    if line.strip():
        print("  " + line)

vfs = bpy.context.scene.albam.vfs
root = [vf for vf in vfs.file_list if vf.is_root][0]
print("\n=== the file browser tree under the new root ===")
print(f"  [root] {root.display_name}")
entries = [vf for vf in vfs.file_list if not vf.is_root]
for vf in sorted(entries, key=lambda v: v.relative_path):
    kind = "dir " if vf.is_expandable else "file"
    print(f"    {kind} {vf.relative_path}")

from albam.lib import fs_registry
game_fs = fs_registry.get(root.fs_key)

def show(path, expect, label):
    vf = vfs.get_vfile("reorc", path)
    data = vf.get_bytes()
    info = game_fs.getinfo("/" + path, namespaces=["details"])
    ok = "PASS" if data == expect else "FAIL"
    print(f"  [{ok}] {label}\n        path={path}\n        origin={game_fs.origin_of('/' + path)}"
          f"  size={info.size}  bytes={data[:24]!r}{'...' if len(data) > 24 else ''}")
    return data == expect

print("\n=== user opens files from the browser ===")
results = {}
results["v5 weapon mesh readable"] = show(
    "a shipped .edgemodel file", b"FM6S" + b"\x12" + b"CURRENT-v18-MESH",
    "shared path resolves to the CURRENT magic-6 mesh, not the v5 revision")
results["v5 matb readable"] = show(
    "dlc/pack1/Weapons/surfaces/ak47.matb", MATB_V5, "v5-only .matb reads its own bytes")
results["v5 hkx readable"] = show(
    "dlc/pack1/Weapons/collision/ak47.hkx", HKX_V5, "v5-only .hkx reads its own bytes")
results["dds is the TPKD texture"] = show(
    "a shipped .dds file", DDS_REAL,
    "TPKH stub stored later still loses the path to the real TPKD texture")
results["v5-only weapon mesh readable"] = show(
    "a shipped .edgemodel file", M9,
    "a weapon mesh only the id_magic 5 archive has, read from its own stored offset")
results["loose file readable"] = show("readme.txt", b"loose file", "loose file still readable")

print("\n=== user instead uses 'Add Files' on one cutscene archive ===")
buf2 = io.StringIO()
with contextlib.redirect_stdout(buf2), contextlib.redirect_stderr(buf2):
    res2 = bpy.ops.albam.add_files(
        'EXEC_DEFAULT', directory=os.path.join(GAME, "NIS"),
        files=[{"name": "nis_tyrant.ssg"}])
print("operator result:", res2)
for line in buf2.getvalue().splitlines():
    if line.strip():
        print("  " + line)

print("\n=== archives deliberately left out ===")
for source, reason in game_fs.skipped_archives():
    print(f"  {source}\n      {reason}")

print("\n=== paths NOT in the tree (refused archives' contents) ===")
for gone in ("a shipped .ssg file", "a shipped .edgemodel file", "a shipped .edgemodel file"):
    print(f"  {gone}: present={game_fs.exists('/' + gone)}")

results["v5-only mesh path present"] = game_fs.exists("/a shipped .edgemodel file")
print("\nRESULT:", "ALL PASS" if all(results.values()) else f"FAILURES: {[k for k,v in results.items() if not v]}")
```
</details>
<details>
<summary>Evidence: Driver script (Add Files scenarios)</summary>

```text
import os, sys, io, contextlib
WORKTREE = "~/.no-mistakes/worktrees/731f537710a6/01M25JG4BMVDH627WP0CSYJ2BY"
sys.path.insert(0, WORKTREE); sys.path.insert(0, os.path.join(WORKTREE, "tests"))
import bpy
from albam import register
register()  # no RERAISE: exactly how a shipped install behaves
from tests.hexn.test_ssg_fs import V5_ENTRIES, V5_MOCAP_ENTRIES, _build_ssg_v5_bytes
d = "<temp path>"; os.makedirs(d, exist_ok=True)
open(os.path.join(d, "a shipped .ssg file"), "wb").write(_build_ssg_v5_bytes(V5_ENTRIES))
open(os.path.join(d, "nis_tyrant.ssg"), "wb").write(_build_ssg_v5_bytes(V5_MOCAP_ENTRIES))
bpy.context.scene.albam.apps.app_selected = "reorc"

for name in ("a shipped .ssg file", "nis_tyrant.ssg"):
    print(f"\n=== user clicks 'Add Files' and picks {name} ===")
    buf = io.StringIO()
    try:
        with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
            res = bpy.ops.albam.add_files('EXEC_DEFAULT', directory=d, files=[{"name": name}])
    except Exception as e:
        res = f"exception: {type(e).__name__}: {e}"
    print("operator result:", res)
    for line in buf.getvalue().splitlines():
        if line.strip():
            print("  " + line)
    vfs = bpy.context.scene.albam.vfs
    print("  file browser now shows:")
    for vf in vfs.file_list:
        print(f"    {'[root] ' if vf.is_root else '       '}{vf.display_name}  ({vf.relative_path})")
    root = [vf for vf in vfs.file_list if vf.is_root]
    if root and name == "a shipped .ssg file":
        got = vfs.get_vfile("reorc", "a shipped .dds file").get_bytes()
        print(f"  opening the .dds from the mounted archive -> {got[:16]!r} ({len(got)} bytes)")
```
</details>
<details>
<summary>Evidence: User-visible operator reports after adding the game folder</summary>

```text
Info: Selected directory: <temp path>
Warning: reorc_install: 3 archive(s) skipped, not mounted
Warning: skipped a shipped .ssg file: id_magic 5 archive holds content types this reader doesn't model (MCPH, SANM, STMH) - not mounted rather than served on the model-data layout's assumptions
Warning: skipped a shipped .ssg file: id_magic 5 archive is chunk-compressed (size_chunks_info=8), which no known one is - its file_info offsets index the stored buffer, not the decompressed stream
Warning: skipped a shipped .ssg file: id_magic 5 archive has an entry running past the end of its buffer (104 > size_chunks_buffer=80), which no known one does - its file_info offsets would slice short bytes
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"af7ba86d6714b7957e3d1a2d6dfcb5d5fd094a1b","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `CHANGELOG.md:55` - The release note says &#34;weapon archives (135 of ~2100 on a full install)&#34; are no longer rejected, but the change&#39;s own census (albam/engines/hexn/fs.py:87-89, ssg.ksy) says 135 is the count of *all* id_magic 5 archives: 130 weapon archives plus 5 under NIS/ holding cutscene/mocap streams. Those 5 are still refused by _check_v5_supported() via SSG_V5_CONTENT_TYPES, so only 130 actually mount. Concrete sequence: a user reads the note, adds a full install, and expects all 135 formerly-missing archives to appear; the 5 NIS ones still do not, and now emit &#34;archive(s) skipped&#34; warnings the note does not prepare them for. Suggest &#34;130 weapon archives (of 135 using this layout)&#34; or equivalent. Flagged as ask-user because it is user-facing release copy, not internal code.
- ℹ️ `albam/engines/hexn/fs.py:197` - For a magic-5 archive, the TPKH stub and the real TPKD texture are documented to share one entry name (fs.py:66-68, ssg.ksy). The loop writes _sizes[path]/_offsets[path] unconditionally, so the correct bytes are served only because TPKD happens to be the later entry in every archive censused. That ordering is never asserted: an archive with TPKH last would silently expose a 4-byte b&#34;DDS &#34; stub as the .dds, with getinfo() reporting size 4 - a wrong value with no error. Note this is the same duplicate-name hazard cited at fs.py:83-85 as the reason to refuse the mocap family, so the model-data family relies on census order where the other is refused outright. Cheap deterministic remedy: when a path is already claimed, keep the entry whose _content_type() is b&#34;TPKD&#34; rather than whichever came last. No real archive on the censused install triggers this, hence info.
- ℹ️ `albam/engines/hexn/fs.py:377` - ssg.ksy records &#34;no entry running past the end of the buffer and no two entries overlapping&#34; as a verified property of the magic-5 layout, and _check_v5_supported() enforces the other two census facts (size_chunks_info == 0, file_type allowlist) but not this one. A magic-5 archive whose ofs_in_buffer_chunks + size exceeds size_chunks_buffer would slice short here and openbin() would hand back a truncated BytesIO rather than raising - the exact &#34;serving the wrong bytes&#34; outcome the module&#39;s stated principle rejects. A truncated file on disk is already caught earlier (Kaitai&#39;s sized buffer_chunks read raises), so this only bites a header that lies, which no censused archive does; recording the tradeoff rather than asking for a change. A third condition in _check_v5_supported() (max(ofs + size) &lt;= ssg.size_chunks_buffer) would close it in the same place as the existing two.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 9 of 10 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Adding a game folder mounts an id_magic 5 weapon archive and its files appear in the file browser | ✅ pass | live | add-folder-reorc-transcript.txt — after bpy.ops.albam.add_folder, the tree lists dlc/pack1/Weapons/{models,surfaces,textures,collision} entries that come from the magic-5 a shipped .ssg file |
| A weapon file only the id_magic 5 archive carries opens and returns its own bytes, read from its stored offset | ✅ pass | live | add-folder-reorc-transcript.txt — a shipped .edgemodel file reads b&#39;FM6S\x0fM9-PISTOL-MESH...&#39; with origin a shipped .ssg file; entries are 16-byte aligned so a sizes-only walk would land on other bytes |
| A .dds filed as a TPKH stub plus a TPKD texture opens as the real texture even when the stub is stored last (adversarial) | ✅ pass | live | add-folder-reorc-transcript.txt — a shipped .dds file returns the 126-byte TPKD payload with getinfo size 126, not the 4-byte &#39;DDS &#39; stub, with the stub stored after the texture |
| An id_magic 5 archive never shadows the current magic-6 archive on a shared path | ✅ pass | live | add-folder-reorc-transcript.txt — the shared a shipped .edgemodel file path resolves to b&#39;FM6S\x12CURRENT-v18-MESH&#39; with origin a shipped .ssg file |
| A cutscene/mocap id_magic 5 archive is refused and reported as skipped instead of silently missing (adversarial) | ✅ pass | live | add-folder-reorc-transcript.txt — Warning lines name a shipped .ssg file with the MCPH/SANM/STMH reason; its stream entries are absent from the tree while every other archive still mounted |
| A magic-5 archive whose header lies about an entry offset (runs past the buffer) is refused rather than serving truncated bytes (adversarial) | ✅ pass | live | add-folder-reorc-transcript.txt — a shipped .ssg file reported skipped (&#39;104 &gt; size_chunks_buffer=80&#39;); a shipped .edgemodel file is not present in the FS |
| A chunk-compressed magic-5 archive is refused rather than slicing the compressed buffer (adversarial) | ✅ pass | live | add-folder-reorc-transcript.txt — a shipped .ssg file reported skipped (size_chunks_info=8); a shipped .edgemodel file is not present in the FS |
| Existing magic-6 archives and loose files keep working after the change | ✅ pass | live | add-folder-reorc-transcript.txt — weapons.ssg entries (knife.edgemodel, a shipped .edgemodel file) and the loose readme.txt all read correctly; `pytest tests/hexn tests/test_vfs_fs_backed.py` green |
| Add Files on a single magic-5 weapon archive mounts it; on a cutscene archive the user gets a loud error naming the reason | ✅ pass | live | add-files-single-archive-transcript.txt — a shipped .ssg file returns {&#39;FINISHED&#39;} with its tree and readable .dds; nis_tyrant.ssg surfaces an operator error carrying the CreateFailed message and leaves the prev… |
| ssg.ksy and the checked-in generated parser stay in sync | ⏸️ untested | no | kaitai-struct-compiler is not installed on this host and installing system packages is outside the allowed boundary; provide the compiler on PATH (or rely on CI, which runs this check) to drive it. |

- <code>`<temp path> -m pytest tests/hexn tests/test_vfs_fs_backed.py tests/test_generated_structs.py -q` (42 passed, rest skipped for missing game data / kaitai compiler)</code>
- <code>`pytest tests/hexn/test_ssg_fs.py tests/hexn/test_vfs_add_files.py` (the change&#39;s own targeted suite, 20 passed)</code>
- <code>Live driver: registered the addon in Blender 5.2 and ran `bpy.ops.albam.add_folder(&#39;EXEC_DEFAULT&#39;, directory=&lt;fake reorc install&gt;)`, then listed the resulting VFS tree and read files via `VirtualFile.get_bytes()` / `HexnFS.getinfo()` / `origin_of()` — evidence file `add-folder-reorc-transcript.txt`</code>
- <code>Live driver: `bpy.ops.albam.add_files(&#39;EXEC_DEFAULT&#39;, ...)` on a single magic-5 weapon archive and on a magic-5 cutscene archive — evidence file `add-files-single-archive-transcript.txt`</code>
</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed ✅</summary>

- ℹ️ `albam/engines/hexn/fs.py:76` - The SSG_V5_CONTENT_TYPES comment states &#34;their 108 .edgemodel entries are all format version 15 ... 129 more of them are already reachable as loose files on disk, and parsing any of the 189 runs off the end of the file today.&#34; 108 + 129 = 237, not 189, so the three census figures only reconcile under an unstated assumption (e.g. the 108 packed entries collapsing to 60 unique virtual paths after the priority ordering, 60 + 129 = 189). I cannot verify the census without the game install, and picking a number would risk replacing a correct-but-terse figure with a wrong one. Either restate the 189 as &#34;189 distinct version-15 .edgemodel files&#34; (if the packed entries dedupe) or correct whichever count is wrong.
- ℹ️ `README.md:82` - README&#39;s &#34;Supported Engines&#34; section lists only MT Framework, while the unreleased CHANGELOG already claims RE4UHD (cie) and RE:ORC (hexn) support, and this change extends RE:ORC archive coverage further. This is pre-existing staleness rather than something this change introduced, so I left it alone under scope discipline; it may also be deliberate if the list means &#34;full import+export support&#34;. Worth a follow-up to either extend the list or say what &#34;supported&#34; means there.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

