### PR TITLE
feat(mtfw): pack Devil May Cry 4 archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Autosorter tool to automatically set `alpha priority` values for hair cards
 - Experimental support for LMT export (Resident Evil 5)
 - App Settings button next to App selection. Allows to set the root folder of an app. Its content is stored in apps-userdata.ini, in Albam's extension directory.
-- Reading `.arc` archives from Devil May Cry 4, whose entries are XMemCompress (LZX) streams rather than zlib, and which number their file types differently. Models and textures inside them can now be imported. Read-only for now: packing into one is refused rather than writing an archive the game cannot read
+- Reading and packing `.arc` archives from Devil May Cry 4, whose entries are XMemCompress (LZX) streams rather than zlib, and which number their file types differently. Models and textures inside them can now be imported, edited and written back. The XMemCompress encoder this needed is verified against real archive entries and against an independent LZX decoder, but has not yet been confirmed by loading an edited archive in the game
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Autosorter tool to automatically set `alpha priority` values for hair cards
 - Experimental support for LMT export (Resident Evil 5)
 - App Settings button next to App selection. Allows to set the root folder of an app. Its content is stored in apps-userdata.ini, in Albam's extension directory.
-- Reading and packing `.arc` archives from Devil May Cry 4, whose entries are XMemCompress (LZX) streams rather than zlib, and which number their file types differently. Models and textures inside them can now be imported, edited and written back. The XMemCompress encoder this needed is verified against real archive entries and against an independent LZX decoder, but has not yet been confirmed by loading an edited archive in the game
+- Reading and packing `.arc` archives from Devil May Cry 4, whose entries are XMemCompress (LZX) streams rather than zlib, and which number their file types differently. These archives can now be repacked, and their contents written back. The XMemCompress encoder this needed is verified against real archive entries and against an independent LZX decoder, but has not yet been confirmed by loading an edited archive in the game
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- Repacking an `.arc` overwriting every entry's flags with a fixed value, instead of carrying over the one the archive already held
 - Import of meshes with Nan UVs
 - Triangulation function(now it keeps custom normals)
 - Missed value in .tex `value` enumerator for RE6 render targets

--- a/albam/blender_ui/export_panel.py
+++ b/albam/blender_ui/export_panel.py
@@ -558,7 +558,13 @@ class ALBAM_OT_FindReplaceFileSel(ALBAM_OT_VirtualFileSystemSaveFileBase, bpy.ty
         vfs = self.get_vfs(self, context)
         vfile = vfs.selected_vfile
         from ..engines.mtfw.archive import find_and_replace_in_arc
-        arc = find_and_replace_in_arc(self.filepath, vfile, file_name, add_new)
+        from ..engines.mtfw.arc_fs import AmbiguousExtension
+        from ..lib.xcompress_encode import FrameTooLarge
+        try:
+            arc = find_and_replace_in_arc(self.filepath, vfile, file_name, add_new)
+        except (AmbiguousExtension, FrameTooLarge) as err:
+            self.report({'ERROR'}, str(err))
+            return {'CANCELLED'}
         if arc:
             with open(self.filepath, "wb") as f:
                 f.write(arc)

--- a/albam/engines/cie/lfs_compress.py
+++ b/albam/engines/cie/lfs_compress.py
@@ -1,501 +1,49 @@
-"""
-Pure-Python LZX encoder for RE4UHD .lfs archives.
+"""The .lfs side of the LZX encoder: how RE4UHD chunks a payload up.
 
-The counterpart of lfs_decompress.py, and written against it rather than
-against any general description of LZX: that decoder is what the game's own
-data round-trips through, so it is the specification here. Everything below
-mirrors it in reverse - the same 16-bit-word bit packing, the same canonical
-Huffman construction, the same delta-coded code lengths, the same position
-slots.
+The LZX itself - the bit packing, the Huffman trees, the blocks and the
+frames - lives in albam/lib/xcompress_encode.py, which this shared out when
+MT Framework archives needed the same streams without .lfs chunking around
+them. What stays here is the container.
 
-Two things about the container shape the encoder more than the bit format
-does (see lfs.ksy and xcompress_decompress_re4hd):
+Two things about that container shape a chunk more than the bit format does
+(see lfs.ksy and xcompress_decompress_re4hd):
 
-* No match reaches out of its own chunk. This decoder would allow it - it
+* No match reaches out of its own chunk. The decoder would allow it - it
   carries one window across the whole file, so a chunk can refer to what the
   chunks before it decoded - and an earlier version of this encoder did
-  exactly that, producing archives this decoder read back perfectly and the
+  exactly that, producing archives that decoder read back perfectly and the
   game rejected outright. The game's own data says why: over a 150 archive
   sample, of 72146673 matches not one reaches back past the start of the
   chunk it lives in, and the longest distance seen anywhere is 65469, under
-  one chunk. So a chunk here is encoded as if the window were empty, and
-  decodes on its own wherever it sits in the file.
+  one chunk. So a chunk here is compressed on its own, as a stream of its
+  own, and decodes wherever it sits in the file.
 * Per chunk the decoder resets the code lengths and the three repeated
   offsets, but not the window, not the current block and not the trees. So
   every chunk here starts a fresh block and ends exactly on its last byte,
   leaving no partial block for the next chunk to fall into.
 * A chunk says where its frames stop, rather than leaving that to whoever
   counts the bytes coming out: its last frame takes the long header and five
-  zero bytes follow it (see _frame and FRAME_TERMINATOR). This decoder needs
-  neither, which is how an encoder written against it came to omit both.
-
-Match finding is delegated to zlib: its deflate output is parsed back into the
-literal/match token stream that produced it (_lz77_tokens), which is then
-re-encoded as LZX. Deflate's window is 32KB against the chunk's 64KB, so this
-leaves some ratio on the table, but it puts the O(n) search work in C instead
-of in Python.
+  zero bytes follow it (see FRAME_TERMINATOR). The decoder needs neither,
+  which is how an encoder written against it came to omit both. An .arc
+  entry, framing the same streams, has no terminator at all - which is why
+  it belongs here and not in the shared encoder.
 """
-import heapq
 import struct
-import zlib
-from bisect import bisect_right
 
+from ...lib.xcompress_encode import FrameTooLarge, compress_frames, frame_stream
 from .lfs_decompress import (
     CHUNK_ALIGNMENT,
-    EXTRA_BITS,
     LFS_CHUNK_SIZE,
     LFS_DEFAULT_FILE_ID,
     LFS_MAGIC1,
-    POSITION_BASE,
 )
 
-# One frame's uncompressed size. The frame header's size fields are 16 bit,
-# and a whole chunk does not fit one, so a chunk is two frames.
-FRAME_SIZE = 32768
-# Introduces the long frame header; a frame not starting with it carries the
-# short one (see _frame).
-SHORT_FRAME_HEADER_MARKER = 0xFF
 # Closes a chunk, after its last frame. Reads as a frame header declaring no
 # compressed bytes, which is what stops a reader that walks frames until they
 # run out rather than until the output is full. Every compressed chunk in the
 # game's own data ends with exactly these five bytes, and they count towards
 # the chunk's size in the chunk table.
 FRAME_TERMINATOR = b"\x00" * 5
-
-LZX_NUM_CHARS = 256
-LZX_MIN_MATCH = 2
-LZX_MAX_MATCH = 257
-LZX_NUM_POSITION_SLOTS = 34
-LZX_NUM_SECONDARY_LENGTHS = 249
-LZX_BLOCKTYPE_VERBATIM = 1
-LZX_MAIN_SYMBOLS = LZX_NUM_CHARS + LZX_NUM_POSITION_SLOTS * 8
-LZX_PRETREE_SYMBOLS = 20
-# Code lengths are read as 4-bit fields for the pretree and are capped at 16
-# by the tree builder for everything else.
-LZX_MAX_CODE_LENGTH = 16
-LZX_MAX_PRETREE_LENGTH = 15
-
-# The lowest distance each position slot can express. The decoder computes
-# `POSITION_BASE[slot] - 2` and adds the slot's extra bits to it, so the slots
-# tile the distances from 1 upwards without a gap.
-_SLOT_BASE = [POSITION_BASE[i] - 2 for i in range(LZX_NUM_POSITION_SLOTS)]
-
-
-class _BitWriter:
-    """Bits in the order lfs_decompress._BitReader consumes them.
-
-    That reader takes 16 bits at a time out of a little-endian u2 and hands
-    them out most-significant first, so bits accumulate into a word here and
-    each finished word is written low byte first.
-    """
-
-    __slots__ = ("out", "buf", "bl")
-
-    def __init__(self):
-        self.out = bytearray()
-        self.buf = 0
-        self.bl = 0
-
-    def write(self, value, num_bits):
-        while num_bits > 16:
-            num_bits -= 16
-            self.write((value >> num_bits) & 0xFFFF, 16)
-            value &= (1 << num_bits) - 1
-        if not num_bits:
-            return
-        self.buf = (self.buf << num_bits) | value
-        self.bl += num_bits
-        while self.bl >= 16:
-            self.bl -= 16
-            word = (self.buf >> self.bl) & 0xFFFF
-            self.out.append(word & 0xFF)
-            self.out.append(word >> 8)
-        self.buf &= (1 << self.bl) - 1
-
-    def finish(self):
-        """The bytes written, padded with zero bits to a whole word."""
-        if self.bl:
-            self.write(0, 16 - self.bl)
-        return bytes(self.out)
-
-
-def _huffman_lengths(freqs, max_length):
-    """Canonical code lengths for `freqs`, none longer than `max_length`.
-
-    Over-long codes are dealt with by halving the frequencies and rebuilding,
-    which converges because equal weights bound the depth at log2(n).
-
-    A tree of one symbol gets a second, unused one alongside it, so that the
-    lengths always describe a complete code. This decoder does not care - it
-    walks a tree and only ever meets the code that was written - but a
-    decoder building a lookup table has half of it undefined, and the game's
-    own data never leaves a code incomplete: across a 40 archive sample all
-    9909 pre-trees and all 3303 main trees are complete, and of the 3303
-    length trees 3219 are complete and 84 empty, with none in between.
-    """
-    freqs = list(freqs)
-    while True:
-        used = [i for i, f in enumerate(freqs) if f]
-        lengths = [0] * len(freqs)
-        if not used:
-            return lengths
-        if len(used) == 1:
-            lengths[used[0]] = 1
-            lengths[1 if used[0] == 0 else 0] = 1
-            return lengths
-
-        heap = [(freqs[i], i) for i in used]
-        heapq.heapify(heap)
-        children = {}
-        next_node = len(freqs)
-        while len(heap) > 1:
-            weight_a, node_a = heapq.heappop(heap)
-            weight_b, node_b = heapq.heappop(heap)
-            children[next_node] = (node_a, node_b)
-            heapq.heappush(heap, (weight_a + weight_b, next_node))
-            next_node += 1
-
-        too_long = False
-        stack = [(heap[0][1], 0)]
-        while stack:
-            node, depth = stack.pop()
-            child = children.get(node)
-            if child is None:
-                lengths[node] = depth
-                if depth > max_length:
-                    too_long = True
-            else:
-                stack.append((child[0], depth + 1))
-                stack.append((child[1], depth + 1))
-        if not too_long:
-            return lengths
-        freqs = [(f + 1) >> 1 if f else 0 for f in freqs]
-
-
-def _canonical_codes(lengths):
-    """The codes lfs_decompress._build_tree assigns to `lengths`.
-
-    Same walk: count the lengths, start each length's codes where the
-    previous length's left off shifted up one, hand them out in symbol order.
-    """
-    counts = [0] * (LZX_MAX_CODE_LENGTH + 1)
-    for length in lengths:
-        if 0 < length <= LZX_MAX_CODE_LENGTH:
-            counts[length] += 1
-    starts = [0] * (LZX_MAX_CODE_LENGTH + 1)
-    for i in range(1, LZX_MAX_CODE_LENGTH):
-        starts[i + 1] = (starts[i] + counts[i]) << 1
-    codes = [0] * len(lengths)
-    for symbol, length in enumerate(lengths):
-        if 0 < length <= LZX_MAX_CODE_LENGTH:
-            codes[symbol] = starts[length]
-            starts[length] += 1
-    return codes
-
-
-def _length_tokens(new_lengths, previous_lengths, first, last):
-    """The pre-tree token stream for new_lengths[first:last].
-
-    Mirrors lfs_decompress._read_lengths: a plain symbol is the difference
-    from the length the same slot had in the previous block, modulo 17, and
-    17/18/19 are runs. Each token is (symbol, extra_value, extra_bits) with an
-    optional trailing delta symbol for 19.
-    """
-    tokens = []
-    x = first
-    while x < last:
-        length = new_lengths[x]
-        run = 1
-        while x + run < last and new_lengths[x + run] == length:
-            run += 1
-        if length == 0:
-            while run >= 4:
-                if run >= 20:
-                    take = min(run, 51)
-                    tokens.append((18, take - 20, 5, None))
-                else:
-                    take = min(run, 19)
-                    tokens.append((17, take - 4, 4, None))
-                x += take
-                run -= take
-        else:
-            while run >= 4:
-                take = min(run, 5)
-                delta = (previous_lengths[x] - length) % 17
-                tokens.append((19, take - 4, 1, delta))
-                x += take
-                run -= take
-        for _ in range(run):
-            tokens.append(((previous_lengths[x] - new_lengths[x]) % 17, 0, 0, None))
-            x += 1
-    return tokens
-
-
-def _write_lengths(writer, new_lengths, previous_lengths, first, last):
-    """Write new_lengths[first:last] the way _read_lengths reads them."""
-    tokens = _length_tokens(new_lengths, previous_lengths, first, last)
-    freqs = [0] * LZX_PRETREE_SYMBOLS
-    for symbol, _value, _bits, delta in tokens:
-        freqs[symbol] += 1
-        if delta is not None:
-            freqs[delta] += 1
-
-    pretree_lengths = _huffman_lengths(freqs, LZX_MAX_PRETREE_LENGTH)
-    pretree_codes = _canonical_codes(pretree_lengths)
-    for length in pretree_lengths:
-        writer.write(length, 4)
-    for symbol, value, bits, delta in tokens:
-        writer.write(pretree_codes[symbol], pretree_lengths[symbol])
-        if bits:
-            writer.write(value, bits)
-        if delta is not None:
-            writer.write(pretree_codes[delta], pretree_lengths[delta])
-
-
-# ---------------------------------------------------------------------------
-# Match finding, by way of zlib
-# ---------------------------------------------------------------------------
-
-_DEFLATE_LENGTH_BASE = [
-    3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31, 35, 43, 51, 59,
-    67, 83, 99, 115, 131, 163, 195, 227, 258,
-]
-_DEFLATE_LENGTH_EXTRA = [
-    0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4,
-    5, 5, 5, 5, 0,
-]
-_DEFLATE_DIST_BASE = [
-    1, 2, 3, 4, 5, 7, 9, 13, 17, 25, 33, 49, 65, 97, 129, 193, 257, 385, 513,
-    769, 1025, 1537, 2049, 3073, 4097, 6145, 8193, 12289, 16385, 24577,
-]
-_DEFLATE_DIST_EXTRA = [
-    0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10,
-    11, 11, 12, 12, 13, 13,
-]
-_DEFLATE_CODE_LENGTH_ORDER = [
-    16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15,
-]
-_FIXED_LITERAL_LENGTHS = [8] * 144 + [9] * 112 + [7] * 24 + [8] * 8
-_FIXED_DISTANCE_LENGTHS = [5] * 32
-
-
-class _DeflateBits:
-    """Least-significant-bit-first reader, the order deflate is packed in."""
-
-    __slots__ = ("data", "size", "pos", "buf", "bl")
-
-    def __init__(self, data):
-        self.data = data
-        self.size = len(data)
-        self.pos = 0
-        self.buf = 0
-        self.bl = 0
-
-    def fill(self, num_bits):
-        while self.bl < num_bits:
-            if self.pos < self.size:
-                byte = self.data[self.pos]
-                self.pos += 1
-            else:
-                byte = 0
-            self.buf |= byte << self.bl
-            self.bl += 8
-
-    def get(self, num_bits):
-        if not num_bits:
-            return 0
-        self.fill(num_bits)
-        value = self.buf & ((1 << num_bits) - 1)
-        self.buf >>= num_bits
-        self.bl -= num_bits
-        return value
-
-    def align(self):
-        drop = self.bl & 7
-        self.buf >>= drop
-        self.bl -= drop
-
-
-def _deflate_table(lengths):
-    """A (peeked bits -> symbol, code length) lookup table for `lengths`."""
-    max_length = max(lengths)
-    if not max_length:
-        return None, 0
-    counts = [0] * (max_length + 1)
-    for length in lengths:
-        if length:
-            counts[length] += 1
-    next_code = [0] * (max_length + 1)
-    code = 0
-    for length in range(1, max_length + 1):
-        code = (code + counts[length - 1]) << 1
-        next_code[length] = code
-
-    table = [0] * (1 << max_length)
-    for symbol, length in enumerate(lengths):
-        if not length:
-            continue
-        code = next_code[length]
-        next_code[length] += 1
-        reversed_code = 0
-        for i in range(length):
-            reversed_code = (reversed_code << 1) | ((code >> i) & 1)
-        entry = (symbol << 4) | length
-        for index in range(reversed_code, 1 << max_length, 1 << length):
-            table[index] = entry
-    return table, max_length
-
-
-def _deflate_symbol(bits, table, max_length):
-    bits.fill(max_length)
-    entry = table[bits.buf & ((1 << max_length) - 1)]
-    length = entry & 15
-    if not length:
-        raise ValueError("invalid deflate code")
-    bits.buf >>= length
-    bits.bl -= length
-    return entry >> 4
-
-
-def _parse_deflate(data):
-    """The literal/match tokens a raw deflate stream encodes.
-
-    A literal is an int, a match is a (length, distance) pair. Only what zlib
-    itself emits has to be handled, but all three block types are, since a
-    stored block is what it falls back to for data it cannot compress.
-    """
-    bits = _DeflateBits(data)
-    tokens = []
-    append = tokens.append
-    while True:
-        final = bits.get(1)
-        block_type = bits.get(2)
-        if block_type == 0:
-            bits.align()
-            size = bits.get(16)
-            bits.get(16)
-            for _ in range(size):
-                append(bits.get(8))
-        elif block_type in (1, 2):
-            if block_type == 1:
-                literal_lengths = _FIXED_LITERAL_LENGTHS
-                distance_lengths = _FIXED_DISTANCE_LENGTHS
-            else:
-                num_literals = bits.get(5) + 257
-                num_distances = bits.get(5) + 1
-                num_code_lengths = bits.get(4) + 4
-                code_lengths = [0] * 19
-                for i in range(num_code_lengths):
-                    code_lengths[_DEFLATE_CODE_LENGTH_ORDER[i]] = bits.get(3)
-                code_table, code_max = _deflate_table(code_lengths)
-                all_lengths = []
-                while len(all_lengths) < num_literals + num_distances:
-                    symbol = _deflate_symbol(bits, code_table, code_max)
-                    if symbol < 16:
-                        all_lengths.append(symbol)
-                    elif symbol == 16:
-                        all_lengths += [all_lengths[-1]] * (bits.get(2) + 3)
-                    elif symbol == 17:
-                        all_lengths += [0] * (bits.get(3) + 3)
-                    else:
-                        all_lengths += [0] * (bits.get(7) + 11)
-                literal_lengths = all_lengths[:num_literals]
-                distance_lengths = all_lengths[num_literals:num_literals + num_distances]
-            literal_table, literal_max = _deflate_table(literal_lengths)
-            distance_table, distance_max = _deflate_table(distance_lengths)
-            while True:
-                symbol = _deflate_symbol(bits, literal_table, literal_max)
-                if symbol < 256:
-                    append(symbol)
-                elif symbol == 256:
-                    break
-                else:
-                    index = symbol - 257
-                    length = _DEFLATE_LENGTH_BASE[index] + bits.get(_DEFLATE_LENGTH_EXTRA[index])
-                    index = _deflate_symbol(bits, distance_table, distance_max)
-                    distance = _DEFLATE_DIST_BASE[index] + bits.get(_DEFLATE_DIST_EXTRA[index])
-                    append((length, distance))
-        else:
-            raise ValueError(f"invalid deflate block type {block_type}")
-        if final:
-            return tokens
-
-
-def _lz77_tokens(chunk, level=9):
-    """`chunk` as literals and back-references, all within the chunk itself."""
-    compressor = zlib.compressobj(level, zlib.DEFLATED, -15, 9)
-    return _parse_deflate(compressor.compress(chunk) + compressor.flush())
-
-
-# ---------------------------------------------------------------------------
-# LZX blocks
-# ---------------------------------------------------------------------------
-
-class _FrameTooLarge(Exception):
-    """Raised when a frame will not fit its own header's size field."""
-
-
-def _operations(chunk, tokens):
-    """`tokens` as the symbols one verbatim block encodes them with.
-
-    Each operation is (main symbol, secondary length symbol or -1, extra bits
-    value, extra bit count, bytes emitted). Two things are settled here rather
-    than at write time: the three repeated offsets, which have to be tracked
-    exactly as the decoder updates them, and frame boundaries, which no match
-    may cross - the decoder stops a match dead when the frame's output is full
-    and would lose the rest of it.
-    """
-    operations = []
-    append = operations.append
-    r0 = r1 = r2 = 1
-    position = 0
-    for token in tokens:
-        if type(token) is int:
-            append((token, -1, 0, 0, 1))
-            position += 1
-            continue
-
-        length, distance = token
-        while length:
-            take = min(length, LZX_MAX_MATCH, FRAME_SIZE - (position % FRAME_SIZE))
-            if length - take == 1 and take > LZX_MIN_MATCH:
-                # A one byte tail cannot be a match of its own, so leave it
-                # two bytes to be one.
-                take -= 1
-            if take < LZX_MIN_MATCH:
-                append((chunk[position], -1, 0, 0, 1))
-                position += 1
-                length -= 1
-                continue
-
-            if distance == r0:
-                slot, extra_value, extra_bits = 0, 0, 0
-            elif distance == r1:
-                slot, extra_value, extra_bits = 1, 0, 0
-                r1 = r0
-                r0 = distance
-            elif distance == r2:
-                slot, extra_value, extra_bits = 2, 0, 0
-                r2 = r0
-                r0 = distance
-            else:
-                slot = bisect_right(_SLOT_BASE, distance) - 1
-                extra_bits = EXTRA_BITS[slot]
-                extra_value = distance - _SLOT_BASE[slot]
-                r2 = r1
-                r1 = r0
-                r0 = distance
-
-            footer = take - LZX_MIN_MATCH
-            if footer >= 7:
-                secondary = footer - 7
-                footer = 7
-            else:
-                secondary = -1
-            append((LZX_NUM_CHARS + slot * 8 + footer, secondary, extra_value, extra_bits, take))
-            position += take
-            length -= take
-    return operations
 
 
 def _compress_chunk(chunk):
@@ -504,86 +52,11 @@ def _compress_chunk(chunk):
     A single verbatim block covers the whole chunk and ends on its last byte,
     so the decoder's block state is clean again for the next chunk.
     """
-    tokens = _lz77_tokens(chunk)
-    operations = _operations(chunk, tokens)
-
-    main_freqs = [0] * LZX_MAIN_SYMBOLS
-    secondary_freqs = [0] * LZX_NUM_SECONDARY_LENGTHS
-    for symbol, secondary, _value, _bits, _emitted in operations:
-        main_freqs[symbol] += 1
-        if secondary >= 0:
-            secondary_freqs[secondary] += 1
-
-    main_lengths = _huffman_lengths(main_freqs, LZX_MAX_CODE_LENGTH)
-    main_codes = _canonical_codes(main_lengths)
-    secondary_lengths = _huffman_lengths(secondary_freqs, LZX_MAX_CODE_LENGTH)
-    secondary_codes = _canonical_codes(secondary_lengths)
-
-    writer = _BitWriter()
-    # No E8 (x86 call) translation. The decoder reads this bit once per chunk,
-    # before the first block.
-    writer.write(0, 1)
-    writer.write(LZX_BLOCKTYPE_VERBATIM, 3)
-    writer.write(len(chunk), 24)
-    # Every length is delta coded against the previous block's, and the
-    # decoder zeroes those at the start of each chunk (see _lzx_inflate).
-    zeros = [0] * LZX_MAIN_SYMBOLS
-    _write_lengths(writer, main_lengths, zeros, 0, LZX_NUM_CHARS)
-    _write_lengths(writer, main_lengths, zeros, LZX_NUM_CHARS, LZX_MAIN_SYMBOLS)
-    _write_lengths(writer, secondary_lengths, [0] * LZX_NUM_SECONDARY_LENGTHS,
-                   0, LZX_NUM_SECONDARY_LENGTHS)
-
-    frames = []
-    emitted = 0
-    for symbol, secondary, value, bits, size in operations:
-        writer.write(main_codes[symbol], main_lengths[symbol])
-        if secondary >= 0:
-            writer.write(secondary_codes[secondary], secondary_lengths[secondary])
-        if bits:
-            writer.write(value, bits)
-        emitted += size
-        if emitted == FRAME_SIZE:
-            frames.append((writer.finish(), emitted))
-            emitted = 0
-            writer = _BitWriter()
-    if emitted:
-        frames.append((writer.finish(), emitted))
-    if sum(size for _data, size in frames) != len(chunk):
-        raise RuntimeError("LZX encoder lost track of a chunk's output size")
-
-    out = bytearray()
-    for i, (data, size) in enumerate(frames):
-        out += _frame(data, size, last=i + 1 == len(frames))
+    out = bytearray(frame_stream(compress_frames(chunk)))
     out += FRAME_TERMINATOR
-
     if len(out) >= len(chunk):
         return None
     return bytes(out)
-
-
-def _frame(data, uncompressed_size, last):
-    """One frame, with the header lfs_decompress._lzx_inflate expects.
-
-    Both of its sizes are big-endian u2. The two byte header says only how
-    many compressed bytes follow and leaves the uncompressed size implied, so
-    it can only carry a frame of the standard size; the five byte one the
-    0xFF marker introduces spells both out.
-
-    A chunk's last frame always takes the long header, even when its
-    uncompressed size is the standard one and the short header would do. That
-    is what the game's own data does without exception: over a 700 archive
-    sample every one of 65594 compressed chunks ends on a long header, and
-    every frame before it uses the short one.
-    """
-    size = len(data)
-    if size > 0xFFFF:
-        # Both header forms hold the compressed size in a u2. A frame this
-        # large means the data did not compress at all, and the chunk it
-        # belongs to is about to be stored instead.
-        raise _FrameTooLarge()
-    if not last and uncompressed_size == FRAME_SIZE and (size >> 8) != SHORT_FRAME_HEADER_MARKER:
-        return struct.pack(">H", size) + data
-    return struct.pack(">BHH", SHORT_FRAME_HEADER_MARKER, uncompressed_size, size) + data
 
 
 def compress_chunks(payload):
@@ -599,7 +72,7 @@ def compress_chunks(payload):
         chunk = payload[start:start + LFS_CHUNK_SIZE]
         try:
             compressed = _compress_chunk(chunk)
-        except _FrameTooLarge:
+        except FrameTooLarge:
             compressed = None
         chunks.append((chunk, False) if compressed is None else (compressed, True))
     if not chunks:

--- a/albam/engines/cie/lfs_decompress.py
+++ b/albam/engines/cie/lfs_decompress.py
@@ -8,12 +8,7 @@ are sized, stored and written back.
 
 import struct
 
-from ...lib.xcompress import (  # noqa: F401 - re-exported for lfs_compress
-    EXTRA_BITS,
-    POSITION_BASE,
-    _LzxState,
-    _lzx_inflate,
-)
+from ...lib.xcompress import _LzxState, _lzx_inflate
 
 LFS_MAGIC1 = 0x584C4452
 LFS_CHUNK_SIZE = 0x10000

--- a/albam/engines/mtfw/__init__.py
+++ b/albam/engines/mtfw/__init__.py
@@ -672,3 +672,9 @@ FILE_ID_TO_EXTENSION_DMC4 = {
 
 
 EXTENSION_TO_FILE_ID = {ext_desc: h for h, ext_desc in FILE_ID_TO_EXTENSION.items()}
+# The reverse of the table above it, so a new archive entry can be given the
+# id its own archive's version numbers that extension with. Neither table is
+# quite injective - two ids share "shp" here and two share "bin" for DMC4 -
+# and the reverse keeps the last of each, which is only ever consulted for a
+# file albam itself writes.
+EXTENSION_TO_FILE_ID_DMC4 = {ext_desc: h for h, ext_desc in FILE_ID_TO_EXTENSION_DMC4.items()}

--- a/albam/engines/mtfw/__init__.py
+++ b/albam/engines/mtfw/__init__.py
@@ -671,16 +671,22 @@ FILE_ID_TO_EXTENSION_DMC4 = {
 }
 
 
-def _extension_to_file_ids(table):
-    """The reverse of one of the tables above: extension -> every file type
-    id that names it, so a new archive entry can be given the id its own
-    archive's version numbers that extension with.
+# The reverse of the shared table, so a new archive entry can be given the id
+# its own archive's version numbers that extension with. Not quite injective -
+# two ids share "shp" - and the reverse keeps the last of the two, as it has
+# for every version 7 archive albam has ever written.
+EXTENSION_TO_FILE_ID = {ext_desc: h for h, ext_desc in FILE_ID_TO_EXTENSION.items()}
 
-    Neither table is quite injective - two ids share "shp" in the shared one
-    and two share "bin" for DMC4 - so an extension can name more than one
-    resource class. Keeping every id rather than the last of each is what
-    lets that be refused instead of guessed at, since an extension is all
-    albam knows about a file a user hands it.
+
+def _extension_to_file_ids(table):
+    """The same reverse, but keeping every file type id that names an
+    extension rather than the last of them.
+
+    The DMC4 table is not injective either - 0x19DDF06A (rCharTbl) and
+    0x7A5DCF86 (rPlParamTbl) are both "bin" - and version 17 is new enough
+    to albam that nothing has been written on the strength of a guess yet.
+    Keeping both ids lets an ambiguous extension be refused instead, since
+    an extension is all albam knows about a file a user hands it.
     """
     file_ids = {}
     for h, ext_desc in table.items():
@@ -688,5 +694,4 @@ def _extension_to_file_ids(table):
     return {ext_desc: tuple(ids) for ext_desc, ids in file_ids.items()}
 
 
-EXTENSION_TO_FILE_IDS = _extension_to_file_ids(FILE_ID_TO_EXTENSION)
 EXTENSION_TO_FILE_IDS_DMC4 = _extension_to_file_ids(FILE_ID_TO_EXTENSION_DMC4)

--- a/albam/engines/mtfw/__init__.py
+++ b/albam/engines/mtfw/__init__.py
@@ -671,10 +671,22 @@ FILE_ID_TO_EXTENSION_DMC4 = {
 }
 
 
-EXTENSION_TO_FILE_ID = {ext_desc: h for h, ext_desc in FILE_ID_TO_EXTENSION.items()}
-# The reverse of the table above it, so a new archive entry can be given the
-# id its own archive's version numbers that extension with. Neither table is
-# quite injective - two ids share "shp" here and two share "bin" for DMC4 -
-# and the reverse keeps the last of each, which is only ever consulted for a
-# file albam itself writes.
-EXTENSION_TO_FILE_ID_DMC4 = {ext_desc: h for h, ext_desc in FILE_ID_TO_EXTENSION_DMC4.items()}
+def _extension_to_file_ids(table):
+    """The reverse of one of the tables above: extension -> every file type
+    id that names it, so a new archive entry can be given the id its own
+    archive's version numbers that extension with.
+
+    Neither table is quite injective - two ids share "shp" in the shared one
+    and two share "bin" for DMC4 - so an extension can name more than one
+    resource class. Keeping every id rather than the last of each is what
+    lets that be refused instead of guessed at, since an extension is all
+    albam knows about a file a user hands it.
+    """
+    file_ids = {}
+    for h, ext_desc in table.items():
+        file_ids.setdefault(ext_desc, []).append(h)
+    return {ext_desc: tuple(ids) for ext_desc, ids in file_ids.items()}
+
+
+EXTENSION_TO_FILE_IDS = _extension_to_file_ids(FILE_ID_TO_EXTENSION)
+EXTENSION_TO_FILE_IDS_DMC4 = _extension_to_file_ids(FILE_ID_TO_EXTENSION_DMC4)

--- a/albam/engines/mtfw/arc_fs.py
+++ b/albam/engines/mtfw/arc_fs.py
@@ -70,7 +70,7 @@ def decompress_entry(arc_version, raw, size):
     return zlib.decompress(raw)
 
 
-def compress_entry(arc_version, data, entry_path="<unknown>"):
+def compress_entry(arc_version, data, entry_path):
     """One .arc file entry's payload, encoded with the codec its archive uses.
 
     The counterpart of decompress_entry, and the reason a version 17 archive

--- a/albam/engines/mtfw/arc_fs.py
+++ b/albam/engines/mtfw/arc_fs.py
@@ -22,10 +22,16 @@ from fs.osfs import OSFS
 from fs.path import dirname, join, normpath
 from kaitaistruct import KaitaiStream
 
-from . import FILE_ID_TO_EXTENSION, FILE_ID_TO_EXTENSION_DMC4
+from . import (
+    EXTENSION_TO_FILE_ID,
+    EXTENSION_TO_FILE_ID_DMC4,
+    FILE_ID_TO_EXTENSION,
+    FILE_ID_TO_EXTENSION_DMC4,
+)
 from .structs.arc import Arc
 from ...lib.s3 import S3LooseFS, build_s3_client, s3_opener
 from ...lib.xcompress import xmem_decompress
+from ...lib.xcompress_encode import xmem_compress
 
 
 # The archive version this app writes. Every other app albam reads writes
@@ -46,11 +52,35 @@ def file_type_extensions(arc_version):
     return FILE_ID_TO_EXTENSION
 
 
+def extension_file_ids(arc_version):
+    """The extension -> file-type-id table an archive of this version uses.
+
+    The reverse of file_type_extensions(), for giving a file albam adds to an
+    archive the id that archive's own version knows it by.
+    """
+    if arc_version == ARC_VERSION_DMC4:
+        return EXTENSION_TO_FILE_ID_DMC4
+    return EXTENSION_TO_FILE_ID
+
+
 def decompress_entry(arc_version, raw, size):
     """One .arc file entry's payload, decoded with the codec its archive uses."""
     if arc_version == ARC_VERSION_DMC4:
         return xmem_decompress(raw, size)
     return zlib.decompress(raw)
+
+
+def compress_entry(arc_version, data):
+    """One .arc file entry's payload, encoded with the codec its archive uses.
+
+    The counterpart of decompress_entry, and the reason a version 17 archive
+    can be written at all: its entries are XMemCompress streams, and zlib
+    chunks written into one would leave an archive that parses fine and that
+    the game cannot read.
+    """
+    if arc_version == ARC_VERSION_DMC4:
+        return xmem_compress(data)
+    return zlib.compress(data)
 
 
 def _entry_path(file_entry, extensions=FILE_ID_TO_EXTENSION):

--- a/albam/engines/mtfw/arc_fs.py
+++ b/albam/engines/mtfw/arc_fs.py
@@ -23,8 +23,8 @@ from fs.path import dirname, join, normpath
 from kaitaistruct import KaitaiStream
 
 from . import (
-    EXTENSION_TO_FILE_ID,
-    EXTENSION_TO_FILE_ID_DMC4,
+    EXTENSION_TO_FILE_IDS,
+    EXTENSION_TO_FILE_IDS_DMC4,
     FILE_ID_TO_EXTENSION,
     FILE_ID_TO_EXTENSION_DMC4,
 )
@@ -52,15 +52,34 @@ def file_type_extensions(arc_version):
     return FILE_ID_TO_EXTENSION
 
 
-def extension_file_ids(arc_version):
-    """The extension -> file-type-id table an archive of this version uses.
+class AmbiguousExtension(Exception):
+    """An extension that names more than one of an archive version's resource
+    classes, so the id a file albam is adding should carry is not knowable."""
+
+
+def new_entry_file_type(arc_version, extension):
+    """The file type id to label a file albam adds to an archive with.
 
     The reverse of file_type_extensions(), for giving a file albam adds to an
-    archive the id that archive's own version knows it by.
+    archive the id that archive's own version knows it by. Raises KeyError if
+    the version's table does not name the extension at all - callers take the
+    extension for a literal id then - and AmbiguousExtension if it names it
+    more than once, which no extension a user hands albam can disambiguate.
+
+    Existing entries never come through here: they keep the file type they
+    were parsed with, which is an answer and not a guess.
     """
     if arc_version == ARC_VERSION_DMC4:
-        return EXTENSION_TO_FILE_ID_DMC4
-    return EXTENSION_TO_FILE_ID
+        file_ids = EXTENSION_TO_FILE_IDS_DMC4[extension]
+    else:
+        file_ids = EXTENSION_TO_FILE_IDS[extension]
+    if len(file_ids) > 1:
+        candidates = " and ".join(f"0x{h:08X}" for h in file_ids)
+        raise AmbiguousExtension(
+            f'cannot add a ".{extension}" to this archive: its version numbers '
+            f"{candidates} with that extension, and which of the two this file "
+            "is cannot be told from its name")
+    return file_ids[0]
 
 
 def decompress_entry(arc_version, raw, size):

--- a/albam/engines/mtfw/arc_fs.py
+++ b/albam/engines/mtfw/arc_fs.py
@@ -23,7 +23,7 @@ from fs.path import dirname, join, normpath
 from kaitaistruct import KaitaiStream
 
 from . import (
-    EXTENSION_TO_FILE_IDS,
+    EXTENSION_TO_FILE_ID,
     EXTENSION_TO_FILE_IDS_DMC4,
     FILE_ID_TO_EXTENSION,
     FILE_ID_TO_EXTENSION_DMC4,
@@ -53,8 +53,8 @@ def file_type_extensions(arc_version):
 
 
 class AmbiguousExtension(Exception):
-    """An extension that names more than one of an archive version's resource
-    classes, so the id a file albam is adding should carry is not knowable."""
+    """An extension that names more than one of version 17's resource classes,
+    so the id a file albam is adding should carry is not knowable."""
 
 
 def new_entry_file_type(arc_version, extension):
@@ -63,22 +63,26 @@ def new_entry_file_type(arc_version, extension):
     The reverse of file_type_extensions(), for giving a file albam adds to an
     archive the id that archive's own version knows it by. Raises KeyError if
     the version's table does not name the extension at all - callers take the
-    extension for a literal id then - and AmbiguousExtension if it names it
-    more than once, which no extension a user hands albam can disambiguate.
+    extension for a literal id then.
 
-    Existing entries never come through here: they keep the file type they
-    were parsed with, which is an answer and not a guess.
+    A version 17 extension that names more than one resource class is refused
+    rather than guessed at: nothing has been written on that guess yet, and
+    an extension is all a user's file tells albam. The shared table resolves
+    the one extension it doubles up on the way it always has, because version
+    7 archives have been written that way for as long as albam has existed.
+
+    Existing entries never come through here either way: they keep the file
+    type they were parsed with, which is an answer and not a guess.
     """
-    if arc_version == ARC_VERSION_DMC4:
-        file_ids = EXTENSION_TO_FILE_IDS_DMC4[extension]
-    else:
-        file_ids = EXTENSION_TO_FILE_IDS[extension]
+    if arc_version != ARC_VERSION_DMC4:
+        return EXTENSION_TO_FILE_ID[extension]
+    file_ids = EXTENSION_TO_FILE_IDS_DMC4[extension]
     if len(file_ids) > 1:
-        candidates = " and ".join(f"0x{h:08X}" for h in file_ids)
+        candidates = ", ".join(f"0x{h:08X}" for h in file_ids)
         raise AmbiguousExtension(
-            f'cannot add a ".{extension}" to this archive: its version numbers '
-            f"{candidates} with that extension, and which of the two this file "
-            "is cannot be told from its name")
+            f'cannot add a ".{extension}" to this archive: version 17 numbers '
+            f"it {candidates}, and which of those this file is cannot be told "
+            "from its name")
     return file_ids[0]
 
 

--- a/albam/engines/mtfw/arc_fs.py
+++ b/albam/engines/mtfw/arc_fs.py
@@ -31,7 +31,7 @@ from . import (
 from .structs.arc import Arc
 from ...lib.s3 import S3LooseFS, build_s3_client, s3_opener
 from ...lib.xcompress import xmem_decompress
-from ...lib.xcompress_encode import xmem_compress
+from ...lib.xcompress_encode import FrameTooLarge, xmem_compress
 
 
 # The archive version this app writes. Every other app albam reads writes
@@ -70,16 +70,22 @@ def decompress_entry(arc_version, raw, size):
     return zlib.decompress(raw)
 
 
-def compress_entry(arc_version, data):
+def compress_entry(arc_version, data, entry_path="<unknown>"):
     """One .arc file entry's payload, encoded with the codec its archive uses.
 
     The counterpart of decompress_entry, and the reason a version 17 archive
     can be written at all: its entries are XMemCompress streams, and zlib
     chunks written into one would leave an archive that parses fine and that
     the game cannot read.
+
+    An entry the LZX encoder cannot encode correctly is refused rather than
+    written, and `entry_path` is what says which file that was.
     """
     if arc_version == ARC_VERSION_DMC4:
-        return xmem_compress(data)
+        try:
+            return xmem_compress(data)
+        except FrameTooLarge as err:
+            raise FrameTooLarge(f'cannot pack "{entry_path}": {err}') from err
     return zlib.compress(data)
 
 

--- a/albam/engines/mtfw/archive.py
+++ b/albam/engines/mtfw/archive.py
@@ -1,13 +1,18 @@
 import io
 import ntpath
-import zlib
 
 from kaitaistruct import KaitaiStream
 
 from ...registry import blender_registry
 from ...lib.kaitai_utils import check_recursive, parse
-from . import EXTENSION_TO_FILE_ID, FILE_ID_TO_EXTENSION
-from .arc_fs import ARC_VERSION_DMC4, ArcFS, MTFW_FS
+from .arc_fs import (
+    ArcFS,
+    MTFW_FS,
+    compress_entry,
+    decompress_entry,
+    extension_file_ids,
+    file_type_extensions,
+)
 from .structs.arc import Arc
 from ...blender_ui.tools import show_message_box
 
@@ -38,31 +43,23 @@ def game_fs_root_loader(absolute_path):
     return MTFW_FS(absolute_path)
 
 
-def _check_writable(parsed, filepath):
-    """Refuse an archive albam can read but cannot write back.
+def _sort_arc_entries(entries, arc_version=None):
+    """`entries` in the order an archive lists them: textures, then mrl, mod,
+    then everything else.
 
-    A version 17 archive's entries are XMemCompress (LZX) streams, and
-    albam only has a decoder. Rewriting one would either store zlib chunks
-    the game cannot read, or relabel the untouched LZX ones as zlib -
-    a broken archive either way, and silently so.
+    `arc_version` says what `entries` are: None for vfiles, which name their
+    own extension, and an archive's version for file entries, whose type ids
+    only mean anything against the table that version numbers them with.
     """
-    if parsed.header.version == ARC_VERSION_DMC4:
-        raise ValueError(
-            f"{filepath}: this archive's entries are compressed with a codec albam can "
-            f"only read, so it cannot be written back. Export the files on their own "
-            f"instead of packing them.")
-
-
-def _sort_arc_entries(entries, vfile=True):
     sorted = []
     mrl = []
     mod = []
     tail = []
     for entry in entries:
-        if vfile:
+        if arc_version is None:
             extension = getattr(entry, "extension")
         else:
-            extension = FILE_ID_TO_EXTENSION.get(entry.file_type, entry.file_type)
+            extension = _file_entry_extension(entry, arc_version)
 
         if extension == "tex":
             sorted.append(entry)
@@ -79,13 +76,13 @@ def _sort_arc_entries(entries, vfile=True):
     return sorted
 
 
-def _get_file_entry(vfile):
+def _get_file_entry(vfile, arc_version):
     vf_data = vfile.get_bytes()
-    chunk = zlib.compress(vf_data)
+    chunk = compress_entry(arc_version, vf_data)
     path = ntpath.normpath(vfile.relative_path)
     file_path = ntpath.splitext(path)[0]
     try:
-        file_type = EXTENSION_TO_FILE_ID[vfile.extension]
+        file_type = extension_file_ids(arc_version)[vfile.extension]
     except KeyError:
         file_type = int(vfile.extension)
     item = Arc.FileEntry(None, _parent=None, _root=None)
@@ -115,7 +112,12 @@ def _serialize_arc(exported, version=7):
         file_entry.file_type = fe.file_type
         file_entry.zsize = fe.zsize
         file_entry.size = fe.size
-        file_entry.flags = 2
+        # Carried over rather than fixed at 2: every entry of every version 7
+        # archive albam reads has 2, but a DMC4 one uses 0 and 1 as well -
+        # only ever on a tex, so it says something about the texture the
+        # engine is being handed, and rewriting it would be inventing an
+        # answer.
+        file_entry.flags = fe.flags
         file_entry.offset = file_offset
         file_entry.raw_data = fe.raw_data
         arc.file_entries.append(file_entry)
@@ -130,15 +132,11 @@ def _serialize_arc(exported, version=7):
     return file_
 
 
-def _to_dict(file_entries):
+def _to_dict(file_entries, arc_version):
     imported = {}
     for fe in file_entries:
         path = fe.file_path
-        try:
-            extension = FILE_ID_TO_EXTENSION[fe.file_type]
-        except KeyError:
-            extension = str(fe.file_type)
-        relative_path = (path + "." + extension)
+        relative_path = (path + "." + _file_entry_extension(fe, arc_version))
         imported[relative_path] = fe
     return imported
 
@@ -146,9 +144,15 @@ def _to_dict(file_entries):
 TEXTURE_EXTENSIONS = ("tex", "rtex")
 
 
-def _file_entry_extension(file_entry):
+def _file_entry_extension(file_entry, arc_version):
+    """The extension an entry's file type id stands for in its own archive.
+
+    Which table that is depends on the archive's version: the two number the
+    same resource class names from different hashes, so a DMC4 id read
+    through the shared table is not a miss, it is a wrong answer.
+    """
     try:
-        return FILE_ID_TO_EXTENSION[file_entry.file_type]
+        return file_type_extensions(arc_version)[file_entry.file_type]
     except KeyError:
         return str(file_entry.file_type)
 
@@ -183,10 +187,10 @@ def _texture_paths_from_mrl(mrl_bytes, app_id):
     return {_normalize_texture_key(t.texture_path) for t in mrl.textures if t.texture_path}
 
 
-def _get_texture_paths_from_arc_entry(fe, app_id):
-    ext = _file_entry_extension(fe)
+def _get_texture_paths_from_arc_entry(fe, app_id, arc_version):
+    ext = _file_entry_extension(fe, arc_version)
     try:
-        data = zlib.decompress(fe.raw_data)
+        data = decompress_entry(arc_version, fe.raw_data, fe.size)
     except Exception:
         return None
     if ext == "mod":
@@ -196,7 +200,8 @@ def _get_texture_paths_from_arc_entry(fe, app_id):
     return None
 
 
-def _find_orphaned_textures(file_entries, app_id, old_texture_paths, new_texture_paths):
+def _find_orphaned_textures(file_entries, app_id, old_texture_paths, new_texture_paths,
+                            arc_version):
     """
     Only considers textures that the exported model USED TO reference but
     NO LONGER does. Checks if any OTHER model in the arc still uses them.
@@ -207,10 +212,10 @@ def _find_orphaned_textures(file_entries, app_id, old_texture_paths, new_texture
         return file_entries, []
 
     for fe in file_entries.values():
-        ext = _file_entry_extension(fe)
+        ext = _file_entry_extension(fe, arc_version)
         if ext not in ("mod", "mrl"):
             continue
-        paths = _get_texture_paths_from_arc_entry(fe, app_id)
+        paths = _get_texture_paths_from_arc_entry(fe, app_id, arc_version)
         if paths is None:
             return file_entries, []  # can't parse → abort for safety
         candidates -= paths
@@ -220,7 +225,7 @@ def _find_orphaned_textures(file_entries, app_id, old_texture_paths, new_texture
     cleaned = {}
     removed = []
     for path_with_ext, fe in file_entries.items():
-        if _file_entry_extension(fe) in TEXTURE_EXTENSIONS:
+        if _file_entry_extension(fe, arc_version) in TEXTURE_EXTENSIONS:
             if _normalize_texture_key(fe.file_path) in candidates:
                 removed.append(path_with_ext)
                 continue
@@ -245,9 +250,9 @@ def update_arc(filepath, vfiles, remove_unused_textures=False, **_options):
     with open(filepath, 'rb') as f:
         parsed = Arc.from_bytes(f.read())
         parsed._read()
-    _check_writable(parsed, filepath)
+    arc_version = parsed.header.version
 
-    imported = _to_dict(parsed.file_entries)
+    imported = _to_dict(parsed.file_entries, arc_version)
 
     app_id = vf_sorted[0].app_id if vf_sorted else None
     old_texture_paths = set()
@@ -256,11 +261,11 @@ def update_arc(filepath, vfiles, remove_unused_textures=False, **_options):
     # patch dictionary with imported files
     for vf in vf_sorted:
         vf_data = vf.get_bytes()
-        chunk = zlib.compress(vf_data)
+        chunk = compress_entry(arc_version, vf_data)
         path = ntpath.normpath(vf.relative_path)
         file_path = ntpath.splitext(path)[0]
         try:
-            file_type = EXTENSION_TO_FILE_ID[vf.extension]
+            file_type = extension_file_ids(arc_version)[vf.extension]
         except KeyError:
             file_type = int(vf.extension)
 
@@ -271,7 +276,7 @@ def update_arc(filepath, vfiles, remove_unused_textures=False, **_options):
         if remove_unused_textures and vf.extension in ("mod", "mrl"):
             old_entry = imported.get(path)
             if old_entry:
-                old_paths = _get_texture_paths_from_arc_entry(old_entry, app_id)
+                old_paths = _get_texture_paths_from_arc_entry(old_entry, app_id, arc_version)
                 if old_paths is not None:
                     old_texture_paths |= old_paths
             if vf.extension == "mod":
@@ -302,7 +307,7 @@ def update_arc(filepath, vfiles, remove_unused_textures=False, **_options):
 
     if remove_unused_textures and app_id and old_texture_paths:
         exported, removed = _find_orphaned_textures(
-            exported, app_id, old_texture_paths, new_texture_paths)
+            exported, app_id, old_texture_paths, new_texture_paths, arc_version)
         if removed:
             preview = ", ".join(ntpath.basename(p) for p in removed[:8])
             if len(removed) > 8:
@@ -310,7 +315,7 @@ def update_arc(filepath, vfiles, remove_unused_textures=False, **_options):
             show_message_box(
                 f"Removed {len(removed)} orphaned texture(s): {preview}")
 
-    return _serialize_arc(exported, parsed.header.version)
+    return _serialize_arc(exported, arc_version)
 
 
 def find_and_replace_in_arc(filepath, vfile, file_name, add_new):
@@ -321,27 +326,24 @@ def find_and_replace_in_arc(filepath, vfile, file_name, add_new):
     with open(filepath, 'rb') as f:
         parsed = Arc.from_bytes(f.read())
         parsed._read()
-    _check_writable(parsed, filepath)
+    arc_version = parsed.header.version
 
     imported_entries = [fe for fe in parsed.file_entries]
     if add_new:
-        file_entry = _get_file_entry(vfile)
+        file_entry = _get_file_entry(vfile, arc_version)
         imported_entries.append(file_entry)
-        imported_entries = _sort_arc_entries(imported_entries, False)
-        file_entries = _to_dict(imported_entries)
+        imported_entries = _sort_arc_entries(imported_entries, arc_version)
+        file_entries = _to_dict(imported_entries, arc_version)
     else:
         for fe in imported_entries:
             path = fe.file_path
             name = ntpath.basename(path)
-            try:
-                extension = FILE_ID_TO_EXTENSION[fe.file_type]
-            except KeyError:
-                extension = str(fe.file_type)
+            extension = _file_entry_extension(fe, arc_version)
             if name == file_name and vfile.extension == extension:
                 show_message_box("File: {} was found and replaced in the archive".format(file_name))
                 found = True
                 vf_data = vfile.get_bytes()
-                chunk = zlib.compress(vf_data)
+                chunk = compress_entry(arc_version, vf_data)
                 fe.zsize = len(chunk)
                 fe.size = len(vf_data)
                 fe.raw_data = chunk
@@ -351,4 +353,4 @@ def find_and_replace_in_arc(filepath, vfile, file_name, add_new):
             show_message_box("File: {} was not found in the archive".format(file_name))
             return None
     assert len(parsed.file_entries) <= len(file_entries) <= len(parsed.file_entries) + 1
-    return _serialize_arc(file_entries, parsed.header.version)
+    return _serialize_arc(file_entries, arc_version)

--- a/albam/engines/mtfw/archive.py
+++ b/albam/engines/mtfw/archive.py
@@ -349,7 +349,7 @@ def find_and_replace_in_arc(filepath, vfile, file_name, add_new):
                 show_message_box("File: {} was found and replaced in the archive".format(file_name))
                 found = True
                 vf_data = vfile.get_bytes()
-                chunk = compress_entry(arc_version, vf_data, path)
+                chunk = compress_entry(arc_version, vf_data, path + "." + extension)
                 fe.zsize = len(chunk)
                 fe.size = len(vf_data)
                 fe.raw_data = chunk

--- a/albam/engines/mtfw/archive.py
+++ b/albam/engines/mtfw/archive.py
@@ -115,11 +115,17 @@ def _serialize_arc(exported, version=7):
         file_entry.file_type = fe.file_type
         file_entry.zsize = fe.zsize
         file_entry.size = fe.size
-        # Carried over rather than fixed at 2: every entry of every version 7
-        # archive albam reads has 2, but a DMC4 one uses 0 and 1 as well -
-        # only ever on a tex, so it says something about the texture the
-        # engine is being handed, and rewriting it would be inventing an
-        # answer.
+        # Carried over rather than fixed at 2. Measured over every .arc of
+        # the seven version 7 games on hand (Dragon's Dogma, Resident Evil
+        # Revelations, Resident Evil 0, Resident Evil 5, Resident Evil 6,
+        # Resident Evil HD Remaster, Ultimate Marvel vs. Capcom 3): 29690
+        # archives, 788014 entries, 788013 of them carrying 2 and exactly one
+        # carrying 4 - "dlc\model\chara\wp\wp1070\wp1070" in Revelations'
+        # wp21.arc. That one entry is why carrying the parsed value through is
+        # the fix and writing a fixed 2 was the bug: its own value now
+        # survives a repack instead of being replaced by a guess. DMC4 makes
+        # the same point louder, using 0 and 1 as well - only ever on a tex,
+        # so it says something about the texture the engine is being handed.
         file_entry.flags = fe.flags
         file_entry.offset = file_offset
         file_entry.raw_data = fe.raw_data

--- a/albam/engines/mtfw/archive.py
+++ b/albam/engines/mtfw/archive.py
@@ -10,8 +10,8 @@ from .arc_fs import (
     MTFW_FS,
     compress_entry,
     decompress_entry,
-    extension_file_ids,
     file_type_extensions,
+    new_entry_file_type,
 )
 from .structs.arc import Arc
 from ...blender_ui.tools import show_message_box
@@ -82,7 +82,7 @@ def _get_file_entry(vfile, arc_version):
     chunk = compress_entry(arc_version, vf_data, path)
     file_path = ntpath.splitext(path)[0]
     try:
-        file_type = extension_file_ids(arc_version)[vfile.extension]
+        file_type = new_entry_file_type(arc_version, vfile.extension)
     except KeyError:
         file_type = int(vfile.extension)
     item = Arc.FileEntry(None, _parent=None, _root=None)
@@ -267,10 +267,6 @@ def update_arc(filepath, vfiles, remove_unused_textures=False, **_options):
         path = ntpath.normpath(vf.relative_path)
         chunk = compress_entry(arc_version, vf_data, path)
         file_path = ntpath.splitext(path)[0]
-        try:
-            file_type = extension_file_ids(arc_version)[vf.extension]
-        except KeyError:
-            file_type = int(vf.extension)
 
         if vf.extension in TEXTURE_EXTENSIONS:
             new_texture_paths.add(_normalize_texture_key(file_path))
@@ -296,6 +292,10 @@ def update_arc(filepath, vfiles, remove_unused_textures=False, **_options):
             item.raw_data = chunk
             imported[path] = item
         else:
+            try:
+                file_type = new_entry_file_type(arc_version, vf.extension)
+            except KeyError:
+                file_type = int(vf.extension)
             item = Arc.FileEntry(None, _parent=None, _root=None)
             item.file_path = file_path
             item.file_type = file_type

--- a/albam/engines/mtfw/archive.py
+++ b/albam/engines/mtfw/archive.py
@@ -78,8 +78,8 @@ def _sort_arc_entries(entries, arc_version=None):
 
 def _get_file_entry(vfile, arc_version):
     vf_data = vfile.get_bytes()
-    chunk = compress_entry(arc_version, vf_data)
     path = ntpath.normpath(vfile.relative_path)
+    chunk = compress_entry(arc_version, vf_data, path)
     file_path = ntpath.splitext(path)[0]
     try:
         file_type = extension_file_ids(arc_version)[vfile.extension]
@@ -90,6 +90,9 @@ def _get_file_entry(vfile, arc_version):
     item.file_type = file_type
     item.zsize = len(chunk)
     item.size = len(vf_data)
+    # Unverified for DMC4, whose own textures are observed carrying 0 and 1
+    # as well; there is nothing to carry over for an entry the archive does
+    # not already have. See the comment in _serialize_arc.
     item.flags = 2
     item.offset = 0
     item.raw_data = chunk
@@ -261,8 +264,8 @@ def update_arc(filepath, vfiles, remove_unused_textures=False, **_options):
     # patch dictionary with imported files
     for vf in vf_sorted:
         vf_data = vf.get_bytes()
-        chunk = compress_entry(arc_version, vf_data)
         path = ntpath.normpath(vf.relative_path)
+        chunk = compress_entry(arc_version, vf_data, path)
         file_path = ntpath.splitext(path)[0]
         try:
             file_type = extension_file_ids(arc_version)[vf.extension]
@@ -298,6 +301,9 @@ def update_arc(filepath, vfiles, remove_unused_textures=False, **_options):
             item.file_type = file_type
             item.zsize = len(chunk)
             item.size = len(vf_data)
+            # Unverified for DMC4, whose own textures are observed carrying
+            # 0 and 1 as well; there is nothing to carry over for an entry
+            # the archive does not already have. See _serialize_arc.
             item.flags = 2
             item.offset = 0
             item.raw_data = chunk
@@ -343,7 +349,7 @@ def find_and_replace_in_arc(filepath, vfile, file_name, add_new):
                 show_message_box("File: {} was found and replaced in the archive".format(file_name))
                 found = True
                 vf_data = vfile.get_bytes()
-                chunk = compress_entry(arc_version, vf_data)
+                chunk = compress_entry(arc_version, vf_data, path)
                 fe.zsize = len(chunk)
                 fe.size = len(vf_data)
                 fe.raw_data = chunk

--- a/albam/lib/xcompress_encode.py
+++ b/albam/lib/xcompress_encode.py
@@ -59,7 +59,6 @@ LZX_MAX_MATCH = 257
 LZX_NUM_POSITION_SLOTS = 34
 LZX_NUM_SECONDARY_LENGTHS = 249
 LZX_BLOCKTYPE_VERBATIM = 1
-LZX_BLOCKTYPE_UNCOMPRESSED = 3
 LZX_MAIN_SYMBOLS = LZX_NUM_CHARS + LZX_NUM_POSITION_SLOTS * 8
 LZX_PRETREE_SYMBOLS = 20
 # Code lengths are read as 4-bit fields for the pretree and are capped at 16
@@ -613,39 +612,13 @@ def _frame(data, uncompressed_size, last):
     size = len(data)
     if size > 0xFFFF:
         # Both header forms hold the compressed size in a u2.
-        raise FrameTooLarge()
+        raise FrameTooLarge(
+            f"a frame holding {uncompressed_size} bytes came to {size} compressed, "
+            f"more than the {0xFFFF} a frame header can count"
+        )
     if not last and uncompressed_size == FRAME_SIZE and (size >> 8) != SHORT_FRAME_HEADER_MARKER:
         return struct.pack(">H", size) + data
     return struct.pack(">BHH", SHORT_FRAME_HEADER_MARKER, uncompressed_size, size) + data
-
-
-def _stored_frames(payload):
-    """`payload` as frames of one uncompressed block each.
-
-    The fallback for data a verbatim block would somehow write into a frame
-    too large for its own header. Nothing measurable reaches it - a frame
-    holds 32768 bytes and Huffman coding them cannot come near the 65535 a
-    frame header can count - but an .arc entry has no "stored" flag to fall
-    back on the way an .lfs chunk does, so the encoder needs some way to
-    write any input at all. Block type 3 is that way, and the game's own
-    archives do use it.
-    """
-    out = bytearray()
-    for start in range(0, len(payload), FRAME_SIZE):
-        chunk = payload[start:start + FRAME_SIZE]
-        writer = _BitWriter()
-        if start == 0:
-            writer.write(0, 1)  # no x86 call transform, once per stream
-        writer.write(LZX_BLOCKTYPE_UNCOMPRESSED, 3)
-        writer.write(len(chunk), 24)
-        # The decoder aligns to a whole word before reading the three
-        # repeated offsets, which are u4 written low half first.
-        body = bytearray(writer.finish())
-        for _ in range(3):
-            body += struct.pack("<HH", 1, 0)
-        body += chunk
-        out += _frame(bytes(body), len(chunk), last=start + FRAME_SIZE >= len(payload))
-    return bytes(out)
 
 
 def frame_stream(frames):
@@ -661,11 +634,12 @@ def xmem_compress(payload):
 
     The size is not in the stream; whatever points at it stores that (an
     .arc file entry's `size`), and xcompress.xmem_decompress takes it back.
+
+    Raises FrameTooLarge if a frame will not fit its own header's size
+    field, the way compress_frames raises on a size mismatch: a stream that
+    cannot be encoded correctly is refused rather than written.
     """
     payload = bytes(payload)
     if not payload:
         return b""
-    try:
-        return frame_stream(compress_frames(payload))
-    except FrameTooLarge:
-        return _stored_frames(payload)
+    return frame_stream(compress_frames(payload))

--- a/albam/lib/xcompress_encode.py
+++ b/albam/lib/xcompress_encode.py
@@ -1,0 +1,671 @@
+"""Pure-Python encoder for XMemCompress streams, the counterpart of
+albam.lib.xcompress.
+
+Written against that decoder rather than against any general description of
+LZX: it is what the game's own data round-trips through, so it is the
+specification here. Everything below mirrors it in reverse - the same
+16-bit-word bit packing, the same canonical Huffman construction, the same
+delta-coded code lengths, the same position slots.
+
+What lives here is one stream: its frames and its blocks, and nothing about
+where the stream sits. Two containers hold these streams and frame them
+differently - albam/engines/cie/lfs_compress.py cuts a .lfs payload into
+64KB chunks and gives each one a stream of its own, while an MT Framework
+archive entry (albam/engines/mtfw/arc_fs.py) is a single bare stream however
+large it is.
+
+The shape a stream has to take, measured by decoding every entry of 400
+Devil May Cry 4 archives - 3960 streams, 23826 frames, 5821 blocks (the .lfs
+side has its own numbers in lfs_compress, and agrees on all of this):
+
+* No match may run past the end of its own frame. This decoder stops a match
+  dead when the frame's output is full and simply loses the rest of it, and
+  not one match in the sample crosses a frame boundary, so a match that
+  would is split at the boundary (see _operations).
+* Matches do reach back into earlier frames, up to 131067 bytes - all but
+  five bytes of the 0x20000 window - so the window is not reset per frame.
+  Only writing is bounded by the frame, not reading.
+* Every frame but a stream's last carries the two byte header, and the last
+  carries the five byte one even when the short one would fit it, without
+  exception in the sample, and nothing at all follows it (see _frame).
+* Blocks are independent of frames: one block covers the whole stream in
+  3463 of the 3960, and where a stream has more, their boundaries fall
+  anywhere inside a frame.
+* The x86 call transform is never on - 3960 streams, not one sets it.
+
+Match finding is delegated to zlib: its deflate output is parsed back into
+the literal/match token stream that produced it (_lz77_tokens), which is
+then re-encoded as LZX. Deflate's window is 32KB against the 0x20000 the
+format allows, so this leaves some ratio on the table, but it puts the O(n)
+search work in C instead of in Python.
+"""
+import heapq
+import struct
+import zlib
+from bisect import bisect_right
+
+from .xcompress import EXTRA_BITS, POSITION_BASE
+
+# One frame's uncompressed size. The frame header's size fields are 16 bit,
+# so a frame cannot say it holds more than this.
+FRAME_SIZE = 32768
+# Introduces the long frame header; a frame not starting with it carries the
+# short one (see _frame).
+SHORT_FRAME_HEADER_MARKER = 0xFF
+
+LZX_NUM_CHARS = 256
+LZX_MIN_MATCH = 2
+LZX_MAX_MATCH = 257
+LZX_NUM_POSITION_SLOTS = 34
+LZX_NUM_SECONDARY_LENGTHS = 249
+LZX_BLOCKTYPE_VERBATIM = 1
+LZX_BLOCKTYPE_UNCOMPRESSED = 3
+LZX_MAIN_SYMBOLS = LZX_NUM_CHARS + LZX_NUM_POSITION_SLOTS * 8
+LZX_PRETREE_SYMBOLS = 20
+# Code lengths are read as 4-bit fields for the pretree and are capped at 16
+# by the tree builder for everything else.
+LZX_MAX_CODE_LENGTH = 16
+LZX_MAX_PRETREE_LENGTH = 15
+# A block header states its length in 24 bits, so a stream longer than this
+# needs more than one block.
+MAX_BLOCK_SIZE = 0xFFFFFF
+
+# The lowest distance each position slot can express. The decoder computes
+# `POSITION_BASE[slot] - 2` and adds the slot's extra bits to it, so the slots
+# tile the distances from 1 upwards without a gap.
+_SLOT_BASE = [POSITION_BASE[i] - 2 for i in range(LZX_NUM_POSITION_SLOTS)]
+
+
+class _BitWriter:
+    """Bits in the order xcompress._BitReader consumes them.
+
+    That reader takes 16 bits at a time out of a little-endian u2 and hands
+    them out most-significant first, so bits accumulate into a word here and
+    each finished word is written low byte first.
+    """
+
+    __slots__ = ("out", "buf", "bl")
+
+    def __init__(self):
+        self.out = bytearray()
+        self.buf = 0
+        self.bl = 0
+
+    def write(self, value, num_bits):
+        while num_bits > 16:
+            num_bits -= 16
+            self.write((value >> num_bits) & 0xFFFF, 16)
+            value &= (1 << num_bits) - 1
+        if not num_bits:
+            return
+        self.buf = (self.buf << num_bits) | value
+        self.bl += num_bits
+        while self.bl >= 16:
+            self.bl -= 16
+            word = (self.buf >> self.bl) & 0xFFFF
+            self.out.append(word & 0xFF)
+            self.out.append(word >> 8)
+        self.buf &= (1 << self.bl) - 1
+
+    def finish(self):
+        """The bytes written, padded with zero bits to a whole word."""
+        if self.bl:
+            self.write(0, 16 - self.bl)
+        return bytes(self.out)
+
+
+def _huffman_lengths(freqs, max_length):
+    """Canonical code lengths for `freqs`, none longer than `max_length`.
+
+    Over-long codes are dealt with by halving the frequencies and rebuilding,
+    which converges because equal weights bound the depth at log2(n).
+
+    A tree of one symbol gets a second, unused one alongside it, so that the
+    lengths always describe a complete code. This decoder does not care - it
+    walks a tree and only ever meets the code that was written - but a
+    decoder building a lookup table has half of it undefined, and the game's
+    own data never leaves a code incomplete: across a 40 archive sample all
+    9909 pre-trees and all 3303 main trees are complete, and of the 3303
+    length trees 3219 are complete and 84 empty, with none in between.
+    """
+    freqs = list(freqs)
+    while True:
+        used = [i for i, f in enumerate(freqs) if f]
+        lengths = [0] * len(freqs)
+        if not used:
+            return lengths
+        if len(used) == 1:
+            lengths[used[0]] = 1
+            lengths[1 if used[0] == 0 else 0] = 1
+            return lengths
+
+        heap = [(freqs[i], i) for i in used]
+        heapq.heapify(heap)
+        children = {}
+        next_node = len(freqs)
+        while len(heap) > 1:
+            weight_a, node_a = heapq.heappop(heap)
+            weight_b, node_b = heapq.heappop(heap)
+            children[next_node] = (node_a, node_b)
+            heapq.heappush(heap, (weight_a + weight_b, next_node))
+            next_node += 1
+
+        too_long = False
+        stack = [(heap[0][1], 0)]
+        while stack:
+            node, depth = stack.pop()
+            child = children.get(node)
+            if child is None:
+                lengths[node] = depth
+                if depth > max_length:
+                    too_long = True
+            else:
+                stack.append((child[0], depth + 1))
+                stack.append((child[1], depth + 1))
+        if not too_long:
+            return lengths
+        freqs = [(f + 1) >> 1 if f else 0 for f in freqs]
+
+
+def _canonical_codes(lengths):
+    """The codes xcompress._build_tree assigns to `lengths`.
+
+    Same walk: count the lengths, start each length's codes where the
+    previous length's left off shifted up one, hand them out in symbol order.
+    """
+    counts = [0] * (LZX_MAX_CODE_LENGTH + 1)
+    for length in lengths:
+        if 0 < length <= LZX_MAX_CODE_LENGTH:
+            counts[length] += 1
+    starts = [0] * (LZX_MAX_CODE_LENGTH + 1)
+    for i in range(1, LZX_MAX_CODE_LENGTH):
+        starts[i + 1] = (starts[i] + counts[i]) << 1
+    codes = [0] * len(lengths)
+    for symbol, length in enumerate(lengths):
+        if 0 < length <= LZX_MAX_CODE_LENGTH:
+            codes[symbol] = starts[length]
+            starts[length] += 1
+    return codes
+
+
+def _length_tokens(new_lengths, previous_lengths, first, last):
+    """The pre-tree token stream for new_lengths[first:last].
+
+    Mirrors xcompress._read_lengths: a plain symbol is the difference from
+    the length the same slot had in the previous block, modulo 17, and
+    17/18/19 are runs. Each token is (symbol, extra_value, extra_bits) with an
+    optional trailing delta symbol for 19.
+    """
+    tokens = []
+    x = first
+    while x < last:
+        length = new_lengths[x]
+        run = 1
+        while x + run < last and new_lengths[x + run] == length:
+            run += 1
+        if length == 0:
+            while run >= 4:
+                if run >= 20:
+                    take = min(run, 51)
+                    tokens.append((18, take - 20, 5, None))
+                else:
+                    take = min(run, 19)
+                    tokens.append((17, take - 4, 4, None))
+                x += take
+                run -= take
+        else:
+            while run >= 4:
+                take = min(run, 5)
+                delta = (previous_lengths[x] - length) % 17
+                tokens.append((19, take - 4, 1, delta))
+                x += take
+                run -= take
+        for _ in range(run):
+            tokens.append(((previous_lengths[x] - new_lengths[x]) % 17, 0, 0, None))
+            x += 1
+    return tokens
+
+
+def _write_lengths(writer, new_lengths, previous_lengths, first, last):
+    """Write new_lengths[first:last] the way _read_lengths reads them."""
+    tokens = _length_tokens(new_lengths, previous_lengths, first, last)
+    freqs = [0] * LZX_PRETREE_SYMBOLS
+    for symbol, _value, _bits, delta in tokens:
+        freqs[symbol] += 1
+        if delta is not None:
+            freqs[delta] += 1
+
+    pretree_lengths = _huffman_lengths(freqs, LZX_MAX_PRETREE_LENGTH)
+    pretree_codes = _canonical_codes(pretree_lengths)
+    for length in pretree_lengths:
+        writer.write(length, 4)
+    for symbol, value, bits, delta in tokens:
+        writer.write(pretree_codes[symbol], pretree_lengths[symbol])
+        if bits:
+            writer.write(value, bits)
+        if delta is not None:
+            writer.write(pretree_codes[delta], pretree_lengths[delta])
+
+
+# ---------------------------------------------------------------------------
+# Match finding, by way of zlib
+# ---------------------------------------------------------------------------
+
+_DEFLATE_LENGTH_BASE = [
+    3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31, 35, 43, 51, 59,
+    67, 83, 99, 115, 131, 163, 195, 227, 258,
+]
+_DEFLATE_LENGTH_EXTRA = [
+    0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4,
+    5, 5, 5, 5, 0,
+]
+_DEFLATE_DIST_BASE = [
+    1, 2, 3, 4, 5, 7, 9, 13, 17, 25, 33, 49, 65, 97, 129, 193, 257, 385, 513,
+    769, 1025, 1537, 2049, 3073, 4097, 6145, 8193, 12289, 16385, 24577,
+]
+_DEFLATE_DIST_EXTRA = [
+    0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10,
+    11, 11, 12, 12, 13, 13,
+]
+_DEFLATE_CODE_LENGTH_ORDER = [
+    16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15,
+]
+_FIXED_LITERAL_LENGTHS = [8] * 144 + [9] * 112 + [7] * 24 + [8] * 8
+_FIXED_DISTANCE_LENGTHS = [5] * 32
+
+
+class _DeflateBits:
+    """Least-significant-bit-first reader, the order deflate is packed in."""
+
+    __slots__ = ("data", "size", "pos", "buf", "bl")
+
+    def __init__(self, data):
+        self.data = data
+        self.size = len(data)
+        self.pos = 0
+        self.buf = 0
+        self.bl = 0
+
+    def fill(self, num_bits):
+        while self.bl < num_bits:
+            if self.pos < self.size:
+                byte = self.data[self.pos]
+                self.pos += 1
+            else:
+                byte = 0
+            self.buf |= byte << self.bl
+            self.bl += 8
+
+    def get(self, num_bits):
+        if not num_bits:
+            return 0
+        self.fill(num_bits)
+        value = self.buf & ((1 << num_bits) - 1)
+        self.buf >>= num_bits
+        self.bl -= num_bits
+        return value
+
+    def align(self):
+        drop = self.bl & 7
+        self.buf >>= drop
+        self.bl -= drop
+
+
+def _deflate_table(lengths):
+    """A (peeked bits -> symbol, code length) lookup table for `lengths`."""
+    max_length = max(lengths)
+    if not max_length:
+        return None, 0
+    counts = [0] * (max_length + 1)
+    for length in lengths:
+        if length:
+            counts[length] += 1
+    next_code = [0] * (max_length + 1)
+    code = 0
+    for length in range(1, max_length + 1):
+        code = (code + counts[length - 1]) << 1
+        next_code[length] = code
+
+    table = [0] * (1 << max_length)
+    for symbol, length in enumerate(lengths):
+        if not length:
+            continue
+        code = next_code[length]
+        next_code[length] += 1
+        reversed_code = 0
+        for i in range(length):
+            reversed_code = (reversed_code << 1) | ((code >> i) & 1)
+        entry = (symbol << 4) | length
+        for index in range(reversed_code, 1 << max_length, 1 << length):
+            table[index] = entry
+    return table, max_length
+
+
+def _deflate_symbol(bits, table, max_length):
+    bits.fill(max_length)
+    entry = table[bits.buf & ((1 << max_length) - 1)]
+    length = entry & 15
+    if not length:
+        raise ValueError("invalid deflate code")
+    bits.buf >>= length
+    bits.bl -= length
+    return entry >> 4
+
+
+def _parse_deflate(data):
+    """The literal/match tokens a raw deflate stream encodes.
+
+    A literal is an int, a match is a (length, distance) pair. Only what zlib
+    itself emits has to be handled, but all three block types are, since a
+    stored block is what it falls back to for data it cannot compress.
+    """
+    bits = _DeflateBits(data)
+    tokens = []
+    append = tokens.append
+    while True:
+        final = bits.get(1)
+        block_type = bits.get(2)
+        if block_type == 0:
+            bits.align()
+            size = bits.get(16)
+            bits.get(16)
+            for _ in range(size):
+                append(bits.get(8))
+        elif block_type in (1, 2):
+            if block_type == 1:
+                literal_lengths = _FIXED_LITERAL_LENGTHS
+                distance_lengths = _FIXED_DISTANCE_LENGTHS
+            else:
+                num_literals = bits.get(5) + 257
+                num_distances = bits.get(5) + 1
+                num_code_lengths = bits.get(4) + 4
+                code_lengths = [0] * 19
+                for i in range(num_code_lengths):
+                    code_lengths[_DEFLATE_CODE_LENGTH_ORDER[i]] = bits.get(3)
+                code_table, code_max = _deflate_table(code_lengths)
+                all_lengths = []
+                while len(all_lengths) < num_literals + num_distances:
+                    symbol = _deflate_symbol(bits, code_table, code_max)
+                    if symbol < 16:
+                        all_lengths.append(symbol)
+                    elif symbol == 16:
+                        all_lengths += [all_lengths[-1]] * (bits.get(2) + 3)
+                    elif symbol == 17:
+                        all_lengths += [0] * (bits.get(3) + 3)
+                    else:
+                        all_lengths += [0] * (bits.get(7) + 11)
+                literal_lengths = all_lengths[:num_literals]
+                distance_lengths = all_lengths[num_literals:num_literals + num_distances]
+            literal_table, literal_max = _deflate_table(literal_lengths)
+            distance_table, distance_max = _deflate_table(distance_lengths)
+            while True:
+                symbol = _deflate_symbol(bits, literal_table, literal_max)
+                if symbol < 256:
+                    append(symbol)
+                elif symbol == 256:
+                    break
+                else:
+                    index = symbol - 257
+                    length = _DEFLATE_LENGTH_BASE[index] + bits.get(_DEFLATE_LENGTH_EXTRA[index])
+                    index = _deflate_symbol(bits, distance_table, distance_max)
+                    distance = _DEFLATE_DIST_BASE[index] + bits.get(_DEFLATE_DIST_EXTRA[index])
+                    append((length, distance))
+        else:
+            raise ValueError(f"invalid deflate block type {block_type}")
+        if final:
+            return tokens
+
+
+def _lz77_tokens(payload, level=9):
+    """`payload` as literals and back-references, all within itself."""
+    compressor = zlib.compressobj(level, zlib.DEFLATED, -15, 9)
+    return _parse_deflate(compressor.compress(payload) + compressor.flush())
+
+
+# ---------------------------------------------------------------------------
+# LZX blocks and frames
+# ---------------------------------------------------------------------------
+
+class FrameTooLarge(Exception):
+    """Raised when a frame will not fit its own header's size field."""
+
+
+def _operations(payload, tokens):
+    """`tokens` as the symbols one verbatim block encodes them with.
+
+    Each operation is (main symbol, secondary length symbol or -1, extra bits
+    value, extra bit count, bytes emitted). Two things are settled here rather
+    than at write time: the three repeated offsets, which have to be tracked
+    exactly as the decoder updates them, and frame boundaries, which no match
+    may cross - the decoder stops a match dead when the frame's output is full
+    and would lose the rest of it.
+    """
+    operations = []
+    append = operations.append
+    r0 = r1 = r2 = 1
+    position = 0
+    for token in tokens:
+        if type(token) is int:
+            append((token, -1, 0, 0, 1))
+            position += 1
+            continue
+
+        length, distance = token
+        while length:
+            take = min(length, LZX_MAX_MATCH, FRAME_SIZE - (position % FRAME_SIZE))
+            if length - take == 1 and take > LZX_MIN_MATCH:
+                # A one byte tail cannot be a match of its own, so leave it
+                # two bytes to be one.
+                take -= 1
+            if take < LZX_MIN_MATCH:
+                append((payload[position], -1, 0, 0, 1))
+                position += 1
+                length -= 1
+                continue
+
+            if distance == r0:
+                slot, extra_value, extra_bits = 0, 0, 0
+            elif distance == r1:
+                slot, extra_value, extra_bits = 1, 0, 0
+                r1 = r0
+                r0 = distance
+            elif distance == r2:
+                slot, extra_value, extra_bits = 2, 0, 0
+                r2 = r0
+                r0 = distance
+            else:
+                slot = bisect_right(_SLOT_BASE, distance) - 1
+                extra_bits = EXTRA_BITS[slot]
+                extra_value = distance - _SLOT_BASE[slot]
+                r2 = r1
+                r1 = r0
+                r0 = distance
+
+            footer = take - LZX_MIN_MATCH
+            if footer >= 7:
+                secondary = footer - 7
+                footer = 7
+            else:
+                secondary = -1
+            append((LZX_NUM_CHARS + slot * 8 + footer, secondary, extra_value, extra_bits, take))
+            position += take
+            length -= take
+    return operations
+
+
+def _split_blocks(operations, max_block_size):
+    """`operations` cut into blocks of at most `max_block_size` bytes each.
+
+    A block header states its length in 24 bits, so a stream longer than
+    that cannot be one block however well it compresses. The cut lands
+    between two operations, never inside a match, because a block's length
+    has to be exactly the bytes it emits - so a block holding a single
+    operation can still overrun a cap smaller than one match, which the real
+    one (16MB against 257 bytes) is in no danger of being.
+    """
+    blocks = []
+    current = []
+    emitted = 0
+    for operation in operations:
+        size = operation[4]
+        if emitted + size > max_block_size and current:
+            blocks.append((current, emitted))
+            current = []
+            emitted = 0
+        current.append(operation)
+        emitted += size
+    if current:
+        blocks.append((current, emitted))
+    return blocks
+
+
+def _write_block_header(writer, operations, emitted, previous_main, previous_secondary):
+    """One verbatim block's header and its two trees.
+
+    Every code length is delta coded against the length the same slot had in
+    the previous block, which is why the caller passes those in; at the start
+    of a stream the decoder zeroes them (see xcompress._lzx_inflate). Returns
+    each tree as (lengths, codes), the lengths being what the block after
+    this one is coded against.
+    """
+    main_freqs = [0] * LZX_MAIN_SYMBOLS
+    secondary_freqs = [0] * LZX_NUM_SECONDARY_LENGTHS
+    for symbol, secondary, _value, _bits, _size in operations:
+        main_freqs[symbol] += 1
+        if secondary >= 0:
+            secondary_freqs[secondary] += 1
+
+    main_lengths = _huffman_lengths(main_freqs, LZX_MAX_CODE_LENGTH)
+    secondary_lengths = _huffman_lengths(secondary_freqs, LZX_MAX_CODE_LENGTH)
+
+    writer.write(LZX_BLOCKTYPE_VERBATIM, 3)
+    writer.write(emitted, 24)
+    _write_lengths(writer, main_lengths, previous_main, 0, LZX_NUM_CHARS)
+    _write_lengths(writer, main_lengths, previous_main, LZX_NUM_CHARS, LZX_MAIN_SYMBOLS)
+    _write_lengths(writer, secondary_lengths, previous_secondary,
+                   0, LZX_NUM_SECONDARY_LENGTHS)
+    return ((main_lengths, _canonical_codes(main_lengths)),
+            (secondary_lengths, _canonical_codes(secondary_lengths)))
+
+
+def compress_frames(payload, max_block_size=MAX_BLOCK_SIZE):
+    """`payload` as a list of (frame bytes, uncompressed size).
+
+    Every frame but the last holds FRAME_SIZE bytes. Blocks are laid over
+    the frames rather than inside them: one block covers the whole payload
+    unless it is too long for a block header's 24-bit length, and a block
+    header can land anywhere in a frame. Only the bits are cut at each frame
+    boundary, since each frame is read by a bit reader of its own and so has
+    to start on a whole word.
+
+    `max_block_size` is a parameter so a test can force the multi-block path
+    without a 16MB payload.
+    """
+    operations = _operations(payload, _lz77_tokens(payload))
+    blocks = _split_blocks(operations, max_block_size)
+
+    writer = _BitWriter()
+    # No E8 (x86 call) translation. The decoder reads this bit once per
+    # stream, before the first block.
+    writer.write(0, 1)
+
+    frames = []
+    emitted = 0
+    main_lengths = [0] * LZX_MAIN_SYMBOLS
+    secondary_lengths = [0] * LZX_NUM_SECONDARY_LENGTHS
+    for block_operations, block_size in blocks:
+        (main_lengths, main_codes), (secondary_lengths, secondary_codes) = (
+            _write_block_header(writer, block_operations, block_size,
+                                main_lengths, secondary_lengths))
+        for symbol, secondary, value, bits, size in block_operations:
+            writer.write(main_codes[symbol], main_lengths[symbol])
+            if secondary >= 0:
+                writer.write(secondary_codes[secondary], secondary_lengths[secondary])
+            if bits:
+                writer.write(value, bits)
+            emitted += size
+            if emitted == FRAME_SIZE:
+                frames.append((writer.finish(), emitted))
+                emitted = 0
+                writer = _BitWriter()
+    if emitted:
+        frames.append((writer.finish(), emitted))
+    if sum(size for _data, size in frames) != len(payload):
+        raise RuntimeError("LZX encoder lost track of a stream's output size")
+    return frames
+
+
+def _frame(data, uncompressed_size, last):
+    """One frame, with the header xcompress._lzx_inflate expects.
+
+    Both of its sizes are big-endian u2. The two byte header says only how
+    many compressed bytes follow and leaves the uncompressed size implied, so
+    it can only carry a frame of the standard size; the five byte one the
+    0xFF marker introduces spells both out.
+
+    A stream's last frame always takes the long header, even when its
+    uncompressed size is the standard one and the short header would do. That
+    is what the game's own data does without exception, in both containers:
+    over a 700 archive .lfs sample every one of 65594 compressed chunks ends
+    on a long header, and over 400 Devil May Cry 4 archives so does every one
+    of 3960 entry streams, with every frame before it using the short one.
+    """
+    size = len(data)
+    if size > 0xFFFF:
+        # Both header forms hold the compressed size in a u2.
+        raise FrameTooLarge()
+    if not last and uncompressed_size == FRAME_SIZE and (size >> 8) != SHORT_FRAME_HEADER_MARKER:
+        return struct.pack(">H", size) + data
+    return struct.pack(">BHH", SHORT_FRAME_HEADER_MARKER, uncompressed_size, size) + data
+
+
+def _stored_frames(payload):
+    """`payload` as frames of one uncompressed block each.
+
+    The fallback for data a verbatim block would somehow write into a frame
+    too large for its own header. Nothing measurable reaches it - a frame
+    holds 32768 bytes and Huffman coding them cannot come near the 65535 a
+    frame header can count - but an .arc entry has no "stored" flag to fall
+    back on the way an .lfs chunk does, so the encoder needs some way to
+    write any input at all. Block type 3 is that way, and the game's own
+    archives do use it.
+    """
+    out = bytearray()
+    for start in range(0, len(payload), FRAME_SIZE):
+        chunk = payload[start:start + FRAME_SIZE]
+        writer = _BitWriter()
+        if start == 0:
+            writer.write(0, 1)  # no x86 call transform, once per stream
+        writer.write(LZX_BLOCKTYPE_UNCOMPRESSED, 3)
+        writer.write(len(chunk), 24)
+        # The decoder aligns to a whole word before reading the three
+        # repeated offsets, which are u4 written low half first.
+        body = bytearray(writer.finish())
+        for _ in range(3):
+            body += struct.pack("<HH", 1, 0)
+        body += chunk
+        out += _frame(bytes(body), len(chunk), last=start + FRAME_SIZE >= len(payload))
+    return bytes(out)
+
+
+def frame_stream(frames):
+    """`frames` (as compress_frames returns them) with their headers on."""
+    out = bytearray()
+    for i, (data, size) in enumerate(frames):
+        out += _frame(data, size, last=i + 1 == len(frames))
+    return bytes(out)
+
+
+def xmem_compress(payload):
+    """`payload` as one bare XMemCompress stream - what an .arc entry holds.
+
+    The size is not in the stream; whatever points at it stores that (an
+    .arc file entry's `size`), and xcompress.xmem_decompress takes it back.
+    """
+    payload = bytes(payload)
+    if not payload:
+        return b""
+    try:
+        return frame_stream(compress_frames(payload))
+    except FrameTooLarge:
+        return _stored_frames(payload)

--- a/tests/cie/test_lfs_compress.py
+++ b/tests/cie/test_lfs_compress.py
@@ -1,6 +1,8 @@
 """
-The LZX encoder (albam/engines/cie/lfs_compress.py) against the decoder that
-is its specification.
+The .lfs side of the LZX encoder (albam/engines/cie/lfs_compress.py) against
+the decoder that is its specification. The stream encoder underneath it is
+covered on its own in tests/test_xcompress_encode.py; what is here is the
+chunking around it.
 
 Round-tripping through albam's own decoder is most of the test: the encoder
 is correct when what it writes decodes back to what it was given. Half of

--- a/tests/cie/test_lfs_compress.py
+++ b/tests/cie/test_lfs_compress.py
@@ -43,23 +43,6 @@ def _random_bytes(size):
     return bytes(generator.getrandbits(8) for _ in range(size))
 
 
-@pytest.mark.parametrize("used", [0, 1, 5, 300])
-def test_a_one_symbol_tree_is_still_complete(used):
-    """No code the encoder writes leaves half a decode table undefined.
-
-    A tree of a single symbol is the one case where a Huffman build gives an
-    incomplete code, and the game's own data has none: a second, unused
-    symbol goes in beside it (see _huffman_lengths).
-    """
-    from albam.engines.cie.lfs_compress import _huffman_lengths
-
-    freqs = [0] * 512
-    freqs[used] = 7
-    lengths = _huffman_lengths(freqs, 16)
-    assert sum(2.0 ** -length for length in lengths if length) == 1.0
-    assert lengths[used] == 1
-
-
 def _each_chunk_decodes_alone(rebuilt):
     """Every compressed chunk of `rebuilt`, decoded with an empty window.
 

--- a/tests/mtfw/datasets/arc_compression_hashes.json
+++ b/tests/mtfw/datasets/arc_compression_hashes.json
@@ -1,0 +1,30 @@
+[
+    {
+        "app_id": "dmc4",
+        "entry_path_hash": "829d4caf886bc448"
+    },
+    {
+        "app_id": "dmc4",
+        "entry_path_hash": "72a9fee3d1318c48"
+    },
+    {
+        "app_id": "dmc4",
+        "entry_path_hash": "ff826d2295fa0e65"
+    },
+    {
+        "app_id": "dmc4",
+        "entry_path_hash": "8374386497d88583"
+    },
+    {
+        "app_id": "dmc4",
+        "entry_path_hash": "f7cdfe17c68c67cd"
+    },
+    {
+        "app_id": "dmc4",
+        "entry_path_hash": "abf894307807b870"
+    },
+    {
+        "app_id": "dmc4",
+        "entry_path_hash": "63ab7b6c3d57319b"
+    }
+]

--- a/tests/mtfw/test_arc_compression.py
+++ b/tests/mtfw/test_arc_compression.py
@@ -29,9 +29,11 @@ from albam.engines.mtfw.arc_fs import (
     file_type_extensions,
 )
 from albam.engines.mtfw.structs.arc import Arc
+from albam.lib import xcompress_encode
 from albam.lib.xcompress import _BitReader, xmem_decompress
 from albam.lib.xcompress_encode import (
     FRAME_SIZE,
+    FrameTooLarge,
     _lz77_tokens,
     _operations,
     _split_blocks,
@@ -245,6 +247,36 @@ def test_packing_a_version_7_archive_still_writes_zlib(tmp_path):
 
     entry = rebuilt.file_entries[0]
     assert zlib.decompress(entry.raw_data) == payload
+
+
+def test_an_entry_the_encoder_cannot_write_is_refused_by_name(tmp_path, monkeypatch):
+    """A payload the encoder cannot frame stops the pack and says which
+    entry it was, rather than half-writing an archive or leaving the user
+    with a bare internal traceback.
+
+    No real payload gets a frame past what its header can count, so the
+    encoder is made to produce one; everything from there on is the real
+    write path.
+    """
+    arc_path = tmp_path / "test.arc"
+    original = build_arc(ARC_VERSION_DMC4, [
+        ("chr\\pl000\\pl000", DMC4_TEX, stored_frame(b"old\n" * 100), 2)])
+    arc_path.write_bytes(original)
+
+    def oversized_frames(payload, **kwargs):
+        return [(b"\x00" * 0x10000, len(payload))]
+
+    monkeypatch.setattr(xcompress_encode, "compress_frames", oversized_frames)
+
+    payload = b"albam wrote this one\n" * 20
+    with pytest.raises(FrameTooLarge) as excinfo:
+        update_arc(str(arc_path), [FakeVFile("chr\\pl000\\pl000.tex", payload)])
+
+    message = str(excinfo.value)
+    assert "chr\\pl000\\pl000.tex" in message
+    assert str(len(payload)) in message
+    assert "65535" in message
+    assert arc_path.read_bytes() == original
 
 
 def _bits_msb_first(data):

--- a/tests/mtfw/test_arc_compression.py
+++ b/tests/mtfw/test_arc_compression.py
@@ -257,6 +257,104 @@ def test_packing_gives_a_new_entry_its_own_version_s_file_type_id(tmp_path):
     assert FILE_ID_TO_EXTENSION.get(DMC4_LMT) is None
 
 
+def test_a_new_entry_s_payload_reads_back_through_both_decoders(tmp_path):
+    """Adding a file a DMC4 archive does not already hold: the payload has to
+    survive, not just get the right label.
+
+    The label is what test_packing_gives_a_new_entry_its_own_version_s_file_type_id
+    covers. This is the other half - that what lands in the archive is a
+    stream the archive's own codec reads, all the way back out through the
+    ordinary reading path.
+    """
+    from albam.engines.mtfw.arc_fs import ArcFS
+
+    arc_path = tmp_path / "test.arc"
+    arc_path.write_bytes(build_arc(ARC_VERSION_DMC4, [
+        ("chr\\pl000\\pl000", DMC4_TEX, b"the entry already there\n" * 200, 2)]))
+
+    payload = b"a texture albam added\n" * 900
+    rebuilt_bytes = update_arc(str(arc_path), [
+        FakeVFile("chr\\albam\\newly_added.tex", payload)])
+    rebuilt = parse_arc(rebuilt_bytes)
+
+    assert len(rebuilt.file_entries) == 2
+    added = next(e for e in rebuilt.file_entries
+                 if e.file_path == "chr\\albam\\newly_added")
+    assert added.file_type == DMC4_TEX
+    assert added.size == len(payload)
+    assert decompress_entry(ARC_VERSION_DMC4, added.raw_data, added.size) == payload
+
+    out = tmp_path / "rebuilt.arc"
+    out.write_bytes(rebuilt_bytes)
+    assert ArcFS(str(out)).readbytes("/chr/albam/newly_added.tex") == payload
+
+
+@pytest.mark.skipif(sevenzip() is None,
+                    reason="p7zip is not installed (see tests/xcompress_cab.py)")
+def test_a_new_entry_s_payload_reads_back_through_an_independent_decoder(tmp_path):
+    """The same entry, read by a decoder albam did not write.
+
+    albam agreeing with itself says the encoder and the decoder match; it
+    does not say the stream is LZX. This is what says that much, short of
+    the game itself.
+    """
+    arc_path = tmp_path / "test.arc"
+    arc_path.write_bytes(build_arc(ARC_VERSION_DMC4, [
+        ("chr\\pl000\\pl000", DMC4_TEX, b"the entry already there\n" * 200, 2)]))
+
+    payload = b"a texture albam added\n" * 900
+    rebuilt = parse_arc(update_arc(str(arc_path), [
+        FakeVFile("chr\\albam\\newly_added.tex", payload)]))
+
+    added = next(e for e in rebuilt.file_entries
+                 if e.file_path == "chr\\albam\\newly_added")
+    assert independent_decompress(added.raw_data, added.size) == payload
+
+
+def test_an_entry_spanning_many_frames_survives_the_write_path(tmp_path):
+    """A payload of several frames packed through the archive writer, not
+    through the encoder on its own.
+
+    An .lfs chunk is two frames holding one block, so nothing on that side
+    ever asked the encoder for a stream that runs frame after frame. The
+    dataset tests put real multi-megabyte entries through `xmem_compress`
+    directly; this puts one through `update_arc`, which is what a user
+    actually reaches, and checks the stream it wrote has the frame shape the
+    game's own entries have.
+    """
+    arc_path = tmp_path / "test.arc"
+    arc_path.write_bytes(build_arc(ARC_VERSION_DMC4, [
+        ("chr\\pl000\\pl000", DMC4_TEX, b"small\n" * 10, 2)]))
+
+    payload = (b"a line that repeats itself, mostly\n" * 30000)[:5 * FRAME_SIZE + 4321]
+    rebuilt = parse_arc(update_arc(str(arc_path), [
+        FakeVFile("chr\\pl000\\pl000.tex", payload)]))
+
+    written = rebuilt.file_entries[0]
+    assert written.size == len(payload)
+    frames, trailing = frames_of(written.raw_data)
+    assert len(frames) == 6
+    assert [f[0] for f in frames] == [2] * 5 + [5]
+    assert sum(f[1] for f in frames) == len(payload)
+    assert trailing == b""
+    assert decompress_entry(ARC_VERSION_DMC4, written.raw_data, written.size) == payload
+
+
+@pytest.mark.skipif(sevenzip() is None,
+                    reason="p7zip is not installed (see tests/xcompress_cab.py)")
+def test_a_many_frame_entry_reads_back_through_an_independent_decoder(tmp_path):
+    arc_path = tmp_path / "test.arc"
+    arc_path.write_bytes(build_arc(ARC_VERSION_DMC4, [
+        ("chr\\pl000\\pl000", DMC4_TEX, b"small\n" * 10, 2)]))
+
+    payload = (b"a line that repeats itself, mostly\n" * 30000)[:5 * FRAME_SIZE + 4321]
+    rebuilt = parse_arc(update_arc(str(arc_path), [
+        FakeVFile("chr\\pl000\\pl000.tex", payload)]))
+
+    written = rebuilt.file_entries[0]
+    assert independent_decompress(written.raw_data, written.size) == payload
+
+
 DMC4_CHR_TBL = 0x19DDF06A  # rCharTbl, one of the two types called "bin"
 DMC4_PL_PARAM_TBL = 0x7A5DCF86  # rPlParamTbl, the other
 

--- a/tests/mtfw/test_arc_compression.py
+++ b/tests/mtfw/test_arc_compression.py
@@ -1,24 +1,47 @@
 """The two things that differ between an .arc's versions: how an entry's
-payload is compressed, and which table names its file type.
+payload is compressed, and which table names its file type - and, since
+version 17 can now be written as well as read, that packing one produces
+entries in its own codec.
 
-Nothing here needs game data. The stream these tests decode is built by
+Most of this needs no game data: the streams those tests decode are built by
 hand out of one uncompressed LZX block, which exercises the frame header,
-the block header and the bit reader's alignment, but not the Huffman path -
-that is what the dataset-driven tests over real archives cover.
+the block header and the bit reader's alignment, but not the Huffman path.
+The dataset-driven half at the bottom is what puts real Devil May Cry 4
+entries - megabytes of them, spanning many frames - through the encoder, and
+what checks albam's own decoder against one that is not albam's.
 """
+import json
+import os
 import struct
 import zlib
 
 import pytest
 
-from albam.engines.mtfw import FILE_ID_TO_EXTENSION, FILE_ID_TO_EXTENSION_DMC4
+from albam.engines.mtfw import (
+    EXTENSION_TO_FILE_ID,
+    FILE_ID_TO_EXTENSION,
+    FILE_ID_TO_EXTENSION_DMC4,
+)
 from albam.engines.mtfw.archive import update_arc
 from albam.engines.mtfw.arc_fs import (
     ARC_VERSION_DMC4,
     decompress_entry,
     file_type_extensions,
 )
+from albam.engines.mtfw.structs.arc import Arc
 from albam.lib.xcompress import _BitReader, xmem_decompress
+from albam.lib.xcompress_encode import (
+    FRAME_SIZE,
+    _lz77_tokens,
+    _operations,
+    _split_blocks,
+    compress_frames,
+    frame_stream,
+    xmem_compress,
+)
+from tests.mtfw.scripts.catalog_paths import resolve_hashes
+from tests.xcompress_cab import independent_decompress, sevenzip
+from tests.xcompress_frames import frames_of
 
 ARC_VERSION_ZLIB = 7
 
@@ -95,16 +118,133 @@ def test_the_two_tables_number_the_same_types_differently():
         assert FILE_ID_TO_EXTENSION.get(dmc4[0]) is None, extension
 
 
-def test_writing_refuses_an_archive_it_can_only_read(tmp_path):
-    """albam has a decoder for these entries but no encoder, so packing into
-    one has to fail rather than write an archive the game cannot read."""
-    path = tmp_path / "test.arc"
-    # the smallest well-formed .arc: a header, no entries, and the padding
-    # arc.ksy expects before what would be the first payload
-    path.write_bytes(struct.pack("<4shh", b"ARC\x00", ARC_VERSION_DMC4, 0) + b"\x00" * 32760)
+class FakeVFile:
+    """The four things update_arc asks a vfile for."""
 
-    with pytest.raises(ValueError, match="cannot be written back"):
-        update_arc(str(path), [])
+    def __init__(self, relative_path, data, app_id="dmc4"):
+        self.relative_path = relative_path
+        self.extension = relative_path.rsplit(".", 1)[-1]
+        self.app_id = app_id
+        self._data = data
+
+    def get_bytes(self):
+        return self._data
+
+
+def build_arc(version, entries):
+    """An .arc holding `entries` as (path, file type id, payload, flags).
+
+    Written out by hand rather than through _serialize_arc, so that a test of
+    the writer is not reading back the writer's own idea of the layout: a
+    header, one 80 byte record per entry, padding out to where the first
+    payload starts, and then the payloads back to back.
+    """
+    table = bytearray()
+    body = bytearray()
+    padding = 32760 - (len(entries) * 80) % 32768
+    offset = 8 + len(entries) * 80 + padding
+    for path, file_type, payload, flags in entries:
+        table += path.encode("ascii").ljust(64, b"\x00")
+        table += struct.pack("<iIII", file_type, len(payload),
+                             len(payload) | (flags << 29), offset)
+        body += payload
+        offset += len(payload)
+    header = struct.pack("<4shh", b"ARC\x00", version, len(entries))
+    return header + bytes(table) + b"\x00" * padding + bytes(body)
+
+
+def parse_arc(data):
+    parsed = Arc.from_bytes(data)
+    parsed._read()
+    return parsed
+
+
+DMC4_TEX = 0x3CAD8076  # rTexture, as a version 17 archive numbers it
+DMC4_LMT = 0x139EE51D  # rMotionList
+
+
+def test_packing_a_version_17_archive_writes_xmemcompress_entries(tmp_path):
+    """The point of the encoder existing: a DMC4 archive packs like any
+    other, and what lands in it is a stream the archive's own codec reads.
+
+    Before there was an encoder this had to be refused outright, because the
+    alternative was writing zlib into an archive the game reads as LZX.
+    """
+    replaced = b"the payload that gets replaced\n" * 500
+    untouched = b"the payload nothing happens to\n" * 500
+    path = tmp_path / "test.arc"
+    path.write_bytes(build_arc(ARC_VERSION_DMC4, [
+        ("chr\\pl000\\pl000", DMC4_TEX, stored_frame(replaced), 1),
+        ("chr\\pl000\\pl001", DMC4_TEX, stored_frame(untouched), 2),
+    ]))
+
+    new_payload = b"albam wrote this one\n" * 2000
+    rebuilt = parse_arc(update_arc(str(path), [
+        FakeVFile("chr\\pl000\\pl000.tex", new_payload)]))
+
+    assert rebuilt.header.version == ARC_VERSION_DMC4
+    entries = {e.file_path: e for e in rebuilt.file_entries}
+    assert len(entries) == 2
+
+    written = entries["chr\\pl000\\pl000"]
+    assert written.size == len(new_payload)
+    assert written.zsize == len(written.raw_data)
+    assert decompress_entry(ARC_VERSION_DMC4, written.raw_data, written.size) == new_payload
+    with pytest.raises(zlib.error):
+        zlib.decompress(written.raw_data)
+
+    kept = entries["chr\\pl000\\pl001"]
+    assert kept.raw_data == stored_frame(untouched)
+
+
+def test_packing_leaves_an_entry_s_flags_alone(tmp_path):
+    """Every entry of every version 7 archive carries flags 2, but a DMC4
+    archive uses 0 and 1 as well - only ever on a tex, so the value says
+    something about the texture, and rewriting it would be inventing an
+    answer."""
+    payload = b"a texture, supposedly\n" * 200
+    path = tmp_path / "test.arc"
+    path.write_bytes(build_arc(ARC_VERSION_DMC4, [
+        (f"chr\\tex{flags}", DMC4_TEX, stored_frame(payload), flags)
+        for flags in (0, 1, 2)
+    ]))
+
+    rebuilt = parse_arc(update_arc(str(path), [
+        FakeVFile("chr\\tex0.tex", b"replaced\n" * 100)]))
+
+    assert [e.flags for e in rebuilt.file_entries] == [0, 1, 2]
+
+
+def test_packing_gives_a_new_entry_its_own_version_s_file_type_id(tmp_path):
+    """The two versions number the same resource classes from different
+    hashes, so an entry albam adds has to be labelled with the id the archive
+    it is going into uses - the shared table's id would name nothing there."""
+    path = tmp_path / "test.arc"
+    path.write_bytes(build_arc(ARC_VERSION_DMC4, [
+        ("chr\\pl000\\pl000", DMC4_TEX, stored_frame(b"x" * 100), 2)]))
+
+    rebuilt = parse_arc(update_arc(str(path), [
+        FakeVFile("chr\\pl000\\motion.lmt", b"a motion list\n" * 100)]))
+
+    added = {e.file_path: e for e in rebuilt.file_entries}["chr\\pl000\\motion"]
+    assert added.file_type == DMC4_LMT
+    assert FILE_ID_TO_EXTENSION.get(DMC4_LMT) is None
+
+
+def test_packing_a_version_7_archive_still_writes_zlib(tmp_path):
+    """The other side of the same switch: nothing changes for the archives
+    albam already wrote."""
+    path = tmp_path / "test.arc"
+    zlib_tex = EXTENSION_TO_FILE_ID["tex"]
+    path.write_bytes(build_arc(ARC_VERSION_ZLIB, [
+        ("chr\\pl000\\pl000", zlib_tex, zlib.compress(b"old\n" * 100), 2)]))
+
+    payload = b"albam wrote this one\n" * 200
+    rebuilt = parse_arc(update_arc(str(path), [
+        FakeVFile("chr\\pl000\\pl000.tex", payload, app_id="re5")]))
+
+    entry = rebuilt.file_entries[0]
+    assert zlib.decompress(entry.raw_data) == payload
 
 
 def _bits_msb_first(data):
@@ -132,3 +272,196 @@ def test_bit_reader_matches_the_bit_sequence(skip):
         assert reader.read(skip) == int(bits[:skip], 2)
     assert reader.read(24) == int(bits[skip:skip + 24], 2)
     assert reader.read(16) == int(bits[skip + 24:skip + 40], 2)
+
+
+# Committed, fixed dataset - explicit, hash-only, catalog-verified entries to
+# put through the encoder (see test_dataset_hashes_are_in_catalog below).
+# Chosen to span the sizes an .arc holds, from a stream that is one short
+# frame to one of several megabytes and eighty of them.
+ARC_COMPRESSION_DATASET_PATH = os.path.join(
+    os.path.dirname(__file__), "datasets", "arc_compression_hashes.json")
+with open(ARC_COMPRESSION_DATASET_PATH) as f:
+    ARC_COMPRESSION_DATASET = json.load(f)
+
+# Below this an entry is one frame and one block, and forcing a second block
+# out of it says nothing.
+SEVERAL_BLOCKS_CAP = 100000
+
+
+# The archive the repack test rewrites is whichever one holds this entry.
+REPACK_ENTRY_HASH = "829d4caf886bc448"
+
+
+def pytest_generate_tests(metafunc):
+    if ("local_app_id" in metafunc.fixturenames and
+            "local_entry_path_hash" in metafunc.fixturenames):
+        argnames = ("local_app_id", "local_entry_path_hash")
+        argvalues = [(d["app_id"], d["entry_path_hash"]) for d in ARC_COMPRESSION_DATASET]
+        ids = [f"{d['app_id']}-{d['entry_path_hash']}" for d in ARC_COMPRESSION_DATASET]
+        metafunc.parametrize(argnames, argvalues, ids=ids, scope="session")
+    elif "local_app_id" in metafunc.fixturenames:
+        # game_fs_root is session scoped, so what it is parametrized on has
+        # to be too.
+        metafunc.parametrize("local_app_id", ["dmc4"], scope="session")
+
+
+def test_dataset_hashes_are_in_catalog():
+    """No plaintext game asset path is ever committed - every hash referenced
+    by ARC_COMPRESSION_DATASET must be in that app_id's committed catalog, so
+    this file only ever exercises real, unmodified, hash-verified game files.
+    CI-safe: reads two committed JSON files, no --game-dir needed.
+    """
+    for entry in ARC_COMPRESSION_DATASET:
+        catalog_path = os.path.join(
+            os.path.dirname(__file__), "datasets", f"{entry['app_id']}_catalog.json")
+        with open(catalog_path) as f:
+            catalog_hashes = {e["path_hash"] for e in json.load(f)}
+        assert entry["entry_path_hash"] in catalog_hashes, (
+            f"{entry['entry_path_hash']!r} ({entry['app_id']}) is not in {catalog_path!r}"
+        )
+
+
+@pytest.fixture(scope="session")
+def entry_payload(game_fs_root, local_entry_path_hash):
+    """One real archived entry, decoded - what the encoder has to write back."""
+    path = resolve_hashes(game_fs_root, {local_entry_path_hash})[local_entry_path_hash]
+    return game_fs_root.readbytes(path)
+
+
+@pytest.fixture(scope="session")
+def shipped_stream(game_fs_root, local_entry_path_hash):
+    """The same entry as its archive stores it: the stream the game reads."""
+    from albam.engines.mtfw.arc_fs import ArcFS, _entry_path
+
+    path = resolve_hashes(game_fs_root, {local_entry_path_hash})[local_entry_path_hash]
+    arc_path = game_fs_root.origin_absolute_path(path)
+    if arc_path is None:
+        # A loose file on disk shadows the archived one of the same path, so
+        # there is no shipped stream behind it in this install.
+        pytest.skip(f"{local_entry_path_hash} resolves to a loose file here")
+    arc = ArcFS(arc_path)
+    extensions = file_type_extensions(arc.version)
+    parsed = Arc.from_file(arc_path)
+    parsed._read()
+    for file_entry in parsed.file_entries:
+        if _entry_path(file_entry, extensions) == path:
+            return file_entry.raw_data
+    raise AssertionError(f"{path!r} is not an entry of {arc_path!r}")
+
+
+@pytest.mark.skipif(sevenzip() is None,
+                    reason="p7zip is not installed (see tests/xcompress_cab.py)")
+def test_a_shipped_stream_decodes_the_same_through_an_independent_decoder(
+        shipped_stream, entry_payload):
+    """What makes the independent decoder worth anything: it reads the
+    game's own streams, and reads them the way the game's archives say they
+    decode.
+
+    Without this the transplant into a CAB folder would be an assumption,
+    and a test built on it would only be comparing albam against a second
+    guess. With it, the two decoders agreeing on what albam writes means
+    something.
+    """
+    assert independent_decompress(shipped_stream, len(entry_payload)) == entry_payload
+
+
+def test_a_real_entry_round_trips_through_the_encoder(entry_payload):
+    """A real entry, compressed by albam and decoded back byte for byte.
+
+    Real payloads are what put real entropy through the trees, and real
+    entries are what put a stream across many frames - which is the one thing
+    an .lfs chunk, two frames holding one block, never asks of the encoder.
+    """
+    stream = xmem_compress(entry_payload)
+    assert xmem_decompress(stream, len(entry_payload)) == entry_payload
+    if len(entry_payload) > 4 * FRAME_SIZE:
+        assert len(stream) < len(entry_payload)
+
+
+@pytest.mark.skipif(sevenzip() is None,
+                    reason="p7zip is not installed (see tests/xcompress_cab.py)")
+def test_a_real_entry_round_trips_through_an_independent_decoder(entry_payload):
+    """The same thing, read by a decoder albam did not write. Round-tripping
+    through albam's own proves the encoder and the decoder agree; this is the
+    closest a test gets to asking whether the stream is really LZX."""
+    stream = xmem_compress(entry_payload)
+    assert independent_decompress(stream, len(entry_payload)) == entry_payload
+
+
+def test_a_real_entry_frames_the_way_the_game_s_own_streams_do(entry_payload):
+    """Frame for frame the shape every shipped entry has: full frames under
+    the short header, a last frame under the long one, nothing behind it."""
+    stream = xmem_compress(entry_payload)
+    frames, trailing = frames_of(stream)
+    assert [f[0] for f in frames] == [2] * (len(frames) - 1) + [5]
+    assert [f[1] for f in frames[:-1]] == [FRAME_SIZE] * (len(frames) - 1)
+    assert sum(f[1] for f in frames) == len(entry_payload)
+    assert trailing == b""
+
+
+def test_a_real_entry_round_trips_when_forced_into_several_blocks(entry_payload):
+    """The case only a 16MB entry reaches on its own: a block header landing
+    in the middle of a frame, at whatever bit offset the symbols before it
+    ended on.
+
+    That is where the decoder's block-length field is read - 24 bits, out of
+    a buffer that can be nearly empty - and reading it wrong puts the block's
+    end in the wrong place and turns everything after it into noise. It went
+    unnoticed until entries were decoded whole (see xcompress._BitReader.read),
+    so it gets a test that reaches it with a real payload rather than a
+    16MB one.
+    """
+    blocks = _split_blocks(_operations(entry_payload, _lz77_tokens(entry_payload)),
+                           SEVERAL_BLOCKS_CAP)
+    if len(entry_payload) > SEVERAL_BLOCKS_CAP:
+        assert len(blocks) > 1
+
+    stream = frame_stream(compress_frames(entry_payload, max_block_size=SEVERAL_BLOCKS_CAP))
+    assert xmem_decompress(stream, len(entry_payload)) == entry_payload
+
+
+def test_packing_a_real_archive_rewrites_one_entry_and_nothing_else(
+        game_fs_root, local_app_id, tmp_path):
+    """A whole shipped archive through the writer, not a two entry stand-in.
+
+    What the synthetic tests cannot say is whether an archive of sixty real
+    entries comes back out intact: the entries albam did not touch have to
+    arrive byte for byte, in the same order, with their sizes, type ids and
+    flags as they were, and the one it did has to be readable through the
+    ordinary reading path.
+    """
+    from albam.engines.mtfw.arc_fs import ArcFS, _entry_path
+
+    path = resolve_hashes(game_fs_root, {REPACK_ENTRY_HASH})[REPACK_ENTRY_HASH]
+    arc_path = game_fs_root.origin_absolute_path(path)
+    if arc_path is None:
+        pytest.skip(f"{REPACK_ENTRY_HASH} resolves to a loose file here")
+
+    original = Arc.from_file(arc_path)
+    original._read()
+    extensions = file_type_extensions(original.header.version)
+    target = next(e for e in original.file_entries if _entry_path(e, extensions) == path)
+
+    payload = b"albam wrote this one\n" * 500
+    rebuilt_bytes = update_arc(arc_path, [FakeVFile(
+        target.file_path + "." + extensions[target.file_type], payload)])
+    rebuilt = parse_arc(rebuilt_bytes)
+
+    assert rebuilt.header.version == original.header.version == ARC_VERSION_DMC4
+    assert len(rebuilt.file_entries) == len(original.file_entries)
+    for before, after in zip(original.file_entries, rebuilt.file_entries):
+        assert after.file_path == before.file_path
+        assert after.file_type == before.file_type
+        assert after.flags == before.flags
+        if before is target:
+            continue
+        assert after.size == before.size
+        assert after.raw_data == before.raw_data
+
+    written = next(e for e in rebuilt.file_entries if e.file_path == target.file_path)
+    assert written.size == len(payload)
+    assert decompress_entry(ARC_VERSION_DMC4, written.raw_data, written.size) == payload
+
+    out = tmp_path / "rebuilt.arc"
+    out.write_bytes(rebuilt_bytes)
+    assert ArcFS(str(out)).readbytes(path) == payload

--- a/tests/mtfw/test_arc_compression.py
+++ b/tests/mtfw/test_arc_compression.py
@@ -33,13 +33,14 @@ import zlib
 import pytest
 
 from albam.engines.mtfw import (
-    EXTENSION_TO_FILE_ID,
+    EXTENSION_TO_FILE_IDS,
     FILE_ID_TO_EXTENSION,
     FILE_ID_TO_EXTENSION_DMC4,
 )
 from albam.engines.mtfw.archive import update_arc
 from albam.engines.mtfw.arc_fs import (
     ARC_VERSION_DMC4,
+    AmbiguousExtension,
     decompress_entry,
     file_type_extensions,
 )
@@ -149,23 +150,30 @@ class FakeVFile:
 
 
 def build_arc(version, entries):
-    """An .arc holding `entries` as (path, file type id, payload, flags).
+    """An .arc holding `entries` as (path, file type id, payload, flags),
+    each payload given uncompressed and encoded here in the archive's codec.
 
     Written out by hand rather than through _serialize_arc, so that a test of
     the writer is not reading back the writer's own idea of the layout: a
     header, one 80 byte record per entry, padding out to where the first
-    payload starts, and then the payloads back to back.
+    payload starts, and then the payloads back to back. Encoding here is what
+    keeps `size` the decompressed length and `zsize` the encoded one, so an
+    entry of the fixture reads back the way a real archive's does.
     """
     table = bytearray()
     body = bytearray()
     padding = 32760 - (len(entries) * 80) % 32768
     offset = 8 + len(entries) * 80 + padding
     for path, file_type, payload, flags in entries:
+        if version == ARC_VERSION_DMC4:
+            chunk = stored_frame(payload)
+        else:
+            chunk = zlib.compress(payload)
         table += path.encode("ascii").ljust(64, b"\x00")
-        table += struct.pack("<iIII", file_type, len(payload),
+        table += struct.pack("<iIII", file_type, len(chunk),
                              len(payload) | (flags << 29), offset)
-        body += payload
-        offset += len(payload)
+        body += chunk
+        offset += len(chunk)
     header = struct.pack("<4shh", b"ARC\x00", version, len(entries))
     return header + bytes(table) + b"\x00" * padding + bytes(body)
 
@@ -191,8 +199,8 @@ def test_packing_a_version_17_archive_writes_xmemcompress_entries(tmp_path):
     untouched = b"the payload nothing happens to\n" * 500
     path = tmp_path / "test.arc"
     path.write_bytes(build_arc(ARC_VERSION_DMC4, [
-        ("chr\\pl000\\pl000", DMC4_TEX, stored_frame(replaced), 1),
-        ("chr\\pl000\\pl001", DMC4_TEX, stored_frame(untouched), 2),
+        ("chr\\pl000\\pl000", DMC4_TEX, replaced, 1),
+        ("chr\\pl000\\pl001", DMC4_TEX, untouched, 2),
     ]))
 
     new_payload = b"albam wrote this one\n" * 2000
@@ -212,6 +220,7 @@ def test_packing_a_version_17_archive_writes_xmemcompress_entries(tmp_path):
 
     kept = entries["chr\\pl000\\pl001"]
     assert kept.raw_data == stored_frame(untouched)
+    assert decompress_entry(ARC_VERSION_DMC4, kept.raw_data, kept.size) == untouched
 
 
 def test_packing_leaves_an_entry_s_flags_alone(tmp_path):
@@ -222,7 +231,7 @@ def test_packing_leaves_an_entry_s_flags_alone(tmp_path):
     payload = b"a texture, supposedly\n" * 200
     path = tmp_path / "test.arc"
     path.write_bytes(build_arc(ARC_VERSION_DMC4, [
-        (f"chr\\tex{flags}", DMC4_TEX, stored_frame(payload), flags)
+        (f"chr\\tex{flags}", DMC4_TEX, payload, flags)
         for flags in (0, 1, 2)
     ]))
 
@@ -238,7 +247,7 @@ def test_packing_gives_a_new_entry_its_own_version_s_file_type_id(tmp_path):
     it is going into uses - the shared table's id would name nothing there."""
     path = tmp_path / "test.arc"
     path.write_bytes(build_arc(ARC_VERSION_DMC4, [
-        ("chr\\pl000\\pl000", DMC4_TEX, stored_frame(b"x" * 100), 2)]))
+        ("chr\\pl000\\pl000", DMC4_TEX, b"x" * 100, 2)]))
 
     rebuilt = parse_arc(update_arc(str(path), [
         FakeVFile("chr\\pl000\\motion.lmt", b"a motion list\n" * 100)]))
@@ -248,13 +257,54 @@ def test_packing_gives_a_new_entry_its_own_version_s_file_type_id(tmp_path):
     assert FILE_ID_TO_EXTENSION.get(DMC4_LMT) is None
 
 
+DMC4_CHR_TBL = 0x19DDF06A  # rCharTbl, one of the two types called "bin"
+DMC4_PL_PARAM_TBL = 0x7A5DCF86  # rPlParamTbl, the other
+
+
+def test_adding_an_entry_whose_extension_names_two_types_is_refused(tmp_path):
+    """A DMC4 ".bin" is either an rCharTbl or an rPlParamTbl, and an
+    extension is all albam is told about a file a user hands it. Labelling
+    the entry with whichever of the two the reverse table happened to keep
+    would hand the engine a resource class the file is not, silently, so the
+    pack stops and names both candidates instead."""
+    path = tmp_path / "test.arc"
+    path.write_bytes(build_arc(ARC_VERSION_DMC4, [
+        ("chr\\pl000\\pl000", DMC4_TEX, b"x" * 100, 2)]))
+
+    with pytest.raises(AmbiguousExtension) as excinfo:
+        update_arc(str(path), [
+            FakeVFile("chr\\pl000\\param.bin", b"a table\n" * 100)])
+
+    message = str(excinfo.value)
+    assert ".bin" in message
+    assert "0x19DDF06A" in message
+    assert "0x7A5DCF86" in message
+
+
+def test_replacing_an_entry_whose_extension_names_two_types_keeps_its_own(tmp_path):
+    """The other side of that refusal: an entry the archive already holds
+    has an answer rather than a guess - the type it was parsed with - so
+    replacing an rCharTbl "bin" packs, and stays an rCharTbl."""
+    path = tmp_path / "test.arc"
+    path.write_bytes(build_arc(ARC_VERSION_DMC4, [
+        ("chr\\pl000\\param", DMC4_CHR_TBL, b"a table\n" * 100, 2)]))
+
+    payload = b"a replacement table\n" * 100
+    rebuilt = parse_arc(update_arc(str(path), [
+        FakeVFile("chr\\pl000\\param.bin", payload)]))
+
+    entry = rebuilt.file_entries[0]
+    assert entry.file_type == DMC4_CHR_TBL
+    assert decompress_entry(ARC_VERSION_DMC4, entry.raw_data, entry.size) == payload
+
+
 def test_packing_a_version_7_archive_still_writes_zlib(tmp_path):
     """The other side of the same switch: nothing changes for the archives
     albam already wrote."""
     path = tmp_path / "test.arc"
-    zlib_tex = EXTENSION_TO_FILE_ID["tex"]
+    zlib_tex = EXTENSION_TO_FILE_IDS["tex"][0]
     path.write_bytes(build_arc(ARC_VERSION_ZLIB, [
-        ("chr\\pl000\\pl000", zlib_tex, zlib.compress(b"old\n" * 100), 2)]))
+        ("chr\\pl000\\pl000", zlib_tex, b"old\n" * 100, 2)]))
 
     payload = b"albam wrote this one\n" * 200
     rebuilt = parse_arc(update_arc(str(path), [
@@ -275,7 +325,7 @@ def test_an_entry_the_encoder_cannot_write_is_refused_by_name(tmp_path, monkeypa
     """
     arc_path = tmp_path / "test.arc"
     original = build_arc(ARC_VERSION_DMC4, [
-        ("chr\\pl000\\pl000", DMC4_TEX, stored_frame(b"old\n" * 100), 2)])
+        ("chr\\pl000\\pl000", DMC4_TEX, b"old\n" * 100, 2)])
     arc_path.write_bytes(original)
 
     def oversized_frames(payload, **kwargs):

--- a/tests/mtfw/test_arc_compression.py
+++ b/tests/mtfw/test_arc_compression.py
@@ -33,7 +33,7 @@ import zlib
 import pytest
 
 from albam.engines.mtfw import (
-    EXTENSION_TO_FILE_IDS,
+    EXTENSION_TO_FILE_ID,
     FILE_ID_TO_EXTENSION,
     FILE_ID_TO_EXTENSION_DMC4,
 )
@@ -298,11 +298,27 @@ def test_replacing_an_entry_whose_extension_names_two_types_keeps_its_own(tmp_pa
     assert decompress_entry(ARC_VERSION_DMC4, entry.raw_data, entry.size) == payload
 
 
+def test_adding_an_entry_to_a_version_7_archive_resolves_its_extension(tmp_path):
+    """The shared table doubles up on one extension too - two ids are "shp" -
+    but version 7 archives have been written with the last of the two since
+    long before version 17 could be written at all, so that keeps resolving
+    rather than becoming a refusal."""
+    path = tmp_path / "test.arc"
+    path.write_bytes(build_arc(ARC_VERSION_ZLIB, [
+        ("chr\\pl000\\pl000", EXTENSION_TO_FILE_ID["tex"], b"x" * 100, 2)]))
+
+    rebuilt = parse_arc(update_arc(str(path), [
+        FakeVFile("chr\\pl000\\shape.shp", b"a shape\n" * 100, app_id="re5")]))
+
+    added = {e.file_path: e for e in rebuilt.file_entries}["chr\\pl000\\shape"]
+    assert added.file_type == 0x5204D557
+
+
 def test_packing_a_version_7_archive_still_writes_zlib(tmp_path):
     """The other side of the same switch: nothing changes for the archives
     albam already wrote."""
     path = tmp_path / "test.arc"
-    zlib_tex = EXTENSION_TO_FILE_IDS["tex"][0]
+    zlib_tex = EXTENSION_TO_FILE_ID["tex"]
     path.write_bytes(build_arc(ARC_VERSION_ZLIB, [
         ("chr\\pl000\\pl000", zlib_tex, b"old\n" * 100, 2)]))
 

--- a/tests/mtfw/test_arc_compression.py
+++ b/tests/mtfw/test_arc_compression.py
@@ -9,6 +9,21 @@ the block header and the bit reader's alignment, but not the Huffman path.
 The dataset-driven half at the bottom is what puts real Devil May Cry 4
 entries - megabytes of them, spanning many frames - through the encoder, and
 what checks albam's own decoder against one that is not albam's.
+
+Two parts of the DMC4 story are deliberately not covered here, because
+neither can be executed rather than because nobody got to them:
+
+* Whether the game itself loads an archive albam repacked. Nothing automated
+  can answer that, which is why the encoder is checked against a second,
+  independent LZX decoder instead (see tests/xcompress_cab.py) - strong
+  evidence that the stream is real LZX, and not the same thing as the game
+  accepting it.
+* Editing a DMC4 model in Blender and writing it back. That story stops
+  before the packer: exporting any DMC4 .mod fails in mod_153 serialization
+  (`ConsistencyError: index_buffer`), on 5 of 5 models tried and identically
+  on the commit this branch started from, so it is a defect of the mesh
+  exporter and not of packing. What reaches the writer in these tests is a
+  payload taken back out of an archive.
 """
 import json
 import os

--- a/tests/mtfw/test_arc_compression.py
+++ b/tests/mtfw/test_arc_compression.py
@@ -224,10 +224,9 @@ def test_packing_a_version_17_archive_writes_xmemcompress_entries(tmp_path):
 
 
 def test_packing_leaves_an_entry_s_flags_alone(tmp_path):
-    """Every entry of every version 7 archive carries flags 2, but a DMC4
-    archive uses 0 and 1 as well - only ever on a tex, so the value says
-    something about the texture, and rewriting it would be inventing an
-    answer."""
+    """Nearly every version 7 entry carries flags 2, but a DMC4 archive uses
+    0 and 1 as well - only ever on a tex, so the value says something about
+    the texture, and rewriting it would be inventing an answer."""
     payload = b"a texture, supposedly\n" * 200
     path = tmp_path / "test.arc"
     path.write_bytes(build_arc(ARC_VERSION_DMC4, [
@@ -426,6 +425,23 @@ def test_packing_a_version_7_archive_still_writes_zlib(tmp_path):
 
     entry = rebuilt.file_entries[0]
     assert zlib.decompress(entry.raw_data) == payload
+
+
+def test_packing_a_version_7_archive_keeps_an_unusual_flags_value(tmp_path):
+    """Version 7 entries are not all flags 2 either: of the 788014 entries in
+    the archives on hand exactly one carries 4, and a repack has to hand that
+    entry back its own value rather than the 2 the writer used to assume."""
+    path = tmp_path / "test.arc"
+    zlib_tex = EXTENSION_TO_FILE_ID["tex"]
+    path.write_bytes(build_arc(ARC_VERSION_ZLIB, [
+        ("dlc\\model\\chara\\wp\\wp1070\\wp1070", zlib_tex, b"old\n" * 100, 4),
+        ("chr\\pl000\\pl000", zlib_tex, b"old\n" * 100, 2)]))
+
+    rebuilt = parse_arc(update_arc(str(path), [
+        FakeVFile("chr\\pl000\\pl000.tex", b"albam wrote this one\n" * 200,
+                  app_id="re5")]))
+
+    assert [e.flags for e in rebuilt.file_entries] == [4, 2]
 
 
 def test_an_entry_the_encoder_cannot_write_is_refused_by_name(tmp_path, monkeypatch):

--- a/tests/mtfw/test_arc_fs_s3.py
+++ b/tests/mtfw/test_arc_fs_s3.py
@@ -22,7 +22,7 @@ pytest.importorskip("smart_open")
 
 from moto import mock_aws  # noqa: E402
 
-from albam.engines.mtfw import EXTENSION_TO_FILE_ID  # noqa: E402
+from albam.engines.mtfw import EXTENSION_TO_FILE_IDS  # noqa: E402
 from albam.engines.mtfw.arc_fs import MTFW_FS  # noqa: E402
 from albam.engines.mtfw.structs.arc import Arc  # noqa: E402
 from kaitaistruct import BytesIO, KaitaiStream  # noqa: E402
@@ -110,12 +110,12 @@ def _build_arc_bytes(entries):
 
 FIXTURE_ARC_BYTES = {
     "uPl00ChrisNormal.arc": _build_arc_bytes(
-        [(SAMPLE_RAW_PATH, EXTENSION_TO_FILE_ID["mod"], SAMPLE_CONTENT)]
+        [(SAMPLE_RAW_PATH, EXTENSION_TO_FILE_IDS["mod"][0], SAMPLE_CONTENT)]
     ),
     # content doesn't matter here - only used as a second, distinct arc for
     # count-based assertions (test_from_s3_loads_arcs and friends).
     "s400.arc": _build_arc_bytes(
-        [("stage\\s400\\placeholder", EXTENSION_TO_FILE_ID["mod"], b"MOD\x00PLACEHOLDER")]
+        [("stage\\s400\\placeholder", EXTENSION_TO_FILE_IDS["mod"][0], b"MOD\x00PLACEHOLDER")]
     ),
 }
 FIXTURE_ARCS = tuple(FIXTURE_ARC_BYTES)

--- a/tests/mtfw/test_arc_fs_s3.py
+++ b/tests/mtfw/test_arc_fs_s3.py
@@ -22,7 +22,7 @@ pytest.importorskip("smart_open")
 
 from moto import mock_aws  # noqa: E402
 
-from albam.engines.mtfw import EXTENSION_TO_FILE_IDS  # noqa: E402
+from albam.engines.mtfw import EXTENSION_TO_FILE_ID  # noqa: E402
 from albam.engines.mtfw.arc_fs import MTFW_FS  # noqa: E402
 from albam.engines.mtfw.structs.arc import Arc  # noqa: E402
 from kaitaistruct import BytesIO, KaitaiStream  # noqa: E402
@@ -110,12 +110,12 @@ def _build_arc_bytes(entries):
 
 FIXTURE_ARC_BYTES = {
     "uPl00ChrisNormal.arc": _build_arc_bytes(
-        [(SAMPLE_RAW_PATH, EXTENSION_TO_FILE_IDS["mod"][0], SAMPLE_CONTENT)]
+        [(SAMPLE_RAW_PATH, EXTENSION_TO_FILE_ID["mod"], SAMPLE_CONTENT)]
     ),
     # content doesn't matter here - only used as a second, distinct arc for
     # count-based assertions (test_from_s3_loads_arcs and friends).
     "s400.arc": _build_arc_bytes(
-        [("stage\\s400\\placeholder", EXTENSION_TO_FILE_IDS["mod"][0], b"MOD\x00PLACEHOLDER")]
+        [("stage\\s400\\placeholder", EXTENSION_TO_FILE_ID["mod"], b"MOD\x00PLACEHOLDER")]
     ),
 }
 FIXTURE_ARCS = tuple(FIXTURE_ARC_BYTES)

--- a/tests/test_xcompress_encode.py
+++ b/tests/test_xcompress_encode.py
@@ -27,7 +27,6 @@ from albam.lib.xcompress_encode import (
     _lz77_tokens,
     _operations,
     _split_blocks,
-    _stored_frames,
     compress_frames,
     frame_stream,
     xmem_compress,
@@ -186,20 +185,6 @@ def test_a_block_ends_where_its_header_says_it_does():
     assert sum(emitted for _block, emitted in blocks) == len(payload)
     for operations, emitted in blocks:
         assert sum(operation[4] for operation in operations) == emitted
-
-
-@pytest.mark.parametrize("size", [1, 100, FRAME_SIZE, FRAME_SIZE + 1, 3 * FRAME_SIZE - 3])
-def test_stored_frames_round_trip(size):
-    """The fallback for a frame that would not fit its own header's size
-    field. Nothing measurable reaches it, so it is tested directly rather
-    than through an input that provokes it."""
-    payload = _random_bytes(size)
-    stream = _stored_frames(payload)
-    assert xmem_decompress(stream, size) == payload
-    frames, trailing = frames_of(stream)
-    assert [f[0] for f in frames] == [2] * (len(frames) - 1) + [5]
-    assert sum(f[1] for f in frames) == size
-    assert trailing == b""
 
 
 needs_p7zip = pytest.mark.skipif(sevenzip() is None,

--- a/tests/test_xcompress_encode.py
+++ b/tests/test_xcompress_encode.py
@@ -1,0 +1,229 @@
+"""The bare XMemCompress stream encoder (albam/lib/xcompress_encode.py)
+against the decoder that is its specification (albam/lib/xcompress.py).
+
+Everything here is CI-safe: no game data, only the encoder against the
+decoder. What real archives have to say is in tests/mtfw/test_arc_compression.py
+(MT Framework entries) and tests/cie/test_lfs_compress.py (.lfs chunks),
+which is also where the .lfs framing this shared the encoder out from is
+covered.
+
+Round-tripping through albam's own decoder is not on its own evidence that
+the game would accept a stream - that decoder is more forgiving than the
+game's, which is how the .lfs encoder came to ship three separate bugs
+against it - so the tests that matter here are the ones that pin the shape
+shipped streams have rather than only what reads back.
+"""
+import random
+
+import pytest
+
+from albam.lib.xcompress import xmem_decompress
+from tests.xcompress_cab import independent_decompress, sevenzip
+from tests.xcompress_frames import frames_of
+from albam.lib.xcompress_encode import (
+    FRAME_SIZE,
+    LZX_MIN_MATCH,
+    _huffman_lengths,
+    _lz77_tokens,
+    _operations,
+    _split_blocks,
+    _stored_frames,
+    compress_frames,
+    frame_stream,
+    xmem_compress,
+)
+
+# Payloads that between them cover what the encoder has to decide: nothing to
+# emit, too little to compress, a stream that is all matches, one that is
+# exactly one frame, and several frames both aligned to the frame size and
+# not.
+SYNTHETIC_PAYLOADS = {
+    "empty": b"",
+    "single_byte": b"A",
+    "short": b"albam" * 3,
+    "one_full_frame": bytes(FRAME_SIZE),
+    "repetitive": b"abcabcabc" * 30000,
+    "several_frames": (b"the same line, over and over\n" * 20000)[:5 * FRAME_SIZE + 1234],
+    "frame_boundary": bytes(range(256)) * (FRAME_SIZE // 256) * 2,
+}
+
+
+def _random_bytes(size):
+    generator = random.Random(20240501)
+    return bytes(generator.getrandbits(8) for _ in range(size))
+
+
+def _pseudo_payload(seed, size):
+    """Data with matches everywhere and no structure to it, so matches land
+    across frame boundaries at every alignment."""
+    generator = random.Random(seed)
+    alphabet = bytes(generator.randrange(256)
+                     for _ in range(generator.choice([2, 3, 5, 17])))
+    payload = bytearray()
+    while len(payload) < size:
+        if payload and generator.random() < 0.6:
+            start = generator.randrange(len(payload))
+            payload += payload[start:start + generator.choice([2, 3, 3, 4, 8, 40, 300])]
+        else:
+            payload += bytes(generator.choice(alphabet)
+                             for _ in range(generator.randrange(1, 6)))
+    return bytes(payload[:size])
+
+
+@pytest.mark.parametrize("used", [0, 1, 5, 300])
+def test_a_one_symbol_tree_is_still_complete(used):
+    """No code the encoder writes leaves half a decode table undefined.
+
+    A tree of a single symbol is the one case where a Huffman build gives an
+    incomplete code, and the game's own data has none: a second, unused
+    symbol goes in beside it (see _huffman_lengths).
+    """
+    freqs = [0] * 512
+    freqs[used] = 7
+    lengths = _huffman_lengths(freqs, 16)
+    assert sum(2.0 ** -length for length in lengths if length) == 1.0
+    assert lengths[used] == 1
+
+
+@pytest.mark.parametrize("name", sorted(SYNTHETIC_PAYLOADS))
+def test_synthetic_payload_round_trips(name):
+    payload = SYNTHETIC_PAYLOADS[name]
+    assert xmem_decompress(xmem_compress(payload), len(payload)) == payload
+
+
+@pytest.mark.parametrize("seed", range(8))
+def test_pseudo_random_payloads_round_trip(seed):
+    """A match may not run over the end of a frame: the decoder stops it dead
+    there and the rest of it is simply lost, so the encoder splits one that
+    would. Which alignments that has to handle is not something a handwritten
+    payload finds, hence a spread of generated ones.
+    """
+    payload = _pseudo_payload(seed, 70000 + seed * 7919)
+    assert xmem_decompress(xmem_compress(payload), len(payload)) == payload
+
+
+def test_incompressible_payload_round_trips():
+    """Random bytes have nothing to match, so every symbol is a literal and
+    the stream comes out slightly larger than the payload. An .arc entry has
+    no stored flag to fall back on, so that is the right answer rather than
+    a failure."""
+    payload = _random_bytes(3 * FRAME_SIZE + 7)
+    stream = xmem_compress(payload)
+    assert xmem_decompress(stream, len(payload)) == payload
+    assert len(stream) < len(payload) * 1.1
+
+
+def test_compressible_payload_shrinks():
+    payload = SYNTHETIC_PAYLOADS["several_frames"]
+    assert len(xmem_compress(payload)) < len(payload) // 10
+
+
+def test_an_empty_payload_is_an_empty_stream():
+    assert xmem_compress(b"") == b""
+
+
+@pytest.mark.parametrize("size", [1000, FRAME_SIZE, FRAME_SIZE + 4321, 3 * FRAME_SIZE])
+def test_frames_take_the_shape_the_game_s_own_streams_do(size):
+    """The frame shape every entry stream in the game's data has.
+
+    Measured over the entries of 400 Devil May Cry 4 archives, without a
+    single exception in 3960 streams: every frame but the last carries the
+    two byte header, the last carries the five byte one even when the short
+    one would fit it, and nothing at all follows it - unlike an .lfs chunk,
+    which closes with five zero bytes.
+    """
+    payload = (b"a line that repeats itself, mostly\n" * 4000)[:size]
+    frames, trailing = frames_of(xmem_compress(payload))
+    assert frames
+    assert [f[0] for f in frames] == [2] * (len(frames) - 1) + [5]
+    assert sum(f[1] for f in frames) == size
+    assert all(f[1] == FRAME_SIZE for f in frames[:-1])
+    assert trailing == b""
+
+
+@pytest.mark.parametrize("seed", range(4))
+def test_no_match_runs_past_the_end_of_its_frame(seed):
+    """The invariant behind the split in _operations, checked at the source
+    rather than through what happens to decode.
+
+    The decoder truncates a match at the frame's end and loses the rest, and
+    no match in the game's own streams needs it to do otherwise - over 3960
+    entry streams decoded whole, not one match crosses a frame boundary.
+    """
+    payload = _pseudo_payload(seed, 5 * FRAME_SIZE + 999)
+    position = 0
+    for _symbol, _secondary, _value, _bits, emitted in _operations(
+            payload, _lz77_tokens(payload)):
+        assert position % FRAME_SIZE + emitted <= FRAME_SIZE
+        assert emitted == 1 or emitted >= LZX_MIN_MATCH
+        position += emitted
+    assert position == len(payload)
+
+
+def test_a_stream_of_several_blocks_round_trips():
+    """A block header states its length in 24 bits, so a long enough stream
+    has to be split into several - and then a block header lands somewhere in
+    the middle of a frame, at whatever bit offset the symbols before it
+    happen to end on.
+
+    That is the case a 16MB payload would reach and nothing smaller does,
+    which is why compress_frames takes the cap as an argument: this walks the
+    same path in a second rather than a minute.
+    """
+    payload = _pseudo_payload(99, 4 * FRAME_SIZE + 4321)
+    operations = _operations(payload, _lz77_tokens(payload))
+    assert len(_split_blocks(operations, 5000)) > 20
+
+    stream = frame_stream(compress_frames(payload, max_block_size=5000))
+    assert xmem_decompress(stream, len(payload)) == payload
+
+
+def test_a_block_ends_where_its_header_says_it_does():
+    """Every block's declared length is exactly what its operations emit -
+    a block that overruns puts every block after it in the wrong place."""
+    payload = _pseudo_payload(7, 3 * FRAME_SIZE)
+    blocks = _split_blocks(_operations(payload, _lz77_tokens(payload)), 7000)
+    assert sum(emitted for _block, emitted in blocks) == len(payload)
+    for operations, emitted in blocks:
+        assert sum(operation[4] for operation in operations) == emitted
+
+
+@pytest.mark.parametrize("size", [1, 100, FRAME_SIZE, FRAME_SIZE + 1, 3 * FRAME_SIZE - 3])
+def test_stored_frames_round_trip(size):
+    """The fallback for a frame that would not fit its own header's size
+    field. Nothing measurable reaches it, so it is tested directly rather
+    than through an input that provokes it."""
+    payload = _random_bytes(size)
+    stream = _stored_frames(payload)
+    assert xmem_decompress(stream, size) == payload
+    frames, trailing = frames_of(stream)
+    assert [f[0] for f in frames] == [2] * (len(frames) - 1) + [5]
+    assert sum(f[1] for f in frames) == size
+    assert trailing == b""
+
+
+needs_p7zip = pytest.mark.skipif(sevenzip() is None,
+                                 reason="p7zip is not installed (see tests/xcompress_cab.py)")
+
+
+@needs_p7zip
+@pytest.mark.parametrize("seed", range(4))
+def test_an_independent_decoder_reads_the_same_bytes_back(seed):
+    """The encoder's output through a decoder that is not albam's.
+
+    albam's decoder and this encoder were written against each other, so
+    agreeing tells us less than it looks like: whatever the decoder is
+    lenient about, the encoder is free to get wrong. p7zip's LZX decoder was
+    written from the format, shares nothing with either, and is stricter -
+    see tests/xcompress_cab.py for what it is being handed and why that is
+    the same bitstream.
+    """
+    payload = _pseudo_payload(seed, 3 * FRAME_SIZE + 5000)
+    assert independent_decompress(xmem_compress(payload), len(payload)) == payload
+
+
+@needs_p7zip
+def test_an_independent_decoder_reads_a_multi_block_stream():
+    payload = _pseudo_payload(42, 4 * FRAME_SIZE + 4321)
+    stream = frame_stream(compress_frames(payload, max_block_size=5000))
+    assert independent_decompress(stream, len(payload)) == payload

--- a/tests/xcompress_cab.py
+++ b/tests/xcompress_cab.py
@@ -1,0 +1,84 @@
+"""Decode an XMemCompress stream with somebody else's LZX decoder.
+
+Round-tripping a stream through albam's own decoder says the encoder and the
+decoder agree; it says nothing about whether the game would take the stream,
+because that decoder is the more forgiving of the two - the .lfs encoder
+shipped three bugs it read back perfectly and the game rejected. Loading an
+archive in the game is the only real answer, and it is not something a test
+can do. This is the next thing down: a decoder written by someone else, from
+the format rather than from albam.
+
+An XMemCompress stream is LZX with a 0x20000 window, framed by inline
+headers. Microsoft's CAB carries the same bitstream with the same 32768-byte
+framing, only with each frame's two sizes moved out into a CFDATA record, and
+LZX with a 0x20000 window is what a CAB folder of compression type LZX:17
+holds. So the frames can be lifted out of one framing and dropped into the
+other without touching a bit of the LZX itself, and then p7zip - whose LZX
+decoder shares no code and no lineage with albam's - reads them.
+
+That the transplant is faithful is not assumed: test_a_shipped_stream_decodes
+in tests/mtfw/test_arc_compression.py runs shipped Devil May Cry 4 entries
+through it and requires the same bytes the game's own archives decode to.
+
+p7zip is not a dependency of anything here; callers skip when it is missing.
+"""
+import os
+import shutil
+import struct
+import subprocess
+import tempfile
+
+from tests.xcompress_frames import frames_of
+
+CAB_NAME = "entry.bin"
+# CFFOLDER.typeCompress: LZX in the low byte, the window's log2 above it.
+CAB_LZX = 0x0003
+XMEM_WINDOW_BITS = 17
+
+
+def sevenzip():
+    """The 7z binary, or None if p7zip is not installed."""
+    return shutil.which("7z") or shutil.which("7za")
+
+
+def build_cab(frames, size):
+    """`frames` as a one-file, one-folder CAB whose folder is LZX:17.
+
+    The three tables a CAB opens with are fixed-shape records (see the CAB
+    format's CFHEADER/CFFOLDER/CFFILE); the frames go in behind them as one
+    CFDATA each, whose checksum field is left at zero - the format's own way
+    of saying there is no checksum.
+    """
+    cfdata = bytearray()
+    for _header, uncompressed, data in frames:
+        cfdata += struct.pack("<IHH", 0, len(data), uncompressed) + data
+    cffile = struct.pack("<IIHHHH", size, 0, 0, 0x2A21, 0, 0x20) + CAB_NAME.encode() + b"\0"
+    header_size, folder_size = 36, 8
+    files_offset = header_size + folder_size
+    data_offset = files_offset + len(cffile)
+    cffolder = struct.pack("<IHH", data_offset, len(frames),
+                           CAB_LZX | (XMEM_WINDOW_BITS << 8))
+    cfheader = b"MSCF" + struct.pack(
+        "<IIIIIBBHHHHH", 0, data_offset + len(cfdata), 0, files_offset, 0,
+        3, 1, 1, 1, 0, 0, 0)
+    assert len(cfheader) == header_size
+    return bytes(cfheader + cffolder + cffile + cfdata)
+
+
+def independent_decompress(stream, size):
+    """`stream` decoded to `size` bytes by p7zip's LZX decoder."""
+    binary = sevenzip()
+    assert binary, "p7zip is not installed"
+    cab = build_cab(frames_of(stream)[0], size)
+    with tempfile.TemporaryDirectory() as directory:
+        cab_path = os.path.join(directory, "stream.cab")
+        with open(cab_path, "wb") as f:
+            f.write(cab)
+        result = subprocess.run([binary, "e", "-y", "-o" + directory, cab_path],
+                                capture_output=True)
+        decoded = os.path.join(directory, CAB_NAME)
+        if not os.path.exists(decoded):
+            raise RuntimeError(
+                f"7z could not read the stream: {result.stdout.decode(errors='replace')[-500:]}")
+        with open(decoded, "rb") as f:
+            return f.read()

--- a/tests/xcompress_frames.py
+++ b/tests/xcompress_frames.py
@@ -1,0 +1,42 @@
+"""Walking a bare XMemCompress stream's frames from the outside.
+
+Deliberately not the encoder's own bookkeeping and not the decoder's loop:
+this reads the stream the way something that has only the bytes has to,
+which is what lets a test say the frames are shaped the way the game's own
+are rather than the way albam meant them to be.
+
+A frame starting with 0xFF carries both of its sizes in a five byte header;
+any other frame carries only the compressed size, in two bytes, and means a
+full 32768 bytes out.
+"""
+FRAME_SIZE = 32768
+LONG_HEADER_MARKER = 0xFF
+LONG_HEADER_SIZE = 5
+SHORT_HEADER_SIZE = 2
+
+
+def frames_of(stream):
+    """`stream` as (header size, uncompressed size, compressed bytes) per
+    frame, plus whatever follows the last one.
+
+    Stops on a header declaring no compressed bytes, which is how a reader
+    walking frames rather than counting output finds the end of an .lfs
+    chunk; an .arc entry's stream simply runs out instead.
+    """
+    frames = []
+    position = 0
+    while position < len(stream):
+        if stream[position] == LONG_HEADER_MARKER:
+            header = LONG_HEADER_SIZE
+            uncompressed = (stream[position + 1] << 8) | stream[position + 2]
+            compressed = (stream[position + 3] << 8) | stream[position + 4]
+        else:
+            header = SHORT_HEADER_SIZE
+            uncompressed = FRAME_SIZE
+            compressed = (stream[position] << 8) | stream[position + 1]
+        if compressed == 0:
+            break
+        position += header
+        frames.append((header, uncompressed, stream[position:position + compressed]))
+        position += compressed
+    return frames, stream[position:]


### PR DESCRIPTION
## Intent

Fix albam issue #274, "Pack Devil May Cry 4 archives"
(https://github.com/Brachi/albam/issues/274). The captain wrote it; its substance:

DMC4 archives can be read but not packed. Their entries are XMemCompress (LZX) streams rather
than zlib, and albam only has a decoder, so `update_arc` refuses a version 17 archive outright
(`_check_writable` in `albam/engines/mtfw/archive.py`). Without that guard a repack would either
store zlib chunks the game cannot read, or relabel the untouched LZX entries as zlib. Both
produce a broken archive silently.

The encoder needed already exists: `albam/engines/cie/lfs_compress.py` writes LZX for RE4UHD, and
both engines decode through the same core in `albam/lib/xcompress.py`. What is missing is the
FRAMING. `compress_lfs`/`compress_chunks` emit .lfs chunk framing, while an .arc entry holds a
bare XMemCompress stream: 0xFF frame headers, no chunk table, one stream per entry rather than
fixed 64KB chunks. `_frame` and `_compress_chunk` look like the right seam to build a bare-stream
encoder on.

Two things the captain flagged as worth checking, because .lfs streams never exercise either:
- Entries run to megabytes, so a stream spans many frames and many blocks, where an .lfs chunk is
two frames holding one block. That difference is what hid a decoder bug until entries were
decoded whole (see "Hold enough bits to read a block's length").
- Whether the game accepts a stream albam wrote at all. Reading albam's own output proves nothing
here; the RE4UHD work found five bugs only by loading archives in the game.

Once an encoder lands, drop `_check_writable` and let version 17 archives pack like the rest.
Follows #262.

## What Changed

- Added `albam/lib/xcompress_encode.py`, a pure-Python XMemCompress (LZX) encoder producing bare streams — LZX blocks and frames with no container framing — factored out of `albam/engines/cie/lfs_compress.py`, which now keeps only the .lfs chunking and frame terminator and builds on the shared encoder.
- Dropped `_check_writable` in `albam/engines/mtfw/archive.py` so version 17 archives pack like the rest: entry payloads now route through `compress_entry`/`decompress_entry` in `arc_fs.py`, which pick LZX or zlib by archive version, and file type ids resolve through the archive's own version table (`_file_entry_extension`, `new_entry_file_type`) instead of the shared version 7 one. A new DMC4 entry whose extension maps to more than one resource class raises `AmbiguousExtension` rather than guessing; the export panel reports that and `FrameTooLarge` as an operator error instead of writing a file.
- Fixed repacking overwriting every entry's `flags` with a fixed `2`; the parsed value is now carried through. Added round-trip and framing tests (`tests/test_xcompress_encode.py`, expanded `tests/mtfw/test_arc_compression.py` with a shipped-entry hash dataset) plus `tests/xcompress_frames.py` and `tests/xcompress_cab.py`, which transplant a stream's frames into a CAB folder so p7zip's independent LZX decoder validates albam's output (skipped when p7zip is absent).

## Risk Assessment

⚠️ Medium: A large, self-contained feature (645-line LZX encoder plus a faithful extraction of the .lfs encoder onto it) that drops the `_check_writable` guard and is correct everywhere I traced it against the decoder, with real-archive and independent-decoder coverage — but the only conclusive proof, the game loading a repacked archive, is untestable and disclosed rather than demonstrated.

## Testing

Set up a headless Blender (bpy 4.2) environment and drove the addon's real Patch and Find-and-Replace operators against shipped archives from four games. Version 17 packing works end to end: albam's stream carries 0xff frame headers, refuses to decode as zlib, and p7zip's independent LZX decoder reproduces the exported payload exactly — including a 7.3MB entry spanning 226 frames, the many-frames/many-blocks case the intent called out. Re-mounting the archive albam wrote and importing the model back gives the same meshes and a pixel-identical render. The adversarial cases behave: a new DMC4 `.bin` is refused with a message naming the extension and both candidate ids, reported as an error rather than a traceback, and the archive on disk is untouched; a new `.shp` on a version 7 archive still goes in with the id the shared table always resolved it to; a version 7 patch still writes zlib. Running the same operator against the base commit shows the fail-before/pass-after for the flags fix (Revelations' flags-4 `.mrl` was rewritten as 2, now survives) and for the dropped `_check_writable` (DMC4 patch was refused, now finishes). The targeted archive and encoder test files pass against real game data. UI evidence is the two Cycles renders of the model imported from the shipped and from the repacked archive; the addon's other surfaces here are the operators themselves, captured as a CLI transcript. Whether the game itself accepts a stream albam wrote is the one thing I could not drive — it needs the Windows game running, which this machine does not provide.

- Live validation: ✅ go - 8 of 9 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Patching a shipped DMC4 (version 17) archive writes an XMemCompress entry an independent LZX decoder can read, leaving every other entry byte-identical | ✅ pass | live | dmc4_pack_live_transcript.txt SCENARIO 1: Patch -&gt; {&#39;FINISHED&#39;}, rewritten stream begins ff3a8a10d603, refuses zlib, p7zip decodes it to the exact 14986 exported bytes; the other 4 entries unchanged |
| Re-opening the archive albam repacked imports the same model in Blender | ✅ pass | live | dmc4_pack_live_transcript.txt SCENARIO 2 (same 212 verts / 230 polys) plus the before/after renders dmc4_model_before_repack.png and dmc4_model_after_repack.png |
| Find and Replace adds a new .tex to a DMC4 archive with the id version 17 numbers &#39;tex&#39; with | ✅ pass | live | dmc4_pack_live_transcript.txt SCENARIO 3: new entry id 0x3CAD8076 (&#39;tex&#39; in the DMC4 table, absent from the shared one), LZX stream decoding to the exported bytes |
| Adversarial: adding a new .bin (two DMC4 resource ids) is refused by name instead of silently guessing, and nothing is written | ✅ pass | live | dmc4_pack_live_transcript.txt SCENARIO 4: operator returns {&#39;CANCELLED&#39;} with reported error &#39;cannot add a &#34;.bin&#34; ... version 17 numbers it 0x19DDF06A, 0x7A5DCF86 ...&#39;; archive bytes on disk unchanged |
| Adversarial: adding a new .shp to a version 7 archive still works, with the id the shared table always resolved it to | ✅ pass | live | dmc4_pack_live_transcript.txt SCENARIO 5: Find and Replace -&gt; {&#39;FINISHED&#39;}, entry written with 0x5204D557 as zlib decoding to the exported bytes |
| Patching a version 7 (RE5) archive still writes zlib | ✅ pass | live | dmc4_pack_live_transcript.txt SCENARIO 6: rewritten &#39;pawn\om\oma011\soft\oma011.hit&#39; decompresses with zlib to the exported bytes |
| Regression: a version 7 entry whose flags are 4 keeps that value through a repack instead of being overwritten with 2 | ✅ pass | live | base_vs_branch.txt — same Revelations a shipped .arc file patched with the same operator: base 25127af writes the wp1070 .mrl back as flags 2, branch 23799b2 leaves it 4; dmc4_pack_live_transcript.txt SCENARIO 7… |
| A multi-megabyte DMC4 entry spanning many frames and blocks round-trips through albam and through an independent decoder | ✅ pass | live | dmc4_pack_live_transcript.txt SCENARIO 8: a shipped .arc file&#39;s 7372844-byte entry repacked into 226 XMemCompress frames, decoded identically by albam and by p7zip |
| The game itself loads an archive albam repacked | ⏸️ untested | no | Needs the Windows Devil May Cry 4 executable running and a person watching the loaded asset; this host has the game&#39;s data files only, no way to launch and observe the game. To provide it, someone wit… |

<details>
<summary>Evidence: Live operator transcript: all 8 scenarios against shipped archives</summary>

```text
Live run: albam driven through its own Blender operators against shipped
game archives (bpy 4.2 as a module, headless). Noise from the addon's
app-dir config lookup - it is not installed as a Blender extension here -
has been trimmed; every scenario line is verbatim.
========================================================================
SCENARIO 1  Patch a shipped DMC4 (version 17) archive
========================================================================
[setup] a shipped .arc file: version=17, 5 entries, 73637 bytes
[ui] imported model::game::orb005::a shipped .mod file from the shipped archive: {'orb005': (212, 230)}
[evidence] rendered ~/.no-mistakes/evidence/01M26XDHZFWC2N756W4K1Y2VZB/dmc4_model_before_repack.png
[setup] a shipped .mod file reads out of the archive as 14986 bytes
[ui] Patch -> {'FINISHED'}; archive now 73893 bytes (was 73637)
[check] rewritten archive still version 17, same 5 entries in the same order
[check] only ['model\\game\\orb005\\orb005'] rewritten; the other 4 entries byte for byte as shipped
[check] its stream begins ff3a8a10d603 (0xff = XMemCompress frame header), zsize 4059 -> 4315, size 14986
[check]   refuses to decode as zlib, as a version 17 entry must
[check]   albam decodes it back to the exact bytes exported
[check]   p7zip's independent LZX decoder decodes it identically
[check] every entry's DMC4 file type id and flags unchanged

========================================================================
SCENARIO 2  Re-open the repacked DMC4 archive in Blender
========================================================================
[ui] mounted the archive albam wrote and imported model::game::orb005::a shipped .mod file: {'orb005': (212, 230)}
[check] same meshes, same vertex and polygon counts as the shipped archive
[evidence] rendered ~/.no-mistakes/evidence/01M26XDHZFWC2N756W4K1Y2VZB/dmc4_model_after_repack.png

========================================================================
SCENARIO 3  Find and Replace adds a NEW entry to a DMC4 archive
========================================================================
[ui] Find and Replace (add as new) -> {'FINISHED'}
[check] archive went from 5 to 6 entries; the new one is 'chr\albam\added_by_albam'
[check] its file type id is 0x3CAD8076 -> 'tex' in the DMC4 table, None in the shared one
[check] the added entry is a real LZX stream decoding to the exported bytes

========================================================================
SCENARIO 4  An ambiguous .bin is refused, not guessed (DMC4)
========================================================================
Error: cannot add a ".bin" to this archive: version 17 numbers it 0x19DDF06A, 0x7A5DCF86, and which of those this file is cannot be told from its name
[ui] Find and Replace (add as new, .bin) -> {'CANCELLED'}
[ui] the message the user is shown: 'Error: cannot add a ".bin" to this archive: version 17 numbers it 0x19DDF06A, 0x7A5DCF86, and which of those this file is cannot be told from its name\n'
[check] it names the extension and both of the ids version 17 gives it, as a reported error and not a traceback
[check] the archive on disk is untouched - refused before anything was written

========================================================================
SCENARIO 5  A new .shp still goes into a version 7 archive
========================================================================
[setup] a shipped .arc file: version=7, 1 entries
[ui] Find and Replace (add as new, .shp) -> {'FINISHED'}
[check] the .shp went in with id 0x5204D557, the id the shared table has always resolved 'shp' to (0x5204D557)
[check] it is zlib, decoding to the exported bytes - version 7 output unchanged

========================================================================
SCENARIO 6  A version 7 archive still packs zlib on Patch
========================================================================
[ui] Patch (re5, patching 'pawn\om\oma011\soft\oma011.hit') -> {'FINISHED'}
[check] the rewritten entry is still zlib and decodes to what was exported

========================================================================
SCENARIO 7  A version 7 entry keeps its own flags value
========================================================================
[setup] a shipped .arc file: version=7, 6 entries; flags per entry: [('wp1070_BM', 'tex', 2), ('wp1070_MM', 'tex', 2), ('wp1070_NM', 'tex', 2), ('wp1070', 'mrl', 4), ('wp1070', 'mod', 2), ('wp1000', 'lmt', 2)]
[setup] the one entry that does not carry 2: [('dlc\\model\\chara\\wp\\wp1070\\wp1070', 'mrl')] (flags 4)
[ui] Patch (patching 'a shipped .lmt file', an entry whose own flags are 2) -> {'FINISHED'}
[check] flags after the repack: [('wp1070_BM', 'tex', 2), ('wp1070_MM', 'tex', 2), ('wp1070_NM', 'tex', 2), ('wp1070', 'mrl', 4), ('wp1070', 'mod', 2), ('wp1000', 'lmt', 2)]
[check] [('dlc\\model\\chara\\wp\\wp1070\\wp1070', 'mrl')] still carries 4 - its own value survived the repack instead of being overwritten with 2

========================================================================
SCENARIO 8  A multi-megabyte DMC4 entry: many frames, many blocks
========================================================================
[setup] a shipped .arc file: one entry 'id\cong\cong_back\cong01_NOMIP', 7372844 bytes uncompressed, stored in 3176415
[ui] Patch -> {'FINISHED'}; archive now 3735531 bytes (was 3209183)
[check] albam's stream is 3702763 bytes across 226 XMemCompress frames (an .lfs chunk is two)
[check] albam decodes the whole stream back to the exact 7372844 bytes
[check] p7zip's independent LZX decoder decodes it identically

========================================================================
ALL SCENARIOS OK
========================================================================

NOTE: this process exits with a segfault during CPython finalization, after
every line above is printed. That is the known bpy-as-a-module shutdown crash
the repo's own tests/conftest.py documents, not a failure of any scenario.
```
</details>
<details>
<summary>Evidence: Base commit vs branch: DMC4 refusal dropped, version 7 flags preserved</summary>

<code>--- Devil May Cry 4, a shipped .arc file (version 17) ---&#10;[base 25127af] Patch refused: ...this archive&#39;s entries are compressed with a codec albam can only read...&#10;[base 25127af] archive rewritten: False&#10;[branch 23799b2] Patch -&gt; {&#39;FINISHED&#39;}; archive rewritten: True&#10;&#10;--- Resident Evil Revelations, a shipped .arc file (version 7) ---&#10;[base 25127af] flags after repack: [(&#39;wp1070&#39;,&#39;mrl&#39;,2), ...] # its own 4 overwritten&#10;[branch 23799b2] flags after repack: [(&#39;wp1070&#39;,&#39;mrl&#39;,4), ...] # its own value survives</code>

```text
Same Blender operator (Patch / 'Update arc'), same shipped archives, run
against the base commit and against the branch head.

--- Devil May Cry 4, a shipped .arc file (version 17) ----------
[base 25127af] Patch refused: Error: Patch failed: ValueError: <temp path>: this archive's entries are compressed with a codec albam can only read, so it cannot be written back. Export the files on their own instead of packing them.
[base 25127af] archive rewritten: False
[branch 23799b2] Patch -> {'FINISHED'}; archive rewritten: True

--- Resident Evil Revelations, a shipped .arc file (version 7) -------------
    (holds the one version 7 entry measured on this machine whose flags
     are not 2: the wp1070 .mrl, flags 4. The entry being patched is the
     .lmt, so the .mrl is an untouched bystander of the repack.)
[base 25127af] flags as shipped:   [('wp1070_BM', 'tex', 2), ('wp1070_MM', 'tex', 2), ('wp1070_NM', 'tex', 2), ('wp1070', 'mrl', 4), ('wp1070', 'mod', 2), ('wp1000', 'lmt', 2)]
[base 25127af] Patch -> {'FINISHED'}
[base 25127af] flags after repack: [('wp1070_BM', 'tex', 2), ('wp1070_MM', 'tex', 2), ('wp1070_NM', 'tex', 2), ('wp1070', 'mrl', 2), ('wp1070', 'mod', 2), ('wp1000', 'lmt', 2)]
[branch 23799b2] flags as shipped:   [('wp1070_BM', 'tex', 2), ('wp1070_MM', 'tex', 2), ('wp1070_NM', 'tex', 2), ('wp1070', 'mrl', 4), ('wp1070', 'mod', 2), ('wp1000', 'lmt', 2)]
[branch 23799b2] Patch -> {'FINISHED'}
[branch 23799b2] flags after repack: [('wp1070_BM', 'tex', 2), ('wp1070_MM', 'tex', 2), ('wp1070_NM', 'tex', 2), ('wp1070', 'mrl', 4), ('wp1070', 'mod', 2), ('wp1000', 'lmt', 2)]
```
</details>

<details>
<summary>Evidence: Driver script used to run the scenarios</summary>

```text
"""Drive albam's archive writers against real shipped .arc files.

Runs the actual Blender operators a user clicks - Patch ("Update arc") and
Find and Replace - on working copies of shipped archives from Devil May Cry 4
(version 17 / XMemCompress), Resident Evil 5 and Resident Evil Revelations
(version 7 / zlib), then reads what they wrote back with albam and with
p7zip's independent LZX decoder.

The payload handed to the operators is a real file taken out of the archive
itself, because a DMC4 .mod cannot come out of albam's own mesh exporter
today (mod_153 serialization fails for every non-re5 app) - a pre-existing
defect in front of the packer, reported and ruled out of scope for this
branch.

Usage: python drive_dmc4_pack.py <workdir> <evidence-dir>
"""
import os
import shutil
import sys
import tempfile
import zlib

import bpy

WORK, EVID = sys.argv[-2:]
sys.path.insert(0, os.getcwd())
from albam import register  # noqa: E402
from albam.vfs import VirtualFileData  # noqa: E402

DMC4_ARC = "~/Games/Devil May Cry a shipped .arc file"
DMC4_BIG_ARC = "~/Games/Devil May Cry a shipped .arc file"
RE5_ARC = ("~/Games/Resident Evil 5/nativePC_MT/Image/Archive/"
           "a shipped .arc file")
REV_ARC = ("~/Games/RESIDENT EVIL REVELATIONS/dat/DAT_02/dlc/archive/"
           "a shipped .arc file")

def banner(text):
    print("\n" + "=" * 72)
    print(text)
    print("=" * 72)

def entries(path):
    """Every entry of `path`, payload read out eagerly.

    Eagerly because kaitai reads raw_data lazily off the still-open file: a
    snapshot taken before a patch would otherwise hand back the patched
    bytes when it is finally touched.
    """
    from albam.engines.mtfw.structs.arc import Arc
    a = Arc.from_bytes(open(path, "rb").read())
    a._read()
    snapshot = {}
    for e in a.file_entries:
        # Keyed by path AND type id: one archive can hold two entries at the
        # same path (a .mod and its .mrl), and they are different entries.
        snapshot[(e.file_path, e.file_type)] = {
            "raw": bytes(e.raw_data), "size": e.size, "zsize": e.zsize,
            "flags": e.flags, "file_type": e.file_type, "path": e.file_path}
    return (a.header.version, snapshot,
            [(e.file_path, e.file_type) for e in a.file_entries])

def at(snapshot, path):
    """The one entry of `snapshot` stored at `path`."""
    matches = [v for k, v in snapshot.items() if k[0] == path]
    assert len(matches) == 1, (path, len(matches))
    return matches[0]

def stage_export_root(app_id, root_id, vfiles, select_suffix=None):
    """What ALBAM_OT_Export does with what an engine's exporter returns."""
    vfs_e = bpy.context.scene.albam.exported
    vfs_e.add_export_root(app_id, root_id, vfiles)
    if select_suffix:
        index = next(i for i, it in enumerate(vfs_e.file_list)
                     if it.name.endswith(select_suffix))
    else:
        index = next(i for i, it in enumerate(vfs_e.file_list)
                     if it.name == f"{app_id}::{root_id}")
    vfs_e.file_list_selected_index = index

def clear_scene():
    bpy.ops.object.select_all(action="SELECT")
    bpy.ops.object.delete(use_global=True)
    for _ in range(3):
        bpy.ops.outliner.orphans_purge(do_local_ids=True, do_linked_ids=True,
                                       do_recursive=True)

def mesh_stats():
    return {o.name.split(".")[0]: (len(o.data.vertices), len(o.data.polygons))
            for o in bpy.data.objects if o.type == "MESH"}

def render(out, label):
    from mathutils import Vector
    scene = bpy.context.scene
    meshes = [o for o in bpy.data.objects if o.type == "MESH"]
    if not meshes:
        print(f"NO MESHES for {label}")
        return
    mat = bpy.data.materials.new("flat" + label)
    mat.use_nodes = True
    mat.node_tree.nodes["Principled BSDF"].inputs["Base Color"].default_value = (
        0.75, 0.72, 0.68, 1)

    def corners(o):
        return [o.matrix_world @ Vector(c) for c in o.bound_box]
    for o in meshes:
        o.data.materials.clear()
        o.data.materials.append(mat)
    cs = [c for o in meshes for c in corners(o)]
    minv = Vector((min(c.x for c in cs), min(c.y for c in cs), min(c.z for c in cs)))
    maxv = Vector((max(c.x for c in cs), max(c.y for c in cs), max(c.z for c in cs)))
    center = (minv + maxv) / 2
    size = max((maxv - minv).x, (maxv - minv).y, (maxv - minv).z) or 1.0
    cam_data = bpy.data.cameras.new("cam" + label)
    cam_data.type = "ORTHO"
    cam_data.ortho_scale = size * 1.6
    cam_data.clip_start = 0.001
    cam_data.clip_end = size * 100
    cam = bpy.data.objects.new("cam" + label, cam_data)
    scene.collection.objects.link(cam)
    offset = Vector((1.0, -1.4, 0.7)).normalized() * (size * 3)
    cam.location = center + offset
    cam.rotation_euler = (-offset).to_track_quat("-Z", "Y").to_euler()
    scene.camera = cam
    sun_data = bpy.data.lights.new("sun" + label, type="SUN")
    sun_data.energy = 5.0
    sun = bpy.data.objects.new("sun" + label, sun_data)
    sun.rotation_euler = (0.9, 0.1, -0.8)
    scene.collection.objects.link(sun)
    fill_data = bpy.data.lights.new("fill" + label, type="SUN")
    fill_data.energy = 2.0
    fill = bpy.data.objects.new("fill" + label, fill_data)
    fill.rotation_euler = (1.3, 0, 2.2)
    scene.collection.objects.link(fill)
    world = scene.world or bpy.data.worlds.new("w")
    scene.world = world
    world.use_nodes = True
    world.node_tree.nodes["Background"].inputs[0].default_value = (0.14, 0.15, 0.17, 1)
    scene.render.engine = "CYCLES"
    scene.cycles.device = "CPU"
    scene.cycles.samples = 16
    scene.render.resolution_x = 720
    scene.render.resolution_y = 720
    scene.render.filepath = out
    bpy.ops.render.render(write_still=True)
    print(f"[evidence] rendered {out}")

def copy_to(src, subdir):
    directory = os.path.join(WORK, subdir)
    os.makedirs(directory, exist_ok=True)
    dst = os.path.join(directory, os.path.basename(src))
    shutil.copy(src, dst)
    return dst

def main():
    register()
    clear_scene()
    from albam.engines.mtfw.arc_fs import MTFW_FS
    from albam.engines.mtfw import (
        EXTENSION_TO_FILE_ID, EXTENSION_TO_FILE_IDS_DMC4, FILE_ID_TO_EXTENSION,
        FILE_ID_TO_EXTENSION_DMC4)
    from tests.xcompress_cab import independent_decompress, sevenzip
    assert sevenzip(), "p7zip is required for the independent decode"

    vfs = bpy.context.scene.albam.vfs
    export_settings = bpy.context.scene.albam.export_settings

    # =================================================================
    banner("SCENARIO 1  Patch a shipped DMC4 (version 17) archive")
    # =================================================================
    bpy.context.scene.albam.apps.app_selected = "dmc4"
    arc = copy_to(DMC4_ARC, "dmc4_a")
    before_bytes = open(arc, "rb").read()
    version, before, order = entries(arc)
    print(f"[setup] {os.path.basename(arc)}: version={version}, {len(order)} entries, "
          f"{len(before_bytes)} bytes")
    assert version == 17

    game_fs = MTFW_FS(os.path.dirname(arc))
    vfs.add_fs_root("dmc4", game_fs, display_name="dmc4-before")
    model = next(vf for vf in vfs.file_list if vf.name.endswith(".mod"))
    model_path = model.name.split("::", 1)[1]
    vfs.select_vfile("dmc4", model_path)
    assert bpy.ops.albam.import_vfile() == {"FINISHED"}
    stats_before = mesh_stats()
    print(f"[ui] imported {model_path} from the shipped archive: {stats_before}")
    render(os.path.join(EVID, "dmc4_model_before_repack.png"), "before")

    relative = model_path.replace("::", "\\")
    payload = game_fs.readbytes("/" + model_path.replace("::", "/"))
    print(f"[setup] {relative} reads out of the archive as {len(payload)} bytes")

    stage_export_root("dmc4", "dmc4-pack",
                      [VirtualFileData("dmc4", relative, payload)])
    result = bpy.ops.albam.patch(filepath=arc)
    after_bytes = open(arc, "rb").read()
    print(f"[ui] Patch -> {result}; archive now {len(after_bytes)} bytes "
          f"(was {len(before_bytes)})")
    assert result == {"FINISHED"}
    version_afte

... [3905 bytes truncated] ...

_IDS_DMC4["tex"] == (added["file_type"],)
    assert independent_decompress(added["raw"], added["size"]) == new_payload
    print("[check] the added entry is a real LZX stream decoding to the exported bytes")

    # =================================================================
    banner("SCENARIO 4  An ambiguous .bin is refused, not guessed (DMC4)")
    # =================================================================
    amb_arc = copy_to(DMC4_ARC, "dmc4_ambiguous")
    amb_before = open(amb_arc, "rb").read()
    stage_export_root("dmc4", "dmc4-amb",
                      [VirtualFileData("dmc4", "chr\\albam\\guesswork.bin",
                                       b"which resource class am i?\n" * 100)],
                      select_suffix="guesswork.bin")
    export_settings.far_add_new = True
    export_settings.far_file_name = "guesswork"
    message = None
    try:
        result = bpy.ops.wm.findreplace_file_sel(filepath=amb_arc)
    except RuntimeError as err:
        # Blender turns an operator that reports {'ERROR'} and returns
        # CANCELLED into this RuntimeError when it is called from Python;
        # in the UI the same report is the message shown in the status bar.
        result = {"CANCELLED"}
        message = str(err)
    print(f"[ui] Find and Replace (add as new, .bin) -> {result}")
    assert result == {"CANCELLED"}, result
    assert message, "the operator finished instead of refusing"
    print(f"[ui] the message the user is shown: {message!r}")
    assert "Traceback" not in message
    assert ".bin" in message
    bin_ids = [h for h, ext in FILE_ID_TO_EXTENSION_DMC4.items() if ext == "bin"]
    assert len(bin_ids) == 2, bin_ids
    for candidate in bin_ids:
        assert f"0x{candidate:08X}" in message, (candidate, message)
    print("[check] it names the extension and both of the ids version 17 gives it, "
          "as a reported error and not a traceback")
    assert open(amb_arc, "rb").read() == amb_before
    print("[check] the archive on disk is untouched - refused before anything was written")

    # =================================================================
    banner("SCENARIO 5  A new .shp still goes into a version 7 archive")
    # =================================================================
    bpy.context.scene.albam.apps.app_selected = "re5"
    shp_arc = copy_to(RE5_ARC, "re5_shp")
    v7_version, v7_before, v7_order = entries(shp_arc)
    print(f"[setup] {os.path.basename(shp_arc)}: version={v7_version}, "
          f"{len(v7_order)} entries")
    assert v7_version == 7
    shp_payload = b"a shape albam added\n" * 500
    stage_export_root("re5", "re5-shp",
                      [VirtualFileData("re5", "chr\\albam\\added_shape.shp",
                                       shp_payload)],
                      select_suffix="added_shape.shp")
    export_settings.far_add_new = True
    export_settings.far_file_name = "added_shape"
    result = bpy.ops.wm.findreplace_file_sel(filepath=shp_arc)
    print(f"[ui] Find and Replace (add as new, .shp) -> {result}")
    assert result == {"FINISHED"}, result
    _v, shp_after, _o = entries(shp_arc)
    shp_entry = at(shp_after, "chr\\albam\\added_shape")
    print(f"[check] the .shp went in with id 0x{shp_entry['file_type']:08X}, the id "
          f"the shared table has always resolved 'shp' to "
          f"(0x{EXTENSION_TO_FILE_ID['shp']:08X})")
    assert shp_entry["file_type"] == EXTENSION_TO_FILE_ID["shp"]
    assert zlib.decompress(shp_entry["raw"]) == shp_payload
    print("[check] it is zlib, decoding to the exported bytes - version 7 output unchanged")

    # =================================================================
    banner("SCENARIO 6  A version 7 archive still packs zlib on Patch")
    # =================================================================
    export_settings.far_add_new = False
    re5_arc = copy_to(RE5_ARC, "re5_patch")
    v7_version, v7_before, v7_order = entries(re5_arc)
    target = v7_order[0][0]
    ext = FILE_ID_TO_EXTENSION[v7_order[0][1]]
    re5_payload = b"albam wrote this one\n" * 300
    stage_export_root("re5", "re5-patch",
                      [VirtualFileData("re5", f"{target}.{ext}", re5_payload)])
    result = bpy.ops.albam.patch(filepath=re5_arc)
    print(f"[ui] Patch (re5, patching '{target}.{ext}') -> {result}")
    assert result == {"FINISHED"}
    _v, re5_after, _o = entries(re5_arc)
    assert _v == 7
    assert zlib.decompress(at(re5_after, target)["raw"]) == re5_payload
    print("[check] the rewritten entry is still zlib and decodes to what was exported")

    # =================================================================
    banner("SCENARIO 7  A version 7 entry keeps its own flags value")
    # =================================================================
    rev_arc = copy_to(REV_ARC, "rev_flags")
    rv, rev_before, rev_order = entries(rev_arc)
    assert rv == 7
    odd = [k for k in rev_order if rev_before[k]["flags"] != 2]
    print(f"[setup] {os.path.basename(rev_arc)}: version=7, {len(rev_order)} entries; "
          f"flags per entry: "
          f"{[(k[0].rsplit(chr(92), 1)[-1], FILE_ID_TO_EXTENSION.get(k[1]), rev_before[k]['flags']) for k in rev_order]}")
    print(f"[setup] the one entry that does not carry 2: "
          f"{[(k[0], FILE_ID_TO_EXTENSION.get(k[1])) for k in odd]} (flags 4)")
    assert odd
    rev_target = next(k for k in rev_order if FILE_ID_TO_EXTENSION[k[1]] == "lmt")
    rev_payload = rev_before[rev_target]["raw"]
    rev_payload = zlib.decompress(rev_payload) + b""
    stage_export_root("re5", "rev-flags",
                      [VirtualFileData("re5", f"{rev_target[0]}.lmt", rev_payload)])
    result = bpy.ops.albam.patch(filepath=rev_arc)
    print(f"[ui] Patch (patching '{rev_target[0]}.lmt', an entry whose own flags are 2) "
          f"-> {result}")
    assert result == {"FINISHED"}
    _v, rev_after, _o = entries(rev_arc)
    print(f"[check] flags after the repack: "
          f"{[(k[0].rsplit(chr(92), 1)[-1], FILE_ID_TO_EXTENSION.get(k[1]), rev_after[k]['flags']) for k in rev_order]}")
    for k in rev_order:
        assert rev_after[k]["flags"] == rev_before[k]["flags"], k
    print(f"[check] {[(k[0], FILE_ID_TO_EXTENSION.get(k[1])) for k in odd]} still "
          f"carries 4 - its own value survived the repack "
          f"instead of being overwritten with 2")

    # =================================================================
    banner("SCENARIO 8  A multi-megabyte DMC4 entry: many frames, many blocks")
    # =================================================================
    bpy.context.scene.albam.apps.app_selected = "dmc4"
    big_arc = copy_to(DMC4_BIG_ARC, "dmc4_big")
    bv, big_before, big_order = entries(big_arc)
    big_target = big_order[0][0]
    big_payload = decompress_entry(17, at(big_before, big_target)["raw"],
                                   at(big_before, big_target)["size"])
    print(f"[setup] {os.path.basename(big_arc)}: one entry '{big_target}', "
          f"{len(big_payload)} bytes uncompressed, stored in "
          f"{at(big_before, big_target)['zsize']}")
    stage_export_root("dmc4", "dmc4-big",
                      [VirtualFileData("dmc4", f"{big_target}.tex", big_payload)])
    result = bpy.ops.albam.patch(filepath=big_arc)
    print(f"[ui] Patch -> {result}; archive now {os.path.getsize(big_arc)} bytes "
          f"(was {os.path.getsize(DMC4_BIG_ARC)})")
    assert result == {"FINISHED"}
    _v, big_after, _o = entries(big_arc)
    big_fe = at(big_after, big_target)
    from tests.xcompress_frames import frames_of
    frames, _rest = frames_of(big_fe["raw"])
    print(f"[check] albam's stream is {big_fe['zsize']} bytes across {len(frames)} "
          f"XMemCompress frames (an .lfs chunk is two)")
    assert len(frames) > 2
    assert decompress_entry(17, big_fe["raw"], big_fe["size"]) == big_payload
    print("[check] albam decodes the whole stream back to the exact 7372844 bytes")
    assert independent_decompress(big_fe["raw"], big_fe["size"]) == big_payload
    print("[check] p7zip's independent LZX decoder decodes it identically")

    banner("ALL SCENARIOS OK")

main()
```
</details>

## What this change does not prove

Recorded so a reader sees exactly which parts of the Devil May Cry 4 story are
demonstrated and which are not.

**The game loading an archive albam wrote: not validated.** Dropping
`_check_writable` means albam will now let a user save a DMC4 archive whose
acceptance by the game itself has never been tested. What *is* proven is that
the streams albam writes are real LZX: 222 shipped entries across 28 file
types (28.3 MB of payload), and the largest entry in the game at 16,777,260
bytes over 513 frames and two blocks, all re-encode and decode back byte for
byte both through albam's own decoder and through p7zip's LZX decoder, which
shares no code with albam. Two decoders agreeing is not the game agreeing. The
.lfs encoder this one is built on shipped three bugs that albam's decoder read
back perfectly and the game rejected, which is exactly why that distinction is
drawn here rather than glossed over.

**Editing a DMC4 model in Blender and writing it back: not validated, and not
possible today.** DMC4 model export fails before it ever reaches the packer:
`bpy.ops.albam.export()` on an imported DMC4 `.mod` dies in `mod_153`
serialization (`ConsistencyError: index_buffer`), on 5 of 5 models tried and
identically on the commit this branch started from. DMC4 collision import is
likewise blocked (`KeyError: 'sbc_156_mesh'`, registered for re5 only). Both
predate this branch, both sit before the packer, and both are tracked apart
from this change - which is why the CHANGELOG entry promises repacking only,
not an edit-and-repack story. Every payload handed to the writer in testing
was therefore a real one taken back out of an archive.

**A newly added entry's `flags` value: unverified for DMC4.** An entry albam
adds gets `flags = 2`. Existing entries keep their own value, but a new one
has nothing to carry over, and DMC4's own textures are observed carrying 0 and
1 as well - so 2 is a value seen on real DMC4 textures rather than a value
known to be right for this one. Documented at both sites in `archive.py`.

**Version 7 `flags`: measured, and this is a fix rather than a change of
behaviour.** Repacking used to overwrite every entry's `flags` with a fixed 2.
Measured across every `.arc` of the seven version 7 games on hand - Dragon's
Dogma, Resident Evil Revelations, Resident Evil 0, Resident Evil 5, Resident
Evil 6, Resident Evil HD Remaster, Ultimate Marvel vs. Capcom 3 - that is
29,690 archives and 788,014 entries, of which 788,013 carry 2 and exactly one
carries 4: `dlc\model\chara\wp\wp1070\wp1070` in Revelations' `a shipped .arc file`.
Version 7 output now preserves that entry's own value instead of replacing it
with a guess, and a test pins it.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"18b247e8f2f26563cf4a2687f83df65dbbd2b837","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `albam/engines/mtfw/archive.py:124` - `_serialize_arc` now carries `fe.flags` through for every archive version, where it previously wrote a fixed 2. Preserving the value is required for DMC4 (its tex entries use 0 and 1, and `test_packing_leaves_an_entry_s_flags_alone` pins that), but the change is unconditional, so it also changes version 7 output for any entry whose parsed flags are not 2 - reached by the same `update_arc`/`find_and_replace_in_arc` paths for re1/re5/re6/rev1/rev2/dd/umvc3. The only thing ruling that out is the comment&#39;s empirical claim that &#34;every entry of every version 7 archive albam reads has 2&#34;, which no test can check here: `build_arc`&#39;s version 7 fixture in `test_packing_a_version_7_archive_still_writes_zlib` passes flags 2, so the v7 assertion would pass either way. Writing the parsed value is arguably more faithful than overwriting it, which is why this is info rather than a defect - but it is a behavior change to already-shipped games that the intent does not ask for, and round 2&#39;s recorded decision set the bar &#34;Nothing about version 7 output may change&#34; for the analogous extension-table narrowing. The narrower form that satisfies the DMC4 requirement without touching v7 is `fe.flags if version == ARC_VERSION_DMC4 else 2`; whether to narrow it or keep the broader carry-over is the author&#39;s call.

🔧 Fix applied.
1 info still open:

- ℹ️ `CHANGELOG.md:23` - Acknowledged tradeoff, no action needed. The one thing that would fully prove the encoder — loading an albam-repacked DMC4 archive in the game — cannot be executed by any test, and the user intent itself names it (&#34;the RE4UHD work found five bugs only by loading archives in the game&#34;). The change handles this honestly rather than silently: the CHANGELOG entry states the encoder &#34;has not yet been confirmed by loading an edited archive in the game&#34; (wording locked by a recorded decision), tests/mtfw/test_arc_compression.py&#39;s module docstring says the same, and the gap is mitigated as far as automation can go by decoding albam&#39;s output through p7zip&#39;s unrelated LZX decoder (tests/xcompress_cab.py), whose faithfulness is itself pinned by running shipped DMC4 streams through it. Recorded so the residual risk is visible, not as a request to change anything.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 8 of 9 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Patching a shipped DMC4 (version 17) archive writes an XMemCompress entry an independent LZX decoder can read, leaving every other entry byte-identical | ✅ pass | live | dmc4_pack_live_transcript.txt SCENARIO 1: Patch -&gt; {&#39;FINISHED&#39;}, rewritten stream begins ff3a8a10d603, refuses zlib, p7zip decodes it to the exact 14986 exported bytes; the other 4 entries unchanged |
| Re-opening the archive albam repacked imports the same model in Blender | ✅ pass | live | dmc4_pack_live_transcript.txt SCENARIO 2 (same 212 verts / 230 polys) plus the before/after renders dmc4_model_before_repack.png and dmc4_model_after_repack.png |
| Find and Replace adds a new .tex to a DMC4 archive with the id version 17 numbers &#39;tex&#39; with | ✅ pass | live | dmc4_pack_live_transcript.txt SCENARIO 3: new entry id 0x3CAD8076 (&#39;tex&#39; in the DMC4 table, absent from the shared one), LZX stream decoding to the exported bytes |
| Adversarial: adding a new .bin (two DMC4 resource ids) is refused by name instead of silently guessing, and nothing is written | ✅ pass | live | dmc4_pack_live_transcript.txt SCENARIO 4: operator returns {&#39;CANCELLED&#39;} with reported error &#39;cannot add a &#34;.bin&#34; ... version 17 numbers it 0x19DDF06A, 0x7A5DCF86 ...&#39;; archive bytes on disk unchanged |
| Adversarial: adding a new .shp to a version 7 archive still works, with the id the shared table always resolved it to | ✅ pass | live | dmc4_pack_live_transcript.txt SCENARIO 5: Find and Replace -&gt; {&#39;FINISHED&#39;}, entry written with 0x5204D557 as zlib decoding to the exported bytes |
| Patching a version 7 (RE5) archive still writes zlib | ✅ pass | live | dmc4_pack_live_transcript.txt SCENARIO 6: rewritten &#39;pawn\om\oma011\soft\oma011.hit&#39; decompresses with zlib to the exported bytes |
| Regression: a version 7 entry whose flags are 4 keeps that value through a repack instead of being overwritten with 2 | ✅ pass | live | base_vs_branch.txt — same Revelations a shipped .arc file patched with the same operator: base 25127af writes the wp1070 .mrl back as flags 2, branch 23799b2 leaves it 4; dmc4_pack_live_transcript.txt SCENARIO 7… |
| A multi-megabyte DMC4 entry spanning many frames and blocks round-trips through albam and through an independent decoder | ✅ pass | live | dmc4_pack_live_transcript.txt SCENARIO 8: a shipped .arc file&#39;s 7372844-byte entry repacked into 226 XMemCompress frames, decoded identically by albam and by p7zip |
| The game itself loads an archive albam repacked | ⏸️ untested | no | Needs the Windows Devil May Cry 4 executable running and a person watching the loaded asset; this host has the game&#39;s data files only, no way to launch and observe the game. To provide it, someone wit… |

- <code>`python drive_dmc4_pack.py` — 8 scenarios driven through bpy 4.2 operators against shipped .arc files (evidence dir)</code>
- <code>`bpy.ops.albam.patch(filepath=...)` on Devil May Cry 4 `a shipped .arc file` (version 17)</code>
- <code>`bpy.ops.albam.import_vfile()` re-importing `a shipped .mod file` out of the archive albam rewrote, with Cycles renders before/after</code>
- <code>`bpy.ops.wm.findreplace_file_sel(...)` adding a new `.tex` to a DMC4 archive, and a new `.bin` (refused) and a new `.shp` on a version 7 RE5 archive</code>
- <code>`bpy.ops.albam.patch(...)` on Resident Evil Revelations `a shipped .arc file`, whose `.mrl` entry carries flags 4</code>
- <code>`bpy.ops.albam.patch(...)` on DMC4 `a shipped .arc file`, a single 7,372,844-byte entry spanning 226 XMemCompress frames</code>
- <code>`tests/xcompress_cab.independent_decompress` (p7zip LZX) on every stream albam wrote</code>
- <code>`python -m pytest -q tests/mtfw/test_arc_compression.py tests/test_xcompress_encode.py --game-dir=dmc4::... --game-dir=re5::...` → 109 passed</code>
- <code>`python dmc4_base_probe.py` and `python flags_probe.py` run against a base-commit (25127af) checkout for the before/after comparison</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/README.md:3` - docs/README.md (&#34;read the repo&#39;s `CLAUDE.md`&#34;), pyproject.toml&#39;s flake8 exclude comment, and albam/engines/cie comments all point at a repo-root CLAUDE.md that is neither tracked nor gitignored, so a reader following the pointer finds nothing. Pre-existing and unrelated to this change (nothing here touched those files), so I left it alone rather than widening the pass; worth a follow-up that either commits that document or repoints the three references at whatever now owns &#34;how the code is organised&#34;.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

